### PR TITLE
Instrument MME state machine

### DIFF
--- a/src/mme/app-init.c
+++ b/src/mme/app-init.c
@@ -19,10 +19,28 @@
 
 #include "ogs-sctp.h"
 #include "ogs-app.h"
+#include "microhttpd.h"
+#include "prom.h"
+#include "promhttp.h"
+
+struct MHD_Daemon *mhddaemon;
+
+static void init(void) {
+    prom_collector_registry_default_init();
+
+    promhttp_set_active_collector_registry(NULL);
+}
 
 int app_initialize(const char *const argv[])
 {
     int rv;
+
+    init();
+
+    mhddaemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY, 8000, NULL, NULL);
+    if (mhddaemon == NULL) {
+        return 1;
+    }
 
     ogs_sctp_init(ogs_config()->usrsctp.udp_port);
     rv = mme_initialize();
@@ -37,6 +55,9 @@ int app_initialize(const char *const argv[])
 
 void app_terminate(void)
 {
+    prom_collector_registry_destroy(PROM_COLLECTOR_REGISTRY_DEFAULT);
+    MHD_stop_daemon(mhddaemon);
+
     mme_terminate();
     ogs_sctp_final();
     ogs_info("MME terminate...done");

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -41,6 +41,7 @@ libmme_sources = files('''
     sbc-handler.h
     mme-sm.h
     mme-path.h 
+    mme-metrics.h
 
     mme-init.c
     mme-event.c
@@ -94,6 +95,18 @@ libmme_dep = declare_dependency(
                     libdiameter_s6a_dep,
                     libgtp_dep])
 
+libprom_dep = dependency('libprom', version: '>=0.1.0', required: false)
+if not libprom_dep.found()
+  libprom_dep = cc.find_library('libprom', required: true)
+endif
+libpromhttpd_dep = dependency('promhttp', version: '>=0.1.0', required: false)
+if not libpromhttpd_dep.found()
+  libpromhttpd_dep = cc.find_library('libpromhttp', required: true)
+endif
+
+libmicrohttpd_dep = dependency('libmicrohttpd')
+
+
 mme_sources = files('''
     app-init.c
     ../main.c
@@ -103,6 +116,6 @@ executable('open5gs-mmed',
     sources : mme_sources,
     c_args : '-DDEFAULT_CONFIG_FILENAME="@0@/mme.yaml"'.format(open5gs_sysconfdir),
     include_directories : srcinc,
-    dependencies : libmme_dep,
+    dependencies : [libmme_dep,libprom_dep,libpromhttpd_dep,libmicrohttpd_dep],
     install_rpath : libdir,
     install : true)

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -72,7 +72,8 @@ libmme_sources = files('''
     mme-s11-build.c
     mme-s11-handler.c
     mme-sm.c
-    mme-path.c 
+    mme-path.c
+    mme-metrics.c
     sbc-handler.c 
 '''.split())
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -26,6 +26,8 @@
 #include "s1ap-path.h"
 #include "s1ap-handler.h"
 #include "mme-sm.h"
+#include "prom.h"
+#include "mme-metrics.h"
 
 #define MAX_CELL_PER_ENB            8
 
@@ -55,32 +57,39 @@ int num_mme_sessions = 0;
 
 void stats_add_ue(void) {
     num_ues = num_ues + 1;
+    prom_gauge_set(mme_ue_gauge,num_ues,NULL);
     ogs_info("Added a UE. Number of UEs is now %d", num_ues);
 }
 
 void stats_remove_ue(void) {
     num_ues = num_ues - 1;
+    prom_gauge_set(mme_ue_gauge,num_ues,NULL);
     ogs_info("Removed a UE. Number of UEs is now %d", num_ues);
 }
 
 void stats_add_enb(void) {
     num_enbs = num_enbs + 1;
+    prom_gauge_set(mme_enb_gauge,num_enbs,NULL);
     ogs_info("Added a eNB. Number of eNBs is now %d", num_enbs);
 }
 
 void stats_remove_enb(void) {
     num_enbs = num_enbs - 1;
+    prom_gauge_set(mme_enb_gauge,num_enbs,NULL);
     ogs_info("Removed a eNB. Number of eNBs is now %d", num_enbs);
 }
 
 void stats_add_mme_session(void) {
     num_mme_sessions = num_mme_sessions + 1;
+    prom_counter_inc(mme_sessions_counter, NULL);
+    prom_gauge_set(mme_sessions_gauge,num_mme_sessions,NULL);
     ogs_info("Added a session. Number of sessions is now %d",
             num_mme_sessions);
 }
 
 void stats_remove_mme_session(void) {
     num_mme_sessions = num_mme_sessions - 1;
+    prom_gauge_set(mme_sessions_gauge,num_mme_sessions,NULL);
     ogs_info("Removed a session. Number of sessions is now %d",
             num_mme_sessions);
 }

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -26,16 +26,63 @@
 #include "mme-timer.h"
 
 #include "mme-fd-path.h"
+#include "prom.h"
+#include "mme-metrics.h"
+
 
 static ogs_thread_t *thread;
 static void mme_main(void *data);
+void mme_metrics_initialize(void);
 
 static int initialized = 0;
+
+void mme_metrics_initialize(void) {
+    mme_up_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_up",
+                    "Open5gs MME is up",
+                    0,
+                    NULL)
+                    );
+    mme_sessions_counter = prom_collector_registry_must_register_metric(
+            prom_counter_new(
+                    "open5gs_mme_sessions",
+                    "Open5gs MME sessions added",
+                    0,
+                    NULL)
+    );
+
+    mme_ue_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_gauge",
+                    "Open5gs MME number of UE",
+                    0,
+                    NULL)
+                    );
+
+    mme_enb_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_enb_gauge",
+                    "Open5gs MME number of eNB",
+                    0,
+                    NULL)
+                    );
+
+    mme_sessions_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_session_gauge",
+                    "Open5gs MME number of sessions",
+                    0,
+                    NULL)
+                    );
+
+}
 
 int mme_initialize()
 {
     int rv;
 
+    mme_metrics_initialize();
     mme_context_init();
     mme_event_init();
 
@@ -59,6 +106,7 @@ int mme_initialize()
     if (!thread) return OGS_ERROR;
 
     initialized = 1;
+    prom_gauge_set(mme_up_gauge,1,NULL);
 
     return OGS_OK;
 }

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -29,54 +29,10 @@
 #include "prom.h"
 #include "mme-metrics.h"
 
-
 static ogs_thread_t *thread;
 static void mme_main(void *data);
-void mme_metrics_initialize(void);
 
 static int initialized = 0;
-
-void mme_metrics_initialize(void) {
-    mme_up_gauge = prom_collector_registry_must_register_metric(
-            prom_gauge_new(
-                    "open5gs_mme_up",
-                    "Open5gs MME is up",
-                    0,
-                    NULL)
-                    );
-    mme_sessions_counter = prom_collector_registry_must_register_metric(
-            prom_counter_new(
-                    "open5gs_mme_sessions",
-                    "Open5gs MME sessions added",
-                    0,
-                    NULL)
-    );
-
-    mme_ue_gauge = prom_collector_registry_must_register_metric(
-            prom_gauge_new(
-                    "open5gs_mme_gauge",
-                    "Open5gs MME number of UE",
-                    0,
-                    NULL)
-                    );
-
-    mme_enb_gauge = prom_collector_registry_must_register_metric(
-            prom_gauge_new(
-                    "open5gs_enb_gauge",
-                    "Open5gs MME number of eNB",
-                    0,
-                    NULL)
-                    );
-
-    mme_sessions_gauge = prom_collector_registry_must_register_metric(
-            prom_gauge_new(
-                    "open5gs_mme_session_gauge",
-                    "Open5gs MME number of sessions",
-                    0,
-                    NULL)
-                    );
-
-}
 
 int mme_initialize()
 {
@@ -106,7 +62,7 @@ int mme_initialize()
     if (!thread) return OGS_ERROR;
 
     initialized = 1;
-    prom_gauge_set(mme_up_gauge,1,NULL);
+    prom_gauge_set(mme_up_gauge, 1, NULL);
 
     return OGS_OK;
 }

--- a/src/mme/mme-metrics.c
+++ b/src/mme/mme-metrics.c
@@ -24,40 +24,38 @@ void mme_metrics_initialize(void) {
     mme_up_gauge = prom_collector_registry_must_register_metric(
             prom_gauge_new(
                     "open5gs_mme_up",
-                    "Open5gs MME is up",
+                    "Open5GS MME is up",
                     0,
-                    NULL)
-                    );
+                    NULL));
     mme_sessions_counter = prom_collector_registry_must_register_metric(
             prom_counter_new(
-                    "open5gs_mme_sessions",
-                    "Open5gs MME sessions added",
+                    "open5gs_mme_sessions_total",
+                    "Open5GS MME sessions added",
                     0,
-                    NULL)
-    );
-
+                    NULL));
     mme_ue_gauge = prom_collector_registry_must_register_metric(
             prom_gauge_new(
                     "open5gs_mme_gauge",
-                    "Open5gs MME number of UE",
+                    "Open5GS MME number of UE",
                     0,
-                    NULL)
-                    );
-
+                    NULL));
     mme_enb_gauge = prom_collector_registry_must_register_metric(
             prom_gauge_new(
                     "open5gs_enb_gauge",
-                    "Open5gs MME number of eNB",
+                    "Open5GS MME number of eNB",
                     0,
-                    NULL)
-                    );
-
+                    NULL));
     mme_sessions_gauge = prom_collector_registry_must_register_metric(
             prom_gauge_new(
                     "open5gs_mme_session_gauge",
-                    "Open5gs MME number of sessions",
+                    "Open5GS MME number of sessions",
                     0,
-                    NULL)
-                    );
-
+                    NULL));
+    const char* messagesCounterLabels[5] = {"s1ap", "emm", "esm", "s6a", "s11"};
+    mme_messages_counter = prom_collector_registry_must_register_metric(
+            prom_counter_new(
+                    "open5gs_mme_messages_total",
+                    "open5gs MME messages handled by the state machine",
+                    5,
+                    messagesCounterLabels));
 }

--- a/src/mme/mme-metrics.c
+++ b/src/mme/mme-metrics.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mme-metrics.h"
+#include "prom.h"
+
+void mme_metrics_initialize(void) {
+    mme_up_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_up",
+                    "Open5gs MME is up",
+                    0,
+                    NULL)
+                    );
+    mme_sessions_counter = prom_collector_registry_must_register_metric(
+            prom_counter_new(
+                    "open5gs_mme_sessions",
+                    "Open5gs MME sessions added",
+                    0,
+                    NULL)
+    );
+
+    mme_ue_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_gauge",
+                    "Open5gs MME number of UE",
+                    0,
+                    NULL)
+                    );
+
+    mme_enb_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_enb_gauge",
+                    "Open5gs MME number of eNB",
+                    0,
+                    NULL)
+                    );
+
+    mme_sessions_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_mme_session_gauge",
+                    "Open5gs MME number of sessions",
+                    0,
+                    NULL)
+                    );
+
+}

--- a/src/mme/mme-metrics.h
+++ b/src/mme/mme-metrics.h
@@ -20,11 +20,14 @@
 #ifndef BUILD_MME_METRICS_H
 #define BUILD_MME_METRICS_H
 
+#include "prom.h"
+
 prom_gauge_t *mme_up_gauge;
 prom_gauge_t *mme_ue_gauge;
 prom_gauge_t *mme_enb_gauge;
 prom_gauge_t *mme_sessions_gauge;
 prom_counter_t *mme_sessions_counter;
 
+void mme_metrics_initialize(void);
 
 #endif //BUILD_MME_METRICS_H

--- a/src/mme/mme-metrics.h
+++ b/src/mme/mme-metrics.h
@@ -27,6 +27,7 @@ prom_gauge_t *mme_ue_gauge;
 prom_gauge_t *mme_enb_gauge;
 prom_gauge_t *mme_sessions_gauge;
 prom_counter_t *mme_sessions_counter;
+prom_counter_t *mme_messages_counter;
 
 void mme_metrics_initialize(void);
 

--- a/src/mme/mme-metrics.h
+++ b/src/mme/mme-metrics.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BUILD_MME_METRICS_H
+#define BUILD_MME_METRICS_H
+
+prom_gauge_t *mme_up_gauge;
+prom_gauge_t *mme_ue_gauge;
+prom_gauge_t *mme_enb_gauge;
+prom_gauge_t *mme_sessions_gauge;
+prom_counter_t *mme_sessions_counter;
+
+
+#endif //BUILD_MME_METRICS_H

--- a/src/pcrf/meson.build
+++ b/src/pcrf/meson.build
@@ -18,6 +18,7 @@
 libpcrf_sources = files('''
     pcrf-context.h
     pcrf-fd-path.h
+    pcrf-metrics.h
 
     pcrf-init.c
     pcrf-context.c
@@ -41,6 +42,17 @@ libpcrf_dep = declare_dependency(
                     libdiameter_rx_dep,
                     libdiameter_gx_dep])
 
+libprom_dep = dependency('libprom', version: '>=0.1.0', required: false)
+if not libprom_dep.found()
+  libprom_dep = cc.find_library('libprom', required: true)
+endif
+libpromhttpd_dep = dependency('promhttp', version: '>=0.1.0', required: false)
+if not libpromhttpd_dep.found()
+  libpromhttpd_dep = cc.find_library('libpromhttp', required: true)
+endif
+
+libmicrohttpd_dep = dependency('libmicrohttpd')
+
 pcrf_sources = files('''
     app-init.c
     ../main.c
@@ -50,6 +62,6 @@ executable('open5gs-pcrfd',
     sources : pcrf_sources,
     c_args : '-DDEFAULT_CONFIG_FILENAME="@0@/pcrf.yaml"'.format(open5gs_sysconfdir),
     include_directories : srcinc,
-    dependencies : libpcrf_dep,
+    dependencies : [libpcrf_dep,libprom_dep,libpromhttpd_dep,libmicrohttpd_dep],
     install_rpath : libdir,
     install : true)

--- a/src/pcrf/pcrf-context.c
+++ b/src/pcrf/pcrf-context.c
@@ -19,6 +19,8 @@
 
 #include "ogs-dbi.h"
 #include "pcrf-context.h"
+#include "prom.h"
+#include "pcrf-metrics.h"
 
 static pcrf_context_t self;
 static ogs_diam_config_t g_diam_conf;
@@ -634,6 +636,7 @@ int pcrf_sess_set_ipv4(const void *key, uint8_t *sid)
     ogs_thread_mutex_lock(&self.hash_lock);
 
     ogs_hash_set(self.ip_hash, key, OGS_IPV4_LEN, sid);
+    prom_counter_inc(pcrf_sessions_counter, NULL);
 
     ogs_thread_mutex_unlock(&self.hash_lock);
 

--- a/src/pcrf/pcrf-init.c
+++ b/src/pcrf/pcrf-init.c
@@ -19,13 +19,35 @@
 
 #include "pcrf-context.h"
 #include "pcrf-fd-path.h"
+#include "prom.h"
+#include "pcrf-metrics.h"
 
 static int initialized = 0;
+void pcrf_metrics_initialize(void);
+
+void pcrf_metrics_initialize(void) {
+    pcrf_up_gauge = prom_collector_registry_must_register_metric(
+            prom_gauge_new(
+                    "open5gs_pcrf_up",
+                    "Open5gs Pcrf is up",
+                    0,
+                    NULL)
+                    );
+    pcrf_sessions_counter = prom_collector_registry_must_register_metric(
+            prom_counter_new(
+                    "open5gs_pcrf_sessions",
+                    "Open5gs Pcrf active sessions",
+                    0,
+                    NULL)
+    );
+}
+
 
 int pcrf_initialize(void)
 {
     int rv;
 
+    pcrf_metrics_initialize();
     pcrf_context_init();
 
     rv = pcrf_context_parse_config();
@@ -42,6 +64,7 @@ int pcrf_initialize(void)
     if (rv != OGS_OK) return OGS_ERROR;
 
     initialized = 1;
+    prom_gauge_set(pcrf_up_gauge,1,NULL);
 
 	return OGS_OK;
 }

--- a/src/pcrf/pcrf-metrics.h
+++ b/src/pcrf/pcrf-metrics.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef BUILD_PCRF_METRICS_H
+#define BUILD_PCRF_METRICS_H
+
+prom_gauge_t *pcrf_up_gauge;
+prom_counter_t *pcrf_sessions_counter;
+
+
+#endif //BUILD_PCRF_METRICS_H

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -41,6 +41,21 @@ libtestcommon_sources = files('''
 
 libtestcommon_inc = include_directories('.')
 
+
+
+libprom_dep = dependency('libprom', version: '>=0.1.0', required: false)
+if not libprom_dep.found()
+  libprom_dep = cc.find_library('libprom', required: true)
+endif
+libpromhttpd_dep = dependency('promhttp', version: '>=0.1.0', required: false)
+if not libpromhttpd_dep.found()
+  libpromhttpd_dep = cc.find_library('libpromhttp', required: true)
+endif
+
+libmicrohttpd_dep = dependency('libmicrohttpd')
+
+
+
 libtestcommon = static_library('testcomon',
     sources : libtestcommon_sources,
     c_args : testunit_core_cc_flags,
@@ -53,7 +68,10 @@ libtestcommon = static_library('testcomon',
                     libngap_dep,
                     libnas_eps_dep,
                     libnas_5gs_dep,
-                    libdiameter_common_dep],
+                    libdiameter_common_dep,
+                    libprom_dep,
+		    libpromhttpd_dep,
+		    libmicrohttpd_dep],
     install : false)
 
 libtestcommon_dep = declare_dependency(
@@ -67,4 +85,8 @@ libtestcommon_dep = declare_dependency(
                     libngap_dep,
                     libnas_eps_dep,
                     libnas_5gs_dep,
-                    libdiameter_common_dep])
+                    libdiameter_common_dep,
+                    libprom_dep,
+                    libpromhttpd_dep,
+                    libmicrohttpd_dep],
+    )


### PR DESCRIPTION
Besides structuring the Prometheus client code a bit, this adds
counters to the various message types of the MME state machine.
The implementation is a bit clunky as Open5GS is built with C89.