### PR TITLE
need to exit (and therefore restart HSS) on FD_LOG_FATAL

### DIFF
--- a/lib/diameter/common/init.c
+++ b/lib/diameter/common/init.c
@@ -136,6 +136,7 @@ static void diam_log_func(int printlevel, const char *format, va_list ap)
         break;
     case FD_LOG_FATAL:
         diam_log_printf(OGS_LOG_FATAL, "%s\n", buffer);
+        exit(1);
         break;
     default:
         diam_log_printf(OGS_LOG_ERROR, "[%d] %s\n", printlevel, buffer);


### PR DESCRIPTION
Occasionally, I have seen freeDiameter throw a FD_LOG_FATAL error at the HSS, which is defined to be a serious and unrecoverable error (see https://github.com/Metaswitch/freeDiameter/blob/master/include/freeDiameter/libfdproto.h). I am not sure the exact cause of this error, but I have observed it happening completely unprompted (i.e. not in response to a message from the MME).

When this error happens, freeDiameter essentially shuts down and the HSS is left in a "limbo" where it rejects all connections at the tranport layer (e.g. SCTP Abort or TCP Reset). From this state, the only way to recover appears to be by restarting the HSS.

I am continuing to investigate the true cause of these FD_LOG_FATAL errors. In the meantime, I believe that correct HSS behavior is to purposefully crash itself, so that systemctl restarts it into a working state. I know that adding such behavior into the log function is a bit unorthodox and not best practice, but I cannot find any other code that hooks into these FATAL messages sent from freeDiameter.