### PR TITLE
print cellID in hex for consistency

### DIFF
--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -61,7 +61,7 @@ ogs_pkbuf_t *emm_build_attach_accept(
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id),
             mme_ue->tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id),
             mme_ue->e_cgi.cell_id);
     served_tai_index = mme_find_served_tai(&mme_ue->tai);
@@ -430,7 +430,7 @@ ogs_pkbuf_t *emm_build_tau_accept(mme_ue_t *mme_ue)
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id),
             mme_ue->tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id),
             mme_ue->e_cgi.cell_id);
     served_tai_index = mme_find_served_tai(&mme_ue->tai);

--- a/src/mme/emm-handler.c
+++ b/src/mme/emm-handler.c
@@ -90,12 +90,12 @@ int emm_handle_attach_request(mme_ue_t *mme_ue,
 
     ogs_debug("    OLD TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id), mme_ue->e_cgi.cell_id);
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&enb_ue->saved.tai.plmn_id),
             enb_ue->saved.tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&enb_ue->saved.e_cgi.plmn_id),
             enb_ue->saved.e_cgi.cell_id);
 
@@ -483,12 +483,12 @@ int emm_handle_tau_request(mme_ue_t *mme_ue,
 
     ogs_debug("    OLD TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id), mme_ue->e_cgi.cell_id);
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&enb_ue->saved.tai.plmn_id),
             enb_ue->saved.tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&enb_ue->saved.e_cgi.plmn_id),
             enb_ue->saved.e_cgi.cell_id);
 
@@ -601,12 +601,12 @@ int emm_handle_extended_service_request(mme_ue_t *mme_ue,
 
     ogs_debug("    OLD TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id), mme_ue->e_cgi.cell_id);
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&enb_ue->saved.tai.plmn_id),
             enb_ue->saved.tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&enb_ue->saved.e_cgi.plmn_id),
             enb_ue->saved.e_cgi.cell_id);
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -1767,7 +1767,7 @@ void s1ap_handle_path_switch_request(
     ogs_info("    OLD TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id),
             mme_ue->tai.tac);
-    ogs_info("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_info("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id),
             mme_ue->e_cgi.cell_id);
 
@@ -1794,7 +1794,7 @@ void s1ap_handle_path_switch_request(
     ogs_info("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&enb_ue->saved.tai.plmn_id),
             enb_ue->saved.tai.tac);
-    ogs_info("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_info("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&enb_ue->saved.e_cgi.plmn_id),
             enb_ue->saved.e_cgi.cell_id);
 
@@ -2787,13 +2787,13 @@ void s1ap_handle_handover_notification(
     ogs_debug("    OLD TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id),
             mme_ue->tai.tac);
-    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&mme_ue->e_cgi.plmn_id),
             mme_ue->e_cgi.cell_id);
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&target_ue->saved.tai.plmn_id),
             target_ue->saved.tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&target_ue->saved.e_cgi.plmn_id),
             target_ue->saved.e_cgi.cell_id);
 

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -213,7 +213,7 @@ void sgwc_s11_handle_create_session_request(
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
             sgwc_ue->e_tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
             sgwc_ue->e_cgi.cell_id);
 
@@ -368,7 +368,7 @@ void sgwc_s11_handle_modify_bearer_request(
         ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
                 ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
                 sgwc_ue->e_tai.tac);
-        ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+        ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
                 ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
                 sgwc_ue->e_cgi.cell_id);
     }
@@ -639,7 +639,7 @@ void sgwc_s11_handle_create_bearer_response(
     ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
             sgwc_ue->e_tai.tac);
-    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
+    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
             ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
             sgwc_ue->e_cgi.cell_id);
 


### PR DESCRIPTION
Noticed an inconsistency where cell ID is printed in info/debug logs. Sometimes printed as hex (which matches all other logs - although also printed as `CellID[0x%x]`), but it is printed in decimal. So changed to hex representation!
```
cd open5gs
grep -r "CELL_ID:" .

./src/smf/nsmf-handler.c:   ogs_debug("    NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/smf/nsmf-handler.c:   ogs_debug("    NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/mme/s1ap-handler.c:   ogs_info("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/s1ap-handler.c:   ogs_info("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/s1ap-handler.c:   ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/s1ap-handler.c:   ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    OLD E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-handler.c:    ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-build.c:      ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/mme/emm-build.c:      ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/amf/gmm-build.c:      ogs_debug("[%s]    NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]", amf_ue->supi,
./src/amf/gmm-handler.c:    ogs_debug("    OLD NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/amf/gmm-handler.c:    ogs_debug("    NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/amf/gmm-handler.c:    ogs_debug("    OLD NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/amf/gmm-handler.c:    ogs_debug("    NR_CGI[PLMN_ID:%06x,CELL_ID:0x%llx]",
./src/sgwc/s11-handler.c:   ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/sgwc/s11-handler.c:   ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
./src/sgwc/s11-handler.c:   ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:%d]",
```