### PR TITLE
Build system updates

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -119,11 +119,11 @@ endif
 
 message('\n'.join([
   '',
-  '        prefix:                       ' + get_option('prefix'),
-  '        libdir:                       ' + get_option('libdir'),
-  '        bindir:                       ' + get_option('bindir'),
-  '        sysconfdir:                   ' + get_option('sysconfdir'),
-  '        localstatedir:                ' + get_option('localstatedir'),
+  '        prefix:                       ' + prefix,
+  '        libdir:                       ' + libdir,
+  '        bindir:                       ' + bindir,
+  '        sysconfdir:                   ' + sysconfdir,
+  '        localstatedir:                ' + localstatedir,
   '        source code location:         ' + meson.source_root(),
   '        compiler:                     ' + cc.get_id(),
   '        debugging support:            ' + get_option('buildtype'),

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,6 @@ project('open5gs', 'c',
     meson_version : '>= 0.43.0',
     default_options : [
         'c_std=gnu89',
-        'prefix=/usr',
     ],
 )
 


### PR DESCRIPTION
The default prefix for the package installation was set to /usr, which I truly found quite strange, given that normally every package build from source defaults to /usr/local instead. IMHO, using the default /usr/local is much more common and standard and what a user would expect. Especially since setting only the prefix to /usr would end up setting sysconfdir to /usr/etc and that is incredibly confusing :D

A default meson configuration would end up giving:
```
$ meson build
Message: 
        prefix:                       /usr/local
        libdir:                       /usr/local/lib/x86_64-linux-gnu
        bindir:                       /usr/local/bin
        sysconfdir:                   /usr/local/etc
        localstatedir:                /usr/local/var
        source code location:         /home/aleksander/nextepc
        compiler:                     gcc
        debugging support:            debug
```

And with normal system-install prefix settings, e.g. in Ubuntu:
```
$ meson --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/x86_64-linux-gnu build
...
Message: 
        prefix:                       /usr
        libdir:                       /usr/lib/x86_64-linux-gnu
        bindir:                       /usr/bin
        sysconfdir:                   /etc
        localstatedir:                /usr/var
        source code location:         /home/aleksander/nextepc
        compiler:                     gcc
        debugging support:            debug
```