### PR TITLE
mask mongo credentials when logging

### DIFF
--- a/lib/dbi/ogs-mongoc.h
+++ b/lib/dbi/ogs-mongoc.h
@@ -42,6 +42,7 @@ typedef struct ogs_mongoc_s {
     } collection;
 } ogs_mongoc_t;
 
+const char* ogs_mask_db_uri(const char *db_uri);
 int ogs_mongoc_init(const char *db_uri);
 void ogs_mongoc_final(void);
 ogs_mongoc_t *ogs_mongoc(void);


### PR DESCRIPTION
When using credentials to connect to MongoDB, the credentials are leaked through the logs. This will mask the username and password in the logs if they're present.