### PR TITLE
Legacy support for pre-release LTE 11 devices while performing VoLTE call

### DIFF
--- a/configs/open5gs/pcrf.yaml.in
+++ b/configs/open5gs/pcrf.yaml.in
@@ -46,6 +46,10 @@ pcrf:
 #  o Disable Stateless Address Autoconfiguration for IPv6
 #      no_slaac: true
 #
+#  o Legacy support for pre-release LTE 11 devices to do calling
+#    - Replace IPv4/v6 local addr field in AAR Media-Subcomponent AVP by any
+#      no_ipv4v6_local_addr_in_packet_filter: true
+#
 parameter:
 
 #

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -327,6 +327,10 @@ int ogs_app_context_parse_config(void)
                 } else if (!strcmp(parameter_key, "use_openair")) {
                     self.parameter.use_openair =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(
+                    parameter_key, "no_ipv4v6_local_addr_in_packet_filter")) {
+                    self.parameter.no_ipv4v6_local_addr_in_packet_filter =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else
                     ogs_warn("unknown key `%s`", parameter_key);
             }

--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -74,6 +74,7 @@ typedef struct ogs_app_context_s {
         int no_slaac;
 
         int use_openair;
+        int no_ipv4v6_local_addr_in_packet_filter;
     } parameter;
 
     ogs_sockopt_t sockopt;

--- a/src/pcrf/pcrf-rx-path.c
+++ b/src/pcrf/pcrf-rx-path.c
@@ -92,6 +92,8 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
 {
     int rv;
     int ret;
+    int len;
+    char *from_str, *to_str, *rx_flow;
 
 	struct msg *ans, *qry;
     struct avp *avpch1, *avpch2, *avpch3;
@@ -280,12 +282,42 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
                             ogs_flow_t *flow = &sub->flow
                                 [sub->num_of_flow];
 
-                            flow->description = ogs_malloc(
-                                    hdr->avp_value->os.len+1);
-                            ogs_cpystrn(
-                                flow->description,
-                                (char*)hdr->avp_value->os.data,
-                                hdr->avp_value->os.len+1);
+                            rx_flow = NULL;
+                            rx_flow = (char*)hdr->avp_value->os.data;
+                            len = hdr->avp_value->os.len;
+
+                            from_str = NULL;
+                            to_str = NULL;
+                            from_str = strstr(rx_flow, "from");
+                            ogs_assert(from_str);
+                            to_str = strstr(rx_flow, "to");
+                            ogs_assert(to_str);
+
+                            if (!strncmp(rx_flow,
+                                        "permit out", strlen("permit out"))) {
+
+                                flow->description = ogs_malloc(
+                                    len - strlen(to_str) + strlen("to any")+1);
+
+                                strncat(flow->description,
+                                    rx_flow,
+                                    len - strlen(to_str));
+                                strcat(flow->description, "to any");
+                            } else if (!strncmp(rx_flow,
+                                        "permit in", strlen("permit in"))) {
+
+                                flow->description = ogs_malloc(
+                                    len - strlen(from_str)
+                                    + strlen(to_str) + strlen("from any ")+1);
+
+                                strncat(flow->description,
+                                    rx_flow,
+                                    len - strlen(from_str));
+                                strcat(flow->description, "from any ");
+                                strncat(flow->description,
+                                    to_str,
+                                    strlen(to_str));
+                            }
 
                             sub->num_of_flow++;
                             break;


### PR DESCRIPTION
IE (IPV4-local-addr field ) is not supported on the LTE pre release-11 UEs, resulting in failure in establishing a VoLTE call in those devices. In order for the call to work the local address in packet filter must be replaced by any.