### PR TITLE
Bugfix reset type

### DIFF
--- a/lib/asn1c/ngap/NGAP_ResetType.h
+++ b/lib/asn1c/ngap/NGAP_ResetType.h
@@ -21,7 +21,6 @@ extern "C" {
 
 /* Dependencies */
 typedef enum NGAP_ResetType_PR {
-	NGAP_ResetType_PR_NOTHING,	/* No components present */
 	NGAP_ResetType_PR_nG_Interface,
 	NGAP_ResetType_PR_partOfNG_Interface,
 	NGAP_ResetType_PR_choice_Extensions

--- a/lib/asn1c/s1ap/S1AP_ResetType.h
+++ b/lib/asn1c/s1ap/S1AP_ResetType.h
@@ -21,7 +21,6 @@ extern "C" {
 
 /* Dependencies */
 typedef enum S1AP_ResetType_PR {
-	S1AP_ResetType_PR_NOTHING,	/* No components present */
 	S1AP_ResetType_PR_s1_Interface,
 	S1AP_ResetType_PR_partOfS1_Interface
 	/* Extensions may appear below */


### PR DESCRIPTION
Fixes the MME/AMF s1AP/NGAP RESET procedures when eNB/gNB sends ResetType set to partOfS1-Interface/Part of NG interface type