### PR TITLE
Minor fixes: instance extraction & python generator

### DIFF
--- a/lib/core/ogs-tlv.c
+++ b/lib/core/ogs-tlv.c
@@ -227,7 +227,7 @@ static uint8_t *tlv_get_element(ogs_tlv_t *tlv, uint8_t *blk, uint8_t mode)
         tlv->type = *(pos++);
         tlv->length = *(pos++) << 8;
         tlv->length += *(pos++);
-        tlv->instance = *(pos++);
+        tlv->instance = *(pos++) & 0b00001111;
         break;
     case OGS_TLV_MODE_T2_L2:
         tlv->type = *(pos++) << 8;

--- a/lib/gtp/message.h
+++ b/lib/gtp/message.h
@@ -270,7 +270,7 @@ typedef struct ogs_gtp_header_s {
 #define OGS_GTP_BIT_RATE_TYPE 211
 #define OGS_GTP_PC5_QOS_FLOW_TYPE 212
 
-/* Infomration Element TLV Descriptor */
+/* Information Element TLV Descriptor */
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_imsi_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_cause_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_recovery_0;
@@ -428,7 +428,7 @@ extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_1;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_flow_0;
 
-/* Group Infomration Element TLV Descriptor */
+/* Group Information Element TLV Descriptor */
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0;
@@ -498,7 +498,7 @@ extern ogs_tlv_desc_t ogs_gtp_tlv_desc_update_pdn_connection_set_response;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_request;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_response;
 
-/* Structure for Infomration Element */
+/* Structure for Information Element */
 typedef ogs_tlv_octet_t ogs_gtp_tlv_imsi_t;
 typedef ogs_tlv_octet_t ogs_gtp_tlv_cause_t;
 typedef ogs_tlv_uint8_t ogs_gtp_tlv_recovery_t;
@@ -627,7 +627,7 @@ typedef ogs_tlv_octet_t ogs_gtp_tlv_services_authorized_t;
 typedef ogs_tlv_octet_t ogs_gtp_tlv_bit_rate_t;
 typedef ogs_tlv_octet_t ogs_gtp_tlv_pc5_qos_flow_t;
 
-/* Structure for Group Infomration Element */
+/* Structure for Group Information Element */
 typedef struct ogs_gtp_tlv_pc5_qos_parameters_s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_pc5_qos_flow_t pc5_qos_flows;

--- a/lib/gtp/support/gtp-tlv.py
+++ b/lib/gtp/support/gtp-tlv.py
@@ -155,7 +155,7 @@ for o, a in opts:
         if outdir.rfind('/') != len(outdir):
             outdir += '/'
     if o in ("-c", "--cache"):
-        cache = a
+        cachedir = a
         if cachedir.rfind('/') != len(cachedir):
             cachedir += '/'
     if o in ("-h", "--help"):
@@ -457,7 +457,7 @@ for (k, v) in sorted_type_list:
     f.write("#define OGS_GTP_" + v_upper(k) + "_TYPE " + v + "\n")
 f.write("\n")
 
-f.write("/* Infomration Element TLV Descriptor */\n")
+f.write("/* Information Element TLV Descriptor */\n")
 for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
@@ -475,7 +475,7 @@ for k, v in group_list.items():
 tmp = [(k, v["index"]) for k, v in group_list.items()]
 sorted_group_list = sorted(tmp, key=lambda tup: int(tup[1]))
 
-f.write("/* Group Infomration Element TLV Descriptor */\n")
+f.write("/* Group Information Element TLV Descriptor */\n")
 for (k, v) in sorted_group_list:
     for instance in range(0, int(type_list[k]["max_instance"])+1):
         f.write("extern ogs_tlv_desc_t ogs_gtp_tlv_desc_" + v_lower(k))
@@ -487,7 +487,7 @@ for (k, v) in sorted_msg_list:
     f.write("extern ogs_tlv_desc_t ogs_gtp_tlv_desc_" + v_lower(k) + ";\n")
 f.write("\n")
 
-f.write("/* Structure for Infomration Element */\n")
+f.write("/* Structure for Information Element */\n")
 for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
@@ -506,7 +506,7 @@ for (k, v) in sorted_type_list:
         f.write("typedef ogs_tlv_octet_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
 f.write("\n")
 
-f.write("/* Structure for Group Infomration Element */\n")
+f.write("/* Structure for Group Information Element */\n")
 for (k, v) in sorted_group_list:
     f.write("typedef struct ogs_gtp_tlv_" + v_lower(k) + "_s {\n")
     f.write("    ogs_tlv_presence_t presence;\n")

--- a/lib/pfcp/message.h
+++ b/lib/pfcp/message.h
@@ -270,7 +270,7 @@ typedef struct ogs_pfcp_header_s {
 #define OGS_PFCP_SMF_SET_ID_TYPE 180
 #define OGS_PFCP_QUOTA_VALIDITY_TIME_TYPE 181
 
-/* Infomration Element TLV Descriptor */
+/* Information Element TLV Descriptor */
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_cause;
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_source_interface;
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_f_teid;
@@ -407,7 +407,7 @@ extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_packet_replication_and_detection_carry_o
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_smf_set_id;
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_quota_validity_time;
 
-/* Group Infomration Element TLV Descriptor */
+/* Group Information Element TLV Descriptor */
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_ethernet_packet_filter;
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_pdi;
 extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_create_pdr;
@@ -480,7 +480,7 @@ extern ogs_tlv_desc_t ogs_pfcp_msg_desc_pfcp_session_deletion_response;
 extern ogs_tlv_desc_t ogs_pfcp_msg_desc_pfcp_session_report_request;
 extern ogs_tlv_desc_t ogs_pfcp_msg_desc_pfcp_session_report_response;
 
-/* Structure for Infomration Element */
+/* Structure for Information Element */
 typedef ogs_tlv_uint8_t ogs_pfcp_tlv_cause_t;
 typedef ogs_tlv_uint8_t ogs_pfcp_tlv_source_interface_t;
 typedef ogs_tlv_octet_t ogs_pfcp_tlv_f_teid_t;
@@ -617,7 +617,7 @@ typedef ogs_tlv_octet_t ogs_pfcp_tlv_packet_replication_and_detection_carry_on_i
 typedef ogs_tlv_octet_t ogs_pfcp_tlv_smf_set_id_t;
 typedef ogs_tlv_uint32_t ogs_pfcp_tlv_quota_validity_time_t;
 
-/* Structure for Group Infomration Element */
+/* Structure for Group Information Element */
 typedef struct ogs_pfcp_tlv_ethernet_packet_filter_s {
     ogs_tlv_presence_t presence;
     ogs_pfcp_tlv_ethernet_filter_id_t ethernet_filter_id;

--- a/lib/pfcp/support/pfcp-tlv.py
+++ b/lib/pfcp/support/pfcp-tlv.py
@@ -493,7 +493,7 @@ for (k, v) in sorted_type_list:
     f.write("#define OGS_PFCP_" + v_upper(k) + "_TYPE " + v + "\n")
 f.write("\n")
 
-f.write("/* Infomration Element TLV Descriptor */\n")
+f.write("/* Information Element TLV Descriptor */\n")
 for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
@@ -537,7 +537,7 @@ for k, v in group_list.items():
 tmp = [(k, v["index"]) for k, v in group_list.items()]
 sorted_group_list = sorted(tmp, key=lambda tup: int(tup[1]), reverse=False)
 
-f.write("/* Group Infomration Element TLV Descriptor */\n")
+f.write("/* Group Information Element TLV Descriptor */\n")
 for (k, v) in sorted_group_list:
     f.write("extern ogs_tlv_desc_t ogs_pfcp_tlv_desc_" + v_lower(k) + ";\n")
 f.write("\n")
@@ -547,7 +547,7 @@ for (k, v) in sorted_msg_list:
     f.write("extern ogs_tlv_desc_t ogs_pfcp_msg_desc_" + v_lower(k) + ";\n")
 f.write("\n")
 
-f.write("/* Structure for Infomration Element */\n")
+f.write("/* Structure for Information Element */\n")
 for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
@@ -567,7 +567,7 @@ for (k, v) in sorted_type_list:
 f.write("\n")
 
 tmp = []
-f.write("/* Structure for Group Infomration Element */\n")
+f.write("/* Structure for Group Information Element */\n")
 for (k, v) in sorted_group_list:
     f.write("typedef struct ogs_pfcp_tlv_" + v_lower(k) + "_s {\n")
     f.write("    ogs_tlv_presence_t presence;\n")

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -174,7 +174,7 @@ typedef struct smf_bearer_s {
         char        *name;          /* EPC: PCC Rule Name */
         char        *id;            /* 5GC: PCC Rule Id */
     } pcc_rule;
-    ogs_qos_t       qos;            /* QoS Infomration */
+    ogs_qos_t       qos;            /* QoS Information */
 
     OGS_POOL(pf_identifier_pool, uint8_t);
 


### PR DESCRIPTION
This PR fixes some **non-trivial** nits observed during #1201 debug.

 - Proper instance mask, `instance` are always the lower 4 bits [see 3GPP TS 29.274 *"Spare and Instance fields"*]
 
![3gpp-instance](https://user-images.githubusercontent.com/3974360/138564110-15229d1d-57c5-4d28-a3a6-9493703770a6.png)

 - Fix [gtp-tlv.py](https://github.com/open5gs/open5gs/blob/main/lib/gtp/support/gtp-tlv.py) `-c cachedir` CLI option and some more minor typos.

@acetcom 
Cc: @cbrasho

Thank you !