### PR TITLE
Add the modified Bearer level QoS if PCRF changes them

### DIFF
--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -61,6 +61,8 @@ void mme_s11_handle_create_session_response(
     mme_bearer_t *bearer = NULL;
     mme_sess_t *sess = NULL;
     ogs_pdn_t *pdn = NULL;
+    ogs_gtp_bearer_qos_t bearer_qos;
+    uint16_t decoded = 0;
     
     ogs_assert(xact);
     ogs_assert(rsp);
@@ -149,6 +151,20 @@ void mme_s11_handle_create_session_response(
     if (rsp->protocol_configuration_options.presence) {
         OGS_TLV_STORE_DATA(&sess->pgw_pco,
                 &rsp->protocol_configuration_options);
+    }
+
+    /* Bearer QoS */
+    if (rsp->bearer_contexts_created.bearer_level_qos.presence) {
+        decoded = ogs_gtp_parse_bearer_qos(&bearer_qos,
+            &rsp->bearer_contexts_created.bearer_level_qos);
+        ogs_assert(rsp->bearer_contexts_created.bearer_level_qos.len ==
+                decoded);
+        pdn->qos.qci = bearer_qos.qci;
+        pdn->qos.arp.priority_level = bearer_qos.priority_level;
+        pdn->qos.arp.pre_emption_capability =
+                        bearer_qos.pre_emption_capability;
+        pdn->qos.arp.pre_emption_vulnerability =
+                        bearer_qos.pre_emption_vulnerability;
     }
 
     /* Data Plane(UL) : SGW-S1U */

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -62,6 +62,7 @@ void mme_s11_handle_create_session_response(
     mme_sess_t *sess = NULL;
     ogs_pdn_t *pdn = NULL;
     ogs_gtp_bearer_qos_t bearer_qos;
+    ogs_gtp_ambr_t *ambr = NULL;
     uint16_t decoded = 0;
     
     ogs_assert(xact);
@@ -165,6 +166,13 @@ void mme_s11_handle_create_session_response(
                         bearer_qos.pre_emption_capability;
         pdn->qos.arp.pre_emption_vulnerability =
                         bearer_qos.pre_emption_vulnerability;
+    }
+
+    /* AMBR */
+    if (rsp->aggregate_maximum_bit_rate.presence) {
+        ambr = rsp->aggregate_maximum_bit_rate.data;
+        pdn->ambr.downlink = be32toh(ambr->downlink) * 1000;
+        pdn->ambr.uplink = be32toh(ambr->uplink) * 1000;
     }
 
     /* Data Plane(UL) : SGW-S1U */

--- a/src/pgw/pgw-s5c-build.c
+++ b/src/pgw/pgw-s5c-build.c
@@ -36,6 +36,7 @@ ogs_pkbuf_t *pgw_s5c_build_create_session_response(
 
     ogs_gtp_cause_t cause;
     ogs_gtp_f_teid_t pgw_s5c_teid, pgw_s5u_teid;
+    ogs_gtp_ambr_t ambr;
     ogs_gtp_bearer_qos_t bearer_qos;
     char bearer_qos_buf[GTP_BEARER_QOS_LEN];
     int len;
@@ -93,8 +94,20 @@ ogs_pkbuf_t *pgw_s5c_build_create_session_response(
     rsp->apn_restriction.presence = 1;
     rsp->apn_restriction.u8 = OGS_GTP_APN_NO_RESTRICTION;
     
-    /* TODO : APN-AMBR
+    /* APN-AMBR
      * if PCRF changes APN-AMBR, this should be included. */
+    if ((gx_message->pdn.ambr.uplink &&
+        sess->pdn.ambr.uplink != gx_message->pdn.ambr.uplink) ||
+        (gx_message->pdn.ambr.downlink &&
+        sess->pdn.ambr.downlink != gx_message->pdn.ambr.downlink)) {
+
+        memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+        ambr.uplink = htobe32(gx_message->pdn.ambr.uplink / 1000);
+        ambr.downlink = htobe32(gx_message->pdn.ambr.downlink / 1000);
+        rsp->aggregate_maximum_bit_rate.presence = 1;
+        rsp->aggregate_maximum_bit_rate.data = &ambr;
+        rsp->aggregate_maximum_bit_rate.len = sizeof(ambr);
+    }
 
     /* PCO */
     if (sess->ue_pco.presence && sess->ue_pco.len && sess->ue_pco.data) {

--- a/src/pgw/pgw-s5c-build.c
+++ b/src/pgw/pgw-s5c-build.c
@@ -36,6 +36,8 @@ ogs_pkbuf_t *pgw_s5c_build_create_session_response(
 
     ogs_gtp_cause_t cause;
     ogs_gtp_f_teid_t pgw_s5c_teid, pgw_s5u_teid;
+    ogs_gtp_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
     int len;
     uint8_t pco_buf[OGS_MAX_PCO_LEN];
     int16_t pco_len;
@@ -113,8 +115,27 @@ ogs_pkbuf_t *pgw_s5c_build_create_session_response(
     rsp->bearer_contexts_created.cause.len = sizeof(cause);
     rsp->bearer_contexts_created.cause.data = &cause;
 
-    /* TODO : Bearer QoS 
+    /* Bearer QoS
      * if PCRF changes Bearer QoS, this should be included. */
+    if ((gx_message->pdn.qos.qci &&
+        sess->pdn.qos.qci != gx_message->pdn.qos.qci) ||
+        (gx_message->pdn.qos.arp.priority_level &&
+        sess->pdn.qos.arp.priority_level != gx_message->pdn.qos.arp.priority_level) ||
+        sess->pdn.qos.arp.pre_emption_capability != gx_message->pdn.qos.arp.pre_emption_capability ||
+        sess->pdn.qos.arp.pre_emption_vulnerability != gx_message->pdn.qos.arp.pre_emption_vulnerability) {
+
+        memset(&bearer_qos, 0, sizeof(bearer_qos));
+        bearer_qos.qci = gx_message->pdn.qos.qci;
+        bearer_qos.priority_level = gx_message->pdn.qos.arp.priority_level;
+        bearer_qos.pre_emption_capability =
+            gx_message->pdn.qos.arp.pre_emption_capability;
+        bearer_qos.pre_emption_vulnerability =
+            gx_message->pdn.qos.arp.pre_emption_vulnerability;
+
+        rsp->bearer_contexts_created.bearer_level_qos.presence = 1;
+        ogs_gtp_build_bearer_qos(&rsp->bearer_contexts_created.bearer_level_qos,
+                &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+    }
 
     /* Data Plane(UL) : PGW-S5U */
     memset(&pgw_s5u_teid, 0, sizeof(ogs_gtp_f_teid_t));


### PR DESCRIPTION
This patch handles the modification made by PCRF to the Bearer level QoS and AMBR