### PR TITLE
Remove Diameter dependencies from upf

### DIFF
--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -27,7 +27,6 @@
 #endif
 
 #include "ogs-gtp.h"
-#include "ogs-diameter-gx.h"
 #include "ogs-pfcp.h"
 #include "ogs-app.h"
 

--- a/src/upf/meson.build
+++ b/src/upf/meson.build
@@ -87,7 +87,6 @@ libupf = static_library('upf',
     sources : libupf_sources,
     dependencies : [
         libapp_dep,
-        libdiameter_gx_dep,
         libgtp_dep,
         libpfcp_dep,
         libtun_dep,
@@ -99,7 +98,6 @@ libupf_dep = declare_dependency(
     link_with : libupf,
     dependencies : [
         libapp_dep,
-        libdiameter_gx_dep,
         libgtp_dep,
         libpfcp_dep,
         libtun_dep,


### PR DESCRIPTION
The UPF currently includes a dependency to Diameter (specifically the Gx interface) that isn't needed. Best I can tell, Gx interface connects the old PGW-C (now the SMF) to the PCRF, so my guess is that this got left behind during the CUPS refactoring. I already checked that the UPF does not have any Diameter code and removing these dependencies does not appear to create any errors.

The reason I care about this is because I'm currently working to build a very lightweight open5gs User Plane Server (just the SGWU and UPF) and our target environment (OpenWRT) does not support Diameter.

Thanks a ton for all your hard work!
Spencer