### PR TITLE
Fix MME crash on eNB connection when maximum number of eNBs reached

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1919,7 +1919,6 @@ int mme_enb_remove(mme_enb_t *enb)
     }
 
     ogs_free(enb->addr);
-
     ogs_free(enb);
 
     stats_remove_enb();
@@ -3186,4 +3185,18 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     }
 
     return 0;
+}
+
+bool mme_is_maximum_number_of_enbs_reached(void)
+{
+    mme_enb_t *enb = NULL, *next_enb = NULL;
+    int number_of_enbs_online = 0;
+
+    ogs_list_for_each_safe(&self.enb_list, next_enb, enb) {
+        if (enb->s1_setup_success) {
+            number_of_enbs_online++;
+        }
+    }
+
+    return number_of_enbs_online >= ogs_config()->max.enb;
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -41,7 +41,6 @@ static OGS_POOL(mme_pgw_pool, mme_pgw_t);
 static OGS_POOL(mme_vlr_pool, mme_vlr_t);
 static OGS_POOL(mme_csmap_pool, mme_csmap_t);
 
-static OGS_POOL(mme_enb_pool, mme_enb_t);
 static OGS_POOL(mme_ue_pool, mme_ue_t);
 static OGS_POOL(enb_ue_pool, enb_ue_t);
 static OGS_POOL(mme_sess_pool, mme_sess_t);
@@ -124,8 +123,6 @@ void mme_context_init()
     ogs_pool_init(&mme_vlr_pool, ogs_config()->max.vlr);
     ogs_pool_init(&mme_csmap_pool, ogs_config()->max.csmap);
 
-    ogs_pool_init(&mme_enb_pool, ogs_config()->max.enb);
-
     ogs_pool_init(&mme_ue_pool, ogs_config()->pool.ue);
     ogs_pool_init(&enb_ue_pool, ogs_config()->pool.ue);
     ogs_pool_init(&mme_sess_pool, ogs_config()->pool.sess);
@@ -172,8 +169,6 @@ void mme_context_final()
     ogs_pool_final(&mme_sess_pool);
     ogs_pool_final(&mme_ue_pool);
     ogs_pool_final(&enb_ue_pool);
-
-    ogs_pool_final(&mme_enb_pool);
 
     ogs_pool_final(&mme_sgw_pool);
     ogs_pool_final(&mme_pgw_pool);
@@ -1863,9 +1858,8 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     ogs_assert(sock);
     ogs_assert(addr);
 
-    ogs_pool_alloc(&mme_enb_pool, &enb);
+    enb = ogs_calloc(1, sizeof(mme_enb_t));
     ogs_assert(enb);
-    memset(enb, 0, sizeof *enb);
 
     enb->sock = sock;
     enb->addr = addr;
@@ -1926,7 +1920,7 @@ int mme_enb_remove(mme_enb_t *enb)
 
     ogs_free(enb->addr);
 
-    ogs_pool_free(&mme_enb_pool, enb);
+    ogs_free(enb);
 
     stats_remove_enb();
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -226,6 +226,8 @@ typedef struct mme_enb_s {
     ogs_sockaddr_t  *addr;      /* eNB S1AP Address */
     ogs_poll_t      *poll;      /* eNB S1AP Poll */
 
+    bool s1_setup_success;      /* eNB S1AP Setup complete successfuly */
+
     uint16_t        max_num_of_ostreams;/* SCTP Max num of outbound streams */
     uint16_t        ostream_id;         /* enb_ostream_id generator */
 
@@ -791,6 +793,7 @@ void stats_remove_enb(void);
 void stats_add_mme_session(void);
 void stats_remove_mme_session(void);
 
+bool mme_is_maximum_number_of_enbs_reached(void);
 
 
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -163,13 +163,23 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         }
     }
 
+    if (mme_is_maximum_number_of_enbs_reached()) {
+        ogs_warn("S1-Setup failure:");
+        ogs_warn("    Maximum number of eNBs reached");
+        group = S1AP_Cause_PR_misc;
+        cause = S1AP_CauseMisc_unspecified;
+
+        send_s1_setup_failure_response(enb, group, cause);
+        return;
+    }
+
     if (enb->num_of_supported_ta_list == 0) {
         ogs_warn("S1-Setup failure:");
         ogs_warn("    No supported TA exist in S1-Setup request");
         group = S1AP_Cause_PR_misc;
         cause = S1AP_CauseMisc_unspecified;
 
-        send_s1_setup_failure_response(enb, cause, group);
+        send_s1_setup_failure_response(enb, group, cause);
         return;
     }
 
@@ -179,7 +189,7 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         group = S1AP_Cause_PR_misc;
         cause = S1AP_CauseMisc_unknown_PLMN;
 
-        send_s1_setup_failure_response(enb, cause, group);
+        send_s1_setup_failure_response(enb, group, cause);
         return;
     }
 


### PR DESCRIPTION
Closes #421 

Instead of crash `open5gs-mme` it will respond with S1 Setup Failure when maximum number of eNBs is reached.

In this PR `mme_enb_t` pool has been deleted. IMHO, to have a pool with the size of the configuration and taking account the current architecture, it would be more complex to send a S1 Setup Failure when it's reached. (the eNB instance is created on SCTP accept)

The S1 Setup Failure response is as follows:
```
S1 Application Protocol
    S1AP-PDU: unsuccessfulOutcome (2)
        unsuccessfulOutcome
            procedureCode: id-S1Setup (17)
            criticality: reject (0)
            value
                S1SetupFailure
                    protocolIEs: 2 items
                        Item 0: id-Cause
                            ProtocolIE-Field
                                id: id-Cause (2)
                                criticality: ignore (1)
                                value
                                    Cause: misc (4)
                                        misc: unspecified (4)
                        Item 1: id-TimeToWait
                            ProtocolIE-Field
                                id: id-TimeToWait (65)
                                criticality: ignore (1)
                                value
                                    TimeToWait: v10s (3)
```

I have tested the code using a forced configuration of 2 maximum eNBs:
```yaml
#/etc/open5gs/mme.yaml
logger:
    file: /home/user/open5gs/install/var/log/open5gs/mme.log

max:
    enb: 2
```

MME log
```
04/25 01:57:59.791: [mme] INFO: eNB-S1 accepted[10.10.0.193]:36412 in s1_path module (../src/mme/s1ap-sctp.c:109)
04/25 01:57:59.791: [mme] INFO: Added a eNB. Number of eNBs is now 3 (../src/mme/mme-context.c:67)
04/25 01:57:59.791: [mme] INFO: eNB-S1 accepted[10.10.0.193] in master_sm module (../src/mme/mme-sm.c:95)
04/25 01:57:59.793: [mme] WARNING: S1-Setup failure: (../src/mme/s1ap-handler.c:167)
04/25 01:57:59.793: [mme] WARNING:     Maximum number of eNBs reached (../src/mme/s1ap-handler.c:168)
04/25 01:57:59.794: [mme] INFO: eNB-S1[10.10.0.193] connection refused!!! (../src/mme/mme-sm.c:223)
04/25 01:57:59.794: [mme] INFO: Removed a eNB. Number of eNBs is now 2 (../src/mme/mme-context.c:72
```

[s1_setup_failure_pcap.zip](https://github.com/open5gs/open5gs/files/4532197/s1_setup_failure_pcap.zip)


