### PR TITLE
Enable selection of UPF by TAC from the SMF

### DIFF
--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -69,6 +69,13 @@ logger:
 #      - addr: 127.0.0.3
 #      - addr: ::1
 #
+#  o UPF (PFCP) selection based on round robin or TAC
+#    pfcp:
+#      - addr: 127.0.0.3
+#      - upf_selection_mode: rr (default)
+#      - upf_selection_mode: tac
+#
+#
 #  <GTP-C Server>
 #
 #  o GTP-C Server(127.0.0.3:2123, [fe80::3%@loopback_devname@]:2123)

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -179,6 +179,11 @@ logger:
 #      - 127.0.0.1
 #      - ::1
 #
+#  o upf_selection_mode can be set to rr (round-robin), or TAC (see upf config section
+#    for how to configure a UPF to be used for certain TACs)
+#
+#
+
 smf:
     sbi:
       - addr: 127.0.0.3
@@ -198,6 +203,7 @@ smf:
       - 2001:4860:4860::8888
       - 2001:4860:4860::8844
     mtu: 1400
+    upf_selection_mode: rr
     freeDiameter: @sysconfdir@/freeDiameter/pgw.conf
 
 #
@@ -239,13 +245,16 @@ nrf:
 #  <PFCP Client>>
 #
 #  o PFCP Client(127.0.0.4:8805)
+#  - optional parameter for TACs to serve from this UPF
 # 
 #    pfcp:
 #      addr: 127.0.0.4
+#      tac: 1
 #
 upf:
     pfcp:
       addr: 127.0.0.4
+      tac: 1
 
 #
 # parameter:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -69,11 +69,19 @@ logger:
 #      - addr: 127.0.0.3
 #      - addr: ::1
 #
-#  o UPF (PFCP) selection based on round robin or TAC
-#    pfcp:
-#      - addr: 127.0.0.3
-#      - upf_selection_mode: rr (default)
-#      - upf_selection_mode: tac
+#  o UPF (PFCP) selection can be based on three options. Round Robin is default.
+#      Round Robin (rr)
+#        OR
+#      UE's serving eNB/gNB TAC (tac)
+#        OR
+#      UE's APN (apn)
+#
+#    smf:
+#      pfcp:
+#        - addr: 127.0.0.3
+#        - upf_selection_mode: rr   < one of these
+#        - upf_selection_mode: tac
+#        - upf_selection_mode: apn
 #
 #
 #  <GTP-C Server>
@@ -186,8 +194,6 @@ logger:
 #      - 127.0.0.1
 #      - ::1
 #
-#  o upf_selection_mode can be set to rr (round-robin), or TAC (see upf config section
-#    for how to configure a UPF to be used for certain TACs)
 #
 #
 
@@ -252,16 +258,26 @@ nrf:
 #  <PFCP Client>>
 #
 #  o PFCP Client(127.0.0.4:8805)
-#  - optional parameter for TACs to serve from this UPF
+#  - optional parameter for TAC(s) to serve from this UPF
+#  - optional parameter for APN(s) to serve from this UPF
 # 
+#  upf:
 #    pfcp:
-#      addr: 127.0.0.4
-#      tac: 1
+#      - addr: 127.0.0.4
+#        tac: 1                   < either single TAC or multiple TACs
+#      - addr: 127.0.0.12
+#        tac: [3,5,8]
+#
+#  upf:
+#    pfcp:
+#      - addr: 127.0.0.4
+#        apn: ims            < either single APN or multiple APNs
+#      - addr: 127.0.0.12
+#        apn: [internet, web]
 #
 upf:
     pfcp:
       addr: 127.0.0.4
-      tac: 1
 
 #
 # parameter:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -199,6 +199,7 @@ smf:
       - addr: 127.0.0.3
       - addr: ::1
     pfcp:
+      - upf_selection_mode: rr
       - addr: 127.0.0.3
       - addr: ::1
     pdn:
@@ -210,7 +211,6 @@ smf:
       - 2001:4860:4860::8888
       - 2001:4860:4860::8844
     mtu: 1400
-    upf_selection_mode: rr
     freeDiameter: @sysconfdir@/freeDiameter/pgw.conf
 
 #

--- a/lib/core/ogs-3gpp-types.h
+++ b/lib/core/ogs-3gpp-types.h
@@ -47,6 +47,7 @@ extern "C" {
 
 #define OGS_MAX_NUM_OF_HOSTNAME         16
 #define OGS_MAX_APN_LEN                 100
+#define OGS_MAX_NUM_OF_APN              16
 #define OGS_MAX_PCO_LEN                 251
 #define OGS_MAX_FQDN_LEN                256
 #define OGS_MAX_IFNAME_LEN              32

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -242,6 +242,18 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                 dev = ogs_yaml_iter_value(&pfcp_iter);
                             } else if (!strcmp(pfcp_key, "apn")) {
                                 /* Skip */
+                            } else if (!strcmp(pfcp_key, "upf_selection_mode")) {
+                                ogs_assert(ogs_yaml_iter_type(&pfcp_iter) !=
+                                        YAML_SCALAR_NODE);
+                                const char *upf_selection_mode = ogs_yaml_iter_value(&pfcp_iter);
+
+                                if (!strcmp(upf_selection_mode, "rr"))
+                                    self.upf_selection_mode = UPF_SELECT_RR;
+                                else if (!strcmp(upf_selection_mode, "tac"))
+                                    self.upf_selection_mode = UPF_SELECT_TAC;
+                                else
+                                    ogs_warn("unknown upf_selection_mode `%s`",
+                                            upf_selection_mode);
                             } else
                                 ogs_warn("unknown key `%s`", pfcp_key);
                         }

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -36,6 +36,7 @@ typedef struct ogs_pfcp_node_s ogs_pfcp_node_t;
 typedef enum {
     UPF_SELECT_RR = 0,  /* Default UPF Selection Method */
     UPF_SELECT_TAC,     /* Select UPF by TAC */
+    UPF_SELECT_APN,     /* Select UPF by APN */
 } upf_select_e;
 
 
@@ -87,6 +88,8 @@ typedef struct ogs_pfcp_node_s {
 
     uint16_t        tac[OGS_MAX_NUM_OF_TAI];
     uint8_t         num_of_tac;
+    const char*     apn[OGS_MAX_APN_LEN];
+    uint8_t         num_of_apn;
 
     ogs_list_t      gtpu_resource_list; /* User Plane IP Resource Information */
 } ogs_pfcp_node_t;

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -88,7 +88,7 @@ typedef struct ogs_pfcp_node_s {
 
     uint16_t        tac[OGS_MAX_NUM_OF_TAI];
     uint8_t         num_of_tac;
-    const char*     apn[OGS_MAX_APN_LEN];
+    const char*     apn[OGS_MAX_NUM_OF_APN];
     uint8_t         num_of_apn;
 
     ogs_list_t      gtpu_resource_list; /* User Plane IP Resource Information */

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -33,6 +33,13 @@ extern "C" {
 
 typedef struct ogs_pfcp_node_s ogs_pfcp_node_t;
 
+typedef enum {
+    UPF_SELECT_RR = 0,  /* Default UPF Selection Method */
+    UPF_SELECT_TAC,     /* Select UPF by TAC */
+} upf_select_e;
+
+
+
 typedef struct ogs_pfcp_context_s {
     uint32_t        pfcp_port;      /* PFCP local port */
     const char      *tun_ifname;    /* PFCP TUN Interface Name */
@@ -47,6 +54,7 @@ typedef struct ogs_pfcp_context_s {
     uint32_t        pfcp_started;   /* UTC time when the PFCP entity started */
 
     ogs_list_t      n4_list;        /* PFCP Node List */
+    upf_select_e    upf_selection_mode;  /* Selection algorithm for selecting UPF */
     ogs_pfcp_node_t *node;    /* Iterator for Peer round-robin */
 
     ogs_list_t      dev_list;       /* Tun Device List */

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -197,7 +197,7 @@ smf_sess_t *smf_sess_add_by_message(ogs_gtp_message_t *message);
 
 smf_sess_t *smf_sess_add(
         uint8_t *imsi, int imsi_len, char *apn,
-        uint8_t pdn_type, uint8_t ebi, ogs_paa_t *addr);
+        uint8_t pdn_type, uint8_t ebi, ogs_paa_t *addr, ogs_gtp_create_session_request_t *message);
 
 int smf_sess_remove(smf_sess_t *sess);
 void smf_sess_remove_all(void);


### PR DESCRIPTION
Adds support for a round-robin and TAC-based selection of UPF from the SMF. Also adds fallback to the first UPF if an invalid TAC-based UPF is provided.

Should address #438 