### PR TITLE
Make it installable in Debian Buster with MongoDB-ORG packages.

### DIFF
--- a/configs/systemd/open5gs-hssd.service.in
+++ b/configs/systemd/open5gs-hssd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Open5GS HSS Daemon
-BindTo=mongodb.service
-After=networking.service mongodb.service
+BindTo=mongod.service
+After=networking.service mongod.service
 
 [Service]
 Type=simple

--- a/configs/systemd/open5gs-pcrfd.service.in
+++ b/configs/systemd/open5gs-pcrfd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Open5GS PCRF Daemon
-BindTo=mongodb.service
-After=networking.service mongodb.service
+BindTo=mongod.service
+After=networking.service mongod.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
I'm not sure how to properly fix this, as Debian Buster (10) and onward dropped the mongodb package. MongoDB Community Version is being recommended, but the systemd daemon service name also changed from mongodb.service to mongod.service in MongoDB Community Version (mongodb-org packages).