### PR TITLE
Add Vendor-Specific-Application-Id in CER for advertising the diameter applications supported

### DIFF
--- a/src/hss/hss-fd-path.c
+++ b/src/hss/hss-fd-path.c
@@ -756,9 +756,30 @@ int hss_fd_init(void)
 {
     int ret;
 	struct disp_when data;
+    struct dict_object * s6a_app, * vnd;
 
     ret = ogs_diam_init(FD_MODE_SERVER,
                 hss_self()->diam_conf_path, hss_self()->diam_config);
+    ogs_assert(ret == 0);
+
+    struct dict_vendor_data vnd_data;
+    vnd_data.vendor_id = 10415;
+    vnd_data.vendor_name = (char *) "3GPP";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict,
+            DICT_VENDOR, &vnd_data, NULL, &vnd);
+    ogs_assert(ret == 0);
+
+    struct dict_application_data s6a_app_data;
+
+    s6a_app_data.application_id = 16777251;
+    s6a_app_data.application_name = (char *) "S6A";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict, DICT_APPLICATION,
+            &s6a_app_data, NULL, &s6a_app);
+    ogs_assert(ret == 0);
+
+    ret = fd_disp_app_support(s6a_app, vnd, 1, 0);
     ogs_assert(ret == 0);
 
 	/* Install objects definitions for this application */

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -1139,10 +1139,31 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
 int mme_fd_init(void)
 {
     int ret;
+    struct dict_object * s6a_app, * vnd;
 
     ret = ogs_diam_init(FD_MODE_CLIENT,
                 mme_self()->diam_conf_path, mme_self()->diam_config);
     ogs_assert(ret == OGS_OK);
+
+    struct dict_vendor_data vnd_data;
+    vnd_data.vendor_id = 10415;
+    vnd_data.vendor_name = (char *) "3GPP";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict,
+            DICT_VENDOR, &vnd_data, NULL, &vnd);
+    ogs_assert(ret == 0);
+
+    struct dict_application_data s6a_app_data;
+
+    s6a_app_data.application_id = 16777251;
+    s6a_app_data.application_name = (char *) "S6A";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict, DICT_APPLICATION,
+            &s6a_app_data, NULL, &s6a_app);
+    ogs_assert(ret == 0);
+
+    ret = fd_disp_app_support(s6a_app, vnd, 1, 0);
+    ogs_assert(ret == 0);
 
 	/* Install objects definitions for this application */
 	ret = ogs_diam_s6a_init();

--- a/src/pcrf/pcrf-fd-path.c
+++ b/src/pcrf/pcrf-fd-path.c
@@ -22,9 +22,39 @@
 
 int pcrf_fd_init(void)
 {
-    int rv;
-    int ret = ogs_diam_init(FD_MODE_CLIENT|FD_MODE_SERVER,
+    int rv, ret;
+    struct dict_object * gx_app, * rx_app, * vnd;
+
+    ret = ogs_diam_init(FD_MODE_CLIENT|FD_MODE_SERVER,
                 pcrf_self()->diam_conf_path, pcrf_self()->diam_config);
+    ogs_assert(ret == 0);
+
+    struct dict_vendor_data vnd_data;
+    vnd_data.vendor_id = 10415;
+    vnd_data.vendor_name = (char *) "3GPP";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict,
+            DICT_VENDOR, &vnd_data, NULL, &vnd);
+    ogs_assert(ret == 0);
+
+    struct dict_application_data gx_app_data, rx_app_data;
+
+    gx_app_data.application_id = 16777238;
+    gx_app_data.application_name = (char *) "Gx";
+
+    rx_app_data.application_id = 16777236;
+    rx_app_data.application_name = (char *) "Rx";
+
+    ret = fd_dict_new(fd_g_config->cnf_dict, DICT_APPLICATION,
+            &gx_app_data, NULL, &gx_app);
+    ogs_assert(ret == 0);
+    ret = fd_dict_new(fd_g_config->cnf_dict, DICT_APPLICATION,
+            &rx_app_data, NULL, &rx_app);
+    ogs_assert(ret == 0);
+
+    ret = fd_disp_app_support(gx_app, vnd, 1, 0);
+    ogs_assert(ret == 0);
+    ret = fd_disp_app_support(rx_app, vnd, 1, 0);
     ogs_assert(ret == 0);
 
     rv = pcrf_gx_init();


### PR DESCRIPTION
- Advertises Gx and Rx for PCRF
- Advertises S6A for HSS and MME