### PR TITLE
Add feature to provide custom SGW GTP-U (S1) address to be advertised inside S1AP messages

### DIFF
--- a/src/sgw/sgw-context.h
+++ b/src/sgw/sgw-context.h
@@ -47,6 +47,10 @@ typedef struct sgw_context_s {
 
     ogs_list_t      gtpu_list;      /* SGW GTPU IPv4 Server List */
     ogs_list_t      gtpu_list6;     /* SGW GTPU IPv6 Server List */
+    ogs_list_t      adv_gtpu_list;  /* Advertised SGW GTPU IPv4 Server List */
+    ogs_list_t      adv_gtpu_list6; /* Advertised SGW GTPU IPv6 Server List */
+    ogs_hash_t      *adv_gtpu_hash; /* Hashtable (SGW GTPU : Advertised SGW GTPU) IPv4 */
+    ogs_hash_t      *adv_gtpu_hash6;/* Hashtable (SGW GTPU : Advertised SGW GTPU) IPv6 */
     ogs_sock_t      *gtpu_sock;     /* SGW GTPU IPv4 Socket */
     ogs_sock_t      *gtpu_sock6;    /* SGW GTPU IPv6 Socket */
     ogs_sockaddr_t  *gtpu_addr;     /* SGW GTPU IPv4 Address */

--- a/src/sgw/sgw-gtp-path.c
+++ b/src/sgw/sgw-gtp-path.c
@@ -360,6 +360,8 @@ void sgw_gtp_close(void)
     ogs_socknode_remove_all(&sgw_self()->gtpc_list6);
     ogs_socknode_remove_all(&sgw_self()->gtpu_list);
     ogs_socknode_remove_all(&sgw_self()->gtpu_list6);
+    ogs_socknode_remove_all(&sgw_self()->adv_gtpu_list);
+    ogs_socknode_remove_all(&sgw_self()->adv_gtpu_list6);
 
     ogs_pkbuf_pool_destroy(packet_pool);
 }

--- a/src/sgw/sgw-s5c-handler.c
+++ b/src/sgw/sgw-s5c-handler.c
@@ -44,6 +44,7 @@ void sgw_s5c_handle_create_session_response(ogs_gtp_xact_t *s5c_xact,
 {
     int rv;
     uint8_t cause_value;
+    ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
     ogs_gtp_node_t *pgw = NULL;
     ogs_gtp_xact_t *s11_xact = NULL;
     sgw_bearer_t *bearer = NULL;
@@ -197,9 +198,25 @@ void sgw_s5c_handle_create_session_response(ogs_gtp_xact_t *s5c_xact,
     memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
     sgw_s1u_teid.interface_type = s1u_tunnel->interface_type;
     sgw_s1u_teid.teid = htonl(s1u_tunnel->local_teid);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    if (sgw_self()->gtpu_addr) {
+        addr = ogs_hash_get(sgw_self()->adv_gtpu_hash,
+                        &sgw_self()->gtpu_addr->sin.sin_addr,
+                        sizeof(sgw_self()->gtpu_addr->sin.sin_addr));
+    }
+    if (sgw_self()->gtpu_addr6) {
+        addr6 = ogs_hash_get(sgw_self()->adv_gtpu_hash6,
+                        &sgw_self()->gtpu_addr6->sin6.sin6_addr,
+                        sizeof(sgw_self()->gtpu_addr6->sin6.sin6_addr));
+    }
+    // Swap the SGW-S1U IP to IP to be advertised to UE
+    if (addr || addr6) {
+        rv = ogs_gtp_sockaddr_to_f_teid(addr,  addr6, &sgw_s1u_teid, &len);
+        ogs_assert(rv == OGS_OK);
+    } else {
+        rv = ogs_gtp_sockaddr_to_f_teid(
         sgw_self()->gtpu_addr,  sgw_self()->gtpu_addr6, &sgw_s1u_teid, &len);
-    ogs_assert(rv == OGS_OK);
+        ogs_assert(rv == OGS_OK);
+    }
     rsp->bearer_contexts_created.s1_u_enodeb_f_teid.presence = 1;
     rsp->bearer_contexts_created.s1_u_enodeb_f_teid.data = &sgw_s1u_teid;
     rsp->bearer_contexts_created.s1_u_enodeb_f_teid.len = len;
@@ -290,6 +307,7 @@ void sgw_s5c_handle_create_bearer_request(ogs_gtp_xact_t *s5c_xact,
 {
     int rv;
     uint8_t cause_value = 0;
+    ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
     ogs_gtp_node_t *pgw = NULL;
     ogs_gtp_xact_t *s11_xact = NULL;
     sgw_bearer_t *bearer = NULL;
@@ -380,9 +398,25 @@ void sgw_s5c_handle_create_bearer_request(ogs_gtp_xact_t *s5c_xact,
     memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
     sgw_s1u_teid.interface_type = s1u_tunnel->interface_type;
     sgw_s1u_teid.teid = htonl(s1u_tunnel->local_teid);
-    rv = ogs_gtp_sockaddr_to_f_teid(
-        sgw_self()->gtpu_addr, sgw_self()->gtpu_addr6, &sgw_s1u_teid, &len);
-    ogs_assert(rv == OGS_OK);
+    if (sgw_self()->gtpu_addr) {
+        addr = ogs_hash_get(sgw_self()->adv_gtpu_hash,
+                        &sgw_self()->gtpu_addr->sin.sin_addr,
+                        sizeof(sgw_self()->gtpu_addr->sin.sin_addr));
+    }
+    if (sgw_self()->gtpu_addr6) {
+        addr6 = ogs_hash_get(sgw_self()->adv_gtpu_hash6,
+                        &sgw_self()->gtpu_addr6->sin6.sin6_addr,
+                        sizeof(sgw_self()->gtpu_addr6->sin6.sin6_addr));
+    }
+    // Swap the SGW-S1U IP to IP to be advertised to UE
+    if (addr || addr6) {
+        rv = ogs_gtp_sockaddr_to_f_teid(addr,  addr6, &sgw_s1u_teid, &len);
+        ogs_assert(rv == OGS_OK);
+    } else {
+        rv = ogs_gtp_sockaddr_to_f_teid(
+        sgw_self()->gtpu_addr,  sgw_self()->gtpu_addr6, &sgw_s1u_teid, &len);
+        ogs_assert(rv == OGS_OK);
+    }
     req->bearer_contexts.s1_u_enodeb_f_teid.presence = 1;
     req->bearer_contexts.s1_u_enodeb_f_teid.data = &sgw_s1u_teid;
     req->bearer_contexts.s1_u_enodeb_f_teid.len = len;


### PR DESCRIPTION
This feature is useful in scenarios where SGW is run inside a container or openstack vm i.e. behind 1-to-1 mapping NAT. In docker/openstack environment, we often have 1-to-1 mapped NAT IP address in order for eNB to reach SGW. But, this 1-to-1 mapping NAT IP address is not seen on SGW host and hence non UDP socket bindable. Since SGW can only bind to IP address visible in it's host (usually a private IP beind a NAT), it advertises the same to UE in S1AP message resulting in eNB not able to reach SGW on Uplink. This commit solves this issue by providing a means to advertise a different IP address than the one SGW UDP socket is bound to.

Example of sgw.yaml to use this feature:
<pre>
logger:
    file: /root/open5gs/install/var/log/open5gs/sgw.log
    level: debug

parameter:
    no_ipv6: true

sgw:
    gtpc:
      addr: 127.0.0.2
    gtpu:
      dev: ens3
      advertise_addr:
        - 172.24.15.30
        - fe80::f816:3eff:fe15:fe34
</pre>