### PR TITLE
Improve open5gs-dbctl

### DIFF
--- a/misc/db/open5gs-dbctl
+++ b/misc/db/open5gs-dbctl
@@ -4,6 +4,7 @@ version=0.9.1
 
 display_help() {
     echo "open5gs-dbctl: Open5GS Database Configuration Tool ($version)"
+	echo "FLAGS: --db_uri=mongodb://localhost"
     echo "COMMANDS:" >&2
     echo "   add {imsi key opc}: adds a user to the database with default values"
 	echo "   add {imsi ip key opc}: adds a user to the database with default values and a IPv4 address for the UE"
@@ -18,6 +19,19 @@ display_help() {
     echo "   default values are as follows: APN \"internet\", dl_bw/ul_bw 1 Gbps, PGW address is 127.0.0.3, IPv4 only"
 }
 
+while test $# -gt 0; do
+  case "$1" in
+    --db_uri*)
+      DB_URI=`echo $1 | sed -e 's/^[^=]*=//g'`
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+DB_URI="${DB_URI:-mongodb://localhost/open5gs}"
 
 if [ "$#" -lt 1 ]; then
 	display_help
@@ -86,7 +100,7 @@ if [ "$1" = "add" ]; then
 					\"__v\" : 0
 				},  
 			},
-			upsert=true);" open5gs
+			upsert=true);"$DB_URI
 		exit $?
 	fi
 
@@ -151,7 +165,7 @@ if [ "$1" = "add" ]; then
 					\"__v\" : 0
 				},  
 			},
-			upsert=true);" open5gs
+			upsert=true);"$DB_URI
 		exit $?
 	fi
 
@@ -256,7 +270,7 @@ if [ "$1" = "addT1" ]; then
 					\"__v\" : 0
 				},  
 			},
-			upsert=true);" open5gs
+			upsert=true);"$DB_URI
 		exit $?
 	fi
 
@@ -369,7 +383,7 @@ if [ "$1" = "addT1" ]; then
 					\"__v\" : 0
 				},  
 			},
-			upsert=true);" open5gs
+			upsert=true);"$DB_URI
 		exit $?
 	fi
 
@@ -384,7 +398,7 @@ if [ "$1" = "remove" ]; then
 	fi
 
 	IMSI=$2 
-	mongo --eval "db.subscribers.remove({\"imsi\": \"$IMSI\"});" open5gs
+	mongo --eval "db.subscribers.remove({\"imsi\": \"$IMSI\"});"$DB_URI
 	exit $?
 fi
 
@@ -394,7 +408,7 @@ if [ "$1" = "reset" ]; then
 		exit 1
 	fi
 
-	mongo --eval "db.subscribers.remove({});" open5gs
+	mongo --eval "db.subscribers.remove({});"$DB_URI
 	exit $?
 fi
 
@@ -406,7 +420,7 @@ if [ "$1" = "static_ip" ]; then
 	IMSI=$2 
 	IP=$3
 
-	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr\": \"$IP\" }});" open5gs
+	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr\": \"$IP\" }});"$DB_URI
 	exit $?
 fi
 
@@ -418,7 +432,7 @@ if [ "$1" = "static_ip6" ]; then
 	IMSI=$2 
 	IP=$3
 
-	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr6\": \"$IP\" }});" open5gs
+	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr6\": \"$IP\" }});"$DB_URI
 	exit $?
 fi
 
@@ -430,7 +444,7 @@ if [ "$1" = "type" ]; then
 	IMSI=$2 
 	TYPE=$3
 
-	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.type\": NumberInt($TYPE) }});" open5gs
+	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.type\": NumberInt($TYPE) }});"$DB_URI
 	exit $?
 fi
 

--- a/misc/db/open5gs-dbctl
+++ b/misc/db/open5gs-dbctl
@@ -87,7 +87,7 @@ if [ "$1" = "add" ]; then
 				},  
 			},
 			upsert=true);" open5gs
-		exit 0
+		exit $?
 	fi
 
 	if [ "$#" -eq 5 ]; then
@@ -152,7 +152,7 @@ if [ "$1" = "add" ]; then
 				},  
 			},
 			upsert=true);" open5gs
-		exit 0
+		exit $?
 	fi
 
 	echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl add imsi key opc\""
@@ -257,7 +257,7 @@ if [ "$1" = "addT1" ]; then
 				},  
 			},
 			upsert=true);" open5gs
-		exit 0
+		exit $?
 	fi
 
 	if [ "$#" -eq 5 ]; then
@@ -370,7 +370,7 @@ if [ "$1" = "addT1" ]; then
 				},  
 			},
 			upsert=true);" open5gs
-		exit 0
+		exit $?
 	fi
 
 	echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl add imsi key opc\""
@@ -385,7 +385,7 @@ if [ "$1" = "remove" ]; then
 
 	IMSI=$2 
 	mongo --eval "db.subscribers.remove({\"imsi\": \"$IMSI\"});" open5gs
-	exit 0
+	exit $?
 fi
 
 if [ "$1" = "reset" ]; then
@@ -395,7 +395,7 @@ if [ "$1" = "reset" ]; then
 	fi
 
 	mongo --eval "db.subscribers.remove({});" open5gs
-	exit 0
+	exit $?
 fi
 
 if [ "$1" = "static_ip" ]; then
@@ -407,7 +407,7 @@ if [ "$1" = "static_ip" ]; then
 	IP=$3
 
 	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr\": \"$IP\" }});" open5gs
-	exit 0
+	exit $?
 fi
 
 if [ "$1" = "static_ip6" ]; then
@@ -419,7 +419,7 @@ if [ "$1" = "static_ip6" ]; then
 	IP=$3
 
 	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.ue.addr6\": \"$IP\" }});" open5gs
-	exit 0
+	exit $?
 fi
 
 if [ "$1" = "type" ]; then
@@ -431,7 +431,7 @@ if [ "$1" = "type" ]; then
 	TYPE=$3
 
 	mongo --eval "db.subscribers.update({\"imsi\": \"$IMSI\"},{\$set: { \"slice.0.session.0.type\": NumberInt($TYPE) }});" open5gs
-	exit 0
+	exit $?
 fi
 
 display_help


### PR DESCRIPTION
This PR fix the exit code of open5gs-dbctl. Before is always 0, now It is the same exit code as the call to the mongo cli.

The PR also enable the control of mongodb other than localhost. You can provide a mongodb uri through the env variable DB_URI or the flag `--db_uri='. flag takes precedence over env variable. If none is provided, the default value is the same as before (mongodb://localhost/open5gs).