### PR TITLE
modify udr smf selection subscription data

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -1085,7 +1085,7 @@ static int parse_json(ogs_sbi_message_t *message,
                             }
                             break;
 
-                        CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
+                        CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA)
                             message->SmfSelectionSubscriptionData =
                                 OpenAPI_smf_selection_subscription_data_parseFromJSON(item);
                             if (!message->SmfSelectionSubscriptionData) {

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -97,6 +97,9 @@ extern "C" {
 #define OGS_SBI_RESOURCE_NAME_SM_DATA               "sm-data"
 #define OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA       "smf-select-data"
 #define OGS_SBI_RESOURCE_NAME_UE_CONTEXT_IN_SMF_DATA "ue-context-in-smf-data"
+#define OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA \
+                                            "smf-selection-subscription-data"
+
 #define OGS_SBI_SERVICE_NAME_NUDM_UEAU              "nudm-ueau"
 #define OGS_SBI_RESOURCE_NAME_SECURITY_INFORMATION  "security-information"
 #define OGS_SBI_RESOURCE_NAME_GENERATE_AUTH_DATA    "generate-auth-data"

--- a/src/udm/nudr-build.c
+++ b/src/udm/nudr-build.c
@@ -176,6 +176,10 @@ ogs_sbi_request_t *udm_nudr_dr_build_query_subscription_provisioned(
             memcpy(&sendmsg.param.single_nssai, &recvmsg->param.single_nssai,
                     sizeof(sendmsg.param.single_nssai));
         }
+	break;
+    CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
+        sendmsg.h.resource.component[4] =
+        (char *)OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA;
     DEFAULT
     END
 

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -545,7 +545,7 @@ bool udm_nudr_dr_handle_subscription_provisioned(
                 sendmsg.AccessAndMobilitySubscriptionData);
         break;
 
-    CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
+    CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA)
         OpenAPI_smf_selection_subscription_data_t *SmfSelectionSubscriptionData;
 
         SmfSelectionSubscriptionData = recvmsg->SmfSelectionSubscriptionData;

--- a/src/udr/nudr-handler.c
+++ b/src/udr/nudr-handler.c
@@ -423,7 +423,7 @@ bool udr_nudr_dr_handle_subscription_provisioned(
 
         break;
 
-    CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
+    CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA)
         OpenAPI_smf_selection_subscription_data_t SmfSelectionSubscriptionData;
 
         memset(&SmfSelectionSubscriptionData, 0,


### PR DESCRIPTION
As TS29.505  5.2.4 SmfSelectionSubscriptionData said:
{apiRoot}/nudr-dr/<apiVersion>/subscription-data/{ueId}/{servingPlmnId}/provisioned-data/smf-selection-subscription-data

UDM:  smf-select-data
UDR:  smf-selection-subscription-data