### PR TITLE
add open5gs-dbctl back into apt packages

### DIFF
--- a/debian/open5gs-common.install
+++ b/debian/open5gs-common.install
@@ -3,4 +3,4 @@ usr/lib/*/libfd*.so*
 usr/lib/*/freeDiameter/*.fdx
 configs/freeDiameter/cacert.pem /etc/freeDiameter
 configs/logrotate/open5gs /etc/logrotate.d
-#misc/db/open5gs-dbctl /usr/bin
+misc/db/open5gs-dbctl /usr/bin


### PR DESCRIPTION
open5gs-dbctl used to be included with apt packages, but it looks like this was commented out in 9af4268bab01e59ea5ca7a61b0825bd534fb2726 when the DB schema was redesigned. Since then, bf5f64b5e59f5702339103e8b54919f234468023 updated open5gs-dbctl to work with the new schema, but forgot to put it back in the Debian packages. Best I can tell, this fix is good and it appears to work as intended.