### PR TITLE
use randomized strings for secrets

### DIFF
--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -1,5 +1,14 @@
 process.env.DB_URI = process.env.DB_URI || 'mongodb://localhost/open5gs';
 
+const crypto = require("crypto");
+if(!process.env.SECRET_KEY){
+  process.env.SECRET_KEY = crypto.randomBytes(32).toString('hex');
+}
+
+if(!process.env.JWT_SECRET_KEY){
+  process.env.JWT_SECRET_KEY = crypto.randomBytes(32).toString('hex');
+}
+
 const _hostname = process.env.HOSTNAME || '0.0.0.0';
 const port = process.env.PORT || 3000;
 
@@ -24,8 +33,7 @@ const LocalStrategy = require('passport-local').Strategy;
 
 const csrf = require('lusca').csrf();
 
-var crypto = require("crypto");
-const secret = process.env.SECRET_KEY || crypto.randomBytes(32).toString('hex');
+const secret = process.env.SECRET_KEY;
 
 const api = require('./routes');
 

--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -23,7 +23,9 @@ const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
 
 const csrf = require('lusca').csrf();
-const secret = process.env.SECRET_KEY || 'change-me';
+
+var crypto = require("crypto");
+const secret = process.env.SECRET_KEY || crypto.randomBytes(32).toString('hex');
 
 const api = require('./routes');
 

--- a/webui/server/routes/auth.js
+++ b/webui/server/routes/auth.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const passport = require('passport');
 
 const jwt = require('jsonwebtoken');
-const secret = process.env.JWT_SECRET_KEY || 'change-me';
+const secret = process.env.JWT_SECRET_KEY;
 
 router.get('/csrf', (req, res) => {
   return res.json({csrfToken: res.locals._csrf});

--- a/webui/server/routes/index.js
+++ b/webui/server/routes/index.js
@@ -4,7 +4,8 @@ const db = require('./db')
 
 const router = express.Router();
 
-const secret = process.env.JWT_SECRET_KEY || 'change-me';
+var crypto = require("crypto");
+const secret = process.env.JWT_SECRET_KEY || crypto.randomBytes(32).toString('hex');;
 const passport = require('passport');
 const JWTstrategy = require('passport-jwt').Strategy;
 const ExtractJWT = require('passport-jwt').ExtractJwt;

--- a/webui/server/routes/index.js
+++ b/webui/server/routes/index.js
@@ -4,8 +4,7 @@ const db = require('./db')
 
 const router = express.Router();
 
-var crypto = require("crypto");
-const secret = process.env.JWT_SECRET_KEY || crypto.randomBytes(32).toString('hex');;
+const secret = process.env.JWT_SECRET_KEY;
 const passport = require('passport');
 const JWTstrategy = require('passport-jwt').Strategy;
 const ExtractJWT = require('passport-jwt').ExtractJwt;


### PR DESCRIPTION
Instead of falling through to a predictable string for secrets this will use a string generated from 32 random bytes making it much harder for an attacker to spoof JWT tokens or crack password hashes. 