### PR TITLE
fix: DRB lost issue when additional TFTs needs to be added to existing bearer with TFTs

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2177,6 +2177,21 @@ smf_pf_t *smf_pf_find_by_id(smf_bearer_t *bearer, uint8_t id)
     return NULL;
 }
 
+smf_pf_t *smf_pf_find_by_flow(
+    smf_bearer_t *bearer, uint8_t direction, char *flow_description)
+{
+    smf_pf_t *pf = NULL;
+
+    ogs_list_for_each(&bearer->pf_list, pf) {
+        if ((pf->direction == direction) &&
+            (!strcmp(pf->flow_description, flow_description))) {
+            return pf;
+        }
+    }
+
+    return NULL;
+}
+
 smf_pf_t *smf_pf_first(smf_bearer_t *bearer)
 {
     return ogs_list_first(&bearer->pf_list);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -407,6 +407,8 @@ smf_pf_t *smf_pf_add(smf_bearer_t *bearer);
 int smf_pf_remove(smf_pf_t *pf);
 void smf_pf_remove_all(smf_bearer_t *bearer);
 smf_pf_t *smf_pf_find_by_id(smf_bearer_t *smf_bearer, uint8_t id);
+smf_pf_t *smf_pf_find_by_flow(
+    smf_bearer_t *bearer, uint8_t direction, char *flow_description);
 smf_pf_t *smf_pf_first(smf_bearer_t *bearer);
 smf_pf_t *smf_pf_next(smf_pf_t *pf);
 


### PR DESCRIPTION
This commit address the issue where a bearer with particular
PCC rule name exists with TFTs and addtional TFTs needs to be added
to same bearer and DRB lost is reported by UE.

This is achieved by creating EPS Bearer Level Traffic Flow Template
with TFT operation code as 'OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT' in
above scenario rather than use 'OGS_GTP_TFT_CODE_CREATE_NEW_TFT' at all times.
And, not remove existing packet filters for the bearer.

Attaching the pcap containing the issue, observe that after packet 1883, the RTP packets are flowing over default bearer for IMS signalling
[drb_lost_before_fix.zip](https://github.com/open5gs/open5gs/files/6555182/drb_lost_before_fix.zip)
