### PR TITLE
NUTC-IMAC_Add Gemtek 4G small cell to eNodeB/gNodeB support list

### DIFF
--- a/docs/_docs/hardware/01-genodebs.md
+++ b/docs/_docs/hardware/01-genodebs.md
@@ -28,6 +28,7 @@ If you have tested radio hardware from a vendor not listed with Open5GS, please 
  * AirHarmony 4000
  * AirHarmony 4200
  * AirHarmony 4400
+ * Gemtek WLTGFC-101 (S/W version 2.1.1746.1116)
 
 ### OpenRAN Hardware
 ---


### PR DESCRIPTION
Hello, Open5GS Support Teams,
Here is Intelligent Mobile Associate Community (IMAC)  Teams department of Taiwan's National Taichung University of Science and Technology Computer Science and Information Engineering.
We test the Open5GS on Monolithic Architecture with Taiwan's Gemtek 4G Small Cell,
and it support Open5GS's MME Element communication and help UE connect to Internet,
So we add it to Open5GS's eNodeBs/gNodeBs support list, and provided we used software version
Signed-off-by: ZhengSheng <j13tw@yahoo.com.tw>