### PR TITLE
BSF bind delete possible fix

### DIFF
--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -433,6 +433,21 @@ pcf_sess_t *pcf_sess_find_by_ipv4addr(char *ipv4addr_string)
     return ogs_hash_get(self.ipv4addr_hash, &ipv4addr, sizeof(ipv4addr));
 }
 
+int pcf_sessions_number_by_snssai_and_dnn(pcf_ue_t *pcf_ue, ogs_s_nssai_t *s_nssai, char *dnn) {
+    int number_of_sessions = 0;
+    pcf_sess_t *sess = NULL;
+
+    ogs_assert(s_nssai);
+    ogs_assert(dnn);
+
+    ogs_list_for_each(&pcf_ue->sess_list, sess)
+        if (sess->s_nssai.sst == s_nssai->sst &&
+            sess->dnn && strcmp(sess->dnn, dnn) == 0)
+            number_of_sessions++;
+
+    return number_of_sessions;
+}
+
 pcf_sess_t *pcf_sess_find_by_ipv6addr(char *ipv6addr_string)
 {
     int rv;

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -180,6 +180,7 @@ pcf_sess_t *pcf_sess_find_by_dnn(pcf_ue_t *pcf_ue, char *dnn);
 pcf_sess_t *pcf_sess_find_by_ipv4addr(char *ipv4addr_string);
 pcf_sess_t *pcf_sess_find_by_ipv6addr(char *ipv6addr_string);
 pcf_sess_t *pcf_sess_find_by_ipv6prefix(char *ipv6prefix_string);
+int pcf_sessions_number_by_snssai_and_dnn(pcf_ue_t *pcf_ue, ogs_s_nssai_t *s_nssai, char *dnn);
 
 pcf_ue_t *pcf_ue_cycle(pcf_ue_t *pcf_ue);
 pcf_sess_t *pcf_sess_cycle(pcf_sess_t *sess);

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -320,9 +320,18 @@ bool pcf_npcf_smpolicycontrol_handle_delete(pcf_sess_t *sess,
         pcf_sbi_send_policyauthorization_terminate_notify(app_session);
     }
 
-    ogs_assert(true ==
-        pcf_sess_sbi_discover_and_send(OpenAPI_nf_type_BSF, sess, stream, NULL,
-            pcf_nbsf_management_build_de_register));
+    if(pcf_sessions_number_by_snssai_and_dnn(pcf_ue, &sess->s_nssai, sess->dnn) > 1){
+        ogs_sbi_message_t sendmsg;
+        memset(&sendmsg, 0, sizeof(sendmsg));
+
+        ogs_sbi_response_t *response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+        ogs_assert(response);
+        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+    } else {
+        ogs_assert(true ==
+                   pcf_sess_sbi_discover_and_send(OpenAPI_nf_type_BSF, sess, stream, NULL,
+                                                  pcf_nbsf_management_build_de_register));
+    }
 
     return true;
 


### PR DESCRIPTION
Hello @acetcom,
working with Open5gs I notice that when a UE establishes two pdu sessions with the same dnn and s-nssai (this is correct, in fact from ts 23.502 4.3.2.2.4: A UE can establish multiple PDU sessions associated with the same DNN and S-NSSAI ) the PCF creates two different sm-policies resources (since the body of the POST / sm-policies request contains the session id). Instead, the BSF binds a bond based on s-nssai and dnn, so only one bond is created.
The first time the UE activates a pdu session release for one of the two previously established the procedure works, after which, for the second, a semantic error is given (in the BSF there is no longer any constraint for the session).
To work around this problem, you can drop the BSF association only when there is only one session associated with the tuple (s-nssai, dnn).