### PR TITLE
change default subnet from 45.45.0.0 to 10.45.0.0

### DIFF
--- a/configs/csfb.yaml.in
+++ b/configs/csfb.yaml.in
@@ -129,7 +129,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/installed.yaml.in
+++ b/configs/installed.yaml.in
@@ -462,46 +462,46 @@ pgw:
 #  <UE Pool>
 #
 #  o IPv4 Pool
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #
 #    ue_pool:
-#      addr: 45.45.0.1/16
+#      addr: 10.45.0.1/16
 #
 #  o IPv4/IPv6 Pool
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
 #
 #
-#  o Specific APN(e.g 'volte') uses 45.46.0.1/16, cafe:2::1/64
-#    All other APNs use 45.45.0.1/16, cafe:1::1/64
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
-#    $ sudo ip addr add 45.46.0.1/16 dev ogstun
+#  o Specific APN(e.g 'volte') uses 10.46.0.1/16, cafe:2::1/64
+#    All other APNs use 10.45.0.1/16, cafe:1::1/64
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.46.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun
 #    $ sudo ip addr add cafe:2::1/64 dev ogstun
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
-#      - addr: 45.46.0.1/16
+#      - addr: 10.46.0.1/16
 #        apn: volte
 #      - addr: cafe:2::1/64
 #        apn: volte
 #
 #  o Multiple Devices (default: ogstun)
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun2
-#    $ sudo ip addr add 45.46.0.1/16 dev ogstun3
+#    $ sudo ip addr add 10.46.0.1/16 dev ogstun3
 #    $ sudo ip addr add cafe:2::1/64 dev ogstun3
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
 #        dev: ogstun2
-#      - addr: 45.46.0.1/16
+#      - addr: 10.46.0.1/16
 #        apn: volte
 #        dev: ogstun3
 #      - addr: cafe:2::1/64
@@ -510,26 +510,26 @@ pgw:
 #
 #  o Pool Range Sample
 #    ue_pool:
-#      - addr: 45.45.0.1/24
-#        range: 45.45.0.100-45.45.0.200
+#      - addr: 10.45.0.1/24
+#        range: 10.45.0.100-10.45.0.200
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/24
+#      - addr: 10.45.0.1/24
 #        range:
-#          - 45.45.0.5-45.45.0.50
-#          - 45.45.0.100-
+#          - 10.45.0.5-10.45.0.50
+#          - 10.45.0.100-
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/24
+#      - addr: 10.45.0.1/24
 #        range:
-#          - -45.45.0.200
-#          - 45.45.0.210-45.45.0.220
+#          - -10.45.0.200
+#          - 10.45.0.210-10.45.0.220
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #        range:
-#          - 45.45.0.100-45.45.0.200
-#          - 45.45.1.100-45.45.1.200
+#          - 10.45.0.100-10.45.0.200
+#          - 10.45.1.100-10.45.1.200
 #      - addr: cafe::1/64
 #        range:
 #          - cafe::a0-cafe:b0
@@ -537,7 +537,7 @@ pgw:
 #
 #
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
 
 #

--- a/configs/mnc3.yaml.in
+++ b/configs/mnc3.yaml.in
@@ -99,7 +99,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/open5gs/pgw.yaml.in
+++ b/configs/open5gs/pgw.yaml.in
@@ -12,7 +12,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/simple.yaml.in
+++ b/configs/simple.yaml.in
@@ -95,7 +95,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/split.yaml.in
+++ b/configs/split.yaml.in
@@ -93,7 +93,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/srslte.yaml.in
+++ b/configs/srslte.yaml.in
@@ -95,7 +95,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/configs/systemd/99-open5gs.network
+++ b/configs/systemd/99-open5gs.network
@@ -2,5 +2,5 @@
 Name=ogstun
 
 [Network]
-Address=45.45.0.1/16
+Address=10.45.0.1/16
 Address=cafe::1/64

--- a/configs/volte.yaml.in
+++ b/configs/volte.yaml.in
@@ -100,7 +100,7 @@ pgw:
       - addr: 127.0.0.3
       - addr: ::1
     ue_pool:
-      - addr: 45.45.0.1/16
+      - addr: 10.45.0.1/16
       - addr: cafe::1/64
     dns:
       - 8.8.8.8

--- a/docker/build/setup.sh
+++ b/docker/build/setup.sh
@@ -3,8 +3,8 @@
 if ! grep "ogstun" /proc/net/dev > /dev/null; then
     ip tuntap add name ogstun mode tun
 fi
-ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-ip addr add 45.45.0.1/16 dev ogstun
+ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+ip addr add 10.45.0.1/16 dev ogstun
 ip addr del cafe::1/64 dev ogstun 2> /dev/null
 ip addr add cafe::1/64 dev ogstun
 ip link set ogstun up

--- a/docker/centos/8/dev/setup.sh
+++ b/docker/centos/8/dev/setup.sh
@@ -3,8 +3,8 @@
 if ! grep "ogstun" /proc/net/dev > /dev/null; then
     ip tuntap add name ogstun mode tun
 fi
-ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-ip addr add 45.45.0.1/16 dev ogstun
+ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+ip addr add 10.45.0.1/16 dev ogstun
 ip addr del cafe::1/64 dev ogstun 2> /dev/null
 ip addr add cafe::1/64 dev ogstun
 ip link set ogstun up

--- a/docker/fedora/30/dev/setup.sh
+++ b/docker/fedora/30/dev/setup.sh
@@ -3,8 +3,8 @@
 if ! grep "ogstun" /proc/net/dev > /dev/null; then
     ip tuntap add name ogstun mode tun
 fi
-ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-ip addr add 45.45.0.1/16 dev ogstun
+ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+ip addr add 10.45.0.1/16 dev ogstun
 ip addr del cafe::1/64 dev ogstun 2> /dev/null
 ip addr add cafe::1/64 dev ogstun
 ip link set ogstun up

--- a/docker/ubuntu/bionic/dev/setup.sh
+++ b/docker/ubuntu/bionic/dev/setup.sh
@@ -3,8 +3,8 @@
 if ! grep "ogstun" /proc/net/dev > /dev/null; then
     ip tuntap add name ogstun mode tun
 fi
-ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-ip addr add 45.45.0.1/16 dev ogstun
+ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+ip addr add 10.45.0.1/16 dev ogstun
 ip addr del cafe::1/64 dev ogstun 2> /dev/null
 ip addr add cafe::1/64 dev ogstun
 ip link set ogstun up

--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -204,7 +204,7 @@ target     prot opt source               destination
 $ sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
 ### Add NAT Rule
-$ sudo iptables -t nat -A POSTROUTING -s 45.45.0.0/16 ! -o ogstun -j MASQUERADE
+$ sudo iptables -t nat -A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE
 ```
 
 **Note:** For the first time, it is a good condition if you do not have any rules in the IP/NAT tables. If a program such as docker has already set up a rule, you will need to add a rule differently.

--- a/docs/_docs/guide/02-building-open5gs-from-sources.md
+++ b/docs/_docs/guide/02-building-open5gs-from-sources.md
@@ -24,7 +24,7 @@ Create the TUN device with the interface name `ogstun`.
 
 ```bash
 $ sudo ip tuntap add name ogstun mode tun
-$ sudo ip addr add 45.45.0.1/16 dev ogstun
+$ sudo ip addr add 10.45.0.1/16 dev ogstun
 $ sudo ip addr add cafe::1/64 dev ogstun
 $ sudo ip link set ogstun up
 ```
@@ -279,7 +279,7 @@ target     prot opt source               destination
 $ sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
 ### Add NAT Rule
-$ sudo iptables -t nat -A POSTROUTING -s 45.45.0.0/16 ! -o ogstun -j MASQUERADE
+$ sudo iptables -t nat -A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE
 ```
 
 **Note:** It is a good condition if you do not have any rules in the IP/NAT tables. If a program such as docker has already set up a rule, you will need to add a rule differently.

--- a/docs/_docs/guide/04-troubleshooting.md
+++ b/docs/_docs/guide/04-troubleshooting.md
@@ -127,7 +127,7 @@ If your device shows as connected (Includes LTE/4G symbol) there are a few simpl
    ```
    $ sudo iptables -I INPUT -i ogstun -j ACCEPT
    ```
-* Check if the UE's IP can be pinged successfully by performing `ping <IP of UE>` e.g.`ping 45.45.0.2`
+* Check if the UE's IP can be pinged successfully by performing `ping <IP of UE>` e.g.`ping 10.45.0.2`
 * Configure the firewall correctly. Some operating systems (Ubuntu) by default enable firewall rules to block traffic
    - Explicitly disable it to see if it resolves the problem of granting data access to the UE by doing
    ```

--- a/docs/_docs/platform/01-debian-ubuntu.md
+++ b/docs/_docs/platform/01-debian-ubuntu.md
@@ -66,7 +66,7 @@ $ sudo sh -c "cat << EOF > /etc/systemd/network/99-open5gs.network
 [Match]
 Name=ogstun
 [Network]
-Address=45.45.0.1/16
+Address=10.45.0.1/16
 Address=cafe::1/64
 EOF"
 ```
@@ -83,7 +83,7 @@ Make sure it is set up properly.
 ```bash
 $ ifconfig ogstun
 ogstun: flags=4305<UP,POINTOPOINT,RUNNING,NOARP,MULTICAST>  mtu 1500
-        inet 45.45.0.1  netmask 255.255.0.0  destination 45.45.0.1
+        inet 10.45.0.1  netmask 255.255.0.0  destination 10.45.0.1
         inet6 cafe::1  prefixlen 64  scopeid 0x0<global>
         inet6 fe80::e86e:86d8:ea24:f8ee  prefixlen 64  scopeid 0x20<link>
         unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 500  (UNSPEC)

--- a/docs/_docs/platform/02-centos.md
+++ b/docs/_docs/platform/02-centos.md
@@ -55,7 +55,7 @@ $ sysctl -n net.ipv6.conf.ogstun.disable_ipv6
 You are now ready to set the IP address on TUN device. 
 
 ```bash
-$ sudo ip addr add 45.45.0.1/16 dev ogstun
+$ sudo ip addr add 10.45.0.1/16 dev ogstun
 $ sudo ip addr add cafe::1/64 dev ogstun
 ```
 

--- a/docs/_docs/platform/03-fedora.md
+++ b/docs/_docs/platform/03-fedora.md
@@ -48,7 +48,7 @@ $ sysctl -n net.ipv6.conf.ogstun.disable_ipv6
 You are now ready to set the IP address on TUN device. 
 
 ```bash
-$ sudo ip addr add 45.45.0.1/16 dev ogstun
+$ sudo ip addr add 10.45.0.1/16 dev ogstun
 $ sudo ip addr add cafe::1/64 dev ogstun
 ```
 

--- a/docs/_docs/platform/05-macosx.md
+++ b/docs/_docs/platform/05-macosx.md
@@ -45,7 +45,7 @@ $ sudo ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
 Enable IP forwarding & Masquerading
 ```bash
 $ sudo sysctl -w net.inet.ip.forwarding=1
-$ sudo sh -c "echo 'nat on {en0} from 45.45.0.0/16 to any -> {en0}' > /etc/pf.anchors/org.open5gs"
+$ sudo sh -c "echo 'nat on {en0} from 10.45.0.0/16 to any -> {en0}' > /etc/pf.anchors/org.open5gs"
 $ sudo pfctl -e -f /etc/pf.anchors/org.open5gs
 ```
 

--- a/docs/_docs/tutorial/01-your-first-lte.md
+++ b/docs/_docs/tutorial/01-your-first-lte.md
@@ -315,7 +315,7 @@ target     prot opt source               destination
 $ sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
 ### Add NAT Rule
-$ sudo iptables -t nat -A POSTROUTING -s 45.45.0.0/16 ! -o ogstun -j MASQUERADE
+$ sudo iptables -t nat -A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE
 ```
 
 **Note:** For the first time, it is a good condition if you do not have any rules in the IP/NAT tables. If a program such as docker has already set up a rule, you will need to add a rule differently.

--- a/docs/_pages/faq.md
+++ b/docs/_pages/faq.md
@@ -62,7 +62,7 @@ $ diff -u oldtables newtables
  -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
  -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
  -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-+-A POSTROUTING -s 45.45.0.0/16 ! -o ogstun -j MASQUERADE
++-A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE
  -A DOCKER -i docker0 -j RETURN
  COMMIT
  # Completed on Sat Jun  1 23:43:50 2019
@@ -115,7 +115,7 @@ target     prot opt source               destination
 $ sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
 ### Add NAT Rule
-$ sudo iptables -t nat -A POSTROUTING -s 45.45.0.0/16 ! -o ogstun -j MASQUERADE
+$ sudo iptables -t nat -A POSTROUTING -s 10.45.0.0/16 ! -o ogstun -j MASQUERADE
 ```
 
 #### How to use a different APN for each PGW
@@ -166,46 +166,46 @@ The IP address of the UE can also use a different UE pool depending on the APN.
 #  <UE Pool>
 #
 #  o IPv4 Pool
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #
 #    ue_pool:
-#      addr: 45.45.0.1/16
+#      addr: 10.45.0.1/16
 #
 #  o IPv4/IPv6 Pool
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
 #
 #
-#  o Specific APN(e.g 'volte') uses 45.46.0.1/16, cafe:2::1/64
-#    All other APNs use 45.45.0.1/16, cafe:1::1/64
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
-#    $ sudo ip addr add 45.46.0.1/16 dev ogstun
+#  o Specific APN(e.g 'volte') uses 10.46.0.1/16, cafe:2::1/64
+#    All other APNs use 10.45.0.1/16, cafe:1::1/64
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.46.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun
 #    $ sudo ip addr add cafe:2::1/64 dev ogstun
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
-#      - addr: 45.46.0.1/16
+#      - addr: 10.46.0.1/16
 #        apn: volte
 #      - addr: cafe:2::1/64
 #        apn: volte
 #
 #  o Multiple Devices (default: ogstun)
-#    $ sudo ip addr add 45.45.0.1/16 dev ogstun
+#    $ sudo ip addr add 10.45.0.1/16 dev ogstun
 #    $ sudo ip addr add cafe:1::1/64 dev ogstun2
-#    $ sudo ip addr add 45.46.0.1/16 dev ogstun3
+#    $ sudo ip addr add 10.46.0.1/16 dev ogstun3
 #    $ sudo ip addr add cafe:2::1/64 dev ogstun3
 #
 #    ue_pool:
-#      - addr: 45.45.0.1/16
+#      - addr: 10.45.0.1/16
 #      - addr: cafe:1::1/64
 #        dev: ogstun2
-#      - addr: 45.46.0.1/16
+#      - addr: 10.46.0.1/16
 #        apn: volte
 #        dev: ogstun3
 #      - addr: cafe:2::1/64
@@ -377,7 +377,7 @@ Currently, the number of UE is limited to `128*128`.
 - UE Network
 
 ```
-* IPv4 : 45.45.0.1/16
+* IPv4 : 10.45.0.1/16
 * IPv6 : cafe::1/64
 ```
 

--- a/misc/ipv6_netconf.sh
+++ b/misc/ipv6_netconf.sh
@@ -6,8 +6,8 @@ if [ "$SYSTEM" = "Linux" ]; then
     if ! grep "ogstun" /proc/net/dev > /dev/null; then
         ip tuntap add name ogstun mode tun
     fi
-    ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-    ip addr add 45.45.0.1/16 dev ogstun
+    ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+    ip addr add 10.45.0.1/16 dev ogstun
     ip addr del cafe::1/64 dev ogstun 2> /dev/null
     ip addr add cafe::1/64 dev ogstun
     ip link set ogstun up

--- a/misc/netconf.sh
+++ b/misc/netconf.sh
@@ -10,8 +10,8 @@ if [ "$SYSTEM" = "Linux" ]; then
 		echo "net.ipv6.conf.ogstun.disable_ipv6=0" > /etc/sysctl.d/30-open5gs.conf
 		sysctl -p /etc/sysctl.d/30-open5gs.conf
 	fi
-    ip addr del 45.45.0.1/16 dev ogstun 2> /dev/null
-    ip addr add 45.45.0.1/16 dev ogstun
+    ip addr del 10.45.0.1/16 dev ogstun 2> /dev/null
+    ip addr add 10.45.0.1/16 dev ogstun
     ip addr del cafe::1/64 dev ogstun 2> /dev/null
     ip addr add cafe::1/64 dev ogstun
     ip link set ogstun up
@@ -23,7 +23,7 @@ else
     ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
     if [ "$SYSTEM" = "Darwin" ]; then
         if ! test -f /etc/pf.anchors/org.open5gs; then
-            sudo sh -c "echo 'nat on {en0} from 45.45.0.0/16 to any -> {en0}' > /etc/pf.anchors/org.open5gs"
+            sudo sh -c "echo 'nat on {en0} from 10.45.0.0/16 to any -> {en0}' > /etc/pf.anchors/org.open5gs"
         fi
         pfctl -e -f /etc/pf.anchors/org.open5gs
     fi

--- a/src/pgw/pgw-gtp-path.c
+++ b/src/pgw/pgw-gtp-path.c
@@ -274,7 +274,7 @@ int pgw_gtp_open(void)
      * Also, before running pgw, assign the one IP from IP pool of UE 
      * to ogstun. The IP should not be assigned to UE
      *
-     * $ sudo ifconfig ogstun 45.45.0.1/16 up
+     * $ sudo ifconfig ogstun 10.45.0.1/16 up
      *
      */
 

--- a/tests/mnc3/mnc3-test.c
+++ b/tests/mnc3/mnc3-test.c
@@ -236,7 +236,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send GTP-U ICMP Packet */
-    rv = testgtpu_build_ping(&sendbuf, "45.45.0.2", "45.45.0.1");
+    rv = testgtpu_build_ping(&sendbuf, "10.45.0.2", "10.45.0.1");
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
     rv = testenb_gtpu_send(gtpu, sendbuf);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);

--- a/tests/simple/attach-test.c
+++ b/tests/simple/attach-test.c
@@ -256,7 +256,7 @@ static void attach_test1(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send GTP-U ICMP Packet */
-    rv = testgtpu_build_ping(&sendbuf, "45.45.0.2", "45.45.0.1");
+    rv = testgtpu_build_ping(&sendbuf, "10.45.0.2", "10.45.0.1");
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
     rv = testenb_gtpu_send(gtpu, sendbuf);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);

--- a/tests/simple/volte-test.c
+++ b/tests/simple/volte-test.c
@@ -365,7 +365,7 @@ static void volte_test2(abts_case *tc, void *data)
             "\"description\" : \"permit out udp from any 1-65535 to 10.200.136.98/32 23454\","
             "\"_id\" : { \"$oid\" : \"599eb929c850caabcbfdcd31\" } },"
           "{ \"direction\" : 1,"
-            "\"description\" : \"permit out ip from 45.45.0.1 to any\","
+            "\"description\" : \"permit out ip from 10.45.0.1 to any\","
             "\"_id\" : { \"$oid\" : \"599eb929c850caabcbfdcd30\" } },"
           "{ \"direction\" : 2,"
             "\"description\" : \"permit out udp from any 1-65535 to 10.200.136.98/24 23455\","
@@ -534,7 +534,7 @@ static void volte_test2(abts_case *tc, void *data)
 #if 0 /* TFT Rule Tester */
     /* Send GTP-U ICMP Packet */
 #if 1
-    rv = testgtpu_build_ping(&sendbuf, "45.45.0.2", "45.45.0.1");
+    rv = testgtpu_build_ping(&sendbuf, "10.45.0.2", "10.45.0.1");
 #else
     rv = testgtpu_build_ping(&sendbuf, "cafe::2", "cafe::1");
 #endif

--- a/tests/volte/volte-test.c
+++ b/tests/volte/volte-test.c
@@ -228,7 +228,7 @@ static void volte_test1(abts_case *tc, void *data)
 
     /* Send AA-Request */
     ogs_msleep(300);
-    pcscf_rx_send_aar(&rx_sid, "45.45.0.3", 1, 1);
+    pcscf_rx_send_aar(&rx_sid, "10.45.0.3", 1, 1);
 
     /* Receive E-RAB Setup Request +
      * Activate dedicated EPS bearer context request */
@@ -250,7 +250,7 @@ static void volte_test1(abts_case *tc, void *data)
 
     /* Send AA-Request without Flow */
     ogs_msleep(300);
-    pcscf_rx_send_aar(&rx_sid, "45.45.0.3", 2, 1);
+    pcscf_rx_send_aar(&rx_sid, "10.45.0.3", 2, 1);
 
     /* Receive E-RAB Modify Request +
      * Modify EPS bearer context request */
@@ -671,7 +671,7 @@ static void volte_test2(abts_case *tc, void *data)
 
     /* Send AA-Request */
     ogs_msleep(300);
-    pcscf_rx_send_aar(&rx_sid, "45.45.0.5", 0, 1);
+    pcscf_rx_send_aar(&rx_sid, "10.45.0.5", 0, 1);
 
     /* Receive downlink NAS transport +
      * Modify EPS bearer context request */


### PR DESCRIPTION
Hi @acetcom!

This PR changes the default UE address subnet from 45.45.0.0/16 to 10.45.0.0/16. I read the discussion in #41 and think this change should be made, I also wanted to address some concerns in that thread:

- You are correct that almost all mobile network operators use NAT, to my understanding. Acceptable subnets for NAT would be 10.0.0.0/8, 172.16.0.0/20, or 192.168.0.0/24. 
- You're correct that someone can always change these values, but I do believe that the default values that work out of the box should definitely be a private IP address range. This is standard and correct practice; assigning public IP addresses you don't own should be strongly avoided.
- As someone mentioned in the comments, 45.45.0.0/16 are generally owned by Canadian networks. This means that default open5gs install will not be able to communicate with those addresses. Assuming your user is behind a NAT still doesn't resolve this issue. It is much easier to choose a separate private IP address range if you don't want to create conflicts.
- 10.45.0.0/16 is not commonly used for anything and is very unlikely to create conflict, so I thought it would be a good choice. This addresses brandon's concern (avoiding 10.0.0.0/16 for example) and should remain easy to identify in pcaps.