### PR TITLE
Increase cluster_2048_pool to 1024

### DIFF
--- a/lib/core/ogs-pkbuf.c
+++ b/lib/core/ogs-pkbuf.c
@@ -96,7 +96,7 @@ void ogs_pkbuf_default_init(ogs_pkbuf_config_t *config)
     config->cluster_256_pool = 16384;
     config->cluster_512_pool = 4096;
     config->cluster_1024_pool = 2048;
-    config->cluster_2048_pool = 512;
+    config->cluster_2048_pool = 1024;
     config->cluster_8192_pool = 512;
     config->cluster_big_pool = 8;
 }


### PR DESCRIPTION
Observed following error while bringing up 1000 simultaneous sessions on K8s cluster:
```
^[[32m08/22 22:30:43.554^[[0m: [^[[33mmem^[[0m] ^[[1;33mERROR^[[0m: cluster_alloc: Expectation `buffer' failed. (../lib/core/ogs-pkbuf.c:310)
^[[32m08/22 22:30:43.554^[[0m: [^[[33mmem^[[0m] ^[[1;33mERROR^[[0m: ogs_pkbuf_alloc() failed [size=1255] (../lib/core/ogs-pkbuf.c:198)
^[[32m08/22 22:30:43.554^[[0m: [^[[33mmem^[[0m] ^[[1;33mERROR^[[0m: ogs_malloc_debug: Expectation `pkbuf' failed. (../lib/core/ogs-memory.c:38)
^[[32m08/22 22:30:43.554^[[0m: [^[[33mcore^[[0m] ^[[1;33mERROR^[[0m: ogs_memdup_debug: Expectation `res' failed. (../lib/core/ogs-strings.c:165)
^[[32m08/22 22:30:43.554^[[0m: [^[[33mcore^[[0m] ^[[1;33mERROR^[[0m: ogs_strdup_debug: Expectation `res' failed. (../lib/core/ogs-strings.c:133)
```
Increasing cluster_2048_pool to 1024 resolved the issue.