### PR TITLE
Change PFCP node search order, fix typo, add feature to disable RR for a node

### DIFF
--- a/configs/open5gs/sgwc.yaml.in
+++ b/configs/open5gs/sgwc.yaml.in
@@ -64,11 +64,15 @@ sgwc:
 #  <SGWU_SELECTION_MODE - EPC only>
 #
 # o Round-Robin
+#   (note that round robin can be disabled for a particular node
+#     by setting flag 'rr' to 0)
 #
 #  sgwu:
 #    pfcp:
 #      - addr: 127.0.0.6
 #      - addr: 127.0.0.12
+#        rr: 0
+#      - addr: 127.0.0.18
 #
 # o SGWU selection by eNodeB TAC
 #   (either single TAC or multiple TACs, DECIMAL representation)

--- a/configs/open5gs/sgwc.yaml.in
+++ b/configs/open5gs/sgwc.yaml.in
@@ -61,15 +61,16 @@ sgwc:
 #    pfcp:
 #      addr: 127.0.0.6
 #
-#  <UPF_SELECTION_MODE - EPC only>
+#  <SGWU_SELECTION_MODE - EPC only>
 #
 # o Round-Robin
+#
 #  sgwu:
 #    pfcp:
 #      - addr: 127.0.0.6
 #      - addr: 127.0.0.12
 #
-# o UPF selection by eNodeB TAC
+# o SGWU selection by eNodeB TAC
 #   (either single TAC or multiple TACs, DECIMAL representation)
 #
 #  sgwu:
@@ -79,24 +80,24 @@ sgwc:
 #      - addr: 127.0.0.12
 #        tac: [3,5,8]
 #
-# o UPF selection by UE's DNN/APN (either single DNN/APN or multiple DNNs/APNs)
+# o SGWU selection by UE's APN (either single APN or multiple APNs)
 #
 #  sgwu:
 #    pfcp:
 #      - addr: 127.0.0.6
-#        dnn: ims
+#        apn: ims
 #      - addr: 127.0.0.12
 #        apn: [internet, web]
 #
-# o UPF selection by CellID(e_cell_id: 28bit, nr_cell_id: 36bit)
-#   (either single enb_id or multiple enb_ids, HEX representation)
+# o SGWU selection by CellID(e_cell_id: 28bit)
+#   (either single e_cell_id or multiple e_cell_id, HEX representation)
 #
 #  sgwu:
 #    pfcp:
 #      - addr: 127.0.0.6
 #        e_cell_id: 463
 #      - addr: 127.0.0.12
-#        nr_cell_id: [123456789, 9413]
+#        e_cell_id: [123456789, 9413]
 #
 sgwu:
     pfcp:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -246,10 +246,15 @@ nrf:
 #  <UPF_SELECTION_MODE - EPC only>
 #
 # o Round-Robin
+#   (note that round robin can be disabled for a particular node
+#     by setting flag 'rr' to 0)
+#
 #  upf:
 #    pfcp:
 #      - addr: 127.0.0.7
 #      - addr: 127.0.0.12
+#        rr: 0
+#      - addr: 127.0.0.19
 #
 # o UPF selection by eNodeB TAC
 #   (either single TAC or multiple TACs, DECIMAL representation)

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -408,6 +408,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         uint8_t num_of_e_cell_id = 0;
                         uint32_t nr_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};
                         uint8_t num_of_nr_cell_id = 0;
+                        uint8_t rr_enable = 1; /* full list RR enabled by default */
 
                         if (ogs_yaml_iter_type(&pfcp_array) ==
                                 YAML_MAPPING_NODE) {
@@ -570,6 +571,9 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                 } while (
                                     ogs_yaml_iter_type(&nr_cell_id_iter) ==
                                         YAML_SEQUENCE_NODE);
+                            } else if (!strcmp(pfcp_key, "rr")) {
+                                const char *v = ogs_yaml_iter_value(&pfcp_iter);
+                                if (v) rr_enable = atoi(v);
                             } else
                                 ogs_warn("unknown key `%s`", pfcp_key);
                         }
@@ -609,6 +613,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         if (num_of_nr_cell_id != 0)
                             memcpy(node->nr_cell_id, nr_cell_id,
                                     sizeof(node->nr_cell_id));
+
+                        node->rr_enable = rr_enable;
                     } while (ogs_yaml_iter_type(&pfcp_array) ==
                             YAML_SEQUENCE_NODE);
                 }

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -93,6 +93,7 @@ typedef struct ogs_pfcp_node_s {
     uint8_t         num_of_e_cell_id;
     uint32_t        nr_cell_id[OGS_MAX_NUM_OF_CELL_ID];
     uint8_t         num_of_nr_cell_id;
+    uint8_t         rr_enable; /* flag to enable/ disable full list RR for this node */
 
     ogs_list_t      gtpu_resource_list; /* User Plane IP Resource Information */
 } ogs_pfcp_node_t;

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -431,14 +431,14 @@ static bool compare_ue_info(ogs_pfcp_node_t *node, sgwc_sess_t *sess)
     sgwc_ue = sess->sgwc_ue;
     ogs_assert(sgwc_ue);
 
-    for (i = 0; i < node->num_of_tac; i++)
-        if (node->tac[i] == sgwc_ue->e_tai.tac) return true;
+    for (i = 0; i < node->num_of_apn; i++)
+        if (strcmp(node->apn[i], sess->pdn.apn) == 0) return true;
 
     for (i = 0; i < node->num_of_e_cell_id; i++)
         if (node->e_cell_id[i] == sgwc_ue->e_cgi.cell_id) return true;
 
-    for (i = 0; i < node->num_of_apn; i++)
-        if (strcmp(node->apn[i], sess->pdn.apn) == 0) return true;
+    for (i = 0; i < node->num_of_tac; i++)
+        if (node->tac[i] == sgwc_ue->e_tai.tac) return true;
 
     return false;
 }

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -461,8 +461,12 @@ static ogs_pfcp_node_t *selected_sgwu_node(
                 if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated) &&
                     compare_ue_info(node, sess) == true) return node;
             } else {
-                if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated))
-                    return node;
+                /*
+                 * we are in RR mode - use next PFCP associated
+                 * node that is suited for full list RR
+                 */
+                if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated) &&
+                    node->rr_enable == 1) return node;
             }
         }
         /* cyclic search from top to current position */
@@ -472,8 +476,12 @@ static ogs_pfcp_node_t *selected_sgwu_node(
                 if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated) &&
                     compare_ue_info(node, sess) == true) return node;
             } else {
-                if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated))
-                    return node;
+                /*
+                 * we are in RR mode - use next PFCP associated
+                 * node that is suited for full list RR
+                 */
+                if (OGS_FSM_CHECK(&node->sm, sgwc_pfcp_state_associated) &&
+                    node->rr_enable == 1) return node;
             }
         }
 
@@ -487,7 +495,7 @@ static ogs_pfcp_node_t *selected_sgwu_node(
         RR = 1;
     }
 
-    ogs_error("No SGWUs are PFCP associated");
+    ogs_error("No SGWUs are PFCP associated that are suited to RR");
     return ogs_list_first(&ogs_pfcp_self()->peer_list);
 }
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -611,9 +611,8 @@ static bool compare_ue_info(ogs_pfcp_node_t *node, smf_sess_t *sess)
     ogs_assert(node);
     ogs_assert(sess);
 
-    for (i = 0; i < node->num_of_tac; i++)
-        if (node->tac[i] == sess->e_tai.tac ||
-            node->tac[i] == sess->nr_tai.tac.v) return true;
+    for (i = 0; i < node->num_of_apn; i++)
+        if (strcmp(node->apn[i], sess->pdn.apn) == 0) return true;
 
     for (i = 0; i < node->num_of_e_cell_id; i++)
         if (node->e_cell_id[i] == sess->e_cgi.cell_id) return true;
@@ -621,8 +620,9 @@ static bool compare_ue_info(ogs_pfcp_node_t *node, smf_sess_t *sess)
     for (i = 0; i < node->num_of_nr_cell_id; i++)
         if (node->nr_cell_id[i] == sess->nr_cgi.cell_id) return true;
 
-    for (i = 0; i < node->num_of_apn; i++)
-        if (strcmp(node->apn[i], sess->pdn.apn) == 0) return true;
+    for (i = 0; i < node->num_of_tac; i++)
+        if (node->tac[i] == sess->e_tai.tac ||
+            node->tac[i] == sess->nr_tai.tac.v) return true;
 
     return false;
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -621,8 +621,8 @@ static bool compare_ue_info(ogs_pfcp_node_t *node, smf_sess_t *sess)
         if (node->nr_cell_id[i] == sess->nr_cgi.cell_id) return true;
 
     for (i = 0; i < node->num_of_tac; i++)
-        if (node->tac[i] == sess->e_tai.tac ||
-            node->tac[i] == sess->nr_tai.tac.v) return true;
+        if ((node->tac[i] == sess->e_tai.tac) ||
+            (node->tac[i] == sess->nr_tai.tac.v)) return true;
 
     return false;
 }
@@ -645,8 +645,12 @@ static ogs_pfcp_node_t *selected_upf_node(
                 if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated) &&
                     compare_ue_info(node, sess) == true) return node;
             } else {
-                if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated))
-                    return node;
+                /*
+                 * we are in RR mode - use next PFCP associated
+                 * node that is suited for full list RR
+                 */
+                if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated) &&
+                    node->rr_enable == 1) return node;
             }
         }
         /* cyclic search from top to current position */
@@ -656,8 +660,12 @@ static ogs_pfcp_node_t *selected_upf_node(
                 if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated) &&
                     compare_ue_info(node, sess) == true) return node;
             } else {
-                if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated))
-                    return node;
+                /*
+                 * we are in RR mode - use next PFCP associated
+                 * node that is suited for full list RR
+                 */
+                if (OGS_FSM_CHECK(&node->sm, smf_pfcp_state_associated) &&
+                    node->rr_enable == 1) return node;
             }
         }
 
@@ -671,7 +679,7 @@ static ogs_pfcp_node_t *selected_upf_node(
         RR = 1;
     }
 
-    ogs_error("No UPFs are PFCP associated");
+    ogs_error("No UPFs are PFCP associated that are suited to RR");
     return ogs_list_first(&ogs_pfcp_self()->peer_list);
 }
 


### PR DESCRIPTION
Hey @acetcom - another one for you!

The first commit deals with the first point in https://github.com/open5gs/open5gs/issues/559, flipping the search order from TAC/APN/cell_ID to APN/ cell_ID/ TAC

This means the logic for (eg) the SMF is now:

1. Search through node list to see if any are dedicated to support the APN
    -- round robin between nodes that support the APN && are PFCP associated
    -- if there are none, move to 2

2. Search through node list to see if any are dedicated to support the e_cell_ID
    -- round robin between nodes that support the e_cell_ID && are PFCP associated
    -- if there are none, move to 3

3. Search through node list to see if any are dedicated to support the nr_cell_ID
    -- round robin between nodes that support the nr_cell_ID && are PFCP associated
    -- if there are none, move to 4

4. Search through node list to see if any are dedicated to support the TAC
    -- round robin between nodes that support the TAC && are PFCP associated
    -- if there are none, move to 5

5. Round robin full list. Use next PFCP associated node.


---

Second commit is fixing a copy paste typo in the SGWC config file

---

Third implements a feature to disable RR for a particular node. This deals with this situation described in in https://github.com/open5gs/open5gs/issues/559 where you want to avoid a dumb RR choice:

>In full list RR mode...
>
>After PR #556 merge we now select the next PFCP associated node and call it a day. This is sound logic, but could end up making a dumb choice, as it may choose a userplane server that is at the end of a very slow broadband line, or one where the firewall is not set up to receive incoming connections, or there is no VPN in place to connect from an eNB/gNB to the userplaneserver.
>
>So I would propose a feature here, where we add an optional flag to the node list (that would be parsed in lib/pfcp/context.c) to disable full list RR mode for a particular node:

By default, RR is still enabled for every node. So if you miss the variable from the PFCP node list it doesn't make any difference. After running through the tests for matching APN, then cell_ID, then TAC and we go into full list round robin, all PFCP associated nodes are eligible for use.

If we add the additional flag,  `rr: 0` to a node, when we are in this full list round robin mode, the node will be skipped. This is to avoid the dumb choice I was talking about. 
```
    pfcp:

      - addr: 127.0.1.4  # userplaneserver1 for IMS (centralised)
        apn: ims

      - addr: 127.0.2.4  # userplaneserver2 for TAC 1 region
        tac: 1

      - addr: 127.0.3.4  # userplaneserver3 for TAC 2 region
        tac: 2

      - addr: 127.0.4.4  # userplaneserver4 at cell site
        e_cell_id: 123
        nr_cell_id: 321
        rr: 0            # do not allow this userplaneserver to be selected when performing full list RR, 
                         #  as there is no S1U/N3 VPN to other eNB/gNBs

      - addr: 127.0.5.4  # userplaneserver5 at cell site
        e_cell_id: 456
        nr_cell_id: 654
        rr: 0            # do not allow this userplaneserver to be selected when performing full list RR, 
                         #  as there is no S1U/N3 VPN to other eNB/gNBs

      - addr: 127.0.6.4  # userplaneserver6 for edge compute use case 1
        apn: mec1

      - addr: 127.0.7.4  # userplaneserver7 for edge compute use case 2
        apn: mec2

      - addr: 127.0.8.4  # userplaneserver8 at cell site, also used for edge compute use case 3
        e_cell_id: 789
        nr_cell_id: 897
        apn: mec3
```

I've tested this with the SGWC, SMF and x4 SGWU/UPF servers, and it all seems to hold up.

Cheers
Kenny