### PR TITLE
Replace tfts if Flow-Information AVP is received via Gx

### DIFF
--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -214,6 +214,13 @@ void smf_bearer_binding(smf_sess_t *sess)
             } else {
                 ogs_assert(strcmp(bearer->pcc_rule.name, pcc_rule->name) == 0);
 
+                if (pcc_rule->num_of_flow) {
+                    /* We'll use always 'Create new TFT'.
+                     * Therefore, all previous flows are removed
+                     * and replaced by the new flow */
+                    smf_pf_remove_all(bearer);
+                }
+
                 if ((pcc_rule->qos.mbr.downlink &&
                     bearer->qos.mbr.downlink != pcc_rule->qos.mbr.downlink) ||
                     (pcc_rule->qos.mbr.uplink &&
@@ -339,7 +346,7 @@ void smf_bearer_binding(smf_sess_t *sess)
                 if (pcc_rule->num_of_flow)
                     encode_traffic_flow_template(
                         &tft, bearer,
-                        OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT);
+                        OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING);
 
                 memset(&h, 0, sizeof(ogs_gtp_header_t));
                 h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
@@ -501,6 +508,13 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
                 ogs_assert_if_reached();
                 ogs_assert(strcmp(qos_flow->pcc_rule.id, pcc_rule->id) == 0);
 
+                if (pcc_rule->num_of_flow) {
+                    /* We'll use always 'Create new TFT'.
+                     * Therefore, all previous flows are removed
+                     * and replaced by the new flow */
+                    smf_pf_remove_all(qos_flow);
+                }
+
                 if ((pcc_rule->qos.mbr.downlink &&
                     qos_flow->qos.mbr.downlink != pcc_rule->qos.mbr.downlink) ||
                     (pcc_rule->qos.mbr.uplink &&
@@ -629,7 +643,7 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
                 if (pcc_rule->num_of_flow)
                     encode_traffic_flow_template(
                         &tft, qos_flow,
-                        OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT);
+                        OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING);
 
                 memset(&h, 0, sizeof(ogs_gtp_header_t));
                 h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -124,6 +124,8 @@ void smf_bearer_binding(smf_sess_t *sess)
         int bearer_created = 0;
         int qos_presence = 0;
 
+        ogs_gtp_tft_t remove_tft;
+
         ogs_assert(pcc_rule);
         if (pcc_rule->name == NULL) {
             ogs_error("No PCC Rule Name");
@@ -215,10 +217,12 @@ void smf_bearer_binding(smf_sess_t *sess)
                 ogs_assert(strcmp(bearer->pcc_rule.name, pcc_rule->name) == 0);
 
                 if (pcc_rule->num_of_flow) {
-                    /* We'll use always 'Create new TFT'.
-                     * Therefore, all previous flows are removed
-                     * and replaced by the new flow */
-                    smf_pf_remove_all(bearer);
+                    /* Backup exisiting TFTs to be removed later */
+                    memset(&remove_tft, 0, sizeof remove_tft);
+                    if (pcc_rule->num_of_flow)
+                        encode_traffic_flow_template(
+                            &remove_tft, bearer,
+                            OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING);
                 }
 
                 if ((pcc_rule->qos.mbr.downlink &&
@@ -259,11 +263,6 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 ogs_expect_or_return(flow);
                 ogs_expect_or_return(flow->description);
-
-                if (smf_pf_find_by_flow(
-                    bearer, flow->direction, flow->description) != NULL) {
-                    continue;
-                }
 
                 if (flow->direction == OGS_FLOW_DOWNLINK_ONLY) {
                     dl_pdr->flow_description[dl_pdr->num_of_flow++] =
@@ -346,7 +345,7 @@ void smf_bearer_binding(smf_sess_t *sess)
                 if (pcc_rule->num_of_flow)
                     encode_traffic_flow_template(
                         &tft, bearer,
-                        OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING);
+                        OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT);
 
                 memset(&h, 0, sizeof(ogs_gtp_header_t));
                 h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
@@ -369,6 +368,38 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 rv = ogs_gtp_xact_commit(xact);
                 ogs_expect(rv == OGS_OK);
+
+                /* Remove old TFTs */
+                if (pcc_rule->num_of_flow) {
+                    smf_pf_t *pf = NULL;
+                    /*
+                     * If Flow-Information AVP is received over Gx
+                     * All previous flows are removed and replaced by the new flow
+                     */
+                    for (i = 0; i < remove_tft.num_of_packet_filter; i++) {
+                        pf = smf_pf_find_by_id(bearer, remove_tft.pf[i].identifier+1);
+                        if (pf)
+                            smf_pf_remove(pf);
+                    }
+
+                    memset(&h, 0, sizeof(ogs_gtp_header_t));
+                    h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
+                    h.teid = sess->sgw_s5c_teid;
+
+                    pkbuf = smf_s5c_build_update_bearer_request(
+                            h.type, bearer,
+                            OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
+                            remove_tft.num_of_packet_filter ? &remove_tft : NULL,
+                            qos_presence);
+                    ogs_expect_or_return(pkbuf);
+
+                    xact = ogs_gtp_xact_local_create(
+                            sess->gnode, &h, pkbuf, bearer_timeout, bearer);
+                    ogs_expect_or_return(xact);
+
+                    rv = ogs_gtp_xact_commit(xact);
+                    ogs_expect(rv == OGS_OK);
+                }
             }
 
         } else if (pcc_rule->type == OGS_PCC_RULE_TYPE_REMOVE) {
@@ -436,6 +467,7 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
 #if 0
         ogs_gtp_header_t h;
         ogs_pkbuf_t *pkbuf = NULL;
+        ogs_gtp_tft_t remove_tft;
 #endif
         smf_bearer_t *qos_flow = NULL;
 
@@ -508,12 +540,16 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
                 ogs_assert_if_reached();
                 ogs_assert(strcmp(qos_flow->pcc_rule.id, pcc_rule->id) == 0);
 
+#if 0
                 if (pcc_rule->num_of_flow) {
-                    /* We'll use always 'Create new TFT'.
-                     * Therefore, all previous flows are removed
-                     * and replaced by the new flow */
-                    smf_pf_remove_all(qos_flow);
+                    /* Backup exisiting TFTs to be removed later */
+                    memset(&remove_tft, 0, sizeof remove_tft);
+                    if (pcc_rule->num_of_flow)
+                        encode_traffic_flow_template(
+                            &remove_tft, qos_flow,
+                            OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING);
                 }
+#endif
 
                 if ((pcc_rule->qos.mbr.downlink &&
                     qos_flow->qos.mbr.downlink != pcc_rule->qos.mbr.downlink) ||
@@ -553,11 +589,6 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
 
                 ogs_expect_or_return(flow);
                 ogs_expect_or_return(flow->description);
-
-                if (smf_pf_find_by_flow(
-                    qos_flow, flow->direction, flow->description) != NULL) {
-                    continue;
-                }
 
                 if (flow->direction == OGS_FLOW_DOWNLINK_ONLY) {
                     dl_pdr->flow_description[dl_pdr->num_of_flow++] =
@@ -643,7 +674,7 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
                 if (pcc_rule->num_of_flow)
                     encode_traffic_flow_template(
                         &tft, qos_flow,
-                        OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING);
+                        OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT);
 
                 memset(&h, 0, sizeof(ogs_gtp_header_t));
                 h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
@@ -666,6 +697,38 @@ void smf_qos_flow_binding(smf_sess_t *sess, ogs_sbi_stream_t *stream)
 
                 rv = ogs_gtp_xact_commit(xact);
                 ogs_expect(rv == OGS_OK);
+
+                /* Remove old TFTs */
+                if (pcc_rule->num_of_flow) {
+                    smf_pf_t *pf = NULL;
+                    /*
+                     * If Flow-Information AVP is received over Gx
+                     * All previous flows are removed and replaced by the new flow
+                     */
+                    for (i = 0; i < remove_tft.num_of_packet_filter; i++) {
+                        pf = smf_pf_find_by_id(qos_flow, remove_tft.pf[i].identifier+1);
+                        if (pf)
+                            smf_pf_remove(pf);
+                    }
+
+                    memset(&h, 0, sizeof(ogs_gtp_header_t));
+                    h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
+                    h.teid = sess->sgw_s5c_teid;
+
+                    pkbuf = smf_s5c_build_update_qos_flow_request(
+                            h.type, qos_flow,
+                            OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
+                            remove_tft.num_of_packet_filter ? &remove_tft : NULL,
+                            qos_presence);
+                    ogs_expect_or_return(pkbuf);
+
+                    xact = ogs_gtp_xact_local_create(
+                            sess->gnode, &h, pkbuf, qos_flow_timeout, qos_flow);
+                    ogs_expect_or_return(xact);
+
+                    rv = ogs_gtp_xact_commit(xact);
+                    ogs_expect(rv == OGS_OK);
+                }
 #endif
             }
         } else if (pcc_rule->type == OGS_PCC_RULE_TYPE_REMOVE) {


### PR DESCRIPTION
As per ETSI TS 129 212 V15.9.0, Section 5.3.4,  If Flow-Information AVP(s) are supplied,
they replace all previous Flow-Information AVP(s). Therefore, rather than adding to exisiting TFTs,
they must be replaced

This is achieved by first sending UPDATE BEARER REQUEST with TFT OPERATION SET to OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT for new Packet Filters and then issue UPDATE BEARER REQUEST with TFT OPERATION SET to OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING for old Packet Filters.

OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING was not used as its a bit tricky in scenarios where there are 2 existing Packet Filters and there are 4 new Flow Rules issued from PCRF to SMF i.e. inconsistency between number of existing Packet Filters to number of new Packet Filters to be replaced with