### PR TITLE
add ConfigureWithoutCarrier=yes to 99-open5gs.network

### DIFF
--- a/configs/systemd/99-open5gs.network
+++ b/configs/systemd/99-open5gs.network
@@ -2,5 +2,6 @@
 Name=ogstun
 
 [Network]
+ConfigureWithoutCarrier=yes
 Address=10.45.0.1/16
 Address=cafe::1/64


### PR DESCRIPTION
On a fresh install of Ubuntu 18.04, my experience is that systemd-networkd will bring up ogstun and then bring it down (with log message ogstun: Lost carrier). When this happens, it wipes out all settings for the interface (e.g. IP address assignment).

I believe the correct behavior for a persistent tun/tap device is to always have the IP addresses assigned to the device; we can accomplish this by adding this setting to 99-open5gs.network. This way, the only change needed is to bring the device UP or DOWN (this is already done by pgwd).