### PR TITLE
make webui listen on 0.0.0.0

### DIFF
--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -101,9 +101,9 @@ co(function* () {
     server.use(morgan('tiny'));
   }
 
-  server.listen(3000, err => {
+  server.listen(3000, "0.0.0.0", err => {
     if (err) throw err;
-    console.log('> Ready on http://localhost:3000');
+    console.log('> Ready on http://0.0.0.0:3000');
   });
 })
 .catch(error => console.error(error.stack));


### PR DESCRIPTION
In order to access the webui from other hosts make it listen on the any address. 
Should be safe as we have user authentication and the default password could be changed.