### PR TITLE
Attach reject for foreign IMSI

### DIFF
--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -45,7 +45,7 @@ static uint8_t emm_cause_from_diameter(
         switch (*dia_exp_err) {
         case OGS_DIAM_S6A_ERROR_USER_UNKNOWN:                   /* 5001 */
             ogs_info("[%s] User Unknown in HSS DB", mme_ue->imsi_bcd);
-            return EMM_CAUSE_EPS_SERVICES_AND_NON_EPS_SERVICES_NOT_ALLOWED;
+            return EMM_CAUSE_PLMN_NOT_ALLOWED;
         case OGS_DIAM_S6A_ERROR_UNKNOWN_EPS_SUBSCRIPTION:       /* 5420 */
             /* FIXME: Error diagnostic? */
             return EMM_CAUSE_NO_SUITABLE_CELLS_IN_TRACKING_AREA;


### PR DESCRIPTION
Hey @acetcom 

When an unknown UE/IMSI attempts to attach, currently the MME responds with EMM Cause 8 "EPS services and non-EPS services not allowed" after the HSS reports the user as unknown. 
https://github.com/open5gs/open5gs/blob/main/src/mme/mme-sm.c#L48

Take the example of a MNO UE in an area of very poor coverage. It is struggling to connect to its home network, so carries out a cell search to try and find other candidate cells to connect to. It sees a number of other rival MNO cells; but these PLMNs are blacklisted in the FPLMN parameter on the USIM. It sees the Open5GS private network... tries to attach and is rejected with Cause 8. This does not explicitly tell the UE it is not permitted to attach to the cell or network, and the result is that after a short timeout period, the UE will reattempt to attach to the private network (and of course fail again). The UE will likely continue reattempting to attach every 30 mins or so, 24/7.

Probably a more correct EMM response from the MME here would be a Cause in the range 11-15. Per TS 24.301 section 5.3.3, responding with Cause 11-15 will result in the PLMN of the network being blacklisted in a temporary forbidden PLMN list on the UE, meaning it will not attempt to reattach, and should remain focused on attaching to its home network! 

Different Open5GS core users will likely want different responses depending on how their networks are setup. Having a variable in the config file would be a nice way to handle this - I might look into it if I get a min! But for the meantime, **Cause 11** should probably be the default response.

Cheers
Kenny