### PR TITLE
Added support for musl libc systems

### DIFF
--- a/lib/core/ogs-macros.h
+++ b/lib/core/ogs-macros.h
@@ -109,6 +109,8 @@ extern "C" {
 
 #elif defined(__FreeBSD__)
 #include <sys/endian.h>
+#elif ! defined(__GLIBC__)
+#include <endian.h>
 #endif
 
 #ifndef WORDS_BIGENDIAN
@@ -181,7 +183,7 @@ static ogs_inline ogs_uint24_t ogs_htobe24(ogs_uint24_t x)
 #endif
 
 #define ogs_container_of(ptr, type, member) \
-    (type *)((u_char *)ptr - offsetof(type, member))
+    (type *)((unsigned char *)ptr - offsetof(type, member))
 
 #ifndef SWITCH_CASE_INIT
 #define SWITCH_CASE_INIT

--- a/lib/ipfw/glue.h
+++ b/lib/ipfw/glue.h
@@ -71,8 +71,8 @@
 static __inline time_t
 _long_to_time(long tlong)
 {
-    if (sizeof(long) == sizeof(__int32_t))
-        return((time_t)(__int32_t)(tlong));
+    if (sizeof(long) == sizeof(u_int32_t))
+        return((time_t)(u_int32_t)(tlong));
     return((time_t)tlong);
 }
 
@@ -165,10 +165,14 @@ struct ether_addr * ether_aton(const char *a);
 
 #define ICMP6_MAXTYPE   201
 #define __u6_addr       in6_u
+#if !defined(__GLIBC__)
+#define in6_u __in6_union /* Adding support for musl libc netinet */
+#define __u6_addr32     s6_addr32
+#else
 #define in6_u __in6_u   /* missing type for ipv6 (linux 2.6.28) */
-
-
 #define __u6_addr32     u6_addr32
+#endif
+
 /* on freebsd sys/socket.h pf specific */
 #define NET_RT_IFLIST   3               /* survey interface list */
 

--- a/lib/ipfw/objs/include_e/netinet/ip_fw.h
+++ b/lib/ipfw/objs/include_e/netinet/ip_fw.h
@@ -517,12 +517,20 @@ typedef struct	_ipfw_insn_nat {
  	struct cfg_nat *nat;	
 } ipfw_insn_nat;
 
+#if !defined(__GLIBC__) /* Adding support for musl libc netint */
 /* Apply ipv6 mask on ipv6 addr */
+#define APPLY_MASK(addr,mask)                          \
+    (addr)->__u6_addr.__s6_addr32[0] &= (mask)->__u6_addr.__s6_addr32[0]; \
+    (addr)->__u6_addr.__s6_addr32[1] &= (mask)->__u6_addr.__s6_addr32[1]; \
+    (addr)->__u6_addr.__s6_addr32[2] &= (mask)->__u6_addr.__s6_addr32[2]; \
+    (addr)->__u6_addr.__s6_addr32[3] &= (mask)->__u6_addr.__s6_addr32[3];
+#else
 #define APPLY_MASK(addr,mask)                          \
     (addr)->__u6_addr.__u6_addr32[0] &= (mask)->__u6_addr.__u6_addr32[0]; \
     (addr)->__u6_addr.__u6_addr32[1] &= (mask)->__u6_addr.__u6_addr32[1]; \
     (addr)->__u6_addr.__u6_addr32[2] &= (mask)->__u6_addr.__u6_addr32[2]; \
     (addr)->__u6_addr.__u6_addr32[3] &= (mask)->__u6_addr.__u6_addr32[3];
+#endif
 
 /* Structure for ipv6 */
 typedef struct _ipfw_insn_ip6 {

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -165,7 +165,7 @@ ogs_sbi_client_t *ogs_sbi_client_find(ogs_sockaddr_t *addr)
 }
 
 #define mycase(code) \
-  case code: s = __STRING(code)
+  case code: s = (code)
 
 static void mcode_or_die(const char *where, CURLMcode code)
 {


### PR DESCRIPTION
Alpine Linux is one of the popular container Image's which is widely used. This PR add's support for systems built using musl libc such as Alpine Linux.

To Build on Alpine Linux follow the same process as documented in https://open5gs.org/open5gs/docs/guide/02-building-open5gs-from-sources/ the only change is as Alpine Linux uses `apk` package management tool need to install required tools on alpine Linux as follows.

`sudo apk add  alpine-sdk cmake yaml-dev lksctp-tools-dev mongo-c-driver  
                         mongo-c-driver-static libgcrypt-dev libidn-dev 
                         gnutls-dev nghttp2-dev libmicrohttpd-dev curl-dev musl-dev  
                         linux-headers lksctp-tools bsd-compat-headers git meson flex 
                         bison make`

Also if you are using Alpine Linux latest-stable (3.13) or > 3.9 you will need to install mangodb from Alpine Linux v3.8 repositories. 

I have tested this PR on Ubuntu Latest , Alpine Linux 3.8 up-to Alpine Linux 3.13 (latest-stable).  
