### PR TITLE
Undo the fix provided for converting Rx to Gx Flow Description

### DIFF
--- a/src/pcrf/pcrf-gx-path.c
+++ b/src/pcrf/pcrf-gx-path.c
@@ -1339,7 +1339,6 @@ static int encode_pcc_rule_definition(
 static int flow_rx_to_gx(ogs_flow_t *rx_flow, ogs_flow_t *gx_flow)
 {
     int len;
-    char *from_str, *to_str;
 
     ogs_assert(rx_flow);
     ogs_assert(gx_flow);
@@ -1360,19 +1359,8 @@ static int flow_rx_to_gx(ogs_flow_t *rx_flow, ogs_flow_t *gx_flow)
         len = strlen(rx_flow->description)+2;
         gx_flow->description = ogs_malloc(len);
         strcpy(gx_flow->description, "permit out");
-        from_str = strstr(&rx_flow->description[strlen("permit in")], "from");
-        ogs_assert(from_str);
-        to_str = strstr(&rx_flow->description[strlen("permit in")], "to");
-        ogs_assert(to_str);
-        strncat(gx_flow->description,
-            &rx_flow->description[strlen("permit in")],
-            strlen(rx_flow->description) -
-                strlen("permit in") - strlen(from_str));
-        strcat(gx_flow->description, "from");
-        strcat(gx_flow->description, &to_str[strlen("to")]);
-        strcat(gx_flow->description, " to");
-        strncat(gx_flow->description, &from_str[strlen("from")],
-                strlen(from_str) - strlen(to_str) - strlen("from") - 1);
+        strcat(gx_flow->description,
+                &rx_flow->description[strlen("permit in")]);
         ogs_assert(len == strlen(gx_flow->description)+1);
     } else {
         ogs_error("Invalid Flow Descripton : [%s]", rx_flow->description);


### PR DESCRIPTION
The fix introduced in commit 768e4d9eb3241b0c817b13a78a54f790f952e104 is wrong, which results in UE replying with bad Semantic error for Activate Dedicated EPS Bearer Context Request. Hence, reverting back to original implementation as its correctly doing the conversion as per 3GPP Spec. ETSI TS 129 214 V14.3.0 Section 5.3.8.