### PR TITLE
Update ngap-sm.c

### DIFF
--- a/src/amf/ngap-sm.c
+++ b/src/amf/ngap-sm.c
@@ -65,6 +65,11 @@ void ngap_state_operational(ogs_fsm_t *s, amf_event_t *e)
     case AMF_EVT_NGAP_MESSAGE:
         pdu = e->ngap.message;
         ogs_assert(pdu);
+            
+        if (!(pdu->present == NGAP_NGAP_PDU_PR_initiatingMessage && pdu->choice.initiatingMessage->procedureCode == NGAP_ProcedureCode_id_NGSetup) && !gnb->state.ng_setup_success)
+        {
+            break;
+        }
 
         switch (pdu->present) {
         case NGAP_NGAP_PDU_PR_initiatingMessage:


### PR DESCRIPTION
AMF should not process any NGAP message before it finish the NGSetup procedure in 3GPP 38413.