### PR TITLE
[GTPv1C] Send conditional IE Reordering Required in CreatePDPCtxResp

### DIFF
--- a/lib/gtp/v1/message.c
+++ b/lib/gtp/v1/message.c
@@ -21,7 +21,7 @@
 /*******************************************************************************
  * This file had been created by gtp1-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-02-02 10:05:26.214723 by pespin
+ * Created on: 2022-02-18 19:21:27.743742 by pespin
  * from 29060-g00.docx
  ******************************************************************************/
 
@@ -84,7 +84,7 @@ ogs_tlv_desc_t ogs_gtp1_tlv_desc_p_tmsi =
 
 ogs_tlv_desc_t ogs_gtp1_tlv_desc_reordering_required =
 {
-    OGS_TV_FIXED_STR,
+    OGS_TV_UINT8,
     "Reordering Required",
     OGS_GTP1_REORDERING_REQUIRED_TYPE,
     1,

--- a/lib/gtp/v1/message.h
+++ b/lib/gtp/v1/message.h
@@ -21,7 +21,7 @@
 /*******************************************************************************
  * This file had been created by gtp1-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-02-02 10:05:26.205986 by pespin
+ * Created on: 2022-02-18 19:21:27.730656 by pespin
  * from 29060-g00.docx
  ******************************************************************************/
 
@@ -465,7 +465,7 @@ typedef ogs_tlv_octet_t ogs_gtp1_tlv_imsi_t;
 typedef ogs_tlv_octet_t ogs_gtp1_tlv_rai_t;
 typedef ogs_tlv_uint32_t ogs_gtp1_tlv_tlli_t;
 typedef ogs_tlv_uint32_t ogs_gtp1_tlv_p_tmsi_t;
-typedef ogs_tlv_octet_t ogs_gtp1_tlv_reordering_required_t;
+typedef ogs_tlv_uint8_t ogs_gtp1_tlv_reordering_required_t;
 typedef ogs_tlv_octet_t ogs_gtp1_tlv_authentication_triplet_t;
 typedef ogs_tlv_octet_t ogs_gtp1_tlv_map_cause_t;
 typedef ogs_tlv_octet_t ogs_gtp1_tlv_p_tmsi_signature_t;

--- a/lib/gtp/v1/support/gtp1-tlv.py
+++ b/lib/gtp/v1/support/gtp1-tlv.py
@@ -314,6 +314,7 @@ set_c_type("Trace Reference", 'uint')
 set_c_type("Trace Type", 'uint')
 set_c_type("MS Not Reachable Reason", 'uint')
 set_c_type("Charging ID", 'uint')
+set_c_type("Reordering Required", 'uint')
 
 msg_list["Echo Request"]["table"] = 12
 msg_list["Echo Response"]["table"] = 13

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -141,6 +141,8 @@ ogs_pkbuf_t *smf_gn_build_create_pdp_context_response(
 
     /* TODO: Reordering required: should be set based on Qos Profile
        delivery_order field, see TS 23.107 Table 7  */
+   rsp->reordering_required.presence = 1;
+   rsp->reordering_required.u8 = 0; /* No */
 
     /* TODO: Recovery */
 


### PR DESCRIPTION
It seems to be actually mandatory in GGSN->SGN directon, though it is
ignored in Release99 upwards. Let's hardcode it to 0 for now, should be
fine in the majority of cases.