### PR TITLE
Add dbconf to hss Debian package

### DIFF
--- a/configs/meson.build
+++ b/configs/meson.build
@@ -50,6 +50,11 @@ foreach file : example_conf
             configuration : conf_data)
 endforeach
 
+configure_file(
+    input : '../misc/dbconf.sh',
+    output : 'open5gs_db,
+    configuration : conf_data)
+
 subdir('open5gs')
 subdir('freeDiameter')
 subdir('systemd')

--- a/configs/meson.build
+++ b/configs/meson.build
@@ -52,7 +52,7 @@ endforeach
 
 configure_file(
     input : '../misc/dbconf.sh',
-    output : 'open5gs_db,
+    output : 'open5gs_db',
     configuration : conf_data)
 
 subdir('open5gs')

--- a/debian/open5gs-hss.install
+++ b/debian/open5gs-hss.install
@@ -2,3 +2,4 @@ usr/bin/open5gs-hssd
 configs/freeDiameter/hss.* etc/freeDiameter
 configs/open5gs/hss.yaml etc/open5gs
 configs/systemd/open5gs-hssd.service lib/systemd/system
+configs/open5gs_db /usr/bin


### PR DESCRIPTION
I like using apt-get to install open5gs, and recommend this approach to others, except it does not come with the database tool that I wrote (which I also recommend people use as a quick-start). I modified /configs/meson.build to copy dbconf.sh into /build/configs/open5gs_db, and modified debian/open5gs-hss.install to install it to /usr/bin/open5gs_db as a part of the HSS package. Feel free to change the names or locations, figured it made the most sense to pair it with the HSS.