### PR TITLE
[SMF] Gx: Prevent sending Gx messages to non-PCRF Diameter peers 

### DIFF
--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -105,6 +105,12 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
     /* Create the request */
     ret = fd_msg_new(ogs_diam_gx_cmd_ccr, MSGFL_ALLOC_ETEID, &req);
     ogs_assert(ret == 0);
+    {
+        struct msg_hdr *h;
+        ret = fd_msg_hdr(req, &h);
+        ogs_assert(ret == 0);
+        h->msg_appl = OGS_DIAM_GX_APPLICATION_ID;
+    }
 
     /* Find Diameter Gx Session */
     if (sess->gx_sid) {


### PR DESCRIPTION
Otherwise, if h->msg_appl is left as 0, libfreediameter will not try to
match against supported peer's AppIds when taking routing decisions for
the packet (see libfreediameter's dont_send_if_no_common_app()).