### PR TITLE
[SMF] Fix router advertisement as per rfc 4861

### DIFF
--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -89,6 +89,7 @@ int ogs_filteraddrinfo(ogs_sockaddr_t **sa_list, int family);
 int ogs_sortaddrinfo(ogs_sockaddr_t **sa_list, int family);
 
 ogs_sockaddr_t *ogs_link_local_addr_by_dev(const char *dev);
+ogs_sockaddr_t *ogs_link_local_addr_by_addr(const ogs_sockaddr_t *sa);
 int ogs_filter_ip_version(ogs_sockaddr_t **addr, 
         int no_ipv4, int no_ipv6, int prefer_ipv4);
 


### PR DESCRIPTION
As per RFC 4861 Router advertisement message
format, Source Address MUST be the link-local address
assigned to the interface from which this message is sent.

Since SMF was not sending it as per RFC, certain
phones were not completing the procedure of stateless
IPv6 address autoconfiguration mentioned in
3GPP TS 23.401 version 15.12.0 Release 15, section 5.3.1.2.2