### PR TITLE
Fixes the stash smashing when number of PFs per bearer > 8

### DIFF
--- a/lib/pfcp/build.c
+++ b/lib/pfcp/build.c
@@ -238,7 +238,7 @@ ogs_pkbuf_t *ogs_pfcp_up_build_association_setup_response(uint8_t type,
 static struct {
     ogs_pfcp_f_teid_t f_teid;
     char dnn[OGS_MAX_DNN_LEN];
-    char *sdf_filter[OGS_MAX_NUM_OF_RULE];
+    char *sdf_filter[OGS_MAX_NUM_OF_PF];
 } pdrbuf[OGS_MAX_NUM_OF_PDR];
 
 void ogs_pfcp_pdrbuf_init(void)
@@ -250,7 +250,7 @@ void ogs_pfcp_pdrbuf_clear(void)
 {
     int i, j;
     for (i = 0; i < OGS_MAX_NUM_OF_PDR; i++) {
-        for (j = 0; j < OGS_MAX_NUM_OF_RULE; j++) {
+        for (j = 0; j < OGS_MAX_NUM_OF_PF; j++) {
             if (pdrbuf[i].sdf_filter[j])
                 ogs_free(pdrbuf[i].sdf_filter[j]);
         }
@@ -261,7 +261,7 @@ void ogs_pfcp_build_create_pdr(
     ogs_pfcp_tlv_create_pdr_t *message, int i, ogs_pfcp_pdr_t *pdr)
 {
     ogs_pfcp_far_t *far = NULL;
-    ogs_pfcp_sdf_filter_t pfcp_sdf_filter[OGS_MAX_NUM_OF_RULE];
+    ogs_pfcp_sdf_filter_t pfcp_sdf_filter[OGS_MAX_NUM_OF_PF];
     int j = 0;
     int len = 0;
 
@@ -376,7 +376,7 @@ void ogs_pfcp_build_created_pdr(
 void ogs_pfcp_build_update_pdr(
     ogs_pfcp_tlv_update_pdr_t *message, int i, ogs_pfcp_pdr_t *pdr)
 {
-    ogs_pfcp_sdf_filter_t pfcp_sdf_filter[OGS_MAX_NUM_OF_RULE];
+    ogs_pfcp_sdf_filter_t pfcp_sdf_filter[OGS_MAX_NUM_OF_PF];
     int j = 0;
     int len = 0;
 

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -79,7 +79,7 @@ void ogs_pfcp_context_init(void)
             ogs_app()->pool.sess * OGS_MAX_NUM_OF_BAR);
 
     ogs_pool_init(&ogs_pfcp_rule_pool,
-            ogs_app()->pool.sess * OGS_MAX_NUM_OF_RULE);
+            ogs_app()->pool.sess * OGS_MAX_NUM_OF_PF);
 
     ogs_pool_init(&ogs_pfcp_dev_pool, OGS_MAX_NUM_OF_DEV);
     ogs_pool_init(&ogs_pfcp_subnet_pool, OGS_MAX_NUM_OF_SUBNET);

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -173,7 +173,7 @@ typedef struct ogs_pfcp_pdr_s {
     ogs_pfcp_qer_t          *qer;
 
     int                     num_of_flow;
-    char                    *flow_description[OGS_MAX_NUM_OF_RULE];
+    char                    *flow_description[OGS_MAX_NUM_OF_PF];
 
     ogs_list_t              rule_list;      /* Rule List */
 

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -313,7 +313,7 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_create_pdr(ogs_pfcp_sess_t *sess,
 
     ogs_pfcp_rule_remove_all(pdr);
 
-    for (i = 0; i < OGS_MAX_NUM_OF_RULE; i++) {
+    for (i = 0; i < OGS_MAX_NUM_OF_PF; i++) {
         ogs_pfcp_sdf_filter_t sdf_filter;
         ogs_pfcp_rule_t *rule = NULL;
         ogs_pfcp_rule_t *oppsite_direction_rule = NULL;
@@ -558,7 +558,7 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_update_pdr(ogs_pfcp_sess_t *sess,
 
         ogs_pfcp_rule_remove_all(pdr);
 
-        for (i = 0; i < OGS_MAX_NUM_OF_RULE; i++) {
+        for (i = 0; i < OGS_MAX_NUM_OF_PF; i++) {
             ogs_pfcp_sdf_filter_t sdf_filter;
             ogs_pfcp_rule_t *rule = NULL;
             ogs_pfcp_rule_t *oppsite_direction_rule = NULL;

--- a/lib/pfcp/message.h
+++ b/lib/pfcp/message.h
@@ -626,7 +626,7 @@ typedef struct ogs_pfcp_tlv_ethernet_packet_filter_s {
     ogs_pfcp_tlv_ethertype_t ethertype;
     ogs_pfcp_tlv_c_tag_t c_tag;
     ogs_pfcp_tlv_s_tag_t s_tag;
-    ogs_pfcp_tlv_sdf_filter_t sdf_filter[8];
+    ogs_pfcp_tlv_sdf_filter_t sdf_filter[OGS_MAX_NUM_OF_PF];
 } ogs_pfcp_tlv_ethernet_packet_filter_t;
 
 typedef struct ogs_pfcp_tlv_pdi_s {
@@ -636,7 +636,7 @@ typedef struct ogs_pfcp_tlv_pdi_s {
     ogs_pfcp_tlv_network_instance_t network_instance;
     ogs_pfcp_tlv_ue_ip_address_t ue_ip_address;
     ogs_pfcp_tlv_traffic_endpoint_id_t traffic_endpoint_id;
-    ogs_pfcp_tlv_sdf_filter_t sdf_filter[8];
+    ogs_pfcp_tlv_sdf_filter_t sdf_filter[OGS_MAX_NUM_OF_PF];
     ogs_pfcp_tlv_application_id_t application_id;
     ogs_pfcp_tlv_ethernet_pdu_session_information_t ethernet_pdu_session_information;
     ogs_pfcp_tlv_ethernet_packet_filter_t ethernet_packet_filter;


### PR DESCRIPTION
@acetcom I am attaching the trace where I see the issue of stack smashing on SMF along with its logs, please let me know what you think of this fix.

In the trace attached, the UE with IP 10.46.0.3 already has 8 PFs for E-RAB ID 7 and when 4 more new Flow rules need to be added SMF crashes (after receiving Update Bearer Response in packet 12132)

[smf_log_pcap.zip](https://github.com/open5gs/open5gs/files/6868668/smf_log_pcap.zip)
