### PR TITLE
[DIAM] Add Gy interface support to lib/diameter

### DIFF
--- a/lib/diameter/common/message.c
+++ b/lib/diameter/common/message.c
@@ -23,11 +23,14 @@
 	CHECK_FCT(  fd_dict_search( fd_g_config->cnf_dict, (_type), (_criteria), (_what), (_result), ENOENT) );
 
 struct dict_object *ogs_diam_session_id = NULL;
+struct dict_object *ogs_diam_termination_cause = NULL;
 struct dict_object *ogs_diam_origin_host = NULL;
 struct dict_object *ogs_diam_origin_realm = NULL;
 struct dict_object *ogs_diam_destination_host = NULL;
 struct dict_object *ogs_diam_destination_realm = NULL;
 struct dict_object *ogs_diam_user_name = NULL;
+struct dict_object *ogs_diam_origin_state_id = NULL;
+struct dict_object *ogs_diam_event_timestamp = NULL;
 struct dict_object *ogs_diam_subscription_id = NULL;
 struct dict_object *ogs_diam_subscription_id_type = NULL;
 struct dict_object *ogs_diam_subscription_id_data = NULL;
@@ -44,6 +47,7 @@ struct dict_object *ogs_diam_mip_home_agent_address = NULL;
 struct dict_object *ogs_diam_authorization_lifetime = NULL;
 struct dict_object *ogs_diam_auth_grace_period = NULL;
 struct dict_object *ogs_diam_session_timeout = NULL;
+struct dict_object *ogs_diam_service_context_id = NULL;
 struct dict_object *ogs_diam_rat_type = NULL;
 struct dict_object *ogs_diam_service_selection = NULL;
 struct dict_object *ogs_diam_visited_plmn_id = NULL;
@@ -64,11 +68,14 @@ int ogs_diam_message_init()
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Vendor-Id", &ogs_diam_vendor_id);
 
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Session-Id", &ogs_diam_session_id);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME, "Termination-Cause", &ogs_diam_termination_cause);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Origin-Host", &ogs_diam_origin_host);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Origin-Realm", &ogs_diam_origin_realm);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Destination-Host", &ogs_diam_destination_host);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Destination-Realm", &ogs_diam_destination_realm);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "User-Name", &ogs_diam_user_name);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME, "Origin-State-Id", &ogs_diam_origin_state_id);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME, "Event-Timestamp", &ogs_diam_event_timestamp);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Subscription-Id", &ogs_diam_subscription_id);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Subscription-Id-Type", &ogs_diam_subscription_id_type);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Subscription-Id-Data", &ogs_diam_subscription_id_data);
@@ -85,6 +92,7 @@ int ogs_diam_message_init()
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Authorization-Lifetime", &ogs_diam_authorization_lifetime);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Auth-Grace-Period", &ogs_diam_auth_grace_period);
     CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Session-Timeout", &ogs_diam_session_timeout);
+    CHECK_dict_search( DICT_AVP, AVP_BY_NAME, "Service-Context-Id", &ogs_diam_service_context_id);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "RAT-Type", &ogs_diam_rat_type);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Service-Selection", &ogs_diam_service_selection);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Visited-PLMN-Id", &ogs_diam_visited_plmn_id);

--- a/lib/diameter/common/message.h
+++ b/lib/diameter/common/message.h
@@ -42,11 +42,22 @@ extern "C" {
 #define OGS_DIAM_INVALID_AVP_VALUE                  5005
 
 extern struct dict_object *ogs_diam_session_id;
+extern struct dict_object *ogs_diam_termination_cause;
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_LOGOUT                   1
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_SERVICE_NOT_PROVIDED     2
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_BAD_ANSWER               3
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_DIAMETER_ADMINISTRATIVE  4
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_LINK_BROKEN              5
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_AUTH_EXPIRED             6
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_USER_MOVED               7
+#define OGS_DIAM_TERMINATION_CAUSE_DIAMETER_SESSION_TIMEOUT          8
 extern struct dict_object *ogs_diam_origin_host;
 extern struct dict_object *ogs_diam_origin_realm;
 extern struct dict_object *ogs_diam_destination_host;
 extern struct dict_object *ogs_diam_destination_realm;
 extern struct dict_object *ogs_diam_user_name;
+extern struct dict_object *ogs_diam_origin_state_id;
+extern struct dict_object *ogs_diam_event_timestamp;
 extern struct dict_object *ogs_diam_subscription_id;
 #define OGS_DIAM_SUBSCRIPTION_ID_TYPE_END_USER_E164      0
 #define OGS_DIAM_SUBSCRIPTION_ID_TYPE_END_USER_IMSI      1
@@ -74,6 +85,7 @@ extern struct dict_object *ogs_diam_mip_home_agent_address;
 extern struct dict_object *ogs_diam_authorization_lifetime;
 extern struct dict_object *ogs_diam_auth_grace_period;
 extern struct dict_object *ogs_diam_session_timeout;
+extern struct dict_object *ogs_diam_service_context_id;
 #define OGS_DIAM_RAT_TYPE_WLAN                              0
 #define OGS_DIAM_RAT_TYPE_VIRTUAL                           1
 #define OGS_DIAM_RAT_TYPE_UTRAN                             1000

--- a/lib/diameter/gy/dict.c
+++ b/lib/diameter/gy/dict.c
@@ -1,0 +1,238 @@
+/*********************************************************************************************************
+ * Software License Agreement (BSD License)                                                               *
+ * Author: Thomas Klausner <tk@giga.or.at>                                                                *
+ *                                                                                                        *
+ * Copyright (c) 2013, Thomas Klausner                                                                    *
+ * All rights reserved.                                                                                   *
+ *                                                                                                        *
+ * Written under contract by nfotex IT GmbH, http://nfotex.com/                                           *
+ *                                                                                                        *
+ * Redistribution and use of this software in source and binary forms, with or without modification, are  *
+ * permitted provided that the following conditions are met:                                              *
+ *                                                                                                        *
+ * * Redistributions of source code must retain the above                                                 *
+ *   copyright notice, this list of conditions and the                                                    *
+ *   following disclaimer.                                                                                *
+ *                                                                                                        *
+ * * Redistributions in binary form must reproduce the above                                              *
+ *   copyright notice, this list of conditions and the                                                    *
+ *   following disclaimer in the documentation and/or other                                               *
+ *   materials provided with the distribution.                                                            *
+ *                                                                                                        *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED *
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A *
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR *
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT     *
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS    *
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR *
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF   *
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                                             *
+ *********************************************************************************************************/
+
+/*
+ * Dictionary definitions for objects specified for DCCA by 3GPP.
+ *
+ * This extensions contains a lot of AVPs from various 3GPP standards
+ * documents, and some rules for the grouped AVPs described therein.
+ *
+ * This extension does not contain ALL AVPs described by 3GPP, but
+ * quite a big number of them.
+ *
+ * When extending the AVPs, please edit dict_rx.org instead and
+ * create pastable code with contrib/tools/org_to_fd.pl.
+ *
+ * Some points of consideration:
+ * 1. This dictionary could be split up per document.
+ *
+ * + pro: you can only load the AVPs/Rules you're interested in ->
+ * smaller memory size
+ *
+ * - con: the documents use AVPs from each other A LOT, so setting the
+ * dependencies correctly will be annoying
+ *
+ * - con: you need to load all of them as extensions
+ *
+ * 2. This dictionary contains ONE AVP in the "3GPP2" vendor space,
+ * since I found it wasteful to write a separate dictionary just for
+ * one AVP. Also, it is defined in a 3GPP document.
+ *
+ * 3. While there are quite a number of rules here already, many more
+ * are missing. I've only added rules for those grouped AVPs or
+ * commands in which I was concretely interested so far; many more
+ * will need to be added to make this complete.
+ *
+ * That being said, I hope this will be useful for you.
+ *
+ */
+
+
+/*
+ * Some comments on the 3GPP Standards documents themselves:
+ *
+ * 1. It would be good if 29.061 was reviewed to check for each AVP if
+ * it is Mandatory or not. The data currently in the document does not
+ * match what was in the previous version of the freeDiameter
+ * extension (the one that existedbefore I rewrote it) or what I saw
+ * so far. IIRC, even the table and the document contradict each
+ * other. The AVP table is also missing an entry for
+ * "External-Identifier", 28.
+ *
+ * 2. 29.140 has conflicting AVP names with other documents:
+ *   - Sequence-Number is also in 32.329
+ *   - Recipient-Address is also in 32.299
+ *   - Status is also in 32.299
+ *
+ * 3. 29.229 has name conflict with 29.329 about User-Data (different
+ * AVP code 702, instead of 606) -- the weird thing is, the latter
+ * uses some AVPs from the former, but not this one.
+*/
+#include <freeDiameter/extension.h>
+#include "ogs-diameter-gy.h"
+
+
+/* The content of this file follows the same structure as dict_base_proto.c */
+
+#define CHECK_dict_new( _type, _data, _parent, _ref )  \
+  CHECK_FCT(  fd_dict_new( fd_g_config->cnf_dict, (_type), (_data), (_parent), (_ref))  );
+
+#define CHECK_dict_search( _type, _criteria, _what, _result )  \
+  CHECK_FCT(  fd_dict_search( fd_g_config->cnf_dict, (_type), (_criteria), (_what), (_result), ENOENT) );
+
+struct local_rules_definition {
+  struct dict_avp_request avp_vendor_plus_name;
+  enum rule_position  position;
+  int       min;
+  int      max;
+};
+
+#define RULE_ORDER( _position ) ((((_position) == RULE_FIXED_HEAD) || ((_position) == RULE_FIXED_TAIL)) ? 1 : 0 )
+
+/* Attention! This version of the macro uses AVP_BY_NAME_AND_VENDOR, in contrast to most other copies! */
+#define PARSE_loc_rules( _rulearray, _parent) {                \
+  int __ar;                      \
+  for (__ar=0; __ar < sizeof(_rulearray) / sizeof((_rulearray)[0]); __ar++) {      \
+    struct dict_rule_data __data = { NULL,               \
+      (_rulearray)[__ar].position,              \
+      0,                     \
+      (_rulearray)[__ar].min,                \
+      (_rulearray)[__ar].max};              \
+    __data.rule_order = RULE_ORDER(__data.rule_position);          \
+    CHECK_FCT(  fd_dict_search(                 \
+      fd_g_config->cnf_dict,                \
+      DICT_AVP,                   \
+      AVP_BY_NAME_AND_VENDOR,               \
+      &(_rulearray)[__ar].avp_vendor_plus_name,          \
+      &__data.rule_avp, 0 ) );              \
+    if ( !__data.rule_avp ) {                \
+      TRACE_DEBUG(INFO, "AVP Not found: '%s'", (_rulearray)[__ar].avp_vendor_plus_name.avp_name);    \
+      return ENOENT;                  \
+    }                      \
+    CHECK_FCT_DO( fd_dict_new( fd_g_config->cnf_dict, DICT_RULE, &__data, _parent, NULL),  \
+      {                          \
+        TRACE_DEBUG(INFO, "Error on rule with AVP '%s'",            \
+              (_rulearray)[__ar].avp_vendor_plus_name.avp_name);    \
+        return EINVAL;                      \
+      } );                          \
+  }                              \
+}
+
+#define enumval_def_u32( _val_, _str_ ) \
+    { _str_,     { .u32 = _val_ }}
+
+#define enumval_def_os( _len_, _val_, _str_ ) \
+    { _str_,     { .os = { .data = (unsigned char *)_val_, .len = _len_ }}}
+
+
+int ogs_dict_gy_entry(char *conffile)
+{
+  /* Applications section */
+  {
+  {
+    //struct dict_object * vendor;
+    //CHECK_FCT(fd_dict_search(fd_g_config->cnf_dict, DICT_VENDOR, VENDOR_BY_NAME, "3GPP", &vendor, ENOENT));
+    struct dict_application_data app_data = { OGS_DIAM_GY_APPLICATION_ID, "Gy" };
+    CHECK_FCT(fd_dict_new(fd_g_config->cnf_dict, DICT_APPLICATION, &app_data, NULL, NULL));
+  }
+
+  }
+
+  /* Credit-Control-Request (CCR) Command - Extension for Gy (3GPP TS 32.299 sec 6.4.2) */
+  {
+    struct dict_object * cmd;
+    struct local_rules_definition rules[] =
+    {
+      {  {                      .avp_name = "Session-Id" }, RULE_FIXED_HEAD, -1, 1 },
+      {  {                      .avp_name = "Origin-Host" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Origin-Realm" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Destination-Realm" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Auth-Application-Id" }, RULE_REQUIRED, -1, 1 },
+      //{  {                      .avp_name = "Service-Context-Id" }, RULE_REQUIRED, -1, 1 }, /* freeDiameter: Conflicting rule position */
+      {  {                      .avp_name = "CC-Request-Type" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "CC-Request-Number" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Destination-Host" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "User-Name" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Origin-State-Id" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Event-Timestamp" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Subscription-Id" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Termination-Cause" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Requested-Action" }, RULE_OPTIONAL, -1, 1 },
+      {  { .avp_vendor = 10415, .avp_name = "AoC-Request-Type" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Multiple-Services-Indicator" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Multiple-Services-Credit-Control" }, RULE_OPTIONAL, -1, -1 },
+      {  { .avp_vendor = 10415, .avp_name = "3GPP-RAT-Type" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "CC-Correlation-Id" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "User-Equipment-Info" }, RULE_OPTIONAL, -1, 1 },
+      //{  {                      .avp_name = "OC-Supported-Features" }, RULE_OPTIONAL, -1, 1 }, /*freeDiameter: AVP Not found: 'OC-Supported-Features' */
+      {  {                      .avp_name = "Proxy-Info" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Route-Record" }, RULE_OPTIONAL, -1, -1 },
+      {  { .avp_vendor = 10415, .avp_name = "Service-Information" }, RULE_OPTIONAL, -1, 1 },
+       /* plus any additional AVPs { "AVP", RULE_OPTIONAL, -1, -1 } */
+    };
+
+    CHECK_dict_search( DICT_COMMAND, CMD_BY_NAME, "Credit-Control-Request", &cmd);
+    PARSE_loc_rules( rules, cmd );
+  }
+
+  /* Credit-Control-Answer (CCA) Command - Extension for Gy (3GPP TS 32.299 sec 6.4.3) */
+  {
+    struct dict_object * cmd;
+    struct local_rules_definition rules[] =
+    {
+      {  {                      .avp_name = "Session-Id" }, RULE_FIXED_HEAD, -1, 1 },
+      {  {                      .avp_name = "Result-Code" }, RULE_REQUIRED, -1, 1 },
+     // {  {                      .avp_name = "Experimental-Result" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Origin-Host" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Origin-Realm" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "Auth-Application-Id" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "CC-Request-Type" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "CC-Request-Number" }, RULE_REQUIRED, -1, 1 },
+      {  {                      .avp_name = "CC-Session-Failover" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Multiple-Services-Credit-Control" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Cost-Information" }, RULE_OPTIONAL, -1, 1 },
+      {  { .avp_vendor = 10415, .avp_name = "Low-Balance-Indication" }, RULE_OPTIONAL, -1, 1 },
+      {  { .avp_vendor = 10415, .avp_name = "Remaining-Balance" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Credit-Control-Failure-Handling" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Direct-Debiting-Failure-Handling" }, RULE_OPTIONAL, -1, 1 },
+      //{  {                      .avp_name = "OC-Supported-Features" }, RULE_OPTIONAL, -1, 1 },  /*freeDiameter: AVP Not found: 'OC-Supported-Features' */
+      //{  {                      .avp_name = "OC-OLR" }, RULE_OPTIONAL, -1, 1 }, /*freeDiameter: AVP Not found: 'OC-OLR' */
+      {  {                      .avp_name = "Redirect-Host" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Redirect-Host-Usage" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Redirect-Max-Cache-Time" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Proxy-Info" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Route-Record" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Failed-AVP" }, RULE_OPTIONAL, -1, -1 }, /* 3GPP TS 32.299 6.4.3 says max=1 but RFC4006 & freeDiameter says max=-1 */
+      {  { .avp_vendor = 10415, .avp_name = "Service-Information" }, RULE_OPTIONAL, -1, 1 },
+       /* plus any additional AVPs { "AVP", RULE_OPTIONAL, -1, -1 } */
+    };
+
+    CHECK_dict_search( DICT_COMMAND, CMD_BY_NAME, "Credit-Control-Answer", &cmd);
+    PARSE_loc_rules( rules, cmd );
+  }
+
+  LOG_D( "Extension 'Dictionary definitions for 3GPP Gy' initialized");
+  return 0;
+}
+
+#if 0 /* modified by acetcom */
+EXTENSION_ENTRY("dict_gy", ogs_dict_gy_entry, "dict_dcca_3gpp");
+#endif

--- a/lib/diameter/gy/meson.build
+++ b/lib/diameter/gy/meson.build
@@ -1,4 +1,5 @@
 # Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+# Copyright (C) 2022 by sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
 
 # This file is part of Open5GS.
 
@@ -15,11 +16,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-subdir('common')
-subdir('gx')
-subdir('gy')
-subdir('rx')
-subdir('s6a')
-subdir('cx')
-subdir('swx')
-subdir('s6b')
+libdiameter_gy_sources = files('''
+    ogs-diameter-gy.h
+
+    message.h
+
+    dict.c
+    message.c
+'''.split())
+
+libdiameter_gy_inc = include_directories('.')
+
+libdiameter_gy = library('ogsdiameter-gy',
+    sources : libdiameter_gy_sources,
+    version : libogslib_version,
+    c_args : libdiameter_common_cc_flags,
+    include_directories : libdiameter_gy_inc,
+    dependencies : libdiameter_common_dep,
+    install : true)
+
+libdiameter_gy_dep = declare_dependency(
+    link_with : libdiameter_gy,
+    include_directories : libdiameter_gy_inc,
+    dependencies : libdiameter_common_dep)

--- a/lib/diameter/gy/message.c
+++ b/lib/diameter/gy/message.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2022 by sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ogs-diameter-gy.h"
+
+#define CHECK_dict_search( _type, _criteria, _what, _result )	\
+	CHECK_FCT(  fd_dict_search( fd_g_config->cnf_dict, (_type), (_criteria), (_what), (_result), ENOENT) );
+
+struct dict_object *ogs_diam_gy_application = NULL;
+
+struct dict_object *ogs_diam_gy_cmd_ccr = NULL;
+struct dict_object *ogs_diam_gy_cmd_cca = NULL;
+struct dict_object *ogs_diam_gy_cmd_rar = NULL;
+struct dict_object *ogs_diam_gy_cmd_raa = NULL;
+
+struct dict_object *ogs_diam_gy_cc_request_type = NULL;
+struct dict_object *ogs_diam_gy_cc_request_number = NULL;
+struct dict_object *ogs_diam_gy_requested_action = NULL;
+struct dict_object *ogs_diam_gy_aoc_request_type = NULL;
+struct dict_object *ogs_diam_gy_multiple_services_ind = NULL;
+struct dict_object *ogs_diam_gy_multiple_services_cc = NULL;
+struct dict_object *ogs_diam_gy_requested_service_unit = NULL;
+struct dict_object *ogs_diam_gy_used_service_unit = NULL;
+struct dict_object *ogs_diam_gy_cc_time = NULL;
+struct dict_object *ogs_diam_gy_cc_total_octets = NULL;
+struct dict_object *ogs_diam_gy_cc_input_octets = NULL;
+struct dict_object *ogs_diam_gy_cc_output_octets = NULL;
+struct dict_object *ogs_diam_gy_cc_service_specific_units = NULL;
+struct dict_object *ogs_diam_gy_reporting_reason = NULL;
+struct dict_object *ogs_diam_gy_service_id = NULL;
+
+struct dict_object *ogs_diam_gy_feature_list_id = NULL;
+struct dict_object *ogs_diam_gy_feature_list = NULL;
+struct dict_object *ogs_diam_gy_qos_information = NULL;
+struct dict_object *ogs_diam_gy_qos_class_identifier = NULL;
+struct dict_object *ogs_diam_gy_max_requested_bandwidth_ul = NULL;
+struct dict_object *ogs_diam_gy_max_requested_bandwidth_dl = NULL;
+struct dict_object *ogs_diam_gy_guaranteed_bitrate_ul = NULL;
+struct dict_object *ogs_diam_gy_guaranteed_bitrate_dl = NULL;
+struct dict_object *ogs_diam_gy_allocation_retention_priority = NULL;
+struct dict_object *ogs_diam_gy_priority_level = NULL;
+struct dict_object *ogs_diam_gy_pre_emption_capability = NULL;
+struct dict_object *ogs_diam_gy_pre_emption_vulnerability = NULL;
+struct dict_object *ogs_diam_gy_apn_aggregate_max_bitrate_ul = NULL;
+struct dict_object *ogs_diam_gy_apn_aggregate_max_bitrate_dl = NULL;
+struct dict_object *ogs_diam_gy_3gpp_user_location_info = NULL;
+struct dict_object *ogs_diam_gy_called_station_id = NULL;
+struct dict_object *ogs_diam_gy_3gpp_ms_timezone = NULL;
+struct dict_object *ogs_diam_gy_charging_rule_base_name = NULL;
+struct dict_object *ogs_diam_gy_flows = NULL;
+struct dict_object *ogs_diam_gy_3gpp_sgsn_mcc_mnc = NULL;
+
+extern int ogs_dict_gy_entry(char *conffile);
+
+int ogs_diam_gy_init(void)
+{
+	application_id_t id = OGS_DIAM_GY_APPLICATION_ID;
+
+	ogs_assert(ogs_dict_gy_entry(NULL) == 0);
+
+	CHECK_dict_search(DICT_APPLICATION, APPLICATION_BY_ID, (void *)&id, &ogs_diam_gy_application);
+
+	CHECK_dict_search(DICT_COMMAND, CMD_BY_NAME, "Credit-Control-Request", &ogs_diam_gy_cmd_ccr);
+	CHECK_dict_search(DICT_COMMAND, CMD_BY_NAME, "Credit-Control-Answer", &ogs_diam_gy_cmd_cca);
+	CHECK_dict_search(DICT_COMMAND, CMD_BY_NAME, "Re-Auth-Request", &ogs_diam_gy_cmd_rar);
+	CHECK_dict_search(DICT_COMMAND, CMD_BY_NAME, "Re-Auth-Answer", &ogs_diam_gy_cmd_raa);
+
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Request-Type", &ogs_diam_gy_cc_request_type);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Request-Number", &ogs_diam_gy_cc_request_number);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Requested-Action", &ogs_diam_gy_requested_action);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "AoC-Request-Type", &ogs_diam_gy_aoc_request_type);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Multiple-Services-Indicator", &ogs_diam_gy_multiple_services_ind);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Multiple-Services-Credit-Control", &ogs_diam_gy_multiple_services_cc);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Requested-Service-Unit", &ogs_diam_gy_requested_service_unit);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Used-Service-Unit", &ogs_diam_gy_used_service_unit);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Time", &ogs_diam_gy_cc_time);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Total-Octets", &ogs_diam_gy_cc_total_octets);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Input-Octets", &ogs_diam_gy_cc_input_octets);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Output-Octets", &ogs_diam_gy_cc_output_octets);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "CC-Service-Specific-Units", &ogs_diam_gy_cc_service_specific_units);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Reporting-Reason", &ogs_diam_gy_reporting_reason);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Service-Identifier", &ogs_diam_gy_service_id);
+
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List-ID", &ogs_diam_gy_feature_list_id);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List", &ogs_diam_gy_feature_list);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "QoS-Information", &ogs_diam_gy_qos_information);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "QoS-Class-Identifier" , &ogs_diam_gy_qos_class_identifier);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Max-Requested-Bandwidth-UL" , &ogs_diam_gy_max_requested_bandwidth_ul);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Max-Requested-Bandwidth-DL" , &ogs_diam_gy_max_requested_bandwidth_dl);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Guaranteed-Bitrate-UL" , &ogs_diam_gy_guaranteed_bitrate_ul);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Guaranteed-Bitrate-DL" , &ogs_diam_gy_guaranteed_bitrate_dl);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Allocation-Retention-Priority" , &ogs_diam_gy_allocation_retention_priority);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Priority-Level", &ogs_diam_gy_priority_level);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Pre-emption-Capability", &ogs_diam_gy_pre_emption_capability);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Pre-emption-Vulnerability", &ogs_diam_gy_pre_emption_vulnerability);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "APN-Aggregate-Max-Bitrate-UL" , &ogs_diam_gy_apn_aggregate_max_bitrate_ul);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "APN-Aggregate-Max-Bitrate-DL" , &ogs_diam_gy_apn_aggregate_max_bitrate_dl);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "3GPP-User-Location-Info", &ogs_diam_gy_3gpp_user_location_info);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Called-Station-Id", &ogs_diam_gy_called_station_id);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "3GPP-MS-TimeZone", &ogs_diam_gy_3gpp_ms_timezone);
+
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Charging-Rule-Base-Name", &ogs_diam_gy_charging_rule_base_name);
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Flows", &ogs_diam_gy_flows);
+
+	CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "3GPP-SGSN-MCC-MNC", &ogs_diam_gy_3gpp_sgsn_mcc_mnc);
+
+	return 0;
+}

--- a/lib/diameter/gy/message.h
+++ b/lib/diameter/gy/message.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2022 by sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if !defined(OGS_DIAMETER_INSIDE) && !defined(OGS_DIAMETER_COMPILATION)
+#error "This header cannot be included directly."
+#endif
+
+#ifndef OGS_DIAM_GY_MESSAGE_H
+#define OGS_DIAM_GY_MESSAGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Gy interface, 3GPP TS 32.299 */
+
+#define OGS_DIAM_GY_APPLICATION_ID 4
+
+#define OGS_DIAM_GY_AVP_CODE_RE_AUTH_REQUEST_TYPE           (285)
+#define OGS_DIAM_GY_AVP_CODE_CC_INPUT_OCTETS                (412)
+#define OGS_DIAM_GY_AVP_CODE_CC_OUTPUT_OCTETS               (414)
+#define OGS_DIAM_GY_AVP_CODE_CC_REQUEST_NUMBER              (415)
+#define OGS_DIAM_GY_AVP_CODE_CC_REQUEST_TYPE                (416)
+#define OGS_DIAM_GY_AVP_CODE_CC_TIME                        (420)
+#define OGS_DIAM_GY_AVP_CODE_CC_TOTAL_OCTETS                (421)
+#define OGS_DIAM_GY_AVP_CODE_GRANTED_SERVICE_UNIT           (431)
+#define OGS_DIAM_GY_AVP_CODE_VALIDITY_TIME                  (448)
+#define OGS_DIAM_GY_AVP_CODE_MULTIPLE_SERVICES_CREDIT_CONTROL (456)
+#define OGS_DIAM_GY_AVP_CODE_SUPPORTED_FEATURES             (628)
+#define OGS_DIAM_GY_AVP_CODE_CHARGING_RULE_BASE_NAME        (1004)
+#define OGS_DIAM_GY_AVP_CODE_FLOW_INFORMATION               (1058)
+#define OGS_DIAM_GY_AVP_CODE_QOS_INFORMATION                (1016)
+
+extern struct dict_object *ogs_diam_gy_application;
+
+extern struct dict_object *ogs_diam_gy_cmd_ccr;
+extern struct dict_object *ogs_diam_gy_cmd_cca;
+extern struct dict_object *ogs_diam_gy_cmd_rar;
+extern struct dict_object *ogs_diam_gy_cmd_raa;
+
+extern struct dict_object *ogs_diam_gy_cc_request_type;
+extern struct dict_object *ogs_diam_gy_cc_request_number;
+extern struct dict_object *ogs_diam_gy_requested_action;
+#define OGS_DIAM_GY_REQUESTED_ACTION_DIRECT_DEBITING   0
+#define OGS_DIAM_GY_REQUESTED_ACTION_REFUND_ACCOUNT    1
+#define OGS_DIAM_GY_REQUESTED_ACTION_CHECK_BALANCE     2
+#define OGS_DIAM_GY_REQUESTED_ACTION_PRICE_ENQUIRY     3
+extern struct dict_object *ogs_diam_gy_aoc_request_type;
+#define OGS_DIAM_GY_AoC_NOT_REQUESTED   0
+#define OGS_DIAM_GY_AoC_FULL            1
+#define OGS_DIAM_GY_AoC_COST_ONLY       2
+#define OGS_DIAM_GY_AoC_TARIFF_ONLY     3
+extern struct dict_object *ogs_diam_gy_multiple_services_ind;
+#define OGS_DIAM_GY_MULTIPLE_SERVICES_NOT_SUPPORTED 0
+#define OGS_DIAM_GY_MULTIPLE_SERVICES_SUPPORTED 1
+extern struct dict_object *ogs_diam_gy_multiple_services_cc;
+extern struct dict_object *ogs_diam_gy_requested_service_unit;
+extern struct dict_object *ogs_diam_gy_used_service_unit;
+extern struct dict_object *ogs_diam_gy_cc_time;
+extern struct dict_object *ogs_diam_gy_cc_total_octets;
+extern struct dict_object *ogs_diam_gy_cc_input_octets;
+extern struct dict_object *ogs_diam_gy_cc_output_octets;
+extern struct dict_object *ogs_diam_gy_cc_service_specific_units;
+extern struct dict_object *ogs_diam_gy_reporting_reason;
+#define OGS_DIAM_GY_REPORTING_REASON_THRESHOLD                  0
+#define OGS_DIAM_GY_REPORTING_REASON_QHT                        1
+#define OGS_DIAM_GY_REPORTING_REASON_FINAL                      2
+#define OGS_DIAM_GY_REPORTING_REASON_QUOTA_EXHAUSTED            3
+#define OGS_DIAM_GY_REPORTING_REASON_VALIDITY_TIME              4
+#define OGS_DIAM_GY_REPORTING_REASON_OTHER_QUOTA_TYPE           5
+#define OGS_DIAM_GY_REPORTING_REASON_RATING_CONDITION_CHANGE    6
+#define OGS_DIAM_GY_REPORTING_REASON_FORCED_REAUTHORISATION     7
+#define OGS_DIAM_GY_REPORTING_REASON_POOL_EXHAUSTED             8
+#define OGS_DIAM_GY_REPORTING_REASON_UNUSED_QUOTA_TIMER         9
+extern struct dict_object *ogs_diam_gy_service_id;
+extern struct dict_object *ogs_diam_gy_feature_list_id;
+extern struct dict_object *ogs_diam_gy_feature_list;
+extern struct dict_object *ogs_diam_gy_qos_information;
+extern struct dict_object *ogs_diam_gy_qos_class_identifier;
+extern struct dict_object *ogs_diam_gy_max_requested_bandwidth_ul;
+extern struct dict_object *ogs_diam_gy_max_requested_bandwidth_dl;
+extern struct dict_object *ogs_diam_gy_guaranteed_bitrate_ul;
+extern struct dict_object *ogs_diam_gy_guaranteed_bitrate_dl;
+extern struct dict_object *ogs_diam_gy_allocation_retention_priority;
+extern struct dict_object *ogs_diam_gy_priority_level;
+extern struct dict_object *ogs_diam_gy_pre_emption_capability;
+extern struct dict_object *ogs_diam_gy_pre_emption_vulnerability;
+extern struct dict_object *ogs_diam_gy_apn_aggregate_max_bitrate_ul;
+extern struct dict_object *ogs_diam_gy_apn_aggregate_max_bitrate_dl;
+#define OGS_DIAM_GY_3GPP_USER_LOCATION_INFO_TYPE_TAI            128
+#define OGS_DIAM_GY_3GPP_USER_LOCATION_INFO_TYPE_ECGI           129
+#define OGS_DIAM_GY_3GPP_USER_LOCATION_INFO_TYPE_TAI_AND_ECGI   130
+extern struct dict_object *ogs_diam_gy_3gpp_user_location_info;
+extern struct dict_object *ogs_diam_gy_called_station_id;
+extern struct dict_object *ogs_diam_gy_3gpp_ms_timezone;
+extern struct dict_object *ogs_diam_gy_charging_rule_base_name;;
+extern struct dict_object *ogs_diam_gy_flows;
+extern struct dict_object *ogs_diam_gy_3gpp_sgsn_mcc_mnc;
+
+typedef struct ogs_diam_gy_service_unit_s {
+    bool cc_time_present;
+    uint32_t cc_time;
+    bool cc_total_octets_present;
+    uint64_t cc_total_octets;
+    bool cc_input_octets_present;
+    uint64_t cc_input_octets;
+    bool cc_output_octets_present;
+    uint64_t cc_output_octets;
+} ogs_diam_gy_service_unit_t;
+
+typedef struct ogs_diam_gy_message_s {
+#define OGS_DIAM_GY_CMD_CODE_CREDIT_CONTROL                         272
+#define OGS_DIAM_GY_CMD_RE_AUTH                                     258
+    uint16_t            cmd_code;
+
+/* Experimental-Result-Codes */
+#define OGS_DIAM_GY_DIAMETER_ERROR_LATE_OVERLAPPING_REQUEST         5453
+#define OGS_DIAM_GY_DIAMETER_ERROR_TIMED_OUT_REQUEST                5454
+#define OGS_DIAM_GY_DIAMETER_ERROR_INITIAL_PARAMETERS               5140
+#define OGS_DIAM_GY_DIAMETER_ERROR_TRIGGER_EVENT                    5141
+#define OGS_DIAM_GY_DIAMETER_PCC_RULE_EVENT                         5142
+#define OGS_DIAM_GY_DIAMETER_ERROR_BEARER_NOT_AUTHORIZED            5143
+#define OGS_DIAM_GY_DIAMETER_ERROR_TRAFFIC_MAPPING_INFO_REJECTED    5144
+#define OGS_DIAM_GY_DIAMETER_ERROR_CONFLICTING_REQUEST              5147
+#define OGS_DIAM_GY_DIAMETER_ADC_RULE_EVENT                         5148
+#define OGS_DIAM_GY_DIAMETER_ERROR_NBIFOM_NOT_AUTHORIZED            5149
+    uint32_t            result_code;
+    uint32_t            *err;
+    uint32_t            *exp_err;
+
+#define OGS_DIAM_GY_CC_REQUEST_TYPE_INITIAL_REQUEST                 1
+#define OGS_DIAM_GY_CC_REQUEST_TYPE_UPDATE_REQUEST                  2
+#define OGS_DIAM_GY_CC_REQUEST_TYPE_TERMINATION_REQUEST             3
+#define OGS_DIAM_GY_CC_REQUEST_TYPE_EVENT_REQUEST                   4
+    uint32_t            cc_request_type;
+
+    union {
+        struct {
+            uint32_t validity_time;
+            ogs_diam_gy_service_unit_t granted;
+        } cca;
+    };
+} ogs_diam_gy_message_t;
+
+int ogs_diam_gy_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OGS_DIAM_GY_MESSAGE_H */

--- a/lib/diameter/gy/ogs-diameter-gy.h
+++ b/lib/diameter/gy/ogs-diameter-gy.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2022 by sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef OGS_DIAMETER_GY_H
+#define OGS_DIAMETER_GY_H
+
+#include "ogs-diameter-common.h"
+
+#define OGS_DIAMETER_INSIDE
+
+#include "diameter/gy/message.h"
+
+#undef OGS_DIAMETER_INSIDE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Nothing */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OGS_DIAMETER_GY_H */


### PR DESCRIPTION
This commit adds required blocks in lib/diameter to be able to handle Gy
messages later in open5gs apps.

The Gy interface is mainly decribed in 3GPP TS 32.299  and 3GPP TS
32.251, which in turn refers to Diameter protcols defined in RFC4006.
This interface allows charging managment through an external OCS node.