### PR TITLE
Doc Update - Added list of eNodeBs / gNodeBs confirmed to work by community, links to CSFB & SMS Docs

### DIFF
--- a/docs/_docs/hardware/01-genodebs.md
+++ b/docs/_docs/hardware/01-genodebs.md
@@ -1,0 +1,34 @@
+---
+title: Tested eNodeBs / gNodeBs
+---
+
+This page lists Radio hardware that has been tested by members of the Open5GS community,
+
+Listed eNodeBs have at a minimum connected to Open5GS. This does not mean all functionality (dedicated bearers, GBRs, etc) has been tested.
+
+If you have confirmed hardware from a vendor not listed works with Open5GS, please add it to this page [by creating a PR on GitHub.](https://github.com/open5gs/open5gs)
+
+### Commercial Macro BTS
+ * Huawei BTS 3900 (S/W version V100R011C10SPC230)
+
+### Small Cells
+ * Baicells Neutrino
+ * Baicells Nova 243
+ * Baicells Nova 246
+ * Baicells Nova 436Q
+ * Baicells Nova 227 (ebs and cbrs)
+ * Baicells Nova 233
+ * Airspan AirSpeed 1030
+ * Airspan AirHarmony 1000
+ * AirHarmony 4000
+ * AirHarmony 4200
+ * AirHarmony 4400
+
+### OpenRAN Hardware
+
+### SDR Hardware
+ * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) LimeSDR
+ * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) BladeRF x40 (Not stable)
+
+### Other Radio Hardware
+ * [OsmoBTS](https://osmocom.org/projects/osmobts/wiki) controlled ip.access NanoBTS (Used for CSFB with Osmocom)

--- a/docs/_docs/hardware/01-genodebs.md
+++ b/docs/_docs/hardware/01-genodebs.md
@@ -1,22 +1,27 @@
 ---
-title: Tested eNodeBs / gNodeBs
+title: eNodeBs / gNodeBs tested on Open5GS
+head_inline: "<style> .blue { color: blue; } .bold { font-weight: bold; } </style>"
 ---
 
 This page lists Radio hardware that has been tested by members of the Open5GS community,
 
 Listed eNodeBs have at a minimum connected to Open5GS. This does not mean all functionality (dedicated bearers, GBRs, etc) has been tested.
 
-If you have confirmed hardware from a vendor not listed works with Open5GS, please add it to this page [by creating a PR on GitHub.](https://github.com/open5gs/open5gs)
+If you have tested radio hardware from a vendor not listed with Open5GS, please add it to this page [by creating a PR on GitHub.](https://github.com/open5gs/open5gs)
 
 ### Commercial Macro BTS
+---
+
  * Huawei BTS 3900 (S/W version V100R011C10SPC230)
 
 ### Small Cells
+---
+
  * Baicells Neutrino
  * Baicells Nova 243
  * Baicells Nova 246
  * Baicells Nova 436Q
- * Baicells Nova 227 (ebs and cbrs)
+ * Baicells Nova 227 (EBS & CBRS)
  * Baicells Nova 233
  * Airspan AirSpeed 1030
  * Airspan AirHarmony 1000
@@ -25,10 +30,16 @@ If you have confirmed hardware from a vendor not listed works with Open5GS, plea
  * AirHarmony 4400
 
 ### OpenRAN Hardware
+---
+
 
 ### SDR Hardware
+---
+
  * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) LimeSDR
  * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) BladeRF x40 (Not stable)
 
 ### Other Radio Hardware
+---
+
  * [OsmoBTS](https://osmocom.org/projects/osmobts/wiki) controlled ip.access NanoBTS (Used for CSFB with Osmocom)

--- a/docs/_docs/hardware/01-genodebs.md
+++ b/docs/_docs/hardware/01-genodebs.md
@@ -39,7 +39,8 @@ If you have tested radio hardware from a vendor not listed with Open5GS, please 
  * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) LimeSDR
  * [srsLTE / SRSenb](https://github.com/srsLTE/srsLTE) BladeRF x40 (Not stable)
 
-### Other Radio Hardware
+### Misc Radio Hardware
 ---
-
  * [OsmoBTS](https://osmocom.org/projects/osmobts/wiki) controlled ip.access NanoBTS (Used for CSFB with Osmocom)
+ * [UERANSIM](https://github.com/aligungr/UERANSIM) 5G RAN Simulator
+ 

--- a/docs/_pages/docs.md
+++ b/docs/_pages/docs.md
@@ -17,6 +17,8 @@ head_inline: "<style> ul { padding-bottom: 1em; } </style>"
   - [Kubernetes Open5GS Deployment](https://dev.to/infinitydon/virtual-4g-simulation-using-kubernetes-and-gns3-3b7k?fbclid=IwAR1p99h13a-mCfejanbBQe0H0-jp5grXkn5mWf1WrTHf47UtegB2-UHGGZQ)
   - [Static IPs for UEs](http://nickvsnetworking.com/open5gs-epc-static-ip-addresses-for-ues-apns-subscribers/)
   - [My first 5G Core: Open5Gs and UERANSIM](http://nickvsnetworking.com/my-first-5g-core-open5gs-and-ueransim/)
+  - [Sending SMS in Open5GS LTE Networks using the SGs Interface and OsmoMSC](https://nickvsnetworking.com/sending-sms-in-open5gs-lte-networks-using-the-sgs-interface-and-osmomsc-with-smsos/)
+  - [OsmoMSC and Open5GS MME – SGs Interface for CSCF / InterRAT Handover](https://nickvsnetworking.com/osmomsc-and-open5gs-mme-sgs-interface-for-cscf-interran-handover/)
 
 - Troubleshooting
   - [Simple Issues](troubleshoot/01-simple-issues)

--- a/docs/_pages/docs.md
+++ b/docs/_pages/docs.md
@@ -27,3 +27,7 @@ head_inline: "<style> ul { padding-bottom: 1em; } </style>"
   - [CentOS](platform/02-centos)
   - [Fedora](platform/03-fedora)
   - [MacOSX](platform/05-macosx)
+  
+- Hardware Specific Notes
+  - [Tested e/gNodeBs](hardware/01-genodebs)
+  


### PR DESCRIPTION
Created pages documenting Radio hardware people in the community have used with Open5GS, as per suggestion in Discord chat.

- Created new folder in docs for Hardware
- Added file containing list of eNodeBs / gNodeBs confirmed to work by the community
- Linked to a post on CSFB Setup with Osmocom GSM stack on docs page
- Linked to a post on SMS over SGs with Osmocom GSM stack on docs page
- Linked to e/gNodeB list from main docs page
