### PR TITLE
PGW service must depend on systemd-networkd

### DIFF
--- a/configs/systemd/open5gs-pgwd.service.in
+++ b/configs/systemd/open5gs-pgwd.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Open5GS P-GW Daemon
 After=networking.service
+Requires=systemd-networkd.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
PGW must "Require" systemd-networkd  for apt-get installation of open5gs. This makes sense (because PGW depends on systemd-networkd to configure the ogstun interface) but also fixes an important bug.

Default install of open5gs starts all the services running. If the PGW is running and you then type "systemctl restart systemd-networkd", the PGW will stay running, and this will allow systemd-networkd to stop, but will then prevent systemd-networkd from restarting. This has massive consequences for network configuration in Debian 10/Ubuntu 1804 (it disables DNS resolution)

Correct behavior should be to (1) restart the PGW when you restart systemd-networkd and (2) much more importantly, ensure that systemd-networkd can safely restart after a default open5gs install.