### PR TITLE
fix compilation warnings/errrors with microhttpd >= v0.97.1

### DIFF
--- a/lib/sbi/server.c
+++ b/lib/sbi/server.c
@@ -22,6 +22,12 @@
 
 #include "microhttpd.h"
 
+#if MHD_VERSION >= 0x00097001
+typedef enum MHD_Result _MHD_Result;
+#else
+typedef int _MHD_Result;
+#endif
+
 typedef struct ogs_sbi_session_s {
     ogs_lnode_t             lnode;
 
@@ -56,7 +62,7 @@ static void notify_connection(void *cls,
         struct MHD_Connection *connection,
         void **socket_context,
         enum MHD_ConnectionNotificationCode toe);
-static int access_handler(
+static _MHD_Result access_handler(
         void *cls,
         struct MHD_Connection *connection,
         const char *url,
@@ -503,7 +509,7 @@ static int get_values(ogs_hash_t *hash,
     return MHD_YES;
 }
 
-static int access_handler(
+static _MHD_Result access_handler(
         void *cls,
         struct MHD_Connection *connection,
         const char *url,


### PR DESCRIPTION
Unfortunately upstream microhttpd has changed their callback function
prototypes in an API-incompatible way.  At least if you build with
-Werror, gcc will fail due to non-matching prototypes.

Work around this by using a typedef which uses the proper return type
depending on the microhttpd version used.

Closes: #497