### PR TITLE
Fix for SMF nr_cell_id selection

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -406,7 +406,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         uint8_t num_of_apn = 0;
                         uint32_t e_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};
                         uint8_t num_of_e_cell_id = 0;
-                        uint32_t nr_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};
+                        uint64_t nr_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};
                         uint8_t num_of_nr_cell_id = 0;
 
                         /* full list RR enabled by default */
@@ -567,7 +567,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                     v = ogs_yaml_iter_value(&nr_cell_id_iter);
                                     if (v) {
                                         nr_cell_id[num_of_nr_cell_id]
-                                            = ogs_uint28_from_string((char*)v);
+                                            = ogs_uint36_from_string((char*)v);
                                         num_of_nr_cell_id++;
                                     }
                                 } while (

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -91,7 +91,7 @@ typedef struct ogs_pfcp_node_s {
     uint8_t         num_of_apn;
     uint32_t        e_cell_id[OGS_MAX_NUM_OF_CELL_ID];
     uint8_t         num_of_e_cell_id;
-    uint32_t        nr_cell_id[OGS_MAX_NUM_OF_CELL_ID];
+    uint64_t        nr_cell_id[OGS_MAX_NUM_OF_CELL_ID];
     uint8_t         num_of_nr_cell_id;
 
     /* flag to enable/ disable full list RR for this node */


### PR DESCRIPTION
Hey @acetcom 

I noticed a couple of typos in the PFCP context files for SMF>UPF selection based  on the `nr_cell_id`

As this is a 36 bit long number, the config file needs to be parsed with `ogs_uint36_from_string` and held in a `uint64`

Kenny