### PR TITLE
Add feature to provide MTU size to be advertised in PCO options

### DIFF
--- a/src/pgw/pgw-context.c
+++ b/src/pgw/pgw-context.c
@@ -671,6 +671,11 @@ int pgw_context_parse_config(void)
 
                     } while (ogs_yaml_iter_type(&ue_pool_array) ==
                             YAML_SEQUENCE_NODE);
+                } else if (!strcmp(pgw_key, "mtu")) {
+                    ogs_assert(ogs_yaml_iter_type(&pgw_iter) !=
+                            YAML_SCALAR_NODE);
+                    self.mtu = atoi(ogs_yaml_iter_value(&pgw_iter));
+                    ogs_assert(self.mtu);
                 } else if (!strcmp(pgw_key, "dns")) {
                     ogs_yaml_iter_t dns_iter;
                     ogs_yaml_iter_recurse(&pgw_iter, &dns_iter);

--- a/src/pgw/pgw-context.h
+++ b/src/pgw/pgw-context.h
@@ -91,6 +91,8 @@ typedef struct pgw_context_s {
     ogs_hash_t      *ipv4_hash;     /* hash table (IPv4 Address) */
     ogs_hash_t      *ipv6_hash;     /* hash table (IPv6 Address) */
 
+    uint16_t        mtu;            /* MTU to advertise in PCO */
+
     ogs_list_t      sess_list;
 } pgw_context_t;
 

--- a/src/pgw/pgw-s5c-build.c
+++ b/src/pgw/pgw-s5c-build.c
@@ -516,7 +516,13 @@ static int16_t pgw_pco_build(uint8_t *pco_buf, ogs_gtp_tlv_pco_t *tlv_pco)
             /* TODO */
             break;
         case OGS_PCO_ID_IPV4_LINK_MTU_REQUEST:
-            /* TODO */
+            if (pgw_self()->mtu) {
+                uint16_t mtu = htons(pgw_self()->mtu);
+                pgw.ids[pgw.num_of_id].id = ue.ids[i].id;
+                pgw.ids[pgw.num_of_id].len = sizeof(uint16_t);
+                pgw.ids[pgw.num_of_id].data = &mtu;
+                pgw.num_of_id++;
+            }
             break;
         case OGS_PCO_ID_MS_SUPPORTS_BCM:
             /* TODO */


### PR DESCRIPTION
This feature can be used for provisioning a limit on the size of the packets
sent by the MS to avoid packet fragmentation in the backbone network between
the MS and the GGSN/PGW and/or across the (S)Gi reference point) when some
of the backbone links does not support packets larger then 1500 octets
(ETSI TS 123 060 V15.5.0 Annex C)

Example of pgw.yaml to use this feature:

<pre>
logger:
    file: @localstatedir@/log/open5gs/pgw.log

parameter:

pgw:
    freeDiameter: @sysconfdir@/freeDiameter/pgw.conf
    gtpc:
      - addr: 127.0.0.3
      - addr: ::1
    gtpu:
      - addr: 127.0.0.3
      - addr: ::1
    ue_pool:
      - addr: 10.45.0.1/16
      - addr: cafe::1/64
    dns:
      - 8.8.8.8
      - 8.8.4.4
      - 2001:4860:4860::8888
      - 2001:4860:4860::8844
    mtu: 1400
</pre>
