### PR TITLE
need to return here to prevent segfault

### DIFF
--- a/lib/pfcp/rule-match.c
+++ b/lib/pfcp/rule-match.c
@@ -159,6 +159,7 @@ ogs_pfcp_rule_t *ogs_pfcp_pdr_rule_find_by_packet(
             ogs_error("Invalid packet [IP version:%d, Packet Length:%d]",
                     ip_h->ip_v, pkbuf->len);
             ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
+            return NULL;
         }
 
         ogs_debug("PROTO:%d SRC:%08x %08x %08x %08x",


### PR DESCRIPTION
I recently encountered a strange situation where the UPF was given a junk packet and segfaulted. I am still investigating the cause of the junk packet (looks like encapsulation, might have more PRs later) but in the meantime, the segfault was caused at line 198 as a result of calling src_addr[k] when src_addr was never set.

I dont know the exact pfcp logic and am not clear if we should return NULL or OGS_ERROR. This seemed correct but I defer to your wisdom. On a related note, I am assuming/hoping that we should free the packet somewhere else along the line to avoid leaks?