### PR TITLE
docs: fix simple typo, speciic -> specific

### DIFF
--- a/lib/asn1c/common/constr_TYPE.h
+++ b/lib/asn1c/common/constr_TYPE.h
@@ -138,7 +138,7 @@ typedef asn_type_selector_result_t(asn_type_selector_f)(
     const void *parent_structure_ptr);
 
 /*
- * Generalized functions for dealing with the speciic type.
+ * Generalized functions for dealing with the specific type.
  * May be directly invoked by applications.
  */
 typedef struct asn_TYPE_operation_s {


### PR DESCRIPTION
There is a small typo in lib/asn1c/common/constr_TYPE.h.

Should read `specific` rather than `speciic`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md