### PR TITLE
fix logrotate action

### DIFF
--- a/configs/logrotate/open5gs.in
+++ b/configs/logrotate/open5gs.in
@@ -8,7 +8,7 @@
 
     postrotate
         for i in pcrfd pgwd sgwd hssd mmed; do
-            systemctl reload open5gs-$i
+            systemctl restart open5gs-$i
         done
     endscript
 }


### PR DESCRIPTION
option `reload` not implemented in open5gs-*
for example:
```
eug@lte:/etc/logrotate.d# systemctl reload open5gs-mmed
Failed to reload open5gs-mmed.service: Job type reload is not applicable for unit open5gs-mmed.service.
```
