### PR TITLE
Fix build on 32bit platform

### DIFF
--- a/src/ausf/context.c
+++ b/src/ausf/context.c
@@ -127,7 +127,7 @@ ausf_ue_t *ausf_ue_add(char *suci)
     memset(ausf_ue, 0, sizeof *ausf_ue);
 
     ausf_ue->ctx_id =
-        ogs_msprintf("%ld", ogs_pool_index(&ausf_ue_pool, ausf_ue));
+        ogs_msprintf("%td", ogs_pool_index(&ausf_ue_pool, ausf_ue));
     ogs_assert(ausf_ue->ctx_id);
 
     ausf_ue->suci = ogs_strdup(suci);

--- a/src/udm/context.c
+++ b/src/udm/context.c
@@ -126,7 +126,7 @@ udm_ue_t *udm_ue_add(char *suci)
     ogs_assert(udm_ue);
     memset(udm_ue, 0, sizeof *udm_ue);
 
-    udm_ue->ctx_id = ogs_msprintf("%ld", ogs_pool_index(&udm_ue_pool, udm_ue));
+    udm_ue->ctx_id = ogs_msprintf("%td", ogs_pool_index(&udm_ue_pool, udm_ue));
     ogs_assert(udm_ue->ctx_id);
 
     udm_ue->suci = ogs_strdup(suci);


### PR DESCRIPTION
The build process uses -Werror=format, but then there is a printf()
call with %ld for an integer:

[ 652s] ../src/udm/context.c: In function ‘udm_ue_add’:
[ 652s] ../src/udm/context.c:129:38: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘int’ [-Werror=format=]
[ 652s] udm_ue->ctx_id = ogs_msprintf("%ld", ogs_pool_index(&udm_ue_pool, udm_ue));

Closes: #465