### PR TITLE
Support for IMS video calling

### DIFF
--- a/configs/open5gs/pcrf.yaml.in
+++ b/configs/open5gs/pcrf.yaml.in
@@ -41,7 +41,7 @@ pcrf:
 #      prefer_ipv4: true
 #
 #  o Legacy support for pre-release LTE 11 devices to do calling
-#    - Replace IPv4/v6 local addr field in AAR Media-Subcomponent AVP by any
+#    - Replace IPv4/v6 local addr field in AAR Media-Subcomponent AVP by any and port
 #      no_ipv4v6_local_addr_in_packet_filter: true
 #
 parameter:

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -95,7 +95,7 @@ static void encode_traffic_flow_template(
     while (pf) {
         tft->pf[i].direction = pf->direction;
         tft->pf[i].identifier = pf->identifier - 1;
-        tft->pf[i].precedence = i+1;
+        tft->pf[i].precedence = pf->precedence;
 
         ogs_pf_content_from_ipfw_rule(
                 pf->direction, &tft->pf[i].content, &pf->ipfw_rule);
@@ -119,6 +119,9 @@ void smf_bearer_binding(smf_sess_t *sess)
         ogs_gtp_header_t h;
         ogs_pkbuf_t *pkbuf = NULL;
         smf_bearer_t *bearer = NULL;
+
+        int total_num_of_pcc_rules = 0;
+        smf_bearer_t *pf_bearer = NULL;
 
         ogs_pcc_rule_t *pcc_rule = &sess->pcc_rule[i];
         int bearer_created = 0;
@@ -240,6 +243,11 @@ void smf_bearer_binding(smf_sess_t *sess)
             dl_pdr->num_of_flow = 0;
             ul_pdr->num_of_flow = 0;
 
+            // Compute total number of PCC rules for per DNN (used to set precedence)
+            ogs_list_for_each(&sess->bearer_list, pf_bearer) {
+                total_num_of_pcc_rules += ogs_list_count(&pf_bearer->pf_list);
+            }
+
             for (j = 0; j < pcc_rule->num_of_flow; j++) {
                 ogs_flow_t *flow = &pcc_rule->flow[j];
                 smf_pf_t *pf = NULL;
@@ -263,6 +271,7 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 pf->direction = flow->direction;
                 pf->flow_description = ogs_strdup(flow->description);
+                pf->precedence = total_num_of_pcc_rules + j;
 
                 rv = ogs_ipfw_compile_rule(
                         &pf->ipfw_rule, pf->flow_description);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -134,6 +134,8 @@ ED3(uint8_t spare:2;,
     uint8_t direction:2;,
     uint8_t identifier:4;)
 
+    uint8_t precedence;
+
     uint8_t *identifier_node;      /* Pool-Node for Identifier */
 
     ogs_ipfw_rule_t ipfw_rule;


### PR DESCRIPTION
The https://github.com/open5gs/open5gs/commit/6cde7e2eb5cb53e483f559688af8aaae18c39fa6 commit addresses the issue seen when a video call is attempted by IMS registered UEs

Since the precedence in a TFTs under a DNN was set 0 to number of flow rules received via Gx. The UE was requesting deletion of TFTs for the bearer serving the audio (QCI 1) whenever a video call/another dedicated bearer creation under the same DNN was attempted. As per Table 10.5.162/3GPP TS 24.008: Traffic flow template information element, 

> The packet filter evaluation precedence field is used to specify the precedence for the packet filter among all packet filters in all TFTs associated with this PDP address. Higher the value of the packet filter evaluation precedence field, lower the precedence of that packet filter is.

Therefore, there is a need to provide different precedence value to the TFTs than the already existing/created TFTs under the same DNN. With this fix UE no longer requests to delete the TFTs of existing bearer and video call is successful

The https://github.com/open5gs/open5gs/commit/12d1cc8c4508a607fc75f4cfb125f8d61021334d commit addresses the fix for pre-release LTE 11, where previously the local IP address field and port both were replaced by any. However, with this commit only local IP address is replaced by any and port is retained (better to preserve the port from the security perspective as well)

