### PR TITLE
[SMF] incorrect GTPv1C cause with changed APN

### DIFF
--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -138,7 +138,10 @@ ogs_pkbuf_t *smf_gn_build_create_pdp_context_response(
 
     /* Set Cause */
     rsp->cause.presence = 1;
-    rsp->cause.u8 = OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
+    if (sess->ue_session_type == sess->session.session_type)
+        rsp->cause.u8 = OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
+    else
+        rsp->cause.u8 = OGS_GTP1_CAUSE_NEW_PDP_TYPE_DUE_TO_NETWORK_PREFERENCE;
 
     /* TODO: Reordering required: should be set based on Qos Profile
        delivery_order field, see TS 23.107 Table 7  */

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -157,14 +157,15 @@ void smf_gn_handle_create_pdp_context_request(
     eua = req->end_user_address.data;
     ogs_assert(eua);
     rv = ogs_gtp1_eua_to_ip(eua, req->end_user_address.len, &sess->session.ue_ip,
-            &sess->session.session_type);
+            &sess->ue_session_type);
     if(rv != OGS_OK) {
         ogs_gtp1_send_error_message(xact, sess->sgw_s5c_teid,
                 OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE,
                 OGS_GTP1_CAUSE_MANDATORY_IE_INCORRECT);
         return;
     }
-
+    /* Initially Set Session Type from UE */
+    sess->session.session_type = sess->ue_session_type;
 
     ogs_assert(OGS_PFCP_CAUSE_REQUEST_ACCEPTED == smf_sess_set_ue_ip(sess));
 


### PR DESCRIPTION
SMF setting incorrect Cause when answering
with a changed APN type IPv4v6 ->IPv4/IPv6

Related: https://github.com/open5gs/open5gs/issues/1360