### PR TITLE
Extend gtp-tlv generator for full tables having context and action

### DIFF
--- a/lib/gtp/message.c
+++ b/lib/gtp/message.c
@@ -20,8 +20,8 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2021-10-16 16:32:20.655097 by acetcom
- * from 29274-g30.docx
+ * Created on: 2021-10-31 11:36:49.519203 by cbalint
+ * from ./lib/gtp/support/29274-g30.docx
  ******************************************************************************/
 
 #include "ogs-gtp.h"
@@ -1742,6 +1742,29 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_flow_0 =
     { NULL }
 };
 
+//  Name: [PC5 QoS Parameters]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-7: PC5 QoS Parameters within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters__forward_relocation_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "PC5 QoS Parameters",
+    OGS_GTP_PC5_QOS_PARAMETERS_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_pc5_qos_parameters__forward_relocation_request__t),
+    {
+        &ogs_gtp_tlv_desc_pc5_qos_flow_0,
+        &ogs_gtp_tlv_desc_bit_rate_0,
+        NULL,
+    }
+};
+
+//  Name: [PC5 QoS Parameters]
+//  Context: []
+//  Action: []
+//  Table 8.140-1: PC5 QoS Parameters Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0 =
 {
     OGS_TLV_COMPOUND,
@@ -1751,12 +1774,52 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0 =
     0,
     sizeof(ogs_gtp_tlv_pc5_qos_parameters_t),
     {
-        &ogs_gtp_tlv_desc_pc5_qos_flow_0,
-        &ogs_gtp_tlv_desc_bit_rate_0,
         NULL,
     }
 };
 
+//  Name: [Remote UE Context]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-5: Remote UE Context Connected within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__create_session_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Remote UE Context",
+    OGS_GTP_REMOTE_UE_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_remote_ue_context__create_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_remote_user_id_0,
+        &ogs_gtp_tlv_desc_remote_ue_ip_information_0,
+        NULL,
+    }
+};
+
+//  Name: [Remote UE Context]
+//  Context: [Remote UE Report Notification]
+//  Action: []
+//  Table 7.2.26-2: Remote UE Context Connected within Remote UE Report Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__remote_ue_report_notification__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Remote UE Context",
+    OGS_GTP_REMOTE_UE_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_remote_ue_context__remote_ue_report_notification__t),
+    {
+        &ogs_gtp_tlv_desc_remote_user_id_0,
+        &ogs_gtp_tlv_desc_remote_ue_ip_information_0,
+        NULL,
+    }
+};
+
+//  Name: [Remote UE Context]
+//  Context: []
+//  Action: []
+//  Table 7.2.26-3: Remote UE Context Disconnected with Remote UE Report Notification 
 ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0 =
 {
     OGS_TLV_COMPOUND,
@@ -1767,19 +1830,60 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0 =
     sizeof(ogs_gtp_tlv_remote_ue_context_t),
     {
         &ogs_gtp_tlv_desc_remote_user_id_0,
+        NULL,
+    }
+};
+
+//  Name: [Remote UE Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__forward_relocation_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Remote UE Context",
+    OGS_GTP_REMOTE_UE_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_remote_ue_context__forward_relocation_request__t),
+    {
+        &ogs_gtp_tlv_desc_remote_user_id_0,
         &ogs_gtp_tlv_desc_remote_ue_ip_information_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0 =
+//  Name: [Remote UE Context]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Context Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__context_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Remote UE Context",
+    OGS_GTP_REMOTE_UE_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_remote_ue_context__context_response__t),
+    {
+        &ogs_gtp_tlv_desc_remote_user_id_0,
+        &ogs_gtp_tlv_desc_remote_ue_ip_information_0,
+        NULL,
+    }
+};
+
+//  Name: [V2X Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-6: Subscribed V2X Information within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context__forward_relocation_request__0 =
 {
     OGS_TLV_COMPOUND,
     "V2X Context",
     OGS_GTP_V2X_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_v2x_context_t),
+    sizeof(ogs_gtp_tlv_v2x_context__forward_relocation_request__t),
     {
         &ogs_gtp_tlv_desc_services_authorized_0,
         &ogs_gtp_tlv_desc_services_authorized_1,
@@ -1790,6 +1894,1121 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0 =
     }
 };
 
+//  Name: [V2X Context]
+//  Context: []
+//  Action: []
+//  Table 8.138-1: V2X Context Grouped Type
+ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0 =
+{
+    OGS_TLV_COMPOUND,
+    "V2X Context",
+    OGS_GTP_V2X_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_v2x_context_t),
+    {
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [created]
+//  Table 7.2.1-2: Bearer Context to be created within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__created__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_request__created__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_teid_7,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [created]
+//  Table 7.2.1-2: Bearer Context to be created within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__created__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_request__created__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_teid_7,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [removed]
+//  Table 7.2.1-3: Bearer Context to be removed within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__removed__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [removed]
+//  Table 7.2.1-3: Bearer Context to be removed within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__removed__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [created]
+//  Table 7.2.2-2: Bearer Context Created within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__created__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_response__created__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [created]
+//  Table 7.2.2-2: Bearer Context Created within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__created__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_response__created__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [removal]
+//  Table 7.2.2-3: Bearer Context marked for removal within a Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__removal__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [removal]
+//  Table 7.2.2-3: Bearer Context marked for removal within a Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__removal__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_session_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-2: Bearer Context within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-2: Bearer Context within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-2: Bearer Context within Create Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        &ogs_gtp_tlv_desc_f_teid_7,
+        &ogs_gtp_tlv_desc_f_teid_8,
+        &ogs_gtp_tlv_desc_f_teid_9,
+        &ogs_gtp_tlv_desc_f_teid_10,
+        &ogs_gtp_tlv_desc_f_teid_11,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-2: Bearer Context within Create Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        &ogs_gtp_tlv_desc_f_teid_7,
+        &ogs_gtp_tlv_desc_f_teid_8,
+        &ogs_gtp_tlv_desc_f_teid_9,
+        &ogs_gtp_tlv_desc_f_teid_10,
+        &ogs_gtp_tlv_desc_f_teid_11,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [modified]
+//  Table 7.2.7-2: Bearer Context to be modified within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__modified__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_request__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [modified]
+//  Table 7.2.7-2: Bearer Context to be modified within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__modified__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_request__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [removed]
+//  Table 7.2.7-3: Bearer Context to be removed within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__removed__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [removed]
+//  Table 7.2.7-3: Bearer Context to be removed within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__removed__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [modified]
+//  Table 7.2.8-2: Bearer Context modified within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__modified__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_response__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [modified]
+//  Table 7.2.8-2: Bearer Context modified within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__modified__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_response__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [removal]
+//  Table 7.2.8-3: Bearer Context marked for removal within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__removal__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [removal]
+//  Table 7.2.8-3: Bearer Context marked for removal within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__removal__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9.2-2: Bearer Context within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9.2-2: Bearer Context within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-2: Bearer Context within Delete Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-2: Bearer Context within Delete Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14.1-2: Bearer Context within Modify Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_command__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14.1-2: Bearer Context within Modify Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_command__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-2: Bearer Context within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_apco_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-2: Bearer Context within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_apco_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-2: Bearer Context within Update Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__update_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-2: Bearer Context within Update Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__update_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_pco_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp_tlv_desc_epco_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-2: Bearer Context within Delete Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_command__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-2: Bearer Context within Delete Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_command__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_ran_nas_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17.2-2: Bearer Context within Delete Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_failure_indication__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17.2-2: Bearer Context within Delete Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_failure_indication__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__delete_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Request]
+//  Action: []
+//  Table 7.2.18-2: Bearer Context within Create Indirect Data Forwarding Tunnel Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Request]
+//  Action: []
+//  Table 7.2.18-2: Bearer Context within Create Indirect Data Forwarding Tunnel Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        &ogs_gtp_tlv_desc_f_teid_6,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Response]
+//  Action: []
+//  Table 7.2.19-2: Bearer Context within Create Indirect Data Forwarding Tunnel Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Response]
+//  Action: []
+//  Table 7.2.19-2: Bearer Context within Create Indirect Data Forwarding Tunnel Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp_tlv_desc_f_teid_3,
+        &ogs_gtp_tlv_desc_f_teid_4,
+        &ogs_gtp_tlv_desc_f_teid_5,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [modified]
+//  Table 7.2.24-2: Bearer Context to be modified within Modify Access Bearers Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__modified__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_request__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [modified]
+//  Table 7.2.24-2: Bearer Context to be modified within Modify Access Bearers Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__modified__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_request__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [removed]
+//  Table 7.2.24-3: Bearer Context to be removed within Modify Access Bearers Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__removed__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [removed]
+//  Table 7.2.24-3: Bearer Context to be removed within Modify Access Bearers Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__removed__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_request__removed__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [modified]
+//  Table 7.2.25-2: Bearer Context modified within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__modified__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_response__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [modified]
+//  Table 7.2.25-2: Bearer Context modified within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__modified__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_response__modified__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [removal]
+//  Table 7.2.25-3: Bearer Context marked for removal within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__removal__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [removal]
+//  Table 7.2.25-3: Bearer Context marked for removal within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__removal__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__modify_access_bearers_response__removal__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_cause_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__forward_relocation_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__forward_relocation_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp_tlv_desc_ti_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__forward_relocation_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__forward_relocation_request__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp_tlv_desc_ti_0,
+        &ogs_gtp_tlv_desc_bearer_flags_0,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: []
+//  Action: []
+//  Table 7.3.2-2: Bearer Context 
 ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_0 =
 {
     OGS_TLV_COMPOUND,
@@ -1800,35 +3019,21 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_0 =
     sizeof(ogs_gtp_tlv_bearer_context_t),
     {
         &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_packet_flow_id_0,
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_f_teid_1,
         &ogs_gtp_tlv_desc_f_teid_2,
         &ogs_gtp_tlv_desc_f_teid_3,
         &ogs_gtp_tlv_desc_f_teid_4,
         &ogs_gtp_tlv_desc_f_teid_5,
-        &ogs_gtp_tlv_desc_f_teid_6,
-        &ogs_gtp_tlv_desc_bearer_qos_0,
-        &ogs_gtp_tlv_desc_f_teid_7,
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_charging_id_0,
-        &ogs_gtp_tlv_desc_bearer_flags_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
-        &ogs_gtp_tlv_desc_f_teid_8,
-        &ogs_gtp_tlv_desc_f_teid_9,
-        &ogs_gtp_tlv_desc_f_teid_10,
-        &ogs_gtp_tlv_desc_f_teid_11,
-        &ogs_gtp_tlv_desc_ran_nas_cause_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_ti_0,
-        &ogs_gtp_tlv_desc_packet_flow_id_0,
         NULL,
     }
 };
 
+//  Name: [Bearer Context]
+//  Context: []
+//  Action: []
+//  Table 7.3.2-2: Bearer Context 
 ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_1 =
 {
     OGS_TLV_COMPOUND,
@@ -1839,43 +3044,117 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_1 =
     sizeof(ogs_gtp_tlv_bearer_context_t),
     {
         &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_packet_flow_id_0,
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_f_teid_1,
         &ogs_gtp_tlv_desc_f_teid_2,
         &ogs_gtp_tlv_desc_f_teid_3,
         &ogs_gtp_tlv_desc_f_teid_4,
         &ogs_gtp_tlv_desc_f_teid_5,
-        &ogs_gtp_tlv_desc_f_teid_6,
-        &ogs_gtp_tlv_desc_bearer_qos_0,
-        &ogs_gtp_tlv_desc_f_teid_7,
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_charging_id_0,
-        &ogs_gtp_tlv_desc_bearer_flags_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
-        &ogs_gtp_tlv_desc_f_teid_8,
-        &ogs_gtp_tlv_desc_f_teid_9,
-        &ogs_gtp_tlv_desc_f_teid_10,
-        &ogs_gtp_tlv_desc_f_teid_11,
-        &ogs_gtp_tlv_desc_ran_nas_cause_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_ti_0,
-        &ogs_gtp_tlv_desc_packet_flow_id_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0 =
+//  Name: [Bearer Context]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Context Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__context_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp_tlv_desc_ti_0,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Context Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__context_response__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_bearer_tft_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_f_teid_1,
+        &ogs_gtp_tlv_desc_bearer_qos_0,
+        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp_tlv_desc_ti_0,
+        &ogs_gtp_tlv_desc_f_teid_2,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Context Acknowledge]
+//  Action: []
+//  Table 7.3.7-2: Bearer Context within Context Acknowledge
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_acknowledge__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_bearer_context__context_acknowledge__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        NULL,
+    }
+};
+
+//  Name: [Bearer Context]
+//  Context: [Context Acknowledge]
+//  Action: []
+//  Table 7.3.7-2: Bearer Context within Context Acknowledge
+ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_acknowledge__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Bearer Context",
+    OGS_GTP_BEARER_CONTEXT_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_bearer_context__context_acknowledge__t),
+    {
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        NULL,
+    }
+};
+
+//  Name: [PDN Connection]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-2: MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection__forward_relocation_request__0 =
 {
     OGS_TLV_COMPOUND,
     "PDN Connection",
     OGS_GTP_PDN_CONNECTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pdn_connection_t),
+    sizeof(ogs_gtp_tlv_pdn_connection__forward_relocation_request__t),
     {
         &ogs_gtp_tlv_desc_apn_0,
         &ogs_gtp_tlv_desc_apn_restriction_0,
@@ -1904,6 +3183,1231 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0 =
     }
 };
 
+//  Name: [PDN Connection]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-2: MME/SGSN/AMF UE EPS PDN Connections within Context Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection__context_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "PDN Connection",
+    OGS_GTP_PDN_CONNECTION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_pdn_connection__context_response__t),
+    {
+        &ogs_gtp_tlv_desc_apn_0,
+        &ogs_gtp_tlv_desc_apn_restriction_0,
+        &ogs_gtp_tlv_desc_selection_mode_0,
+        &ogs_gtp_tlv_desc_ip_address_0,
+        &ogs_gtp_tlv_desc_ip_address_1,
+        &ogs_gtp_tlv_desc_ebi_0,
+        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp_tlv_desc_fqdn_0,
+        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_ambr_0,
+        &ogs_gtp_tlv_desc_charging_characteristics_0,
+        &ogs_gtp_tlv_desc_change_reporting_action_0,
+        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp_tlv_desc_indication_0,
+        &ogs_gtp_tlv_desc_signalling_priority_indication_0,
+        &ogs_gtp_tlv_desc_change_to_report_flags_0,
+        &ogs_gtp_tlv_desc_fqdn_1,
+        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp_tlv_desc_wlan_offloadability_indication_0,
+        &ogs_gtp_tlv_desc_remote_ue_context_0,
+        &ogs_gtp_tlv_desc_pdn_type_0,
+        &ogs_gtp_tlv_desc_header_compression_configuration_0,
+        NULL,
+    }
+};
+
+//  Name: [PDN Connection]
+//  Context: []
+//  Action: []
+//  Table 8.39-1: PDN Connection Grouped Type
+ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0 =
+{
+    OGS_TLV_COMPOUND,
+    "PDN Connection",
+    OGS_GTP_PDN_CONNECTION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_pdn_connection_t),
+    {
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-4: Overload Control Information within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-4: Overload Control Information within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-4: Overload Control Information within Create Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-5: Overload Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-5: Overload Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-5: Overload Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-3: Overload Control Information within Create Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-3: Overload Control Information within Create Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-3: Overload Control Information within Create Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Command]
+//  Action: []
+//  Table 7.2.5-2: Overload Control Information within Bearer Resource Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Command]
+//  Action: []
+//  Table 7.2.5-2: Overload Control Information within Bearer Resource Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Command]
+//  Action: []
+//  Table 7.2.5-2: Overload Control Information within Bearer Resource Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Failure Indication]
+//  Action: []
+//  Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Failure Indication]
+//  Action: []
+//  Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Failure Indication]
+//  Action: []
+//  Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Request]
+//  Action: []
+//  Table 7.2.7-4: Overload Control Information within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Request]
+//  Action: []
+//  Table 7.2.7-4: Overload Control Information within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Request]
+//  Action: []
+//  Table 7.2.7-4: Overload Control Information within Modify Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-5: Overload Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-5: Overload Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-5: Overload Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Request]
+//  Action: []
+//  Table 7.2.9.1-2: Overload Control Information within Delete Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Request]
+//  Action: []
+//  Table 7.2.9.1-2: Overload Control Information within Delete Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Request]
+//  Action: []
+//  Table 7.2.9.1-2: Overload Control Information within Delete Session Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-4: Overload Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-4: Overload Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-4: Overload Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-3: Overload Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-3: Overload Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-3: Overload Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-4: Overload Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-4: Overload Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-4: Overload Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-3: Overload Control Information within Update Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-3: Overload Control Information within Update Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-3: Overload Control Information within Update Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__update_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-3: Overload Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-3: Overload Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-3: Overload Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.111-1: Overload Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_0 =
 {
     OGS_TLV_COMPOUND,
@@ -1913,14 +4417,14 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_0 =
     0,
     sizeof(ogs_gtp_tlv_overload_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apn_0,
         NULL,
     }
 };
 
+//  Name: [Overload Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.111-1: Overload Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_1 =
 {
     OGS_TLV_COMPOUND,
@@ -1930,14 +4434,14 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_1 =
     1,
     sizeof(ogs_gtp_tlv_overload_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apn_0,
         NULL,
     }
 };
 
+//  Name: [Overload Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.111-1: Overload Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2 =
 {
     OGS_TLV_COMPOUND,
@@ -1947,6 +4451,143 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2 =
     2,
     sizeof(ogs_gtp_tlv_overload_control_information_t),
     {
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-4: Load Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-4: Load Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-4: Load Control Information within Create Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__create_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-3: Load Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-3: Load Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-3: Load Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-4: Overload Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_request__t),
+    {
         &ogs_gtp_tlv_desc_sequence_number_0,
         &ogs_gtp_tlv_desc_metric_0,
         &ogs_gtp_tlv_desc_epc_timer_0,
@@ -1955,6 +4596,523 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2 =
     }
 };
 
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-4: Overload Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-4: Overload Control Information within Create Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__create_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        &ogs_gtp_tlv_desc_apn_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-4: Load Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-4: Load Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-4: Load Control Information within Modify Bearer Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_bearer_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-3: Load Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-3: Load Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-3: Load Control Information within Delete Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-2: Load Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-2: Load Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-2: Load Control Information within Delete Session Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__delete_session_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-2: Load Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-2: Load Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-2: Load Control Information within Downlink Data Notification
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__downlink_data_notification__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14-3: Overload Control Information within Modify Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14-3: Overload Control Information within Modify Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14-3: Overload Control Information within Modify Bearer Command
+ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Overload Control Information",
+    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_overload_control_information__modify_bearer_command__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_epc_timer_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-3: Load Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-3: Load Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-3: Load Control Information within Update Bearer Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__update_bearer_request__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-2: Load Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-2: Load Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-2: Load Control Information within Release Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__release_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-4: Load Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__0 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    0,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-4: Load Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__1 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    1,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-4: Load Control Information within Modify Access Bearers Response
+ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__2 =
+{
+    OGS_TLV_COMPOUND,
+    "Load Control Information",
+    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    0,
+    2,
+    sizeof(ogs_gtp_tlv_load_control_information__modify_access_bearers_response__t),
+    {
+        &ogs_gtp_tlv_desc_sequence_number_0,
+        &ogs_gtp_tlv_desc_metric_0,
+        NULL,
+    }
+};
+
+//  Name: [Load Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.112-1: Load Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_0 =
 {
     OGS_TLV_COMPOUND,
@@ -1964,13 +5122,14 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_0 =
     0,
     sizeof(ogs_gtp_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
+//  Name: [Load Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.112-1: Load Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_1 =
 {
     OGS_TLV_COMPOUND,
@@ -1980,13 +5139,14 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_1 =
     1,
     sizeof(ogs_gtp_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
+//  Name: [Load Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.112-1: Load Control Information Grouped Type
 ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_2 =
 {
     OGS_TLV_COMPOUND,
@@ -1996,21 +5156,22 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_2 =
     2,
     sizeof(ogs_gtp_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection_0 =
+//  Name: [SCEF PDN Connection]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-5: MME UE SCEF PDN Connections within Forward Relocation Request
+ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection__forward_relocation_request__0 =
 {
     OGS_TLV_COMPOUND,
     "SCEF PDN Connection",
     OGS_GTP_SCEF_PDN_CONNECTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_scef_pdn_connection_t),
+    sizeof(ogs_gtp_tlv_scef_pdn_connection__forward_relocation_request__t),
     {
         &ogs_gtp_tlv_desc_apn_0,
         &ogs_gtp_tlv_desc_ebi_0,
@@ -2018,6 +5179,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection_0 =
         NULL,
     }
 };
+
+/* Descriptor Structure for Messages */
 
 ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_request =
 {
@@ -2062,8 +5225,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_request =
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_twmi_0,
         &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__create_session_request__created__0,
+        &ogs_gtp_tlv_desc_bearer_context__create_session_request__removed__1,
         &ogs_gtp_tlv_desc_trace_information_0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
@@ -2088,15 +5251,15 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_request =
         &ogs_gtp_tlv_desc_ip_address_3,
         &ogs_gtp_tlv_desc_cn_operator_selection_entity_0,
         &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__create_session_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__create_session_request__1,
+        &ogs_gtp_tlv_desc_overload_control_information__create_session_request__2,
         &ogs_gtp_tlv_desc_millisecond_time_stamp_0,
         &ogs_gtp_tlv_desc_integer_number_0,
         &ogs_gtp_tlv_desc_twan_identifier_1,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
         &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_remote_ue_context_0,
+        &ogs_gtp_tlv_desc_remote_ue_context__create_session_request__0,
         &ogs_gtp_tlv_desc_node_identifier_0,
         &ogs_gtp_tlv_desc_epco_0,
         &ogs_gtp_tlv_desc_serving_plmn_rate_control_0,
@@ -2127,8 +5290,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_response =
         &ogs_gtp_tlv_desc_ambr_0,
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__create_session_response__created__0,
+        &ogs_gtp_tlv_desc_bearer_context__create_session_response__removal__1,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_fqdn_0,
         &ogs_gtp_tlv_desc_ip_address_0,
@@ -2141,11 +5304,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_response =
         &ogs_gtp_tlv_desc_ip4cp_0,
         &ogs_gtp_tlv_desc_indication_0,
         &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__create_session_response__0,
+        &ogs_gtp_tlv_desc_load_control_information__create_session_response__1,
+        &ogs_gtp_tlv_desc_load_control_information__create_session_response__2,
+        &ogs_gtp_tlv_desc_overload_control_information__create_session_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__create_session_response__1,
         &ogs_gtp_tlv_desc_f_container_0,
         &ogs_gtp_tlv_desc_charging_id_0,
         &ogs_gtp_tlv_desc_epco_0,
@@ -2165,8 +5328,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_request =
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_ambr_0,
         &ogs_gtp_tlv_desc_delay_value_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__modified__0,
+        &ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__removed__1,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_ue_time_zone_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
@@ -2180,9 +5343,9 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_request =
         &ogs_gtp_tlv_desc_ip_address_2,
         &ogs_gtp_tlv_desc_cn_operator_selection_entity_0,
         &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__1,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__2,
         &ogs_gtp_tlv_desc_serving_plmn_rate_control_0,
         &ogs_gtp_tlv_desc_counter_0,
         &ogs_gtp_tlv_desc_imsi_0,
@@ -2203,8 +5366,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_response =
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_apn_restriction_0,
         &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__modified__0,
+        &ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__removal__1,
         &ogs_gtp_tlv_desc_change_reporting_action_0,
         &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
         &ogs_gtp_tlv_desc_enb_information_reporting_0,
@@ -2217,11 +5380,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_response =
         &ogs_gtp_tlv_desc_ldn_1,
         &ogs_gtp_tlv_desc_indication_0,
         &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__0,
+        &ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__1,
+        &ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__2,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__1,
         &ogs_gtp_tlv_desc_charging_id_0,
     NULL,
 }};
@@ -2243,9 +5406,9 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_request =
         &ogs_gtp_tlv_desc_ran_nas_cause_0,
         &ogs_gtp_tlv_desc_twan_identifier_0,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_session_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_session_request__1,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_session_request__2,
         &ogs_gtp_tlv_desc_twan_identifier_1,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
         &ogs_gtp_tlv_desc_ip_address_0,
@@ -2265,11 +5428,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_response =
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_pco_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__delete_session_response__0,
+        &ogs_gtp_tlv_desc_load_control_information__delete_session_response__1,
+        &ogs_gtp_tlv_desc_load_control_information__delete_session_response__2,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_session_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_session_response__1,
         &ogs_gtp_tlv_desc_epco_0,
         &ogs_gtp_tlv_desc_apn_rate_control_status_0,
     NULL,
@@ -2281,10 +5444,10 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_command =
     "Modify Bearer Command",
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_bearer_context__modify_bearer_command__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__1,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__2,
         &ogs_gtp_tlv_desc_f_teid_0,
     NULL,
 }};
@@ -2297,8 +5460,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_failure_indication =
         &ogs_gtp_tlv_desc_cause_0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__1,
     NULL,
 }};
 
@@ -2307,12 +5470,12 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_command =
     OGS_TLV_MESSAGE,
     "Delete Bearer Command",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__delete_bearer_command__0,
         &ogs_gtp_tlv_desc_uli_0,
         &ogs_gtp_tlv_desc_uli_timestamp_0,
         &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__1,
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
@@ -2324,11 +5487,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_failure_indication =
     "Delete Bearer Failure Indication",
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__delete_bearer_failure_indication__0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__1,
     NULL,
 }};
 
@@ -2350,8 +5513,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_command =
         &ogs_gtp_tlv_desc_f_teid_1,
         &ogs_gtp_tlv_desc_pco_0,
         &ogs_gtp_tlv_desc_signalling_priority_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__0,
+        &ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__1,
         &ogs_gtp_tlv_desc_f_container_0,
         &ogs_gtp_tlv_desc_epco_0,
         &ogs_gtp_tlv_desc_f_teid_2,
@@ -2367,8 +5530,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_failure_indication =
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_pti_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__0,
+        &ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__1,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_f_container_0,
     NULL,
@@ -2393,7 +5556,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_request =
         &ogs_gtp_tlv_desc_pti_0,
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__create_bearer_request__0,
         &ogs_gtp_tlv_desc_fq_csid_0,
         &ogs_gtp_tlv_desc_fq_csid_1,
         &ogs_gtp_tlv_desc_change_reporting_action_0,
@@ -2401,11 +5564,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_request =
         &ogs_gtp_tlv_desc_enb_information_reporting_0,
         &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__create_bearer_request__0,
+        &ogs_gtp_tlv_desc_load_control_information__create_bearer_request__1,
+        &ogs_gtp_tlv_desc_load_control_information__create_bearer_request__2,
+        &ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__1,
         &ogs_gtp_tlv_desc_f_container_0,
     NULL,
 }};
@@ -2416,7 +5579,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_response =
     "Create Bearer Response",
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__create_bearer_response__0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
         &ogs_gtp_tlv_desc_fq_csid_2,
@@ -2425,11 +5588,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_response =
         &ogs_gtp_tlv_desc_ue_time_zone_0,
         &ogs_gtp_tlv_desc_uli_0,
         &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__1,
         &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
         &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__2,
         &ogs_gtp_tlv_desc_twan_identifier_1,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
         &ogs_gtp_tlv_desc_port_number_0,
@@ -2443,7 +5606,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_request =
     OGS_TLV_MESSAGE,
     "Update Bearer Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__update_bearer_request__0,
         &ogs_gtp_tlv_desc_pti_0,
         &ogs_gtp_tlv_desc_pco_0,
         &ogs_gtp_tlv_desc_ambr_0,
@@ -2454,11 +5617,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_request =
         &ogs_gtp_tlv_desc_fq_csid_0,
         &ogs_gtp_tlv_desc_fq_csid_1,
         &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__update_bearer_request__0,
+        &ogs_gtp_tlv_desc_load_control_information__update_bearer_request__1,
+        &ogs_gtp_tlv_desc_load_control_information__update_bearer_request__2,
+        &ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__1,
         &ogs_gtp_tlv_desc_f_container_0,
     NULL,
 }};
@@ -2469,7 +5632,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_response =
     "Update Bearer Response",
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__update_bearer_response__0,
         &ogs_gtp_tlv_desc_pco_0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
@@ -2480,11 +5643,11 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_response =
         &ogs_gtp_tlv_desc_ue_time_zone_0,
         &ogs_gtp_tlv_desc_uli_0,
         &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__1,
         &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
         &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__2,
         &ogs_gtp_tlv_desc_twan_identifier_1,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
         &ogs_gtp_tlv_desc_port_number_0,
@@ -2500,18 +5663,18 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_request =
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_ebi_0,
         &ogs_gtp_tlv_desc_ebi_1,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__delete_bearer_request__0,
         &ogs_gtp_tlv_desc_pti_0,
         &ogs_gtp_tlv_desc_pco_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
         &ogs_gtp_tlv_desc_fq_csid_1,
         &ogs_gtp_tlv_desc_cause_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__0,
+        &ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__1,
+        &ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__2,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__1,
         &ogs_gtp_tlv_desc_f_container_0,
         &ogs_gtp_tlv_desc_apn_rate_control_status_0,
         &ogs_gtp_tlv_desc_epco_0,
@@ -2525,7 +5688,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_response =
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
         &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__delete_bearer_response__0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_fq_csid_0,
         &ogs_gtp_tlv_desc_fq_csid_1,
@@ -2537,10 +5700,10 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_response =
         &ogs_gtp_tlv_desc_uli_timestamp_0,
         &ogs_gtp_tlv_desc_twan_identifier_0,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__1,
         &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
+        &ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__2,
         &ogs_gtp_tlv_desc_twan_identifier_1,
         &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
         &ogs_gtp_tlv_desc_port_number_0,
@@ -2559,7 +5722,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_request =
         &ogs_gtp_tlv_desc_mei_0,
         &ogs_gtp_tlv_desc_indication_0,
         &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_request__0,
         &ogs_tlv_desc_more8,
         &ogs_gtp_tlv_desc_recovery_0,
     NULL,
@@ -2572,7 +5735,7 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_response 
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
         &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_response__0,
         &ogs_tlv_desc_more8,
         &ogs_gtp_tlv_desc_recovery_0,
     NULL,
@@ -2616,8 +5779,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_release_access_bearers_response =
         &ogs_gtp_tlv_desc_cause_0,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
+        &ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__0,
     NULL,
 }};
 
@@ -2632,8 +5795,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification =
         &ogs_gtp_tlv_desc_imsi_0,
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
+        &ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__0,
+        &ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__0,
         &ogs_gtp_tlv_desc_paging_and_service_information_0,
         &ogs_gtp_tlv_desc_integer_number_0,
     NULL,
@@ -2662,8 +5825,8 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_request =
         &ogs_gtp_tlv_desc_indication_0,
         &ogs_gtp_tlv_desc_f_teid_0,
         &ogs_gtp_tlv_desc_delay_value_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__modified__0,
+        &ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__removed__1,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
@@ -2675,12 +5838,12 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_response =
     "Modify Access Bearers Response",
     0, 0, 0, 0, {
         &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
+        &ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__modified__0,
+        &ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__removal__1,
         &ogs_gtp_tlv_desc_recovery_0,
         &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
+        &ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__0,
+        &ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__0,
     NULL,
 }};
 
@@ -2697,7 +5860,7 @@ int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
 
     h = (ogs_gtp_header_t *)pkbuf->data;
     ogs_assert(h);
-    
+
     memset(gtp_message, 0, sizeof(ogs_gtp_message_t));
 
     if (h->teid_presence)

--- a/lib/gtp/message.h
+++ b/lib/gtp/message.h
@@ -20,8 +20,8 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2021-10-16 16:32:20.650061 by acetcom
- * from 29274-g30.docx
+ * Created on: 2021-10-31 11:36:49.171023 by cbalint
+ * from ./lib/gtp/support/29274-g30.docx
  ******************************************************************************/
 
 #if !defined(OGS_GTP_INSIDE) && !defined(OGS_GTP_COMPILATION)
@@ -429,19 +429,169 @@ extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_1;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_flow_0;
 
 /* Group Information Element TLV Descriptor */
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters__forward_relocation_request__0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__create_session_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__remote_ue_report_notification__0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__forward_relocation_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context__context_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context__forward_relocation_request__0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__created__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__created__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__removed__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_request__removed__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__created__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__created__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__removal__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_session_response__removal__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__modified__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__modified__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__removed__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_request__removed__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__modified__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__modified__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__removal__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_response__removal__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_command__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_bearer_command__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__update_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_command__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_command__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_failure_indication__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__delete_bearer_failure_indication__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__create_indirect_data_forwarding_tunnel_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__modified__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__modified__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__removed__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_request__removed__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__modified__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__modified__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__removal__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__modify_access_bearers_response__removal__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__forward_relocation_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__forward_relocation_request__1;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_acknowledge__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context__context_acknowledge__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection__forward_relocation_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection__context_response__0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_session_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_command__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__bearer_resource_failure_indication__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_session_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__downlink_data_notification__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_failure_indication__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__update_bearer_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_command__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__delete_bearer_failure_indication__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__release_access_bearers_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_access_bearers_response__2;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_1;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_session_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__create_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__create_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_bearer_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__delete_session_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__downlink_data_notification__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information__modify_bearer_command__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__update_bearer_request__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__release_access_bearers_response__2;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__1;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information__modify_access_bearers_response__2;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_0;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_1;
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection_0;
+extern ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection__forward_relocation_request__0;
 
 /* Message Descriptor */
 extern ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_request;
@@ -628,58 +778,472 @@ typedef ogs_tlv_octet_t ogs_gtp_tlv_bit_rate_t;
 typedef ogs_tlv_octet_t ogs_gtp_tlv_pc5_qos_flow_t;
 
 /* Structure for Group Information Element */
-typedef struct ogs_gtp_tlv_pc5_qos_parameters_s {
+//  Name: [PC5 QoS Parameters]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-7: PC5 QoS Parameters within Forward Relocation Request
+typedef struct ogs_gtp_tlv_pc5_qos_parameters__forward_relocation_request__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_pc5_qos_flow_t pc5_qos_flows;
     ogs_gtp_tlv_bit_rate_t pc5_link_aggregated_bit_rates;
+} ogs_gtp_tlv_pc5_qos_parameters__forward_relocation_request__t;
+
+//  Name: [PC5 QoS Parameters]
+//  Context: []
+//  Action: []
+//  Table 8.140-1: PC5 QoS Parameters Grouped Type
+typedef struct ogs_gtp_tlv_pc5_qos_parameters_s {
+    ogs_tlv_presence_t presence;
 } ogs_gtp_tlv_pc5_qos_parameters_t;
 
-typedef struct ogs_gtp_tlv_remote_ue_context_s {
+//  Name: [Remote UE Context]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-5: Remote UE Context Connected within Create Session Request
+typedef struct ogs_gtp_tlv_remote_ue_context__create_session_request__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_remote_user_id_t remote_user_id;
     ogs_gtp_tlv_remote_ue_ip_information_t remote_ue_ip_information;
+} ogs_gtp_tlv_remote_ue_context__create_session_request__t;
+
+//  Name: [Remote UE Context]
+//  Context: [Remote UE Report Notification]
+//  Action: []
+//  Table 7.2.26-2: Remote UE Context Connected within Remote UE Report Notification
+typedef struct ogs_gtp_tlv_remote_ue_context__remote_ue_report_notification__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_remote_user_id_t remote_user_id;
+    ogs_gtp_tlv_remote_ue_ip_information_t remote_ue_ip_information;
+} ogs_gtp_tlv_remote_ue_context__remote_ue_report_notification__t;
+
+//  Name: [Remote UE Context]
+//  Context: []
+//  Action: []
+//  Table 7.2.26-3: Remote UE Context Disconnected with Remote UE Report Notification 
+typedef struct ogs_gtp_tlv_remote_ue_context_s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_remote_user_id_t remote_user_id;
 } ogs_gtp_tlv_remote_ue_context_t;
 
-typedef struct ogs_gtp_tlv_v2x_context_s {
+//  Name: [Remote UE Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Forward Relocation Request
+typedef struct ogs_gtp_tlv_remote_ue_context__forward_relocation_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_remote_user_id_t remote_user_id;
+    ogs_gtp_tlv_remote_ue_ip_information_t remote_ue_ip_information;
+} ogs_gtp_tlv_remote_ue_context__forward_relocation_request__t;
+
+//  Name: [Remote UE Context]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Context Response
+typedef struct ogs_gtp_tlv_remote_ue_context__context_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_remote_user_id_t remote_user_id;
+    ogs_gtp_tlv_remote_ue_ip_information_t remote_ue_ip_information;
+} ogs_gtp_tlv_remote_ue_context__context_response__t;
+
+//  Name: [V2X Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-6: Subscribed V2X Information within Forward Relocation Request
+typedef struct ogs_gtp_tlv_v2x_context__forward_relocation_request__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_services_authorized_t lte_v2x_services_authorized;
     ogs_gtp_tlv_services_authorized_t nr_v2x_services_authorized;
     ogs_gtp_tlv_bit_rate_t lte_ue_sidelink_aggregate_maximum_bit_rate;
     ogs_gtp_tlv_bit_rate_t nr_ue_sidelink_aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_pc5_qos_parameters_t pc5_qos_parameters;
+    ogs_gtp_tlv_pc5_qos_parameters__forward_relocation_request__t pc5_qos_parameters;
+} ogs_gtp_tlv_v2x_context__forward_relocation_request__t;
+
+//  Name: [V2X Context]
+//  Context: []
+//  Action: []
+//  Table 8.138-1: V2X Context Grouped Type
+typedef struct ogs_gtp_tlv_v2x_context_s {
+    ogs_tlv_presence_t presence;
 } ogs_gtp_tlv_v2x_context_t;
 
-typedef struct ogs_gtp_tlv_bearer_context_s {
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [created]
+//  Table 7.2.1-2: Bearer Context to be created within Create Session Request
+typedef struct ogs_gtp_tlv_bearer_context__create_session_request__created__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_ebi_t eps_bearer_id;
     ogs_gtp_tlv_bearer_tft_t tft;
-    ogs_gtp_tlv_f_teid_t s1_u_enodeb_f_teid; /* Instance : 0 */
-    ogs_gtp_tlv_f_teid_t s4_u_sgsn_f_teid; /* Instance : 1 */
-    ogs_gtp_tlv_f_teid_t s5_s8_u_sgw_f_teid; /* Instance : 2 */
-    ogs_gtp_tlv_f_teid_t s5_s8_u_pgw_f_teid; /* Instance : 3 */
-    ogs_gtp_tlv_f_teid_t s12_rnc_f_teid; /* Instance : 4 */
-    ogs_gtp_tlv_f_teid_t s2b_u_epdg_f_teid_5; /* Instance : 5 */
-    ogs_gtp_tlv_f_teid_t s2a_u_twan_f_teid_6; /* Instance : 6 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_enodeb_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgsn_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_s8_u_sgw_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_s8_u_pgw_f_teid; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_rnc_f_teid; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2b_u_epdg_f_teid_5; /* Instance : 5 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2a_u_twan_f_teid_6; /* Instance : 6 */
     ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
-    ogs_gtp_tlv_f_teid_t s11_u_mme_f_teid; /* Instance : 7 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_mme_f_teid; /* Instance : 7 */
+} ogs_gtp_tlv_bearer_context__create_session_request__created__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Request]
+//  Action: [removed]
+//  Table 7.2.1-3: Bearer Context to be removed within Create Session Request
+typedef struct ogs_gtp_tlv_bearer_context__create_session_request__removed__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgsn_f_teid; /* Instance : 0 */
+} ogs_gtp_tlv_bearer_context__create_session_request__removed__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [created]
+//  Table 7.2.2-2: Bearer Context Created within Create Session Response
+typedef struct ogs_gtp_tlv_bearer_context__create_session_response__created__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
     ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgw_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_s8_u_pgw_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_sgw_f_teid; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2b_u_pgw_f_teid; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2a_u_pgw_f_teid; /* Instance : 5 */
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
+    ogs_gtp_tlv_charging_id_t charging_id;
+    ogs_gtp_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_sgw_f_teid; /* Instance : 6 */
+} ogs_gtp_tlv_bearer_context__create_session_response__created__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Session Response]
+//  Action: [removal]
+//  Table 7.2.2-3: Bearer Context marked for removal within a Create Session Response
+typedef struct ogs_gtp_tlv_bearer_context__create_session_response__removal__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+} ogs_gtp_tlv_bearer_context__create_session_response__removal__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-2: Bearer Context within Create Bearer Request
+typedef struct ogs_gtp_tlv_bearer_context__create_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_tft_t tft;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_8_u_pgw_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_sgw_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgw_f_teid; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2b_u_pgw_f_teid; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2a_u_pgw_f_teid; /* Instance : 5 */
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
     ogs_gtp_tlv_charging_id_t charging_id;
     ogs_gtp_tlv_bearer_flags_t bearer_flags;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
     ogs_gtp_tlv_maximum_packet_loss_rate_t maximum_packet_loss_rate;
-    ogs_gtp_tlv_f_teid_t s2b_u_epdg_f_teid_8; /* Instance : 8 */
-    ogs_gtp_tlv_f_teid_t s2b_u_pgw_f_teid; /* Instance : 9 */
-    ogs_gtp_tlv_f_teid_t s2a_u_twan_f_teid_10; /* Instance : 10 */
-    ogs_gtp_tlv_f_teid_t s2a_u_pgw_f_teid; /* Instance : 11 */
+} ogs_gtp_tlv_bearer_context__create_bearer_request__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-2: Bearer Context within Create Bearer Response
+typedef struct ogs_gtp_tlv_bearer_context__create_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_enodeb_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_8_u_sgw_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_8_u_pgw_f_teid; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_rnc_f_teid; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_sgw_f_teid; /* Instance : 5 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgsn_f_teid; /* Instance : 6 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgw_f_teid; /* Instance : 7 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2b_u_epdg_f_teid_8; /* Instance : 8 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2b_u_pgw_f_teid; /* Instance : 9 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2a_u_twan_f_teid_10; /* Instance : 10 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s2a_u_pgw_f_teid; /* Instance : 11 */
+    ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_ran_nas_cause_t ran_nas_cause;
+    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
+} ogs_gtp_tlv_bearer_context__create_bearer_response__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [modified]
+//  Table 7.2.7-2: Bearer Context to be modified within Modify Bearer Request
+typedef struct ogs_gtp_tlv_bearer_context__modify_bearer_request__modified__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_enodeb_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s5_8_u_sgw_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_rnc_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgsn_f_teid; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_mme_f_teid; /* Instance : 4 */
+} ogs_gtp_tlv_bearer_context__modify_bearer_request__modified__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Request]
+//  Action: [removed]
+//  Table 7.2.7-3: Bearer Context to be removed within Modify Bearer Request
+typedef struct ogs_gtp_tlv_bearer_context__modify_bearer_request__removed__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+} ogs_gtp_tlv_bearer_context__modify_bearer_request__removed__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [modified]
+//  Table 7.2.8-2: Bearer Context modified within Modify Bearer Response
+typedef struct ogs_gtp_tlv_bearer_context__modify_bearer_response__modified__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_sgw_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgw_f_teid; /* Instance : 2 */
+    ogs_gtp_tlv_charging_id_t charging_id;
+    ogs_gtp_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_sgw_f_teid; /* Instance : 3 */
+} ogs_gtp_tlv_bearer_context__modify_bearer_response__modified__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Response]
+//  Action: [removal]
+//  Table 7.2.8-3: Bearer Context marked for removal within Modify Bearer Response
+typedef struct ogs_gtp_tlv_bearer_context__modify_bearer_response__removal__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+} ogs_gtp_tlv_bearer_context__modify_bearer_response__removal__t;
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9.2-2: Bearer Context within Delete Bearer Request
+typedef struct ogs_gtp_tlv_bearer_context__delete_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+} ogs_gtp_tlv_bearer_context__delete_bearer_request__t;
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-2: Bearer Context within Delete Bearer Response
+typedef struct ogs_gtp_tlv_bearer_context__delete_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_pco_t protocol_configuration_options;
+    ogs_gtp_tlv_ran_nas_cause_t ran_nas_cause;
+    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
+} ogs_gtp_tlv_bearer_context__delete_bearer_response__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14.1-2: Bearer Context within Modify Bearer Command
+typedef struct ogs_gtp_tlv_bearer_context__modify_bearer_command__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
+} ogs_gtp_tlv_bearer_context__modify_bearer_command__t;
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-2: Bearer Context within Update Bearer Request
+typedef struct ogs_gtp_tlv_bearer_context__update_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_tft_t tft;
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
+    ogs_gtp_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_apco_t additional_protocol_configuration_options;
+    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp_tlv_maximum_packet_loss_rate_t maximum_packet_loss_rate;
+} ogs_gtp_tlv_bearer_context__update_bearer_request__t;
+
+//  Name: [Bearer Context]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-2: Bearer Context within Update Bearer Response
+typedef struct ogs_gtp_tlv_bearer_context__update_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgsn_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_rnc_f_teid; /* Instance : 1 */
+    ogs_gtp_tlv_pco_t protocol_configuration_options;
+    ogs_gtp_tlv_ran_nas_cause_t ran_nas_cause;
+    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
+} ogs_gtp_tlv_bearer_context__update_bearer_response__t;
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-2: Bearer Context within Delete Bearer Command
+typedef struct ogs_gtp_tlv_bearer_context__delete_bearer_command__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp_tlv_ran_nas_cause_t ran_nas_release_cause;
+} ogs_gtp_tlv_bearer_context__delete_bearer_command__t;
+
+//  Name: [Bearer Context]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17.2-2: Bearer Context within Delete Bearer Failure Indication
+typedef struct ogs_gtp_tlv_bearer_context__delete_bearer_failure_indication__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+} ogs_gtp_tlv_bearer_context__delete_bearer_failure_indication__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Request]
+//  Action: []
+//  Table 7.2.18-2: Bearer Context within Create Indirect Data Forwarding Tunnel Request
+typedef struct ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_enodeb_f_teid_for_dl_data_forwarding; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_upf_f_teid_for_dl_data_forwarding; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgsn_f_teid_for_dl_data_forwarding; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_rnc_f_teid_for_dl_data_forwarding; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_enodeb_f_teid_for_ul_data_forwarding; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_f_teid_for_ul_data_forwarding; /* Instance : 5 */
+    ogs_gtp_tlv_f_teid_t gtpv2_mme_f_teid_for_dl_data_forwarding; /* Instance : 6 */
+} ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_request__t;
+
+//  Name: [Bearer Context]
+//  Context: [Create Indirect Data Forwarding Tunnel Response]
+//  Action: []
+//  Table 7.2.19-2: Bearer Context within Create Indirect Data Forwarding Tunnel Response
+typedef struct ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid_for_dl_data_forwarding; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s12_sgw_f_teid_for_dl_data_forwarding; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s4_u_sgw_f_teid_for_dl_data_forwarding; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_f_teid_for_dl_data_forwarding; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid_for_ul_data_forwarding; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_f_teid_for_ul_data_forwarding; /* Instance : 5 */
+} ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_response__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [modified]
+//  Table 7.2.24-2: Bearer Context to be modified within Modify Access Bearers Request
+typedef struct ogs_gtp_tlv_bearer_context__modify_access_bearers_request__modified__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_enodeb_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_mme_f_teid; /* Instance : 1 */
+} ogs_gtp_tlv_bearer_context__modify_access_bearers_request__modified__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Request]
+//  Action: [removed]
+//  Table 7.2.24-3: Bearer Context to be removed within Modify Access Bearers Request
+typedef struct ogs_gtp_tlv_bearer_context__modify_access_bearers_request__removed__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+} ogs_gtp_tlv_bearer_context__modify_access_bearers_request__removed__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [modified]
+//  Table 7.2.25-2: Bearer Context modified within Modify Access Bearers Response
+typedef struct ogs_gtp_tlv_bearer_context__modify_access_bearers_response__modified__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+    ogs_gtp_tlv_f_teid_t gtpv2_s1_u_sgw_f_teid; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_s11_u_sgw_f_teid; /* Instance : 1 */
+} ogs_gtp_tlv_bearer_context__modify_access_bearers_response__modified__t;
+
+//  Name: [Bearer Context]
+//  Context: [Modify Access Bearers Response]
+//  Action: [removal]
+//  Table 7.2.25-3: Bearer Context marked for removal within Modify Access Bearers Response
+typedef struct ogs_gtp_tlv_bearer_context__modify_access_bearers_response__removal__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_cause_t cause;
+} ogs_gtp_tlv_bearer_context__modify_access_bearers_response__removal__t;
+
+//  Name: [Bearer Context]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request
+typedef struct ogs_gtp_tlv_bearer_context__forward_relocation_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_tft_t tft;
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_s1_s4_s12_ip_address_and_teid_for_user_plane; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_pgw_s5_s8_ip_address_and_teid_for_user_plane; /* Instance : 1 */
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
     ogs_gtp_tlv_f_container_t bss_container;
     ogs_gtp_tlv_ti_t transaction_identifier;
+    ogs_gtp_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_s11_ip_address_and_teid_for_user_plane; /* Instance : 2 */
+} ogs_gtp_tlv_bearer_context__forward_relocation_request__t;
+
+//  Name: [Bearer Context]
+//  Context: []
+//  Action: []
+//  Table 7.3.2-2: Bearer Context 
+typedef struct ogs_gtp_tlv_bearer_context_s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
     ogs_gtp_tlv_packet_flow_id_t packet_flow_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_enodeb_f_teid_for_dl_data_forwarding; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_enodeb_f_teid_for_ul_data_forwarding; /* Instance : 1 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_upf_f_teid_for_dl_data_forwarding; /* Instance : 2 */
+    ogs_gtp_tlv_f_teid_t gtpv2_rnc_f_teid_for_dl_data_forwarding; /* Instance : 3 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgsn_f_teid_for_dl_data_forwarding; /* Instance : 4 */
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_f_teid_for_ul_data_forwarding; /* Instance : 5 */
 } ogs_gtp_tlv_bearer_context_t;
 
-typedef struct ogs_gtp_tlv_pdn_connection_s {
+//  Name: [Bearer Context]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Context Response
+typedef struct ogs_gtp_tlv_bearer_context__context_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_bearer_tft_t tft;
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_s1_s4_s12_s11_ip_address_and_teid_for_user_plane; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_pgw_s5_s8_ip_address_and_teid_for_user_plane; /* Instance : 1 */
+    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
+    ogs_gtp_tlv_f_container_t bss_container;
+    ogs_gtp_tlv_ti_t transaction_identifier;
+    ogs_gtp_tlv_f_teid_t gtpv2_sgw_s11_ip_address_and_teid_for_user_plane; /* Instance : 2 */
+} ogs_gtp_tlv_bearer_context__context_response__t;
+
+//  Name: [Bearer Context]
+//  Context: [Context Acknowledge]
+//  Action: []
+//  Table 7.3.7-2: Bearer Context within Context Acknowledge
+typedef struct ogs_gtp_tlv_bearer_context__context_acknowledge__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_ebi_t eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_forwarding_f_teid; /* Instance : 0 */
+} ogs_gtp_tlv_bearer_context__context_acknowledge__t;
+
+//  Name: [PDN Connection]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-2: MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request
+typedef struct ogs_gtp_tlv_pdn_connection__forward_relocation_request__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_apn_t apn;
     ogs_gtp_tlv_apn_restriction_t apn_restriction;
@@ -687,9 +1251,9 @@ typedef struct ogs_gtp_tlv_pdn_connection_s {
     ogs_gtp_tlv_ip_address_t ipv4_address;
     ogs_gtp_tlv_ip_address_t ipv6_address;
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_f_teid_t pgw_s5_s8_ip_address_for_control_plane_or_pmip; /* Instance : 0 */
+    ogs_gtp_tlv_f_teid_t gtpv2_pgw_s5_s8_ip_address_for_control_plane_or_pmip; /* Instance : 0 */
     ogs_gtp_tlv_fqdn_t pgw_node_name;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_;
+    ogs_gtp_tlv_bearer_context__forward_relocation_request__t bearer_contexts_;
     ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
     ogs_gtp_tlv_charging_characteristics_t charging_characteristics;
     ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
@@ -701,32 +1265,412 @@ typedef struct ogs_gtp_tlv_pdn_connection_s {
     ogs_gtp_tlv_fqdn_t local_home_network_id;
     ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
     ogs_gtp_tlv_wlan_offloadability_indication_t wlan_offloadability_indication;
-    ogs_gtp_tlv_remote_ue_context_t remote_ue_context_connected;
+    ogs_gtp_tlv_remote_ue_context__forward_relocation_request__t remote_ue_context_connected;
     ogs_gtp_tlv_pdn_type_t pdn_type;
     ogs_gtp_tlv_header_compression_configuration_t header_compression_configuration;
+} ogs_gtp_tlv_pdn_connection__forward_relocation_request__t;
+
+//  Name: [PDN Connection]
+//  Context: [Context Response]
+//  Action: []
+//  Table 7.3.6-2: MME/SGSN/AMF UE EPS PDN Connections within Context Response
+typedef struct ogs_gtp_tlv_pdn_connection__context_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_apn_t apn;
+    ogs_gtp_tlv_apn_restriction_t apn_restriction;
+    ogs_gtp_tlv_selection_mode_t selection_mode;
+    ogs_gtp_tlv_ip_address_t ipv4_address;
+    ogs_gtp_tlv_ip_address_t ipv6_address;
+    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp_tlv_f_teid_t gtpv2_pgw_s5_s8_ip_address_for_control_plane_or_pmip; /* Instance : 0 */
+    ogs_gtp_tlv_fqdn_t pgw_node_name;
+    ogs_gtp_tlv_bearer_context__context_response__t bearer_contexts_;
+    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp_tlv_charging_characteristics_t charging_characteristics;
+    ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
+    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting_;
+    ogs_gtp_tlv_indication_t indication_flags;
+    ogs_gtp_tlv_signalling_priority_indication_t signalling_priority_indication__;
+    ogs_gtp_tlv_change_to_report_flags_t change_to_report_flags;
+    ogs_gtp_tlv_fqdn_t local_home_network_id;
+    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp_tlv_wlan_offloadability_indication_t wlan_offloadability_indication;
+    ogs_gtp_tlv_remote_ue_context__context_response__t remote_ue_context_connected;
+    ogs_gtp_tlv_pdn_type_t pdn_type;
+    ogs_gtp_tlv_header_compression_configuration_t header_compression_configuration;
+} ogs_gtp_tlv_pdn_connection__context_response__t;
+
+//  Name: [PDN Connection]
+//  Context: []
+//  Action: []
+//  Table 8.39-1: PDN Connection Grouped Type
+typedef struct ogs_gtp_tlv_pdn_connection_s {
+    ogs_tlv_presence_t presence;
 } ogs_gtp_tlv_pdn_connection_t;
 
-typedef struct ogs_gtp_tlv_overload_control_information_s {
+//  Name: [Overload Control Information]
+//  Context: [Create Session Request]
+//  Action: []
+//  Table 7.2.1-4: Overload Control Information within Create Session Request
+typedef struct ogs_gtp_tlv_overload_control_information__create_session_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__create_session_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-5: Overload Control Information within Create Session Response
+typedef struct ogs_gtp_tlv_overload_control_information__create_session_response__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
     ogs_gtp_tlv_metric_t overload_reduction_metric;
     ogs_gtp_tlv_epc_timer_t period_of_validity;
     ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__create_session_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Response]
+//  Action: []
+//  Table 7.2.4-3: Overload Control Information within Create Bearer Response
+typedef struct ogs_gtp_tlv_overload_control_information__create_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__create_bearer_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Command]
+//  Action: []
+//  Table 7.2.5-2: Overload Control Information within Bearer Resource Command
+typedef struct ogs_gtp_tlv_overload_control_information__bearer_resource_command__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__bearer_resource_command__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Bearer Resource Failure Indication]
+//  Action: []
+//  Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication
+typedef struct ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Request]
+//  Action: []
+//  Table 7.2.7-4: Overload Control Information within Modify Bearer Request
+typedef struct ogs_gtp_tlv_overload_control_information__modify_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__modify_bearer_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-5: Overload Control Information within Modify Bearer Response
+typedef struct ogs_gtp_tlv_overload_control_information__modify_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__modify_bearer_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Request]
+//  Action: []
+//  Table 7.2.9.1-2: Overload Control Information within Delete Session Request
+typedef struct ogs_gtp_tlv_overload_control_information__delete_session_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__delete_session_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-4: Overload Control Information within Delete Bearer Request
+typedef struct ogs_gtp_tlv_overload_control_information__delete_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__delete_bearer_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-3: Overload Control Information within Delete Session Response
+typedef struct ogs_gtp_tlv_overload_control_information__delete_session_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__delete_session_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Response]
+//  Action: []
+//  Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response
+typedef struct ogs_gtp_tlv_overload_control_information__delete_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__delete_bearer_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification
+typedef struct ogs_gtp_tlv_overload_control_information__downlink_data_notification__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__downlink_data_notification__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication
+typedef struct ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-4: Overload Control Information within Update Bearer Request
+typedef struct ogs_gtp_tlv_overload_control_information__update_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__update_bearer_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Update Bearer Response]
+//  Action: []
+//  Table 7.2.16-3: Overload Control Information within Update Bearer Response
+typedef struct ogs_gtp_tlv_overload_control_information__update_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__update_bearer_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Command]
+//  Action: []
+//  Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command
+typedef struct ogs_gtp_tlv_overload_control_information__delete_bearer_command__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__delete_bearer_command__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Delete Bearer Failure Indication]
+//  Action: []
+//  Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication
+typedef struct ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-3: Overload Control Information within Release Access Bearers Response
+typedef struct ogs_gtp_tlv_overload_control_information__release_access_bearers_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__release_access_bearers_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response
+typedef struct ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__t;
+
+//  Name: [Overload Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.111-1: Overload Control Information Grouped Type
+typedef struct ogs_gtp_tlv_overload_control_information_s {
+    ogs_tlv_presence_t presence;
 } ogs_gtp_tlv_overload_control_information_t;
 
-typedef struct ogs_gtp_tlv_load_control_information_s {
+//  Name: [Load Control Information]
+//  Context: [Create Session Response]
+//  Action: []
+//  Table 7.2.2-4: Load Control Information within Create Session Response
+typedef struct ogs_gtp_tlv_load_control_information__create_session_response__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
     ogs_gtp_tlv_metric_t load_metric;
     ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__create_session_response__t;
+
+//  Name: [Load Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-3: Load Control Information within Create Bearer Request
+typedef struct ogs_gtp_tlv_load_control_information__create_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__create_bearer_request__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Create Bearer Request]
+//  Action: []
+//  Table 7.2.3-4: Overload Control Information within Create Bearer Request
+typedef struct ogs_gtp_tlv_overload_control_information__create_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+    ogs_gtp_tlv_apn_t list_of_access_point_name;
+} ogs_gtp_tlv_overload_control_information__create_bearer_request__t;
+
+//  Name: [Load Control Information]
+//  Context: [Modify Bearer Response]
+//  Action: []
+//  Table 7.2.8-4: Load Control Information within Modify Bearer Response
+typedef struct ogs_gtp_tlv_load_control_information__modify_bearer_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__modify_bearer_response__t;
+
+//  Name: [Load Control Information]
+//  Context: [Delete Bearer Request]
+//  Action: []
+//  Table 7.2.9-3: Load Control Information within Delete Bearer Request
+typedef struct ogs_gtp_tlv_load_control_information__delete_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__delete_bearer_request__t;
+
+//  Name: [Load Control Information]
+//  Context: [Delete Session Response]
+//  Action: []
+//  Table 7.2.10.1-2: Load Control Information within Delete Session Response
+typedef struct ogs_gtp_tlv_load_control_information__delete_session_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__delete_session_response__t;
+
+//  Name: [Load Control Information]
+//  Context: [Downlink Data Notification]
+//  Action: []
+//  Table 7.2.11.1-2: Load Control Information within Downlink Data Notification
+typedef struct ogs_gtp_tlv_load_control_information__downlink_data_notification__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+} ogs_gtp_tlv_load_control_information__downlink_data_notification__t;
+
+//  Name: [Overload Control Information]
+//  Context: [Modify Bearer Command]
+//  Action: []
+//  Table 7.2.14-3: Overload Control Information within Modify Bearer Command
+typedef struct ogs_gtp_tlv_overload_control_information__modify_bearer_command__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp_tlv_metric_t overload_reduction_metric;
+    ogs_gtp_tlv_epc_timer_t period_of_validity;
+} ogs_gtp_tlv_overload_control_information__modify_bearer_command__t;
+
+//  Name: [Load Control Information]
+//  Context: [Update Bearer Request]
+//  Action: []
+//  Table 7.2.15-3: Load Control Information within Update Bearer Request
+typedef struct ogs_gtp_tlv_load_control_information__update_bearer_request__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp_tlv_load_control_information__update_bearer_request__t;
+
+//  Name: [Load Control Information]
+//  Context: [Release Access Bearers Response]
+//  Action: []
+//  Table 7.2.22-2: Load Control Information within Release Access Bearers Response
+typedef struct ogs_gtp_tlv_load_control_information__release_access_bearers_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+} ogs_gtp_tlv_load_control_information__release_access_bearers_response__t;
+
+//  Name: [Load Control Information]
+//  Context: [Modify Access Bearers Response]
+//  Action: []
+//  Table 7.2.25-4: Load Control Information within Modify Access Bearers Response
+typedef struct ogs_gtp_tlv_load_control_information__modify_access_bearers_response__s {
+    ogs_tlv_presence_t presence;
+    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp_tlv_metric_t load_metric;
+} ogs_gtp_tlv_load_control_information__modify_access_bearers_response__t;
+
+//  Name: [Load Control Information]
+//  Context: []
+//  Action: []
+//  Table 8.112-1: Load Control Information Grouped Type
+typedef struct ogs_gtp_tlv_load_control_information_s {
+    ogs_tlv_presence_t presence;
 } ogs_gtp_tlv_load_control_information_t;
 
-typedef struct ogs_gtp_tlv_scef_pdn_connection_s {
+//  Name: [SCEF PDN Connection]
+//  Context: [Forward Relocation Request]
+//  Action: []
+//  Table 7.3.1-5: MME UE SCEF PDN Connections within Forward Relocation Request
+typedef struct ogs_gtp_tlv_scef_pdn_connection__forward_relocation_request__s {
     ogs_tlv_presence_t presence;
     ogs_gtp_tlv_apn_t apn;
     ogs_gtp_tlv_ebi_t default_eps_bearer_id;
     ogs_gtp_tlv_node_identifier_t scef_id;
-} ogs_gtp_tlv_scef_pdn_connection_t;
+} ogs_gtp_tlv_scef_pdn_connection__forward_relocation_request__t;
 
 /* Structure for Message */
 typedef struct ogs_gtp_echo_request_s {
@@ -758,8 +1702,8 @@ typedef struct ogs_gtp_create_session_request_s {
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_twmi_t trusted_wlan_mode_indication;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_created;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp_tlv_bearer_context__create_session_request__created__t bearer_contexts_to_be_created;
+    ogs_gtp_tlv_bearer_context__create_session_request__removed__t bearer_contexts_to_be_removed;
     ogs_gtp_tlv_trace_information_t trace_information;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_fq_csid_t mme_fq_csid;
@@ -784,15 +1728,15 @@ typedef struct ogs_gtp_create_session_request_s {
     ogs_gtp_tlv_ip_address_t epdg_ip_address;
     ogs_gtp_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
     ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_session_request__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_session_request__t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_session_request__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_millisecond_time_stamp_t origination_time_stamp;
     ogs_gtp_tlv_integer_number_t maximum_wait_time;
     ogs_gtp_tlv_twan_identifier_t wlan_location_information;
     ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
     ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_remote_ue_context_t remote_ue_context_connected;
+    ogs_gtp_tlv_remote_ue_context__create_session_request__t remote_ue_context_connected;
     ogs_gtp_tlv_node_identifier_t _aaa_server_identifier;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
     ogs_gtp_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
@@ -818,8 +1762,8 @@ typedef struct ogs_gtp_create_session_response_s {
     ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_created;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp_tlv_bearer_context__create_session_response__created__t bearer_contexts_created;
+    ogs_gtp_tlv_bearer_context__create_session_response__removal__t bearer_contexts_marked_for_removal;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_fqdn_t charging_gateway_name;
     ogs_gtp_tlv_ip_address_t charging_gateway_address;
@@ -832,11 +1776,11 @@ typedef struct ogs_gtp_create_session_response_s {
     ogs_gtp_tlv_ip4cp_t trusted_wlan_ipv4_parameters_;
     ogs_gtp_tlv_indication_t indication_flags;
     ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__create_session_response__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__create_session_response__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__create_session_response__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__create_session_response__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_session_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_container_t nbifom_container;
     ogs_gtp_tlv_charging_id_t pdn_connection_charging_id;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
@@ -851,8 +1795,8 @@ typedef struct ogs_gtp_modify_bearer_request_s {
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
     ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
     ogs_gtp_tlv_delay_value_t delay_downlink_packet_notification_request;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp_tlv_bearer_context__modify_bearer_request__modified__t bearer_contexts_to_be_modified;
+    ogs_gtp_tlv_bearer_context__modify_bearer_request__removed__t bearer_contexts_to_be_removed;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
     ogs_gtp_tlv_fq_csid_t mme_fq_csid;
@@ -866,9 +1810,9 @@ typedef struct ogs_gtp_modify_bearer_request_s {
     ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
     ogs_gtp_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
     ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_request__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_request__t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_request__t epdg_s_overload_control_information;
     ogs_gtp_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
     ogs_gtp_tlv_counter_t mo_exception_data_counter;
     ogs_gtp_tlv_imsi_t imsi;
@@ -884,8 +1828,8 @@ typedef struct ogs_gtp_modify_bearer_response_s {
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_apn_restriction_t apn_restriction;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp_tlv_bearer_context__modify_bearer_response__modified__t bearer_contexts_modified;
+    ogs_gtp_tlv_bearer_context__modify_bearer_response__removal__t bearer_contexts_marked_for_removal;
     ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
     ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
     ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting_;
@@ -898,11 +1842,11 @@ typedef struct ogs_gtp_modify_bearer_response_s {
     ogs_gtp_tlv_ldn_t pgw_ldn;
     ogs_gtp_tlv_indication_t indication_flags;
     ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__modify_bearer_response__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__modify_bearer_response__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__modify_bearer_response__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_response__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_charging_id_t pdn_connection_charging_id;
 } ogs_gtp_modify_bearer_response_t;
 
@@ -919,9 +1863,9 @@ typedef struct ogs_gtp_delete_session_request_s {
     ogs_gtp_tlv_ran_nas_cause_t ran_nas_release_cause;
     ogs_gtp_tlv_twan_identifier_t twan_identifier;
     ogs_gtp_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_session_request__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_session_request__t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_session_request__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_twan_identifier_t wlan_location_information;
     ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
     ogs_gtp_tlv_ip_address_t ue_local_ip_address;
@@ -936,21 +1880,21 @@ typedef struct ogs_gtp_delete_session_response_s {
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__delete_session_response__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__delete_session_response__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__delete_session_response__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_session_response__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_session_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
     ogs_gtp_tlv_apn_rate_control_status_t apn_rate_control_status;
 } ogs_gtp_delete_session_response_t;
 
 typedef struct ogs_gtp_modify_bearer_command_s {
     ogs_gtp_tlv_ambr_t apn_aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_bearer_context_t bearer_context;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_bearer_context__modify_bearer_command__t bearer_context;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_command__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_command__t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_command__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
 } ogs_gtp_modify_bearer_command_t;
 
@@ -958,28 +1902,28 @@ typedef struct ogs_gtp_modify_bearer_failure_indication_s {
     ogs_gtp_tlv_cause_t cause;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_bearer_failure_indication__t sgw_s_overload_control_information;
 } ogs_gtp_modify_bearer_failure_indication_t;
 
 typedef struct ogs_gtp_delete_bearer_command_s {
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__delete_bearer_command__t bearer_contexts;
     ogs_gtp_tlv_uli_t user_location_information;
     ogs_gtp_tlv_uli_timestamp_t uli_timestamp;
     ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_command__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_command__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
     ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
 } ogs_gtp_delete_bearer_command_t;
 
 typedef struct ogs_gtp_delete_bearer_failure_indication_s {
     ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_context;
+    ogs_gtp_tlv_bearer_context__delete_bearer_failure_indication__t bearer_context;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_failure_indication__t sgw_s_overload_control_information;
 } ogs_gtp_delete_bearer_failure_indication_t;
 
 typedef struct ogs_gtp_bearer_resource_command_s {
@@ -996,8 +1940,8 @@ typedef struct ogs_gtp_bearer_resource_command_s {
     ogs_gtp_tlv_f_teid_t s12_rnc_f_teid;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_signalling_priority_indication_t signalling_priority_indication__;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__bearer_resource_command__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__bearer_resource_command__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_container_t nbifom_container;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
@@ -1008,8 +1952,8 @@ typedef struct ogs_gtp_bearer_resource_failure_indication_s {
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_pti_t procedure_transaction_id;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__bearer_resource_failure_indication__t sgw_s_overload_control_information;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_f_container_t nbifom_container;
 } ogs_gtp_bearer_resource_failure_indication_t;
@@ -1024,7 +1968,7 @@ typedef struct ogs_gtp_create_bearer_request_s {
     ogs_gtp_tlv_pti_t procedure_transaction_id;
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__create_bearer_request__t bearer_contexts;
     ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
     ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
     ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
@@ -1032,17 +1976,17 @@ typedef struct ogs_gtp_create_bearer_request_s {
     ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting;
     ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__create_bearer_request__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__create_bearer_request__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__create_bearer_request__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__create_bearer_request__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_bearer_request__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_container_t nbifom_container;
 } ogs_gtp_create_bearer_request_t;
 
 typedef struct ogs_gtp_create_bearer_response_s {
     ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__create_bearer_response__t bearer_contexts;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_fq_csid_t mme_fq_csid;
     ogs_gtp_tlv_fq_csid_t epdg_fq_csid;
@@ -1051,11 +1995,11 @@ typedef struct ogs_gtp_create_bearer_response_s {
     ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
     ogs_gtp_tlv_uli_t user_location_information;
     ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_bearer_response__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_bearer_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
     ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__create_bearer_response__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_twan_identifier_t wlan_location_information;
     ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
     ogs_gtp_tlv_port_number_t ue_udp_port;
@@ -1064,7 +2008,7 @@ typedef struct ogs_gtp_create_bearer_response_s {
 } ogs_gtp_create_bearer_response_t;
 
 typedef struct ogs_gtp_update_bearer_request_s {
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__update_bearer_request__t bearer_contexts;
     ogs_gtp_tlv_pti_t procedure_transaction_id;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
@@ -1075,17 +2019,17 @@ typedef struct ogs_gtp_update_bearer_request_s {
     ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
     ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
     ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__update_bearer_request__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__update_bearer_request__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__update_bearer_request__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__update_bearer_request__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__update_bearer_request__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_container_t nbifom_container;
 } ogs_gtp_update_bearer_request_t;
 
 typedef struct ogs_gtp_update_bearer_response_s {
     ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__update_bearer_response__t bearer_contexts;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_fq_csid_t mme_fq_csid;
@@ -1096,11 +2040,11 @@ typedef struct ogs_gtp_update_bearer_response_s {
     ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
     ogs_gtp_tlv_uli_t user_location_information;
     ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__update_bearer_response__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__update_bearer_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
     ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__update_bearer_response__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_twan_identifier_t wlan_location_information;
     ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
     ogs_gtp_tlv_port_number_t ue_udp_port;
@@ -1111,18 +2055,18 @@ typedef struct ogs_gtp_update_bearer_response_s {
 typedef struct ogs_gtp_delete_bearer_request_s {
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
     ogs_gtp_tlv_ebi_t eps_bearer_ids;
-    ogs_gtp_tlv_bearer_context_t failed_bearer_contexts;
+    ogs_gtp_tlv_bearer_context__delete_bearer_request__t failed_bearer_contexts;
     ogs_gtp_tlv_pti_t procedure_transaction_id;
     ogs_gtp_tlv_pco_t protocol_configuration_options;
     ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
     ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
     ogs_gtp_tlv_cause_t cause;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__delete_bearer_request__t pgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__delete_bearer_request__t pgw_s_apn_level_load_control_information;
+    ogs_gtp_tlv_load_control_information__delete_bearer_request__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_request__t pgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_request__t sgw_s_overload_control_information;
     ogs_gtp_tlv_f_container_t nbifom_container;
     ogs_gtp_tlv_apn_rate_control_status_t apn_rate_control_status;
     ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
@@ -1131,7 +2075,7 @@ typedef struct ogs_gtp_delete_bearer_request_s {
 typedef struct ogs_gtp_delete_bearer_response_s {
     ogs_gtp_tlv_cause_t cause;
     ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp_tlv_bearer_context__delete_bearer_response__t bearer_contexts;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_fq_csid_t mme_fq_csid;
     ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
@@ -1143,10 +2087,10 @@ typedef struct ogs_gtp_delete_bearer_response_s {
     ogs_gtp_tlv_uli_timestamp_t uli_timestamp;
     ogs_gtp_tlv_twan_identifier_t twan_identifier;
     ogs_gtp_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_response__t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_response__t sgw_s_overload_control_information;
     ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp_tlv_overload_control_information__delete_bearer_response__t twan_epdg_s_overload_control_information;
     ogs_gtp_tlv_twan_identifier_t wlan_location_information;
     ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
     ogs_gtp_tlv_port_number_t ue_udp_port;
@@ -1160,14 +2104,14 @@ typedef struct ogs_gtp_create_indirect_data_forwarding_tunnel_request_s {
     ogs_gtp_tlv_mei_t me_identity;
     ogs_gtp_tlv_indication_t indication_flags;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts[8];
+    ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_request__t bearer_contexts[8];
     ogs_gtp_tlv_recovery_t recovery;
 } ogs_gtp_create_indirect_data_forwarding_tunnel_request_t;
 
 typedef struct ogs_gtp_create_indirect_data_forwarding_tunnel_response_s {
     ogs_gtp_tlv_cause_t cause;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts[8];
+    ogs_gtp_tlv_bearer_context__create_indirect_data_forwarding_tunnel_response__t bearer_contexts[8];
     ogs_gtp_tlv_recovery_t recovery;
 } ogs_gtp_create_indirect_data_forwarding_tunnel_response_t;
 
@@ -1190,8 +2134,8 @@ typedef struct ogs_gtp_release_access_bearers_response_s {
     ogs_gtp_tlv_cause_t cause;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__release_access_bearers_response__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__release_access_bearers_response__t sgw_s_overload_control_information;
 } ogs_gtp_release_access_bearers_response_t;
 
 typedef struct ogs_gtp_downlink_data_notification_s {
@@ -1201,8 +2145,8 @@ typedef struct ogs_gtp_downlink_data_notification_s {
     ogs_gtp_tlv_imsi_t imsi;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__downlink_data_notification__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__downlink_data_notification__t sgw_s_overload_control_information;
     ogs_gtp_tlv_paging_and_service_information_t paging_and_service_information;
     ogs_gtp_tlv_integer_number_t dl_data_packets_size;
 } ogs_gtp_downlink_data_notification_t;
@@ -1221,20 +2165,20 @@ typedef struct ogs_gtp_modify_access_bearers_request_s {
     ogs_gtp_tlv_indication_t indication_flags;
     ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
     ogs_gtp_tlv_delay_value_t delay_downlink_packet_notification_request;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp_tlv_bearer_context__modify_access_bearers_request__modified__t bearer_contexts_to_be_modified;
+    ogs_gtp_tlv_bearer_context__modify_access_bearers_request__removed__t bearer_contexts_to_be_removed;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
 } ogs_gtp_modify_access_bearers_request_t;
 
 typedef struct ogs_gtp_modify_access_bearers_response_s {
     ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp_tlv_bearer_context__modify_access_bearers_response__modified__t bearer_contexts_modified;
+    ogs_gtp_tlv_bearer_context__modify_access_bearers_response__removal__t bearer_contexts_marked_for_removal;
     ogs_gtp_tlv_recovery_t recovery;
     ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp_tlv_load_control_information__modify_access_bearers_response__t sgw_s_node_level_load_control_information;
+    ogs_gtp_tlv_overload_control_information__modify_access_bearers_response__t sgw_s_overload_control_information;
 } ogs_gtp_modify_access_bearers_response_t;
 
 typedef struct ogs_gtp_message_s {

--- a/lib/gtp/support/cache/tlv-group-list.py
+++ b/lib/gtp/support/cache/tlv-group-list.py
@@ -1,5 +1,6 @@
 # [Table 7.2.1-2: Bearer Context to be created within Create Session Request] Index = 11
 ies = []
+paragraph = "Table 7.2.1-2: Bearer Context to be created within Create Session Request"
 ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
 ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "O", "instance" : "0", "comment" : "This IE may be included on the S4/S11 interfaces."})
 ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U eNodeB F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S11 interface for X2-based handover with SGW relocation."})
@@ -18,152 +19,454 @@ ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U TWAN F-TEID", "presence" 
 ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "M", "instance" : "0", "comment" : ""})
 type_list["F-TEID"]["max_instance"] = "7"
 ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U MME F-TEID", "presence" : "CO", "instance" : "7", "comment" : "This IE shall be sent on the S11 interface, if S11-U is being used, during the E-UTRAN Initial Attach and UE requested PDN connectivity procedures. This IE may also be sent on the S11 interface, if S11-U is being used, during a Tracking Area Update procedure with Serving GW change, if the MME needs to establish the S11-U tunnel. See NOTE 2."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : ies }
+group_list[("Bearer Context", "Create Session Request", "created")] = { "index" : "193", "type" : "93", "context" : "Create Session Request", "action" : "created", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.1-3: Bearer Context to be removed within Create Session Request] Index = 12
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.1-3: Bearer Context to be removed within Create Session Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGSN F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent on the S4 interface if the S4-U interface is used. See NOTE 1."})
+group_list[("Bearer Context", "Create Session Request", "removed")] = { "index" : "193", "type" : "93", "context" : "Create Session Request", "action" : "removed", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.1-4: Overload Control Information within Create Session Request] Index = 13
 ies = []
+paragraph = "Table 7.2.1-4: Overload Control Information within Create Session Request"
 ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
 ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
 ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
-group_list["Overload Control Information"] = { "index" : "280", "type" : "180", "ies" : ies }
+group_list[("Overload Control Information", "Create Session Request", "")] = { "index" : "280", "type" : "180", "context" : "Create Session Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.1-5: Remote UE Context Connected within Create Session Request] Index = 14
 ies = []
+paragraph = "Table 7.2.1-5: Remote UE Context Connected within Create Session Request"
 ies.append({ "ie_type" : "Remote User ID", "ie_value" : "Remote User ID", "presence" : "M", "instance" : "0", "comment" : "See clause 8.123 for the description and use of this parameter"})
 ies.append({ "ie_type" : "Remote UE IP Information", "ie_value" : "Remote UE IP Information", "presence" : "M", "instance" : "0", "comment" : "See clause 8.124 for the description and use of this parameter"})
-group_list["Remote UE Context"] = { "index" : "291", "type" : "191", "ies" : ies }
+group_list[("Remote UE Context", "Create Session Request", "")] = { "index" : "291", "type" : "191", "context" : "Create Session Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.2-2: Bearer Context Created within Create Session Response] Index = 16
-added_ies = group_list["Bearer Context"]["ies"]
-added_ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, it gives information on the reason. (NOTE 1, NOTE 2, NOTE 3)"})
-added_ies.append({ "ie_type" : "Charging ID", "ie_value" : "Charging Id", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S5/S8 interface for an E-UTRAN initial attach, a Handover from Trusted or Untrusted Non-3GPP IP Access to E-UTRAN, a PDP Context Activation, a Handover from Trusted or Untrusted Non-3GPP IP Access to UTRAN/GERAN and a UE requested PDN connectivity."})
-added_ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "O", "instance" : "0", "comment" : "Applicable flags are:PPC (Prohibit Payload Compression) : this flag may be set on the S5/S8 and S4 interfaces."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.2.2-2: Bearer Context Created within Create Session Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, it gives information on the reason. (NOTE 1, NOTE 2, NOTE 3)"})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S11 interface if the S1-U interface is used, i.e. if the S11-U Tunnel flag was not set in the Create Session Request. . See NOTE 6."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included on the S4 interface if the S4-U interface is used."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/S8-U PGW F-TEID", "presence" : "C", "instance" : "2", "comment" : "For GTP-based S5/S8, this User Plane IE shall be included on S4/S11 and S5/S8 interfaces during the E-UTRAN Initial Attach, a Handover from Trusted or Untrusted Non-3GPP IP Access to E-UTRAN, a PDP Context Activation, a Handover from Trusted or Untrusted Non-3GPP IP Access to UTRAN/GERAN or a UE Requested PDN Connectivity."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 SGW F-TEID", "presence" : "C", "instance" : "3", "comment" : "This IE shall be included on the S4 interface if the S12 interface is used."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U PGW F-TEID", "presence" : "C", "instance" : "4", "comment" : "This IE (for user plane) shall be included on the S2b interface during the Attach with GTP on S2b, UE initiated Connectivity to Additional PDN with GTP on S2b,  Handover to Untrusted Non-3GPP IP Access with GTP on S2b, and Initial Attach for emergency session (GTP on S2b)."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U PGW F-TEID", "presence" : "C", "instance" : "5", "comment" : "This IE (for user plane) shall be included on the S2a interface during the Initial Attach in WLAN on GTP S2a, an Initial Attach in WLAN for Emergency Service on GTP S2a, UE initiated Connectivity to Additional PDN with GTP on S2a, and Handover to TWAN with GTP on S2a."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S5/S8, S4/S11 and S2a/S2b interfaces if the received QoS parameters have been modified."})
+ies.append({ "ie_type" : "Charging ID", "ie_value" : "Charging Id", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S5/S8 interface for an E-UTRAN initial attach, a Handover from Trusted or Untrusted Non-3GPP IP Access to E-UTRAN, a PDP Context Activation, a Handover from Trusted or Untrusted Non-3GPP IP Access to UTRAN/GERAN and a UE requested PDN connectivity."})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "O", "instance" : "0", "comment" : "Applicable flags are:PPC (Prohibit Payload Compression) : this flag may be set on the S5/S8 and S4 interfaces."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U SGW F-TEID", "presence" : "C", "instance" : "6", "comment" : "This IE shall be included on the S11 interface if the S11-U interface is used, i.e. if the S11-U Tunnel flag was set in the Create Session Request.If the SGW supports both IP address types, the SGW shall send both IP addresses within the F-TEID IE. If only one IP address is included, then the MME shall assume that the SGW does not support the other IP address type."})
+group_list[("Bearer Context", "Create Session Response", "created")] = { "index" : "193", "type" : "93", "context" : "Create Session Response", "action" : "created", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.2-3: Bearer Context marked for removal within a Create Session Response] Index = 17
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.2-3: Bearer Context marked for removal within a Create Session Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives the information on the reason."})
+group_list[("Bearer Context", "Create Session Response", "removal")] = { "index" : "193", "type" : "93", "context" : "Create Session Response", "action" : "removal", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.2-4: Load Control Information within Create Session Response] Index = 18
 ies = []
+paragraph = "Table 7.2.2-4: Load Control Information within Create Session Response"
 ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
 ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.2.5.1.2.2 and 12.2.5.1.2.3 for the description and use of this parameter."})
 ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
-group_list["Load Control Information"] = { "index" : "281", "type" : "181", "ies" : ies }
+group_list[("Load Control Information", "Create Session Response", "")] = { "index" : "281", "type" : "181", "context" : "Create Session Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.2-5: Overload Control Information within Create Session Response] Index = 19
-added_ies = group_list["Overload Control Information"]["ies"]
-added_ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity). See NOTE 1."})
-group_list["Overload Control Information"] = { "index" : "280", "type" : "180", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.2.2-5: Overload Control Information within Create Session Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity). See NOTE 1."})
+group_list[("Overload Control Information", "Create Session Response", "")] = { "index" : "280", "type" : "180", "context" : "Create Session Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.3-2: Bearer Context within Create Bearer Request] Index = 21
-added_ies = group_list["Bearer Context"]["ies"]
-added_ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "O", "instance" : "0", "comment" : "This IE may be sent on the S5/S8 and S4/S11 interfaces if ePCO is not supported by the UE or the network. This bearer level IE takes precedence over the PCO IE in the message body if they both exist."})
-added_ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "O", "instance" : "0", "comment" : "This IE may be sent on the S5/S8 and S11 interfaces if the UE and the network support ePCO. "})
-added_ies.append({ "ie_type" : "Maximum Packet Loss Rate", "ie_value" : "Maximum Packet Loss Rate", "presence" : "O", "instance" : "0", "comment" : "This IE may be included on the S5/S8 interfaces if the PGW needs to send Maximum Packet Loss Rate as specified in clause 5.4.1 of 3GPP TS 23.401 [3]. This IE is only applicable for QCI 1. "})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.2.3-2: Bearer Context within Create Bearer Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "This IE shall be set to 0."})
+ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "M", "instance" : "0", "comment" : "This IE can contain both uplink and downlink packet filters to be sent to the UE or the TWAN/ePDG."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent on the S11 interface if the S1-U interface is used. If SGW supports both IPv4 and IPv6, it shall send both an IPv4 address and an IPv6 address within the S1-U SGW F-TEID IE.See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/8-U PGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be sent on the S4, S5/S8 and S11 interfaces for GTP-based S5/S8 interface. The MME/SGSN shall ignore the IE on S11/S4 for PMIP-based S5/S8 interface."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 SGW F-TEID", "presence" : "C", "instance" : "2", "comment" : "This IE shall be sent on the S4 interface if the S12 interface is used. See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGW F-TEID", "presence" : "C", "instance" : "3", "comment" : "This IE shall be sent on the S4 interface if the S4-U interface is used. See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U PGW F-TEID", "presence" : "C", "instance" : "4", "comment" : "This IE (for user plane) shall be sent on the S2b interface."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U PGW F-TEID", "presence" : "C", "instance" : "5", "comment" : "This IE (for user plane) shall be sent on the S2a interface."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Charging ID", "ie_value" : "Charging Id", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent on the S5/S8 interface."})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "O", "instance" : "0", "comment" : "Applicable flags are:PPC (Prohibit Payload Compression) : this flag may be set on the S5/S8 and S4 interfaces.vSRVCC indicator: This IE may be included by the PGW on the S5/S8 interface according to 3GPP TS 23.216 [43]. When received from S5/S8, SGW shall forward on the S11 interface."})
+ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "O", "instance" : "0", "comment" : "This IE may be sent on the S5/S8 and S4/S11 interfaces if ePCO is not supported by the UE or the network. This bearer level IE takes precedence over the PCO IE in the message body if they both exist."})
+ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "O", "instance" : "0", "comment" : "This IE may be sent on the S5/S8 and S11 interfaces if the UE and the network support ePCO. "})
+ies.append({ "ie_type" : "Maximum Packet Loss Rate", "ie_value" : "Maximum Packet Loss Rate", "presence" : "O", "instance" : "0", "comment" : "This IE may be included on the S5/S8 interfaces if the PGW needs to send Maximum Packet Loss Rate as specified in clause 5.4.1 of 3GPP TS 23.401 [3]. This IE is only applicable for QCI 1. "})
+group_list[("Bearer Context", "Create Bearer Request", "")] = { "index" : "193", "type" : "93", "context" : "Create Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.3-3: Load Control Information within Create Bearer Request] Index = 22
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.3-3: Load Control Information within Create Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.2.5.1.2.2 and 12.2.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
+group_list[("Load Control Information", "Create Bearer Request", "")] = { "index" : "281", "type" : "181", "context" : "Create Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.3-4: Overload Control Information within Create Bearer Request] Index = 23
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.3-4: Overload Control Information within Create Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity).See NOTE 1."})
+group_list[("Overload Control Information", "Create Bearer Request", "")] = { "index" : "281", "type" : "181", "context" : "Create Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.4-2: Bearer Context within Create Bearer Response] Index = 25
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.4-2: Bearer Context within Create Bearer Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, it gives information on the reason."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U eNodeB F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent on the S11 interface if the S1-U interface is used."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be sent on the S11 interface. It shall be used to correlate the bearers with those in the Create Bearer Request."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/8-U SGW F-TEID", "presence" : "C", "instance" : "2", "comment" : "This IE shall be sent on the S5/S8 interfaces."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/8-U PGW F-TEID", "presence" : "C", "instance" : "3", "comment" : "This IE shall be sent on the S5/S8 interfaces. It shall be used to correlate the bearers with those in the Create Bearer Request."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 RNC F-TEID", "presence" : "C", "instance" : "4", "comment" : "This IE shall be sent on the S4 interface if the S12 interface is used. See NOTE1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 SGW F-TEID", "presence" : "C", "instance" : "5", "comment" : "This IE shall be sent on the S4 interface. It shall be used to correlate the bearers with those in the Create Bearer Request. See NOTE1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGSN F-TEID", "presence" : "C", "instance" : "6", "comment" : "This IE shall be sent on the S4 interface if the S4-U interface is used. See NOTE1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGW F-TEID", "presence" : "C", "instance" : "7", "comment" : "This IE shall be sent on the S4 interface. It shall be used to correlate the bearers with those in the Create Bearer Request. See NOTE1."})
 type_list["F-TEID"]["max_instance"] = "8"
-added_ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U ePDG F-TEID", "presence" : "C", "instance" : "8", "comment" : "This IE shall be sent on the S2b interface."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U ePDG F-TEID", "presence" : "C", "instance" : "8", "comment" : "This IE shall be sent on the S2b interface."})
 type_list["F-TEID"]["max_instance"] = "9"
-added_ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U PGW F-TEID", "presence" : "C", "instance" : "9", "comment" : "This IE shall be sent on the S2b interface. It shall be used to correlate the bearers with those in the Create Bearer Request."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2b-U PGW F-TEID", "presence" : "C", "instance" : "9", "comment" : "This IE shall be sent on the S2b interface. It shall be used to correlate the bearers with those in the Create Bearer Request."})
 type_list["F-TEID"]["max_instance"] = "10"
-added_ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U TWAN F-TEID", "presence" : "C", "instance" : "10", "comment" : "This IE shall be sent on the S2a interface."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U TWAN F-TEID", "presence" : "C", "instance" : "10", "comment" : "This IE shall be sent on the S2a interface."})
 type_list["F-TEID"]["max_instance"] = "11"
-added_ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U PGW F-TEID", "presence" : "C", "instance" : "11", "comment" : "This IE shall be sent on the S2a interface. It shall be used to correlate the bearers with those in the Create Bearer Request."})
-added_ies.append({ "ie_type" : "RAN/NAS Cause", "ie_value" : "RAN/NAS Cause", "presence" : "CO", "instance" : "0", "comment" : "If the bearer creation failed, the MME shall include this IE on the S11 interface to indicate the RAN cause and/or the NAS cause of the bearer creation failure, if available and if this information is permitted to be sent to the PGW operator according to MME operators policy. If both a RAN cause and a NAS cause are generated, then several IEs with the same type and instance value shall be included to represent a list of causes.The SGW shall include this IE on the S5/S8 interface if it receives it from the MME."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S2a-U PGW F-TEID", "presence" : "C", "instance" : "11", "comment" : "This IE shall be sent on the S2a interface. It shall be used to correlate the bearers with those in the Create Bearer Request."})
+ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "If the UE includes the PCO IE in the corresponding message, then the MME/SGSN shall copy the content of this IE transparently from the PCO IE included by the UE. If the SGW receives PCO from MME/SGSN, SGW shall forward it to the PGW. This bearer level IE takes precedence over the PCO IE in the message body if they both exist."})
+ies.append({ "ie_type" : "RAN/NAS Cause", "ie_value" : "RAN/NAS Cause", "presence" : "CO", "instance" : "0", "comment" : "If the bearer creation failed, the MME shall include this IE on the S11 interface to indicate the RAN cause and/or the NAS cause of the bearer creation failure, if available and if this information is permitted to be sent to the PGW operator according to MME operators policy. If both a RAN cause and a NAS cause are generated, then several IEs with the same type and instance value shall be included to represent a list of causes.The SGW shall include this IE on the S5/S8 interface if it receives it from the MME."})
+ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "If the UE includes the ePCO IE, then the MME shall copy the content of this IE transparently from the ePCO IE included by the UE. If the SGW receives ePCO from the MME, the SGW shall forward it to the PGW."})
+group_list[("Bearer Context", "Create Bearer Response", "")] = { "index" : "193", "type" : "93", "context" : "Create Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.4-3: Overload Control Information within Create Bearer Response] Index = 26
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.4-3: Overload Control Information within Create Bearer Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Create Bearer Response", "")] = { "index" : "280", "type" : "180", "context" : "Create Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.5-2: Overload Control Information within Bearer Resource Command] Index = 28
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.5-2: Overload Control Information within Bearer Resource Command"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Bearer Resource Command", "")] = { "index" : "280", "type" : "180", "context" : "Bearer Resource Command", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication] Index = 30
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.6-2: Overload Control Information within Bearer Resource Failure Indication"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity).See NOTE 1."})
+group_list[("Overload Control Information", "Bearer Resource Failure Indication", "")] = { "index" : "280", "type" : "180", "context" : "Bearer Resource Failure Indication", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.7-2: Bearer Context to be modified within Modify Bearer Request] Index = 32
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.7-2: Bearer Context to be modified within Modify Bearer Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "See NOTE 1, NOTE 2."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1 eNodeB F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent on the S11 interface if the S1-U is being used:for an E-UTRAN initial attach;for a Handover from Trusted or Untrusted Non-3GPP IP Access to E-UTRAN;for an UE triggered Service Request;for an UE initiated Connection Resume procedure;in all S1-U GTP-U tunnel setup procedure during a TAU procedure (see 3GPP TS 24.301 [23]) /handover cases;in all procedures where the UE is already in ECM-CONNECTED state, e.g. E-UTRAN Initiated E-RAB modification procedure, possibly HSS-based P-CSCF restoration for 3GPP access. See NOTE 4;in the Establishment of S1-U bearer during Data Transport in Control Plane CIoT EPS optimisation procedure. See NOTE 7.If an MME is aware that the eNodeB supports both IP address types, the MME shall send both IP addresses within an F-TEID IE. If only one IP address is included, then the SGW shall assume that the eNodeB does not support the other IP address type. See NOTE 2, NOTE 5, NOTE 6."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/8-U SGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be sent on the S5/S8 interfaces for a Handover or a TAU/RAU with a SGW change."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 RNC F-TEID", "presence" : "C", "instance" : "2", "comment" : "If available, this IE shall be included if the message is sent on the S4 interface if S12 interface is being used. If an S4-SGSN is aware that the RNC supports both IP address types, the S4-SGSN shall send both IP addresses within an F-TEID IE. If only one IP address is included, then the SGW shall assume that the RNC does not support the other IP address type.See NOTE 2, NOTE 6."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGSN F-TEID", "presence" : "C", "instance" : "3", "comment" : "If available, this IE shall be included if the message is sent on the S4 interface, if S4-U is being used. If an S4-SGSN supports both IP address types, the S4-SGSN shall send both IP addresses within an F-TEID IE. If only one IP address is included, then the SGW shall assume that the S4-SGSN does not support the other IP address type. See , NOTE 6."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U MME F-TEID", "presence" : "CO", "instance" : "4", "comment" : "This IE shall be sent on the S11 interface if S11-U is being used, i.e. for the following procedures: Mobile Originated Data transport in Control Plane CIoT EPS optimisation with P-GW connectivityMobile Terminated Data Transport in Control Plane CIoT EPS optimisation with P-GW connectivityin all procedures where the S11-U tunnel is already established, e.g. when reporting a change of User Location Information. TAU/RAU with SGW change procedure and data forwarding of DL data buffered in the old SGW (see clause 5.3.3.1A of 3GPP TS 23.401 [3]) for a Control Plane Only PDN connection. See NOTE 6.This IE may also be sent on the S11 interface, if S11-U is being used, during a E-UTRAN Tracking Area Update without SGW Change, if the MME needs to establish the S11-U tunnel.See NOTE 8."})
+group_list[("Bearer Context", "Modify Bearer Request", "modified")] = { "index" : "193", "type" : "93", "context" : "Modify Bearer Request", "action" : "modified", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.7-3: Bearer Context to be removed within Modify Bearer Request] Index = 33
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.7-3: Bearer Context to be removed within Modify Bearer Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+group_list[("Bearer Context", "Modify Bearer Request", "removed")] = { "index" : "193", "type" : "93", "context" : "Modify Bearer Request", "action" : "removed", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.7-4: Overload Control Information within Modify Bearer Request] Index = 34
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.7-4: Overload Control Information within Modify Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Modify Bearer Request", "")] = { "index" : "280", "type" : "180", "context" : "Modify Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.8-2: Bearer Context modified within Modify Bearer Response] Index = 36
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.8-2: Bearer Context modified within Modify Bearer Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives information on the reason."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be used on the S11 interface, if the S1 interface is used, i.e. if the S11-U Tunnel flag was not set in the Modify Bearer Request. If the Change F-TEID support Indication flag was set to 1 in the Modify Bearer Request and the SGW needs to change the F-TEID, the SGW shall include the new GTP-U F-TEID value. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value. See NOTE 1"})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 SGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included on the S4 interface if the S12 interface is being used. If the Change F-TEID support Indication flag was set to 1 in the Modify Bearer Request and the SGW needs to change the F-TEID, the SGW shall include the new GTP-U F-TEID value. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value. See NOTE 1"})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGW F-TEID", "presence" : "C", "instance" : "2", "comment" : "This IE shall be present if used on the S4 interface if the S4-U interface is being used. If the Change F-TEID support Indication flag was set to 1 in the Modify Bearer Request and the SGW needs to change the F-TEID, the SGW shall include the new GTP-U F-TEID value. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value. See NOTE 1"})
+ies.append({ "ie_type" : "Charging ID", "ie_value" : "Charging ID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be present on the S5/S8 interface if this message is triggered due to one of the following procedures:TAU/RAU/HO with SGW relocationTAU/RAU/HO from Gn/Gp SGSN to MME/S4-SGSN   "})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "CO", "instance" : "0", "comment" : "Applicable flags are:PPC (Prohibit Payload Compression): This flag shall be sent on the S5/S8 and the S4 interfaces at S4-SGSN relocation."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U SGW F-TEID", "presence" : "C", "instance" : "3", "comment" : "This IE shall be present on the S11 interface if S11-U is being used, i.e. if the S11-U Tunnel flag was set in the Modify Bearer Request. If the Change F-TEID support Indication flag was set to 1 in the Modify Bearer Request and the SGW needs to change the F-TEID, the SGW shall include the new GTP-U F-TEID value. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value. "})
+group_list[("Bearer Context", "Modify Bearer Response", "modified")] = { "index" : "193", "type" : "93", "context" : "Modify Bearer Response", "action" : "modified", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.8-3: Bearer Context marked for removal within Modify Bearer Response] Index = 37
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.8-3: Bearer Context marked for removal within Modify Bearer Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives information on the reason."})
+group_list[("Bearer Context", "Modify Bearer Response", "removal")] = { "index" : "193", "type" : "93", "context" : "Modify Bearer Response", "action" : "removal", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.8-4: Load Control Information within Modify Bearer Response] Index = 38
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.8-4: Load Control Information within Modify Bearer Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.2.5.1.2.2 and 12.2.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
+group_list[("Load Control Information", "Modify Bearer Response", "")] = { "index" : "281", "type" : "181", "context" : "Modify Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.8-5: Overload Control Information within Modify Bearer Response] Index = 39
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.8-5: Overload Control Information within Modify Bearer Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity). See NOTE 1."})
+group_list[("Overload Control Information", "Modify Bearer Response", "")] = { "index" : "280", "type" : "180", "context" : "Modify Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.9.1-2: Overload Control Information within Delete Session Request] Index = 41
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.9.1-2: Overload Control Information within Delete Session Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Delete Session Request", "")] = { "index" : "280", "type" : "180", "context" : "Delete Session Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.9.2-2: Bearer Context within Delete Bearer Request] Index = 43
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.9.2-2: Bearer Context within Delete Bearer Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate the reason of the unsuccessful handling of the bearer."})
+group_list[("Bearer Context", "Delete Bearer Request", "")] = { "index" : "193", "type" : "93", "context" : "Delete Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.9-3: Load Control Information within Delete Bearer Request] Index = 44
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.9-3: Load Control Information within Delete Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.2.5.1.2.2 and 12.2.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
+group_list[("Load Control Information", "Delete Bearer Request", "")] = { "index" : "281", "type" : "181", "context" : "Delete Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.9-4: Overload Control Information within Delete Bearer Request] Index = 45
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.9-4: Overload Control Information within Delete Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity). See NOTE 1."})
+group_list[("Overload Control Information", "Delete Bearer Request", "")] = { "index" : "280", "type" : "180", "context" : "Delete Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.10.1-2: Load Control Information within Delete Session Response] Index = 47
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.10.1-2: Load Control Information within Delete Session Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.2 for the description and use of this parameter."})
+ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
+group_list[("Load Control Information", "Delete Session Response", "")] = { "index" : "281", "type" : "181", "context" : "Delete Session Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.10.1-3: Overload Control Information within Delete Session Response] Index = 48
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.10.1-3: Overload Control Information within Delete Session Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity).See NOTE 1."})
+group_list[("Overload Control Information", "Delete Session Response", "")] = { "index" : "280", "type" : "180", "context" : "Delete Session Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.10.2-2: Bearer Context within Delete Bearer Response] Index = 50
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.10.2-2: Bearer Context within Delete Bearer Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives information on the reason."})
+ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "An MME/SGSN shall include the PCO IE if such information was received from the UE. If the SGW receives this IE, the SGW shall forward it to PGW on the S5/S8 interface.This bearer level IE takes precedence over the PCO IE in the message body if they both exist."})
+ies.append({ "ie_type" : "RAN/NAS Cause", "ie_value" : "RAN/NAS Cause", "presence" : "CO", "instance" : "0", "comment" : "The MME shall include this IE on the S11 interface to indicate the RAN release cause and/or NAS release cause to release the bearer, if this information is available and is permitted to be sent to the PGW operator according to the MME operators policy. If both a RAN release cause and a NAS release cause are generated, then several IEs with the same type and instance value shall be included to represent a list of causes.The SGW shall include this IE on the S5/S8 interface if it receives it from the MME. See NOTE 1."})
+ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "An MME shall include the ePCO IE if such information is received from the UE. If the SGW receives this IE, the SGW shall forward it to the PGW on the S5/S8 interface."})
+group_list[("Bearer Context", "Delete Bearer Response", "")] = { "index" : "193", "type" : "93", "context" : "Delete Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response] Index = 51
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.10.2-3: Overload Control Information within Delete Bearer Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Delete Bearer Response", "")] = { "index" : "280", "type" : "180", "context" : "Delete Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.11.1-2: Load Control Information within Downlink Data Notification] Index = 53
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.11.1-2: Load Control Information within Downlink Data Notification"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.2 for the description and use of this parameter."})
+group_list[("Load Control Information", "Downlink Data Notification", "")] = { "index" : "281", "type" : "181", "context" : "Downlink Data Notification", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification] Index = 54
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.11.1-3: Overload Control Information within Downlink Data Notification"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Downlink Data Notification", "")] = { "index" : "280", "type" : "180", "context" : "Downlink Data Notification", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.14.1-2: Bearer Context within Modify Bearer Command] Index = 60
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.14.1-2: Bearer Context within Modify Bearer Command"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "This IE shall contain the default bearer ID."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "C", "instance" : "0", "comment" : "Mandatory if other parameters than the APN-AMBR have been changed"})
+group_list[("Bearer Context", "Modify Bearer Command", "")] = { "index" : "193", "type" : "93", "context" : "Modify Bearer Command", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.14-3: Overload Control Information within Modify Bearer Command] Index = 61
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.14-3: Overload Control Information within Modify Bearer Command"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Modify Bearer Command", "")] = { "index" : "281", "type" : "181", "context" : "Modify Bearer Command", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication] Index = 63
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.14-2: Overload Control Information within Modify Bearer Failure Indication"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric).See NOTE 1."})
+group_list[("Overload Control Information", "Modify Bearer Failure Indication", "")] = { "index" : "280", "type" : "180", "context" : "Modify Bearer Failure Indication", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.15-2: Bearer Context within Update Bearer Request] Index = 65
-added_ies = group_list["Bearer Context"]["ies"]
-added_ies.append({ "ie_type" : "APCO", "ie_value" : "Additional Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "The PGW shall include the Additional Prococol Configuration Options (APCO) IE on the S2b interface, including the list of available P-CSCF addresses, as part of the P-CSCF restoration extension procedure for the untrusted WLAN access, as specified in 3GPP TS 23.380 [61]."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.2.15-2: Bearer Context within Update Bearer Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S5/S8, S4/S11 and S2a/S2b interfaces if message relates to Bearer Modification and TFT change."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S5/S8, S4/S11 and S2a/S2b interfaces if QoS modification is requested "})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "O", "instance" : "0", "comment" : "Applicable flags:PPC (Prohibit Payload Compression): this flag may be set on the S5/S8 and S4 interfaces.vSRVCC indicator: This IE may be included by the PGW on the S5/S8 interface according to 3GPP TS 23.216 [43]. When received from S5/S8, SGW shall forward on the S11 interface."})
+ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "PGW shall include Protocol Configuration Options (PCO) IE on the S5/S8 interface, if available and if ePCO is not supported by the UE or the network. The PCO IE shall carry a P-CSCF address list only when the UE is required to perform an IMS registration, e.g during the P-CSCF restoration procedure as defined in clause 5.1 of 3GPP TS 23.380 [61]. This bearer level IE takes precedence over the PCO IE in the message body if they both exist. If the SGW receives this IE, the SGW shall forward it to the SGSN/MME on the S4/S11 interface."})
+ies.append({ "ie_type" : "APCO", "ie_value" : "Additional Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "The PGW shall include the Additional Prococol Configuration Options (APCO) IE on the S2b interface, including the list of available P-CSCF addresses, as part of the P-CSCF restoration extension procedure for the untrusted WLAN access, as specified in 3GPP TS 23.380 [61]."})
+ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "The PGW shall include Extended Protocol Configuration Options (ePCO) IE on the S5/S8 interface, if available and if the UE and the network support ePCO. The ePCO IE shall carry a P-CSCF address list only when the UE is required to perform an IMS registration, e.g during the P-CSCF restoration procedure as defined in clause 5.1 of 3GPP TS 23.380 [61]. If the SGW receives this IE, the SGW shall forward it to the MME on the S11 interface."})
+ies.append({ "ie_type" : "Maximum Packet Loss Rate", "ie_value" : "Maximum Packet Loss Rate", "presence" : "O", "instance" : "0", "comment" : "This IE may be included on the S5/S8 interfaces if the PGW needs to send Maximum Packet Loss Rate as specified in clause 5.4.2.1 of 3GPP TS 23.401 [3]. This IE is only applicable for QCI 1."})
+group_list[("Bearer Context", "Update Bearer Request", "")] = { "index" : "193", "type" : "93", "context" : "Update Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.15-3: Load Control Information within Update Bearer Request] Index = 66
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.15-3: Load Control Information within Update Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.2.5.1.2.2 and 12.2.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "APN and Relative Capacity", "ie_value" : "List of APN and Relative Capacity", "presence" : "CO", "instance" : "0", "comment" : "The IE shall (only) be present in the PGWs APN level Load Control Information IE.For indicating the APN level load, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) & its respective Relative Capacity (sharing the same Load Metric).See clause 12.2.5.1.2.3 for the description and use of this parameter.See NOTE 1."})
+group_list[("Load Control Information", "Update Bearer Request", "")] = { "index" : "281", "type" : "181", "context" : "Update Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.15-4: Overload Control Information within Update Bearer Request] Index = 67
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.15-4: Overload Control Information within Update Bearer Request"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity).See NOTE 1."})
+group_list[("Overload Control Information", "Update Bearer Request", "")] = { "index" : "280", "type" : "180", "context" : "Update Bearer Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.16-2: Bearer Context within Update Bearer Response] Index = 69
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.16-2: Bearer Context within Update Bearer Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE Indicates if the bearer handling was successful, and if not, gives information on the reason."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGSN F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included on the S4 interface when direct tunnel is not established. See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 RNC F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included on the S4 interface when direct tunnel flag is set to 1. See NOTE 1."})
+ies.append({ "ie_type" : "PCO", "ie_value" : "Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "An MME/SGSN shall include the PCO IE if such information was received from the UE. If the SGW receives this IE, the SGW shall forward it to PGW on the S5/S8 interface.This bearer level IE takes precedence over the PCO IE in the message body if they both exist."})
+ies.append({ "ie_type" : "RAN/NAS Cause", "ie_value" : "RAN/NAS Cause", "presence" : "CO", "instance" : "0", "comment" : "If the bearer modification failed, the MME shall include this IE on the S11 interface to indicate the RAN cause and/or the NAS cause of the bearer modification failure, if available and if this information is permitted to be sent to the PGW operator according to MME operators policy. If both a RAN cause and a NAS cause are generated, then several IEs with the same type and instance value shall be included to represent a list of causes.The SGW shall include this IE on the S5/S8 interface if it receives it from the MME."})
+ies.append({ "ie_type" : "ePCO", "ie_value" : "Extended Protocol Configuration Options", "presence" : "CO", "instance" : "0", "comment" : "The MME shall include the ePCO IE if such information is received from the UE. If the SGW receives this IE, the SGW shall forward it to PGW on the S5/S8 interface."})
+group_list[("Bearer Context", "Update Bearer Response", "")] = { "index" : "193", "type" : "93", "context" : "Update Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.16-3: Overload Control Information within Update Bearer Response] Index = 70
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.16-3: Overload Control Information within Update Bearer Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Update Bearer Response", "")] = { "index" : "280", "type" : "180", "context" : "Update Bearer Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.17.1-2: Bearer Context within Delete Bearer Command] Index = 72
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.17.1-2: Bearer Context within Delete Bearer Command"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "CO", "instance" : "0", "comment" : "Applicable flags are:VB (Voice Bearer) indicator shall be set to indicate a voice bearer for PS-to-CS (v)SRVCC handover.Vind (vSRVCC indicator) indicator shall be set to indicate a video bearer for PS-to-CS vSRVCC handover."})
+ies.append({ "ie_type" : "RAN/NAS Cause", "ie_value" : "RAN/NAS Release Cause", "presence" : "CO", "instance" : "0", "comment" : "The MME shall include this IE on the S11 interface to indicate the RAN release cause and/or NAS release cause to release the bearer, if available and this information is permitted to be sent to the PGW operator according to MME operators policy. If both a RAN release cause and a NAS release cause are generated, then several IEs with the same type and instance value shall be included to represent a list of causes.The SGW shall include this IE on the S5/S8 interface if it receives it from the MME."})
+group_list[("Bearer Context", "Delete Bearer Command", "")] = { "index" : "193", "type" : "93", "context" : "Delete Bearer Command", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command] Index = 73
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.17.1-3: Overload Control Information within Delete Bearer Command"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Delete Bearer Command", "")] = { "index" : "280", "type" : "180", "context" : "Delete Bearer Command", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.17.2-2: Bearer Context within Delete Bearer Failure Indication] Index = 75
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.17.2-2: Bearer Context within Delete Bearer Failure Indication"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "See clause 6.1.1 Presence requirements of Information Elements."})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate the reason of the unsuccessful handling of the bearer."})
+group_list[("Bearer Context", "Delete Bearer Failure Indication", "")] = { "index" : "193", "type" : "93", "context" : "Delete Bearer Failure Indication", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication] Index = 76
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.17-3: Overload Control Information within Delete Bearer Failure Indication"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clauses 12.3.5.1.2.3 and 12.3.5.1.2.4 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+ies.append({ "ie_type" : "APN", "ie_value" : "List of Access Point Name", "presence" : "CO", "instance" : "0", "comment" : "The IE may (only) be present in the PGWs Overload Control Information IE.For indicating the APN level overload, the PGW shall include one or more instances of this IE, up to maximum of 10, with the same type and instance value, representing a list of APN(s) (sharing the same Overload Reduction Metric and Period of Validity).See NOTE 1."})
+group_list[("Overload Control Information", "Delete Bearer Failure Indication", "")] = { "index" : "280", "type" : "180", "context" : "Delete Bearer Failure Indication", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.18-2: Bearer Context within Create Indirect Data Forwarding Tunnel Request] Index = 78
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.18-2: Bearer Context within Create Indirect Data Forwarding Tunnel Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "eNodeB F-TEID for DL data forwarding", "presence" : "C", "instance" : "0", "comment" : "Target eNodeB F-TEID. This IE shall be present in the message sent from the target MME to the SGW selected by the target MME for indirect data forwarding, or shall be included in the message sent from the source SGSN/MME to the SGW selected by the source MME for indirect data forwarding if the eNodeB F-TEID for DL data forwarding is included in the Forward Relocation Response message."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW/UPF F-TEID for DL data forwarding", "presence" : "C", "instance" : "1", "comment" : "Target SGW F-TEIDThis IE shall be present in the message sent from the source MME/SGSN to the SGW selected by the source MME for indirect data forwarding if SGW F-TEID for DL data forwarding is included in the Forward Relocation Response message. This F-TEID is assigned by the SGW that the target MME/SGSN selects for indirect data forwarding."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGSN F-TEID for DL data forwarding", "presence" : "C", "instance" : "2", "comment" : "Target SGSN F-TEIDThis IE shall be present in the message sent from the target SGSN to the SGW selected by the target SGSN for indirect data forwarding in E-UTRAN to GERAN/UTRAN inter RAT handover with SGW relocation procedure, or shall be included in the message sent from the source MME to the SGW selected by the source MME for indirect data forwarding if the SGSN F-TEID for DL data forwarding is included in the Forwarding Relocation Response message."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "RNC F-TEID for DL data forwarding", "presence" : "C", "instance" : "3", "comment" : "Target RNC F-TEIDThis IE shall be present in the message sent from the target SGSN to the SGW selected by the target SGSN for indirect data forwarding in E-UTRAN to UTRAN inter RAT handover with SGW relocation procedure, or shall be included in the message sent from the source MME to the SGW selected by the source MME for indirect data forwarding if the RNC F-TEID for DL data forwarding is included in the Forwarding Relocation Response message."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "eNodeB F-TEID for UL data forwarding", "presence" : "O", "instance" : "4", "comment" : "Target eNodeB F-TEID. If available this IE may be present in the message, which is sent during the intra-EUTRAN HO from the target MME to the SGW selected by the target MME for indirect data forwarding, or may be included in the message sent from the source MME to the SGW selected by the source MME for indirect data forwarding if the eNodeB F-TEID for data UL forwarding is included in the Forward Relocation Response message."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW F-TEID for UL data forwarding", "presence" : "O", "instance" : "5", "comment" : "Target SGW F-TEIDIf available this IE may be present in the message, which is sent during the intra-EUTRAN HO from the source MME to the SGW selected by the source MME for indirect data forwarding if SGW F-TEID for UL data forwarding is included in the Forward Relocation Response message. This F-TEID is assigned by the SGW that the target MME selects for indirect data forwarding."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "MME F-TEID for DL data forwarding", "presence" : "CO", "instance" : "6", "comment" : "Target MME S11-U F-TEIDThis IE shall be present in the message sent from the target MME to the SGW selected by the target MME for indirect data forwarding, during a TAU procedure with SGW change and data forwarding, with Control Plane CIoT EPS optimisation, as specified in clause 5.3.3.1A of 3GPP TS 23.401 [3]."})
+group_list[("Bearer Context", "Create Indirect Data Forwarding Tunnel Request", "")] = { "index" : "193", "type" : "93", "context" : "Create Indirect Data Forwarding Tunnel Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.19-2: Bearer Context within Create Indirect Data Forwarding Tunnel Response] Index = 80
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.19-2: Bearer Context within Create Indirect Data Forwarding Tunnel Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the tunnel setup was successful, and if not, gives information on the reason."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID for DL data forwarding", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included in the response sent from the SGW selected by the source MME for indirect data forwarding to the source MME. See NOTE 3."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S12 SGW F-TEID for DL data forwarding", "presence" : "C", "instance" : "1", "comment" : "S12 usage only.This IE shall be included in the response sent from the SGW selected by the source SGSN for indirect data forwarding to the source SGSN. See NOTE 3."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S4-U SGW F-TEID for DL data forwarding", "presence" : "C", "instance" : "2", "comment" : "S4-U usage only.This IE shall be included in the response sent from the SGW selected by the source SGSN for indirect data forwarding to the source SGSN. See NOTE 3."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW F-TEID for DL data forwarding", "presence" : "C", "instance" : "3", "comment" : "This IE shall be included in the response message sent from the SGW selected by the target MME/SGSN for indirect data forwarding to the target MME/SGSN. See NOTE 3."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID for UL data forwarding", "presence" : "O", "instance" : "4", "comment" : "If available this IE may be included in the response sent during the intra-EUTRAN HO from the SGW  selected by the source MME for indirect data forwarding to the source MME. See NOTE 4."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW F-TEID for UL data forwarding", "presence" : "O", "instance" : "5", "comment" : "If available this IE may be included in the response message sent during the intra-EUTRAN HO from the SGW selected by the target MME for indirect data forwarding to the target MME. See NOTE 4."})
+group_list[("Bearer Context", "Create Indirect Data Forwarding Tunnel Response", "")] = { "index" : "193", "type" : "93", "context" : "Create Indirect Data Forwarding Tunnel Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.22-2: Load Control Information within Release Access Bearers Response] Index = 83
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.22-2: Load Control Information within Release Access Bearers Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.2 for the description and use of this parameter."})
+group_list[("Load Control Information", "Release Access Bearers Response", "")] = { "index" : "281", "type" : "181", "context" : "Release Access Bearers Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.22-3: Overload Control Information within Release Access Bearers Response] Index = 84
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.22-3: Overload Control Information within Release Access Bearers Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Release Access Bearers Response", "")] = { "index" : "280", "type" : "180", "context" : "Release Access Bearers Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.24-2: Bearer Context to be modified within Modify Access Bearers Request] Index = 87
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.24-2: Bearer Context to be modified within Modify Access Bearers Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U eNodeB F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent if S1-U is being used for:an UE triggered Service Request;S1-based Handover without SGW relocation;X2-based handover without SGW relocation;in S1-U GTP-U tunnel setup procedure during an Inter-MME E-UTRAN Tracking Area Update without SGW Change procedure or Intra-MME E-UTRAN Tracking Area Update without SGW Change procedure with Active Flag   (see 3GPP TS 24.301 [23]);an E-UTRAN Initiated E-RAB modification procedure;an UE initiated Connection Resume;the Establishment of S1-U bearer during Data Transport in Control Plane CIoT EPS optimisation procedure. See NOTE 2.If an MME is aware that the eNodeB supports both IP address types, the MME shall send both IP addresses within an F-TEID IE. If only one IP address is included, then the SGW shall assume that the eNodeB does not support the other IP address type."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U MME F-TEID", "presence" : "CO", "instance" : "1", "comment" : "This IE shall be sent on the S11 interface if S11-U is being used, i.e. for the following procedures:Mobile Originated Data transport in Control Plane CIoT EPS optimisation with P-GW connectivityMobile Terminated Data Transport in Control Plane CIoT EPS optimisation with P-GW connectivity "})
+group_list[("Bearer Context", "Modify Access Bearers Request", "modified")] = { "index" : "193", "type" : "93", "context" : "Modify Access Bearers Request", "action" : "modified", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.24-3: Bearer Context to be removed within Modify Access Bearers Request] Index = 88
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.24-3: Bearer Context to be removed within Modify Access Bearers Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+group_list[("Bearer Context", "Modify Access Bearers Request", "removed")] = { "index" : "193", "type" : "93", "context" : "Modify Access Bearers Request", "action" : "removed", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.25-2: Bearer Context modified within Modify Access Bearers Response] Index = 90
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.25-2: Bearer Context modified within Modify Access Bearers Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives information on the reason."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be present on the S11 interface if S1-U is being used, i.e. if the S11-U Tunnel flag was not set in the Modify Access Bearers Request. The SGW may change the GTP-U F-TEID value if the Change F-TEID support Indication flag was set to 1 in the Modify Access Bearers Request. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value.See NOTE 1."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "S11-U SGW F-TEID", "presence" : "C", "instance" : "1", "comment" : "This IE shall be present on the S11 interface if S11-U is being used, i.e. if the S11-U Tunnel flag was set in the Modify Access Bearers Request. If the Change F-TEID support Indication flag was set to 1 in the Modify Bearer Request and the SGW needs to change the F-TEID, the SGW shall include the new GTP-U F-TEID value. Otherwise, the SGW shall return the currently allocated GTP-U F-TEID value. "})
+group_list[("Bearer Context", "Modify Access Bearers Response", "modified")] = { "index" : "193", "type" : "93", "context" : "Modify Access Bearers Response", "action" : "modified", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.25-3: Bearer Context marked for removal within Modify Access Bearers Response] Index = 91
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.25-3: Bearer Context marked for removal within Modify Access Bearers Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Cause", "ie_value" : "Cause", "presence" : "M", "instance" : "0", "comment" : "This IE shall indicate if the bearer handling was successful, and if not, gives information on the reason."})
+group_list[("Bearer Context", "Modify Access Bearers Response", "removal")] = { "index" : "193", "type" : "93", "context" : "Modify Access Bearers Response", "action" : "removal", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.25-4: Load Control Information within Modify Access Bearers Response] Index = 92
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.25-4: Load Control Information within Modify Access Bearers Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Load Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Load Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.2.5.1.2.2 for the description and use of this parameter."})
+group_list[("Load Control Information", "Modify Access Bearers Response", "")] = { "index" : "281", "type" : "181", "context" : "Modify Access Bearers Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response] Index = 93
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 7.2.25-5: Overload Control Information within Modify Access Bearers Response"
+ies.append({ "ie_type" : "Sequence Number", "ie_value" : "Overload Control Sequence Number", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.1 for the description and use of this parameter."})
+ies.append({ "ie_type" : "Metric", "ie_value" : "Overload Reduction Metric", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.3 for the description and use of this parameter."})
+ies.append({ "ie_type" : "EPC Timer", "ie_value" : "Period of Validity", "presence" : "M", "instance" : "0", "comment" : "See clause 12.3.5.1.2.2 for the description and use of this parameter.This IE should be set to 0 if the Overload Reduction Metric is null. This IE shall be ignored by the receiver if the Overload Reduction Metric is null."})
+group_list[("Overload Control Information", "Modify Access Bearers Response", "")] = { "index" : "280", "type" : "180", "context" : "Modify Access Bearers Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.26-2: Remote UE Context Connected within Remote UE Report Notification] Index = 95
-added_ies = group_list["Remote UE Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.26-2: Remote UE Context Connected within Remote UE Report Notification"
+ies.append({ "ie_type" : "Remote User ID", "ie_value" : "Remote User ID", "presence" : "M", "instance" : "0", "comment" : "See clause 8.123 for the description and use of this parameter"})
+ies.append({ "ie_type" : "Remote UE IP Information", "ie_value" : "Remote UE IP Information", "presence" : "M", "instance" : "0", "comment" : "See clause 8.124 for the description and use of this parameter"})
+group_list[("Remote UE Context", "Remote UE Report Notification", "")] = { "index" : "291", "type" : "191", "context" : "Remote UE Report Notification", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.2.26-3: Remote UE Context Disconnected with Remote UE Report Notification ] Index = 96
-added_ies = group_list["Remote UE Context"]["ies"]
+ies = []
+paragraph = "Table 7.2.26-3: Remote UE Context Disconnected with Remote UE Report Notification "
+ies.append({ "ie_type" : "Remote User ID", "ie_value" : "Remote User ID", "presence" : "M", "instance" : "0", "comment" : "See clause 8.123 for the description and use of this parameter"})
+group_list[("Remote UE Context", "", "")] = { "index" : "291", "type" : "191", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-2: MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request] Index = 99
 ies = []
+paragraph = "Table 7.3.1-2: MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request"
 ies.append({ "ie_type" : "APN", "ie_value" : "APN", "presence" : "M", "instance" : "0", "comment" : ""})
 ies.append({ "ie_type" : "APN Restriction", "ie_value" : "APN Restriction", "presence" : "C", "instance" : "0", "comment" : "This IE denotes the restriction on the combination of types of APN for the APN associated with this EPS bearer Context. The target MME or SGSN determines the Maximum APN Restriction using the APN Restriction. If available, the source MME/S4SGSN shall include this IE."})
 ies.append({ "ie_type" : "Selection Mode", "ie_value" : "Selection Mode", "presence" : "CO", "instance" : "0", "comment" : "When available, this IE shall be included by the source MME/S4-SGSN/AMF."})
@@ -189,22 +492,36 @@ ies.append({ "ie_type" : "WLAN Offloadability Indication", "ie_value" : "WLAN Of
 ies.append({ "ie_type" : "Remote UE Context", "ie_value" : "Remote UE Context Connected", "presence" : "CO", "instance" : "0", "comment" : "The source MME shall include this IE on the S10 interface during an inter MME mobility procedure if such information is available. Several IEs with the same type and instance value may be included as necessary to represent a list of remote UEs connected. "})
 ies.append({ "ie_type" : "PDN Type", "ie_value" : "PDN Type", "presence" : "CO", "instance" : "0", "comment" : "The source MME/SGSN/AMF shall include this IE on the S10/S3/S16/N26 interface, for a Non-IP PDN Connection, during an inter MME/SGSN/AMF mobility procedure, if the target MME/SGSN/AMF supports SGi Non-IP or Ethernet PDN connections."})
 ies.append({ "ie_type" : "Header Compression Configuration", "ie_value" : "Header Compression Configuration", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be sent over the S10 interface if the use of IP Header Compression for Control Plane CIoT EPS optimisations has been negotiated with the UE and the target MME is known to support CIoT EPS optimisations."})
-group_list["PDN Connection"] = { "index" : "209", "type" : "109", "ies" : ies }
+group_list[("PDN Connection", "Forward Relocation Request", "")] = { "index" : "209", "type" : "109", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request] Index = 100
-added_ies = group_list["Bearer Context"]["ies"]
-added_ies.append({ "ie_type" : "F-Container", "ie_value" : "BSS Container", "presence" : "CO", "instance" : "0", "comment" : "The MME/S4 SGSN shall include the Packet Flow ID, Radio Priority, SAPI, PS Handover XID parameters in the TAU/RAU/Handover procedure, if available. See Figure 8.48-2. The Container Type shall be set to 2."})
-added_ies.append({ "ie_type" : "TI", "ie_value" : "Transaction Identifier", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent over S3/S10/S16 if the UE supports A/Gb and/or Iu mode."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.3.1-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Forward Relocation Request"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "See NOTE 3."})
+ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "C", "instance" : "0", "comment" : "This IE shall be present if a TFT is defined for this bearer."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW S1/S4/S12 IP Address and TEID for user plane", "presence" : "M", "instance" : "0", "comment" : "This IE shall contain the SGW S1/S4/S12 IP Address and TEID for user plane. Over the N26 interface, the SMF (on behalf of the source AMF) shall set the IP address and TEID to the following values:-	any reserved TEID (e.g. all 0s, or all 1s);-	IPv4 address set to 0.0.0.0, or IPv6 Prefix Length and IPv6 prefix and Interface Identifier all set to zero.See NOTE2, NOTE 4."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "PGW S5/S8 IP Address and TEID for user plane", "presence" : "C", "instance" : "1", "comment" : "This IE shall be present for GTP based S5/S8."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "F-Container", "ie_value" : "BSS Container", "presence" : "CO", "instance" : "0", "comment" : "The MME/S4 SGSN shall include the Packet Flow ID, Radio Priority, SAPI, PS Handover XID parameters in the TAU/RAU/Handover procedure, if available. See Figure 8.48-2. The Container Type shall be set to 2."})
+ies.append({ "ie_type" : "TI", "ie_value" : "Transaction Identifier", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent over S3/S10/S16 if the UE supports A/Gb and/or Iu mode."})
+ies.append({ "ie_type" : "Bearer Flags", "ie_value" : "Bearer Flags", "presence" : "CO", "instance" : "0", "comment" : "Applicable flags:vSRVCC indicator: This IE shall be sent by the source MME to the target MME on the S10 interface if vSRVCC indicator is available in the source MME. ASI (Activity Status Indicator): the source S4-SGSN shall set this indicator to 1 on the S16 interface if the bearer context is preserved in the CN without an associated RAB."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW S11 IP Address and TEID for user plane", "presence" : "CO", "instance" : "2", "comment" : "This IE shall be present if available. See NOTE 2."})
+group_list[("Bearer Context", "Forward Relocation Request", "")] = { "index" : "193", "type" : "93", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Forward Relocation Request] Index = 101
-added_ies = group_list["Remote UE Context"]["ies"]
+ies = []
+paragraph = "Table 7.3.1-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Forward Relocation Request"
+ies.append({ "ie_type" : "Remote User ID", "ie_value" : "Remote User ID", "presence" : "M", "instance" : "0", "comment" : "See clause 8.123 for the description and use of this parameter"})
+ies.append({ "ie_type" : "Remote UE IP Information", "ie_value" : "Remote UE IP Information", "presence" : "M", "instance" : "0", "comment" : "See clause 8.124 for the description and use of this parameter"})
+group_list[("Remote UE Context", "Forward Relocation Request", "")] = { "index" : "291", "type" : "191", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-5: MME UE SCEF PDN Connections within Forward Relocation Request] Index = 102
 ies = []
+paragraph = "Table 7.3.1-5: MME UE SCEF PDN Connections within Forward Relocation Request"
 ies.append({ "ie_type" : "APN", "ie_value" : "APN", "presence" : "M", "instance" : "0", "comment" : ""})
 ies.append({ "ie_type" : "EBI", "ie_value" : "Default EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "This IE shall identify the default bearer of the SCEF PDN Connection."})
 ies.append({ "ie_type" : "Node Identifier", "ie_value" : "SCEF ID", "presence" : "M", "instance" : "0", "comment" : "This IE shall include the SCEF Identifier and the SCEF Realm for the APN."})
-group_list["SCEF PDN Connection"] = { "index" : "295", "type" : "195", "ies" : ies }
+group_list[("SCEF PDN Connection", "Forward Relocation Request", "")] = { "index" : "295", "type" : "195", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-6: Subscribed V2X Information within Forward Relocation Request] Index = 103
 ies = []
+paragraph = "Table 7.3.1-6: Subscribed V2X Information within Forward Relocation Request"
 ies.append({ "ie_type" : "Services Authorized", "ie_value" : "LTE V2X Services Authorized", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included to indicate the authorization status of the UE to use the LTE sidelink for V2X services."})
 type_list["Services Authorized"]["max_instance"] = "1"
 ies.append({ "ie_type" : "Services Authorized", "ie_value" : "NR V2X Services Authorized", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included to indicate the authorization status of the UE to use the NR sidelink for V2X services."})
@@ -212,37 +529,99 @@ ies.append({ "ie_type" : "Bit Rate", "ie_value" : "LTE UE Sidelink Aggregate Max
 type_list["Bit Rate"]["max_instance"] = "1"
 ies.append({ "ie_type" : "Bit Rate", "ie_value" : "NR UE Sidelink Aggregate Maximum Bit Rate", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included if the UE is authorized for NR V2X services."})
 ies.append({ "ie_type" : "PC5 QoS Parameters", "ie_value" : "PC5 QoS Parameters", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included if the UE is authorized for NR V2X services."})
-group_list["V2X Context"] = { "index" : "102", "type" : "2", "ies" : ies }
+group_list[("V2X Context", "Forward Relocation Request", "")] = { "index" : "102", "type" : "2", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.1-7: PC5 QoS Parameters within Forward Relocation Request] Index = 104
 ies = []
+paragraph = "Table 7.3.1-7: PC5 QoS Parameters within Forward Relocation Request"
 ies.append({ "ie_type" : "PC5 QoS Flow", "ie_value" : "PC5 QoS Flows", "presence" : "M", "instance" : "0", "comment" : "Several IEs with this type and same instance value may be included as necessary to represent a list of PC5 QoS Flows."})
 ies.append({ "ie_type" : "Bit Rate", "ie_value" : "PC5 Link Aggregated Bit Rates", "presence" : "O", "instance" : "0", "comment" : "This IE may be included for the non-GBR PC5 QoS Flows."})
-group_list["PC5 QoS Parameters"] = { "index" : "105", "type" : "5", "ies" : ies }
+group_list[("PC5 QoS Parameters", "Forward Relocation Request", "")] = { "index" : "105", "type" : "5", "context" : "Forward Relocation Request", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.2-2: Bearer Context ] Index = 106
-added_ies = group_list["Bearer Context"]["ies"]
-added_ies.append({ "ie_type" : "Packet Flow ID", "ie_value" : "Packet Flow ID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included if the message is used for PS handover and Inter RAT handover to/from A/Gb mode procedures."})
-group_list["Bearer Context"] = { "index" : "193", "type" : "93", "ies" : added_ies }
+ies = []
+paragraph = "Table 7.3.2-2: Bearer Context "
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included if the message is used for S1-Based handover procedure, 5GS to EPS handover or EPS to 5GS handover. This IE shall be included if the message is used for SRNS relocation procedure and Inter RAT handover to/from Iu mode procedures."})
+ies.append({ "ie_type" : "Packet Flow ID", "ie_value" : "Packet Flow ID", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included if the message is used for PS handover and Inter RAT handover to/from A/Gb mode procedures."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "eNodeB F-TEID for DL data forwarding", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included for the message sent from the target MME, if the DL Transport Layer Address and DL GTP TEID are included in the SAE Bearers Admitted List of the S1AP: HANDOVER REQUEST ACKNOWLEDGE and direct forwarding or indirect forwarding without SGW change is applied."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "eNodeB F-TEID for UL data forwarding", "presence" : "O", "instance" : "1", "comment" : "This IE may be included for the message sent from the target MME during the intra-EUTRAN HO, if the UL Transport Layer Address and UL GTP TEID are included in the SAE Bearers Admitted List of the S1AP: HANDOVER REQUEST ACKNOWLEDGE and direct forwarding or indirect forwarding without SGW change is applied."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW/UPF F-TEID for DL data forwarding", "presence" : "C", "instance" : "2", "comment" : "This IE shall be included when indirect data forwarding with SGW change is applied. "})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "RNC F-TEID for DL data forwarding", "presence" : "C", "instance" : "3", "comment" : "This RNC F-TEID shall be included in the message sent from SGSN, if the target system decides using RNC F-TEID for data forwarding."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGSN F-TEID for DL data forwarding", "presence" : "C", "instance" : "4", "comment" : "This SGSN F-TEID shall be included in the message sent from SGSN, if the target system decides using SGSN F-TEID for data forwarding."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW F-TEID for UL data forwarding", "presence" : "O", "instance" : "5", "comment" : "If available this SGW F-TEID may be included when indirect data forwarding with SGW change is applied, during the intra-EUTRAN HO."})
+group_list[("Bearer Context", "", "")] = { "index" : "193", "type" : "93", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.6-2: MME/SGSN/AMF UE EPS PDN Connections within Context Response] Index = 111
-added_ies = group_list["PDN Connection"]["ies"]
+ies = []
+paragraph = "Table 7.3.6-2: MME/SGSN/AMF UE EPS PDN Connections within Context Response"
+ies.append({ "ie_type" : "APN", "ie_value" : "APN", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "APN Restriction", "ie_value" : "APN Restriction", "presence" : "C", "instance" : "0", "comment" : "This IE denotes the restriction on the combination of types of APN for the APN associated with this EPS bearer Context. The target MME or SGSN determines the Maximum APN Restriction using the APN Restriction. If available, the source MME/S4 SGSN shall include this IE. "})
+ies.append({ "ie_type" : "Selection Mode", "ie_value" : "Selection Mode", "presence" : "CO", "instance" : "0", "comment" : "When available, this IE shall be included by the source MME/S4-SGSN/AMF."})
+ies.append({ "ie_type" : "IP Address", "ie_value" : "IPv4 Address", "presence" : "C", "instance" : "0", "comment" : "This IE shall not be included if no IPv4 Address is assigned. See NOTE 1. See NOTE 5."})
+ies.append({ "ie_type" : "IP Address", "ie_value" : "IPv6 Address", "presence" : "C", "instance" : "1", "comment" : "This IE shall not be included if no IPv6 Address is assigned. See NOTE 5."})
+ies.append({ "ie_type" : "EBI", "ie_value" : "Linked EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "This IE identifies the default bearer of the PDN Connection."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "PGW S5/S8 IP Address for Control Plane or PMIP", "presence" : "M", "instance" : "0", "comment" : "This IE shall include the TEID in the GTP based S5/S8 case and the uplink GRE key in the PMIP based S5/S8 case.See NOTE 3."})
+ies.append({ "ie_type" : "FQDN", "ie_value" : "PGW node name", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included if the source MME, SGSN or AMF has the PGW FQDN."})
+ies.append({ "ie_type" : "Bearer Context", "ie_value" : "Bearer Contexts ", "presence" : "M", "instance" : "0", "comment" : "Several IEs with this type and instance values may be included as necessary to represent a list of Bearers."})
+ies.append({ "ie_type" : "AMBR", "ie_value" : "Aggregate Maximum Bit Rate", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "Charging Characteristics", "ie_value" : "Charging characteristics", "presence" : "C", "instance" : "0", "comment" : "This IE shall be present if charging characteristics was supplied by the HSS to the MME/SGSN, or by the UDM to the SMF, as a part of subscription information."})
+ies.append({ "ie_type" : "Change Reporting Action", "ie_value" : "Change Reporting Action", "presence" : "C", "instance" : "0", "comment" : "This IE shall be included whenever available at the source MME/SGSN. See NOTE 4."})
+ies.append({ "ie_type" : "CSG Information Reporting Action", "ie_value" : "CSG Information Reporting Action", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be included whenever available at the source MME/SGSN."})
+ies.append({ "ie_type" : "eNB Information Reporting", "ie_value" : "HNB Information Reporting ", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be included whenever available at the source MME/SGSN."})
+ies.append({ "ie_type" : "Indication", "ie_value" : "Indication flags", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be included if any one of the applicable flags is set to 1.Applicable flags:Subscribed QoS Change Indication: This flag shall be set to 1 if the subscribed QoS profile of the related PDN connection has changed in the old MME/SGSN when the UE is in ECM-IDLE state and ISR is activated. Change Reporting support indication flag: This flag shall be set to 1 if the source S4-SGSN/MME supports Location Change Reporting mechanism and if the S4-SGSN/MME has indicated the support for the Location Change Reporting mechanism to the PGW, during the session establishment and/or modification procedures. See NOTE 2.CSG Change Reporting Support Indication flag: This flag shall be set to 1 if the Source S4-SGSN/MME supports CSG Information Change Reporting mechanism and if the S4-SGSN/MME has indicated the support for the CSG Information Change Reporting to the PGW, during the session establishment and/or modification procedures. See NOTE 2. Pending Subscription Change Indication flag: This flag shall be set to 1 if the source MME has received Subscribed QoS profile updates for QCI/ARP/APN-AMBR from the HSS but has deferred the reporting of these updates to the PGW/PCRF because the UE was not reachable. Pending Network Initiated PDN Connection Signalling Indication flag: This flag shall be set to 1 by the source MME/SGSN if there is pending network initiated signalling for the PDN connection.Delay Tolerant Connection Indication flag: This flag shall be set to 1 interface by the source MME/SGSN if the PGW indicated that this PDN Connection is delay tolerant.Extended PCO Support Indication flag: This flag shall be set to 1 on S10/N26 interface by the source MME if the UE and the source MME support Extended PCO. It shall be set to 1 on the N26 interface during a 5GS to EPS Idle mode mobility.Control Plane Only PDN Connection Indication: This flag shall be set to 1 if the PDN Connection is set to Control Plane Only.NO 5GS N26 mobility Indication flag: This flag shall be set to 1 on S10 interface if the PDN connection cannot be moved to 5GS via N26."})
+ies.append({ "ie_type" : "Signalling Priority Indication", "ie_value" : "Signalling Priority Indication  ", "presence" : "CO", "instance" : "0", "comment" : "The source SGSN/MME shall include this IE if the UE indicated low access priority when establishing the PDN connection."})
+ies.append({ "ie_type" : "Change to Report Flags", "ie_value" : "Change to Report Flags", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be included by the MME/SGSN if any one of the applicable flags is set to 1.Applicable flags:Serving Network Change to Report: This flag shall be set to 1 if the source MME/SGSN has detected a Serving Network change during a TAU/RAU procedure without MME/SGSN change but has not yet reported this change to the PGW.Time Zone Change to Report: This flag shall be set to 1 if the source MME/SGSN has detected a UE Time Zone change during a TAU/RAU procedure without MME/SGSN change but has not yet reported this change to the PGW."})
+ies.append({ "ie_type" : "FQDN", "ie_value" : "Local Home Network ID", "presence" : "CO", "instance" : "1", "comment" : "This IE shall be sent over the S3/S10/S16 interface if SIPTO at the Local Network is active for the PDN connection in the SIPTO at the Local Network architecture with stand-alone GW. "})
+ies.append({ "ie_type" : "Presence Reporting Area Action", "ie_value" : "Presence Reporting Area Action", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be included if the PGW requested the source MME/SGSN to report changes of UE presence in a Presence Reporting Area. The source MME/SGSN shall include the Presence Reporting Area Identifier and, if received from the PGW, the list of the Presence Reporting Area elements.Several IEs with the same type and instance value may be included as necessary to represent a list of Presence Reporting Area Actions. One IE shall be included for each Presence Reporting Area."})
+ies.append({ "ie_type" : "WLAN Offloadability Indication", "ie_value" : "WLAN Offloadability Indication", "presence" : "CO", "instance" : "0", "comment" : "If the MME/SGSN supports WLAN/3GPP Radio Interworking with RAN rules then this IE shall be included on S3/S10/S16 if the UE has been authorized to perform WLAN offload for at least one RAT. "})
+ies.append({ "ie_type" : "Remote UE Context", "ie_value" : "Remote UE Context Connected", "presence" : "CO", "instance" : "0", "comment" : "The source MME shall include this IE on the S10 interface during an inter MME mobility procedure if such information is available. Several IEs with the same type and instance value may be included as necessary to represent a list of remote UEs connected. "})
+ies.append({ "ie_type" : "PDN Type", "ie_value" : "PDN Type", "presence" : "CO", "instance" : "0", "comment" : "The source MME/SGSN/AMF shall include this IE on the S10/S3/S16/N26 interface, for a Non-IP or Ethernet PDN Connection, during an inter MME/SGSN/AMF mobility procedure if the new MME/SGSN/AMF supports non-IP or Ethernet PDN connection using SGi as indicated in the Context Request message."})
+ies.append({ "ie_type" : "Header Compression Configuration", "ie_value" : "Header Compression Configuration", "presence" : "CO", "instance" : "0", "comment" : "This IE shall be sent over the S10 interface if the use of IP Header Compression for Control Plane CIoT EPS optimisations has been negotiated with the UE and the target MME has set the IHCSI bit of the CIoT Optimizations Support Indication IE to 1 in the Context Request as specified in clause 8.125."})
+group_list[("PDN Connection", "Context Response", "")] = { "index" : "209", "type" : "109", "context" : "Context Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.6-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Context Response] Index = 112
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.3.6-3: Bearer Context within MME/SGSN/AMF UE EPS PDN Connections within Context Response"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : "See NOTE 4."})
+ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "C", "instance" : "0", "comment" : "This IE shall be present if a TFT is defined for this bearer."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW S1/S4/S12/S11 IP Address and TEID for user plane", "presence" : "C", "instance" : "0", "comment" : "The IE shall be present except if:the source and target MME/S4-SGSN support the MME/S4-SGSN triggered SGW restoration procedure, and the source MME/S4-SGSN has not performed the SGW relocation procedure after the SGW has failed as specified in 3GPP TS 23.007 [17].Over the N26 interface, the SMF (on behalf of the source AMF) shall set the IP address and TEID to the following values:-	any reserved TEID (e.g. all 0s, or all 1s);-	IPv4 address set to 0.0.0.0, or IPv6 Prefix Length and IPv6 prefix and Interface Identifier all set to zero.See NOTE 2, NOTE3 and NOTE 5."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "PGW S5/S8 IP Address and TEID for user plane", "presence" : "C", "instance" : "1", "comment" : "This IE shall be included for GTP based S5/S8."})
+ies.append({ "ie_type" : "Bearer QoS", "ie_value" : "Bearer Level QoS", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "F-Container", "ie_value" : "BSS Container", "presence" : "CO", "instance" : "0", "comment" : "The MME/S4 SGSN shall include the Packet Flow ID, Radio Priority, SAPI, PS Handover XID parameters in the TAU/RAU/Handover procedure, if available. The Container Type shall be set to 2."})
+ies.append({ "ie_type" : "TI", "ie_value" : "Transaction Identifier", "presence" : "C", "instance" : "0", "comment" : "This IE shall be sent over S3/S10/S16 if the UE supports A/Gb and/or Iu mode."})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "SGW S11 IP Address and TEID for user plane", "presence" : "CO", "instance" : "2", "comment" : "This IE shall be present if available. See NOTE 3."})
+group_list[("Bearer Context", "Context Response", "")] = { "index" : "193", "type" : "93", "context" : "Context Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.6-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Context Response] Index = 113
-added_ies = group_list["Remote UE Context"]["ies"]
+ies = []
+paragraph = "Table 7.3.6-4: Remote UE Context Connected within MME/SGSN UE EPS PDN Connections within Context Response"
+ies.append({ "ie_type" : "Remote User ID", "ie_value" : "Remote User ID", "presence" : "M", "instance" : "0", "comment" : "See clause 8.123 for the description and use of this parameter"})
+ies.append({ "ie_type" : "Remote UE IP Information", "ie_value" : "Remote UE IP Information", "presence" : "M", "instance" : "0", "comment" : "See clause 8.124 for the description and use of this parameter"})
+group_list[("Remote UE Context", "Context Response", "")] = { "index" : "291", "type" : "191", "context" : "Context Response", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 7.3.7-2: Bearer Context within Context Acknowledge] Index = 116
-added_ies = group_list["Bearer Context"]["ies"]
+ies = []
+paragraph = "Table 7.3.7-2: Bearer Context within Context Acknowledge"
+ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M", "instance" : "0", "comment" : ""})
+ies.append({ "ie_type" : "F-TEID", "ie_value" : "Forwarding F-TEID", "presence" : "M", "instance" : "0", "comment" : "The interface type of the Forwarding F-TEID should be set to either: 23 (SGW/UPF GTP-U interface for DL data forwarding) for indirect forwarding, 0 ( S1-U eNodeB GTP-U interface) or 3 (S12 RNC GTP-U interface), if the eNB or RNC supports such forwarding, or15 (S4 SGSN GTP-U interface)."})
+group_list[("Bearer Context", "Context Acknowledge", "")] = { "index" : "193", "type" : "93", "context" : "Context Acknowledge", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 8.28-1: Bearer Context Grouped Type] Index = 198
-added_ies = group_list["Bearer Context"]["ies"]
+added_ies = group_list[("Bearer Context", "", "")]["ies"]
 # [Table 8.39-1: PDN Connection Grouped Type] Index = 221
-added_ies = group_list["PDN Connection"]["ies"]
+ies = []
+paragraph = "Table 8.39-1: PDN Connection Grouped Type"
+group_list[("PDN Connection", "", "")] = { "index" : "209", "type" : "109", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 8.111-1: Overload Control Information Grouped Type] Index = 326
-added_ies = group_list["Overload Control Information"]["ies"]
+ies = []
+paragraph = "Table 8.111-1: Overload Control Information Grouped Type"
+group_list[("Overload Control Information", "", "")] = { "index" : "280", "type" : "180", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 8.112-1: Load Control Information Grouped Type] Index = 327
-added_ies = group_list["Load Control Information"]["ies"]
+ies = []
+paragraph = "Table 8.112-1: Load Control Information Grouped Type"
+group_list[("Load Control Information", "", "")] = { "index" : "281", "type" : "181", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 8.122-1: Remote UE Context Grouped Type] Index = 337
-added_ies = group_list["Bearer Context"]["ies"]
+added_ies = group_list[("Bearer Context", "", "")]["ies"]
 # [Table 8.126-1: PDN Connection Grouped Type] Index = 341
-added_ies = group_list["PDN Connection"]["ies"]
+added_ies = group_list[("PDN Connection", "", "")]["ies"]
 # [Table 8.138-1: V2X Context Grouped Type] Index = 356
-added_ies = group_list["V2X Context"]["ies"]
+ies = []
+paragraph = "Table 8.138-1: V2X Context Grouped Type"
+group_list[("V2X Context", "", "")] = { "index" : "102", "type" : "2", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }
 # [Table 8.140-1: PC5 QoS Parameters Grouped Type] Index = 357
-added_ies = group_list["PC5 QoS Parameters"]["ies"]
+ies = []
+paragraph = "Table 8.140-1: PC5 QoS Parameters Grouped Type"
+group_list[("PC5 QoS Parameters", "", "")] = { "index" : "105", "type" : "5", "context" : "", "action" : "", "paragraph" : paragraph, "ies" : ies }


### PR DESCRIPTION
This PR adds **full version** for gtp-group-list generation from top level **gtp-tlv.py** as an improvement.

 * from [29274-g30.docx](https://github.com/open5gs/open5gs/blob/main/lib/gtp/support/29274-g30.docx) updated context and action aware tables are extracted in the [tlv-group-list.py](https://github.com/cbalint13/open5gs/blob/main/lib/gtp/support/cache/tlv-group-list.py)
 * this **full variant** also sets on the `group_list_full` some additional [context](https://github.com/cbalint13/open5gs/blob/main/lib/gtp/support/cache/tlv-group-list.py#L28) and [action](https://github.com/cbalint13/open5gs/blob/main/lib/gtp/support/cache/tlv-group-list.py#L28) properties

 
Sample from the new [tlv-group-list.py](https://github.com/cbalint13/open5gs/blob/main/lib/gtp/support/cache/tlv-group-list.py):
```
...
# [Table 7.2.3-2: Bearer Context within Create Bearer Request] Index = 21
ies = []
ies.append({ "ie_type" : "EBI", "ie_value" : "EPS Bearer ID", "presence" : "M" ...
ies.append({ "ie_type" : "Bearer TFT", "ie_value" : "TFT", "presence" : "M" ...
ies.append({ "ie_type" : "F-TEID", "ie_value" : "S1-U SGW F-TEID", "presence" : "C" ...
ies.append({ "ie_type" : "F-TEID", "ie_value" : "S5/8-U PGW F-TEID", "presence" : "C" ...
...
group_list_full["Bearer Context"] = { "index" : "193", "type" : "93", 
"context" : "Create Bearer Request",  "action" : "", "ies" : ies }
...
```

To be noticed there are the **new property fields** :
   * the `context` property (i.e. *"Create Bearer Request", "Create Session Request", ...*)
   * the `action` property (i.e. *"created", "removed" or ""*)

----

### Progress steps

- [x] Update **gtp-tlv.py**  generator to be context & action aware
- [x] Generate *new* message.c & message.h and validate compilation of them
- [ ] Remap rest of O5GS codebase to the new **gtpv2_** teid types (as old equivalence)
- [ ] Pass check internal *volte* and *handover* tests
