### PR TITLE
Relax systemd requirements

### DIFF
--- a/configs/systemd/open5gs-smfd.service.in
+++ b/configs/systemd/open5gs-smfd.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Open5GS SMF Daemon
 After=network-online.target
-Requires=systemd-networkd.service
 
 [Service]
 Type=simple

--- a/configs/systemd/open5gs-upfd.service.in
+++ b/configs/systemd/open5gs-upfd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Open5GS UPF Daemon
-After=network-online.target
-Requires=systemd-networkd.service
+After=network-online.target systemd-networkd.service
+Wants=systemd-networkd.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This pull request relaxes the systemd "Requires" specifications currently used for the smf and upf. This allows them to keep running when systems using netplan.io (ubuntu) run `netplan apply` to update interface configurations. This PR has been tested on Ubuntu 20.04 and Debian 11, but please check if I am misunderstading a reason why the hard Requires dependency is needed!