### PR TITLE
modify building from source md file

### DIFF
--- a/docs/_docs/guide/02-building-open5gs-from-sources.md
+++ b/docs/_docs/guide/02-building-open5gs-from-sources.md
@@ -210,7 +210,6 @@ If you modify the config files while Open5GS daemons are running, please restart
 ---
 
 ```bash
-$ cd install/bin/
 $ ./install/bin/open5gs-mmed
 Open5GS daemon v2.1.0
 


### PR DESCRIPTION
Signed-off-by: ji3k54j062k7 <ji3k54g4j062k7@gmail.com>
Since `cd install/bin/` cannot execute `./install/bin/open5gs-mmed` and other 5G components, this command should not be executed. 