### PR TITLE
debian/control: Add build dependency to 'git'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Harald Welte <laforge@gnumonks.org>
 Uploaders: Sukchan Lee <acetcom@gmail.com>
 Build-Depends: debhelper (>= 11),
+               git,
                pkg-config,
                meson (>= 0.43.0),
                flex,


### PR DESCRIPTION
meson seems to need the 'git' program available at build time:
	lib/diameter/common/meson.build:36:0: ERROR: Git program not found.

Closes: #372 