### PR TITLE
add an option for PDN Type (IPv4, IPv6, IPv4v6) to webui

### DIFF
--- a/webui/src/components/Profile/Edit.js
+++ b/webui/src/components/Profile/Edit.js
@@ -127,6 +127,13 @@ const schema = {
               }
             }
           },
+          "type": {
+            "type": "number",
+            "title": "Type*",
+            "enum": [0, 1, 2],
+            "enumNames": ["IPv4", "IPv6", "IPv4v6"],
+            "default": 0,
+          },
           "ambr": {
             "type": "object",
             "title": "",

--- a/webui/src/components/Subscriber/Edit.js
+++ b/webui/src/components/Subscriber/Edit.js
@@ -133,6 +133,13 @@ const schema = {
               }
             }
           },
+          "type": {
+            "type": "number",
+            "title": "Type*",
+            "enum": [0, 1, 2],
+            "enumNames": ["IPv4", "IPv6", "IPv4v6"],
+            "default": 0,
+          },          
           "ambr": {
             "type": "object",
             "title": "",

--- a/webui/src/components/Subscriber/View.js
+++ b/webui/src/components/Subscriber/View.js
@@ -255,6 +255,7 @@ const View = ({ visible, disableOnClickOutside, subscriber, onEdit, onDelete, on
                 <div className="small_data">ARP</div>
                 <div className="medium_data">Capability</div>
                 <div className="medium_data">Vulnerablility</div>
+                <div className="medium_data">Type</div>
                 <div className="large_data">MBR DL/UL(Kbps)</div>
                 <div className="large_data">GBR DL/UL(Kbps)</div>
               </div>
@@ -266,6 +267,7 @@ const View = ({ visible, disableOnClickOutside, subscriber, onEdit, onDelete, on
                     <div className="small_data">{pdn.qos.arp.priority_level}</div>
                     <div className="medium_data">{pdn.qos.arp.pre_emption_capability === 1 ? "Disabled" : "Enabled"}</div>
                     <div className="medium_data">{pdn.qos.arp.pre_emption_vulnerability === 1 ? "Disabled" : "Enabled"}</div>
+                    <div className="medium_data">{pdn.type === 0 ? "IPv4" : (pdn.type === 1 ? "IPv6" : "IPv4v6")}</div>
                     {pdn['ambr'] === undefined ? 
                       <div className="large_data">
                         unlimited/unlimited
@@ -305,6 +307,7 @@ const View = ({ visible, disableOnClickOutside, subscriber, onEdit, onDelete, on
                           <div className="small_data">{pcc_rule.qos.arp.priority_level}</div>
                           <div className="medium_data">{pcc_rule.qos.arp.pre_emption_capability === 1 ? "Disabled" : "Enabled"}</div>
                           <div className="medium_data">{pcc_rule.qos.arp.pre_emption_vulnerability === 1 ? "Disabled" : "Enabled"}</div>
+                          <div className="medium_data">{pdn.type === 0 ? "IPv4" : (pdn.type === 1 ? "IPv6" : "IPv4v6")}</div>
                           {pcc_rule.qos['mbr'] === undefined ? 
                             <div className="large_data">
                               unlimited/unlimited


### PR DESCRIPTION
I am working on supporting different PDN types and realized we need this feature in the WebUI. Right now it functionally works, but has two small problems. First, the selection bar has a blank option above IPv4. Second, I think the bar is too big and makes more sense to put it on the line above. @acetcom if you have a moment to help on this, I couldn't figure out how to make node do what I want, but I think you're more familiar with this code base than I am :-).