### PR TITLE
modify handover request and uplink ran status transfer debug info

### DIFF
--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -2266,7 +2266,7 @@ ogs_pkbuf_t *ngap_build_handover_command(ran_ue_t *source_ue)
     amf_ue = source_ue->amf_ue;
     ogs_assert(amf_ue);
 
-    ogs_debug("Handover request");
+    ogs_debug("Handover command");
 
     memset(&pdu, 0, sizeof (NGAP_NGAP_PDU_t));
     pdu.present = NGAP_NGAP_PDU_PR_successfulOutcome;

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2926,7 +2926,7 @@ void ngap_handle_uplink_ran_status_transfer(
         &initiatingMessage->value.choice.UplinkRANStatusTransfer;
     ogs_assert(UplinkRANStatusTransfer);
 
-    ogs_debug("Handover notify");
+    ogs_debug("Uplink ran status transfer");
 
     for (i = 0; i < UplinkRANStatusTransfer->protocolIEs.list.count; i++) {
         ie = UplinkRANStatusTransfer->protocolIEs.list.array[i];


### PR DESCRIPTION
ngap-build.c file:  ngap_build_handover_command,
```
ogs_debug("Handover request");
```

ngap-handler.c:  ngap_handle_uplink_ran_status_transfer
```
ogs_debug("Handover notify");
```