### PR TITLE
Fix prefix length in Gx CCR Framed-IPv6-Prefix AVP

### DIFF
--- a/src/pcrf/pcrf-gx-path.c
+++ b/src/pcrf/pcrf-gx-path.c
@@ -345,7 +345,7 @@ static int pcrf_gx_ccr_cb( struct msg **msg, struct avp *avp,
 
         paa = (ogs_paa_t *)hdr->avp_value->os.data;
         ogs_assert(paa);
-        ogs_assert(paa->len == OGS_IPV6_LEN * 8 /* 128bit */);
+        ogs_assert(paa->len == OGS_IPV6_DEFAULT_PREFIX_LEN /* 64bit */);
         memcpy(sess_data->addr6, paa->addr6, sizeof sess_data->addr6);
         pcrf_sess_set_ipv6(sess_data->addr6, sess_data->sid);
         sess_data->ipv6 = 1;


### PR DESCRIPTION
As per 3GPP TS 23.401 version 15.12.0, section 5.3.1.2.2
The PDN GW allocates a globally unique /64
IPv6 prefix via Router Advertisement to a given UE.

After the UE has received the Router Advertisement message, it
constructs a full IPv6 address via IPv6 Stateless Address
autoconfiguration in accordance with RFC 4862 using the interface
identifier assigned by PDN GW.

For stateless address autoconfiguration however, the UE can
choose any interface identifier to generate IPv6 addresses, other
than link-local, without involving the network.

And, from section 5.3.1.1, Both EPS network elements and UE shall
support the following mechanisms:

/64 IPv6 prefix allocation via IPv6 Stateless Address
autoconfiguration according to RFC 4862, if IPv6 is
supported.