### PR TITLE
Functionality for  send sms with using IMS service.

### DIFF
--- a/configs/open5gs/hss.yaml.in
+++ b/configs/open5gs/hss.yaml.in
@@ -26,7 +26,7 @@ logger:
 hss:
     freeDiameter: @sysconfdir@/freeDiameter/hss.conf
 
-#      smsip: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060"
+#    sms_over_ims: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060"
 
 #
 # parameter:

--- a/configs/open5gs/hss.yaml.in
+++ b/configs/open5gs/hss.yaml.in
@@ -26,7 +26,7 @@ logger:
 hss:
     freeDiameter: @sysconfdir@/freeDiameter/hss.conf
 
-#    sms_over_ims: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060"
+#    sms_over_ims: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060;transport=tcp"
 
 #
 # parameter:

--- a/configs/open5gs/hss.yaml.in
+++ b/configs/open5gs/hss.yaml.in
@@ -26,6 +26,8 @@ logger:
 hss:
     freeDiameter: @sysconfdir@/freeDiameter/hss.conf
 
+#      smsip: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060"
+
 #
 # parameter:
 #

--- a/lib/diameter/common/base.h
+++ b/lib/diameter/common/base.h
@@ -38,6 +38,9 @@ typedef struct ogs_diam_config_s {
     /* IP address of the local peer */
     const char *cnf_addr;
 
+    /* SMS Center IP*/
+    const char *cnf_smsip;
+
     /* the local port for legacy Diameter (default: 3868) in host byte order */
     uint16_t cnf_port;
     /* the local port for Diameter/TLS (default: 5658) in host byte order */

--- a/lib/diameter/common/base.h
+++ b/lib/diameter/common/base.h
@@ -38,9 +38,6 @@ typedef struct ogs_diam_config_s {
     /* IP address of the local peer */
     const char *cnf_addr;
 
-    /* SMS Center IP*/
-    const char *cnf_smsip;
-
     /* the local port for legacy Diameter (default: 3868) in host byte order */
     uint16_t cnf_port;
     /* the local port for Diameter/TLS (default: 5658) in host byte order */

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -964,7 +964,7 @@ char *hss_cx_download_user_data(
 
             user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                         ogs_diam_cx_xml_priority_s,
-                        "10", 
+                        "2", 
                         ogs_diam_cx_xml_priority_e); 
             ogs_assert(user_data);
 
@@ -981,33 +981,7 @@ char *hss_cx_download_user_data(
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_condition_negated_s, 
-                            "0", 
-                            ogs_diam_cx_xml_condition_negated_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_group_s, 
-                            "0", 
-                            ogs_diam_cx_xml_group_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_method_s, 
-                            "MESSAGE", 
-                            ogs_diam_cx_xml_method_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_spt_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_spt_s); 
-                ogs_assert(user_data);
-
+//1
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_condition_negated_s, 
                             "0", 
@@ -1021,15 +995,123 @@ char *hss_cx_download_user_data(
                 ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_method_s, 
+                            "MESSAGE", 
+                            ogs_diam_cx_xml_method_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_extension_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_registration_type_s, 
+                            "0", 
+                            ogs_diam_cx_xml_registration_type_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_extension_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+//2
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_condition_negated_s, 
+                            "0", 
+                            ogs_diam_cx_xml_condition_negated_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_group_s, 
+                            "2", 
+                            ogs_diam_cx_xml_group_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_sip_hdr_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_header_s, 
+                            "Content-Type", 
+                            ogs_diam_cx_xml_header_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_content_s, 
+                            "application/vnd.3gpp.sms", 
+                            ogs_diam_cx_xml_content_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_sip_hdr_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_extension_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_registration_type_s, 
+                            "0", 
+                            ogs_diam_cx_xml_registration_type_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_extension_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+//3
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_condition_negated_s, 
+                            "0", 
+                            ogs_diam_cx_xml_condition_negated_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_group_s, 
+                            "3", 
+                            ogs_diam_cx_xml_group_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_session_case_s, 
                             "0", 
                             ogs_diam_cx_xml_session_case_e); 
                 ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_spt_e); 
+                            ogs_diam_cx_xml_extension_s); 
                 ogs_assert(user_data);
 
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_registration_type_s, 
+                            "0", 
+                            ogs_diam_cx_xml_registration_type_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_extension_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+//end 3
             user_data = ogs_mstrcatf(user_data, "%s", 
                         ogs_diam_cx_xml_tp_e); 
             ogs_assert(user_data);

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -199,10 +199,7 @@ int hss_context_parse_config(void)
                             } else if (!strcmp(fd_key, "realm")) {
                                 self.diam_config->cnf_diamrlm = 
                                     ogs_yaml_iter_value(&fd_iter);
-                            } else if (!strcmp(fd_key, "smsip")) {
-                                self.diam_config->cnf_smsip = 
-                                    ogs_yaml_iter_value(&fd_iter);
-                            }  else if (!strcmp(fd_key, "port")) {
+                            } else if (!strcmp(fd_key, "port")) {
                                 const char *v = ogs_yaml_iter_value(&fd_iter);
                                 if (v) self.diam_config->cnf_port = atoi(v);
                             } else if (!strcmp(fd_key, "sec_port")) {
@@ -326,6 +323,9 @@ int hss_context_parse_config(void)
                                 ogs_warn("unknown key `%s`", fd_key);
                         }
                     }
+                } else if (!strcmp(hss_key, "smsip")) {
+                            self.diam_config->cnf_smsip = 
+                                ogs_yaml_iter_value(&hss_iter);
                 } else
                     ogs_warn("unknown key `%s`", hss_key);
             }

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -199,7 +199,10 @@ int hss_context_parse_config(void)
                             } else if (!strcmp(fd_key, "realm")) {
                                 self.diam_config->cnf_diamrlm = 
                                     ogs_yaml_iter_value(&fd_iter);
-                            } else if (!strcmp(fd_key, "port")) {
+                            } else if (!strcmp(fd_key, "smsip")) {
+                                self.diam_config->cnf_smsip = 
+                                    ogs_yaml_iter_value(&fd_iter);
+                            }  else if (!strcmp(fd_key, "port")) {
                                 const char *v = ogs_yaml_iter_value(&fd_iter);
                                 if (v) self.diam_config->cnf_port = atoi(v);
                             } else if (!strcmp(fd_key, "sec_port")) {
@@ -951,108 +954,110 @@ char *hss_cx_download_user_data(
                         ogs_diam_cx_xml_public_id_e);
             ogs_assert(user_data);
         }
-#if(1) //SMSIP
 
-        user_data = ogs_mstrcatf(user_data, "%s", 
-                    ogs_diam_cx_xml_ifc_s); 
-        ogs_assert(user_data);
-
-          user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                      ogs_diam_cx_xml_priority_s,
-                      "10", 
-                      ogs_diam_cx_xml_priority_e); 
-          ogs_assert(user_data);
-
-          user_data = ogs_mstrcatf(user_data, "%s", 
-                      ogs_diam_cx_xml_tp_s); 
-          ogs_assert(user_data);
-
-            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                        ogs_diam_cx_xml_cnf_s, 
-                        "1", 
-                        ogs_diam_cx_xml_cnf_e); 
-            ogs_assert(user_data);
+        /* smsip: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060" */
+        if(self.diam_config->cnf_smsip) {
 
             user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_spt_s); 
-            ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_condition_negated_s, 
-                          "0", 
-                          ogs_diam_cx_xml_condition_negated_e); 
-              ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_group_s, 
-                          "0", 
-                          ogs_diam_cx_xml_group_e); 
-              ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_method_s, 
-                          "MESSAGE", 
-                          ogs_diam_cx_xml_method_e); 
-              ogs_assert(user_data);
-
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_spt_e); 
-            ogs_assert(user_data);
-
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_spt_s); 
-            ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_condition_negated_s, 
-                          "0", 
-                          ogs_diam_cx_xml_condition_negated_e); 
-              ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_group_s, 
-                          "1", 
-                          ogs_diam_cx_xml_group_e); 
-              ogs_assert(user_data);
-
-              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                          ogs_diam_cx_xml_session_case_s, 
-                          "0", 
-                          ogs_diam_cx_xml_session_case_e); 
-              ogs_assert(user_data);
-
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_spt_e); 
-            ogs_assert(user_data);
-
-          user_data = ogs_mstrcatf(user_data, "%s", 
-                      ogs_diam_cx_xml_tp_e); 
-          ogs_assert(user_data);
-
-          user_data = ogs_mstrcatf(user_data, "%s", 
-                      ogs_diam_cx_xml_app_server_s); 
-          ogs_assert(user_data);
-
-            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                        ogs_diam_cx_xml_server_name_s, 
-                        "sip:smsc.mnc001.mcc001.3gppnetwork.org:5060", 
-                        ogs_diam_cx_xml_server_name_e); 
+                        ogs_diam_cx_xml_ifc_s); 
             ogs_assert(user_data);
 
             user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                        ogs_diam_cx_xml_default_handling_s, 
-                        "0",
-                        ogs_diam_cx_xml_default_handling_e); 
+                        ogs_diam_cx_xml_priority_s,
+                        "10", 
+                        ogs_diam_cx_xml_priority_e); 
             ogs_assert(user_data);
 
-          user_data = ogs_mstrcatf(user_data, "%s", 
-                      ogs_diam_cx_xml_app_server_e); 
-          ogs_assert(user_data);
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_tp_s); 
+            ogs_assert(user_data);
 
-        user_data = ogs_mstrcatf(user_data, "%s", 
-                    ogs_diam_cx_xml_ifc_e);
-        ogs_assert(user_data);
-#endif
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_cnf_s, 
+                            "1", 
+                            ogs_diam_cx_xml_cnf_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_condition_negated_s, 
+                            "0", 
+                            ogs_diam_cx_xml_condition_negated_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_group_s, 
+                            "0", 
+                            ogs_diam_cx_xml_group_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_method_s, 
+                            "MESSAGE", 
+                            ogs_diam_cx_xml_method_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_s); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_condition_negated_s, 
+                            "0", 
+                            ogs_diam_cx_xml_condition_negated_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_group_s, 
+                            "1", 
+                            ogs_diam_cx_xml_group_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_session_case_s, 
+                            "0", 
+                            ogs_diam_cx_xml_session_case_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_tp_e); 
+            ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_app_server_s); 
+            ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_server_name_s, 
+                            self.diam_config->cnf_smsip, 
+                            ogs_diam_cx_xml_server_name_e); 
+                ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                            ogs_diam_cx_xml_default_handling_s, 
+                            "0",
+                            ogs_diam_cx_xml_default_handling_e); 
+                ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_app_server_e); 
+            ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_ifc_e);
+            ogs_assert(user_data);
+        }
 
       user_data = ogs_mstrcatf(user_data, "%s",
                   ogs_diam_cx_xml_service_profile_e);

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -951,6 +951,108 @@ char *hss_cx_download_user_data(
                         ogs_diam_cx_xml_public_id_e);
             ogs_assert(user_data);
         }
+#if(1) //SMSIP
+
+        user_data = ogs_mstrcatf(user_data, "%s", 
+                    ogs_diam_cx_xml_ifc_s); 
+        ogs_assert(user_data);
+
+          user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                      ogs_diam_cx_xml_priority_s,
+                      "10", 
+                      ogs_diam_cx_xml_priority_e); 
+          ogs_assert(user_data);
+
+          user_data = ogs_mstrcatf(user_data, "%s", 
+                      ogs_diam_cx_xml_tp_s); 
+          ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                        ogs_diam_cx_xml_cnf_s, 
+                        "1", 
+                        ogs_diam_cx_xml_cnf_e); 
+            ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_spt_s); 
+            ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_condition_negated_s, 
+                          "0", 
+                          ogs_diam_cx_xml_condition_negated_e); 
+              ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_group_s, 
+                          "0", 
+                          ogs_diam_cx_xml_group_e); 
+              ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_method_s, 
+                          "MESSAGE", 
+                          ogs_diam_cx_xml_method_e); 
+              ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_spt_e); 
+            ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_spt_s); 
+            ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_condition_negated_s, 
+                          "0", 
+                          ogs_diam_cx_xml_condition_negated_e); 
+              ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_group_s, 
+                          "1", 
+                          ogs_diam_cx_xml_group_e); 
+              ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_session_case_s, 
+                          "0", 
+                          ogs_diam_cx_xml_session_case_e); 
+              ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s", 
+                        ogs_diam_cx_xml_spt_e); 
+            ogs_assert(user_data);
+
+          user_data = ogs_mstrcatf(user_data, "%s", 
+                      ogs_diam_cx_xml_tp_e); 
+          ogs_assert(user_data);
+
+          user_data = ogs_mstrcatf(user_data, "%s", 
+                      ogs_diam_cx_xml_app_server_s); 
+          ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                        ogs_diam_cx_xml_server_name_s, 
+                        "sip:smsc.mnc001.mcc001.3gppnetwork.org:5060", 
+                        ogs_diam_cx_xml_server_name_e); 
+            ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                        ogs_diam_cx_xml_default_handling_s, 
+                        "0",
+                        ogs_diam_cx_xml_default_handling_e); 
+            ogs_assert(user_data);
+
+          user_data = ogs_mstrcatf(user_data, "%s", 
+                      ogs_diam_cx_xml_app_server_e); 
+          ogs_assert(user_data);
+
+        user_data = ogs_mstrcatf(user_data, "%s", 
+                    ogs_diam_cx_xml_ifc_e);
+        ogs_assert(user_data);
+#endif
 
       user_data = ogs_mstrcatf(user_data, "%s",
                   ogs_diam_cx_xml_service_profile_e);

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -323,8 +323,8 @@ int hss_context_parse_config(void)
                                 ogs_warn("unknown key `%s`", fd_key);
                         }
                     }
-                } else if (!strcmp(hss_key, "smsip")) {
-                            self.diam_config->cnf_smsip = 
+                } else if (!strcmp(hss_key, "sms_over_ims")) {
+                            self.sms_over_ims = 
                                 ogs_yaml_iter_value(&hss_iter);
                 } else
                     ogs_warn("unknown key `%s`", hss_key);
@@ -956,7 +956,7 @@ char *hss_cx_download_user_data(
         }
 
         /* smsip: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060" */
-        if(self.diam_config->cnf_smsip) {
+        if(self.sms_over_ims) {
 
             user_data = ogs_mstrcatf(user_data, "%s", 
                         ogs_diam_cx_xml_ifc_s); 
@@ -1040,7 +1040,7 @@ char *hss_cx_download_user_data(
 
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_server_name_s, 
-                            self.diam_config->cnf_smsip, 
+                            self.sms_over_ims, 
                             ogs_diam_cx_xml_server_name_e); 
                 ogs_assert(user_data);
 

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -956,20 +956,19 @@ char *hss_cx_download_user_data(
         }
 
         if(self.sms_over_ims) {
-
             user_data = ogs_mstrcatf(user_data, "%s", 
                         ogs_diam_cx_xml_ifc_s); 
             ogs_assert(user_data);
 
-            user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                        ogs_diam_cx_xml_priority_s,
-                        "2", 
-                        ogs_diam_cx_xml_priority_e); 
-            ogs_assert(user_data);
+              user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                          ogs_diam_cx_xml_priority_s,
+                          "2", 
+                          ogs_diam_cx_xml_priority_e); 
+              ogs_assert(user_data);
 
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_tp_s); 
-            ogs_assert(user_data);
+              user_data = ogs_mstrcatf(user_data, "%s", 
+                          ogs_diam_cx_xml_tp_s); 
+              ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_cnf_s, 
@@ -981,91 +980,37 @@ char *hss_cx_download_user_data(
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_condition_negated_s, 
-                            "0", 
-                            ogs_diam_cx_xml_condition_negated_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_condition_negated_s, 
+                              "0", 
+                              ogs_diam_cx_xml_condition_negated_e); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_group_s, 
-                            "1", 
-                            ogs_diam_cx_xml_group_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_group_s, 
+                              "1", 
+                              ogs_diam_cx_xml_group_e); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_method_s, 
-                            "MESSAGE", 
-                            ogs_diam_cx_xml_method_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_method_s, 
+                              "MESSAGE", 
+                              ogs_diam_cx_xml_method_e); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_s); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_s); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_registration_type_s, 
-                            "0", 
-                            ogs_diam_cx_xml_registration_type_e); 
-                ogs_assert(user_data);
+                    user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                                ogs_diam_cx_xml_registration_type_s, 
+                                "0", 
+                                ogs_diam_cx_xml_registration_type_e); 
+                    ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_spt_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_spt_s); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_condition_negated_s, 
-                            "0", 
-                            ogs_diam_cx_xml_condition_negated_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_group_s, 
-                            "2", 
-                            ogs_diam_cx_xml_group_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_sip_hdr_s); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_header_s, 
-                            "Content-Type", 
-                            ogs_diam_cx_xml_header_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_content_s, 
-                            "application/vnd.3gpp.sms", 
-                            ogs_diam_cx_xml_content_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_sip_hdr_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_s); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_registration_type_s, 
-                            "0", 
-                            ogs_diam_cx_xml_registration_type_e); 
-                ogs_assert(user_data);
-
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_e); 
+                  ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_e); 
@@ -1075,49 +1020,103 @@ char *hss_cx_download_user_data(
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_condition_negated_s, 
-                            "0", 
-                            ogs_diam_cx_xml_condition_negated_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_condition_negated_s, 
+                              "0", 
+                              ogs_diam_cx_xml_condition_negated_e); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_group_s, 
-                            "3", 
-                            ogs_diam_cx_xml_group_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_group_s, 
+                              "2", 
+                              ogs_diam_cx_xml_group_e); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_session_case_s, 
-                            "0", 
-                            ogs_diam_cx_xml_session_case_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_sip_hdr_s); 
+                  ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_s); 
-                ogs_assert(user_data);
+                    user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                                ogs_diam_cx_xml_header_s, 
+                                "Content-Type", 
+                                ogs_diam_cx_xml_header_e); 
+                    ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s%s%s", 
-                            ogs_diam_cx_xml_registration_type_s, 
-                            "0", 
-                            ogs_diam_cx_xml_registration_type_e); 
-                ogs_assert(user_data);
+                    user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                                ogs_diam_cx_xml_content_s, 
+                                "application/vnd.3gpp.sms", 
+                                ogs_diam_cx_xml_content_e); 
+                    ogs_assert(user_data);
 
-                user_data = ogs_mstrcatf(user_data, "%s", 
-                            ogs_diam_cx_xml_extension_e); 
-                ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_sip_hdr_e); 
+                  ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_s); 
+                  ogs_assert(user_data);
+
+                    user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                                ogs_diam_cx_xml_registration_type_s, 
+                                "0", 
+                                ogs_diam_cx_xml_registration_type_e); 
+                    ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_e); 
+                  ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_e); 
                 ogs_assert(user_data);
 
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_tp_e); 
-            ogs_assert(user_data);
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_s); 
+                ogs_assert(user_data);
 
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_app_server_s); 
-            ogs_assert(user_data);
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_condition_negated_s, 
+                              "0", 
+                              ogs_diam_cx_xml_condition_negated_e); 
+                  ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_group_s, 
+                              "3", 
+                              ogs_diam_cx_xml_group_e); 
+                  ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                              ogs_diam_cx_xml_session_case_s, 
+                              "0", 
+                              ogs_diam_cx_xml_session_case_e); 
+                  ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_s); 
+                  ogs_assert(user_data);
+
+                    user_data = ogs_mstrcatf(user_data, "%s%s%s", 
+                                ogs_diam_cx_xml_registration_type_s, 
+                                "0", 
+                                ogs_diam_cx_xml_registration_type_e); 
+                    ogs_assert(user_data);
+
+                  user_data = ogs_mstrcatf(user_data, "%s", 
+                              ogs_diam_cx_xml_extension_e); 
+                  ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s", 
+                            ogs_diam_cx_xml_spt_e); 
+                ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s", 
+                          ogs_diam_cx_xml_tp_e); 
+              ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s", 
+                          ogs_diam_cx_xml_app_server_s); 
+              ogs_assert(user_data);
 
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_server_name_s, 
@@ -1131,9 +1130,9 @@ char *hss_cx_download_user_data(
                             ogs_diam_cx_xml_default_handling_e); 
                 ogs_assert(user_data);
 
-            user_data = ogs_mstrcatf(user_data, "%s", 
-                        ogs_diam_cx_xml_app_server_e); 
-            ogs_assert(user_data);
+              user_data = ogs_mstrcatf(user_data, "%s", 
+                          ogs_diam_cx_xml_app_server_e); 
+              ogs_assert(user_data);
 
             user_data = ogs_mstrcatf(user_data, "%s", 
                         ogs_diam_cx_xml_ifc_e);

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -955,7 +955,6 @@ char *hss_cx_download_user_data(
             ogs_assert(user_data);
         }
 
-        /* smsip: "sip:smsc.mnc001.mcc001.3gppnetwork.org:7060" */
         if(self.sms_over_ims) {
 
             user_data = ogs_mstrcatf(user_data, "%s", 
@@ -981,7 +980,7 @@ char *hss_cx_download_user_data(
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
-//1
+
                 user_data = ogs_mstrcatf(user_data, "%s%s%s", 
                             ogs_diam_cx_xml_condition_negated_s, 
                             "0", 
@@ -1017,7 +1016,7 @@ char *hss_cx_download_user_data(
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_e); 
                 ogs_assert(user_data);
-//2
+
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
@@ -1071,7 +1070,7 @@ char *hss_cx_download_user_data(
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_e); 
                 ogs_assert(user_data);
-//3
+
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_s); 
                 ogs_assert(user_data);
@@ -1111,7 +1110,7 @@ char *hss_cx_download_user_data(
                 user_data = ogs_mstrcatf(user_data, "%s", 
                             ogs_diam_cx_xml_spt_e); 
                 ogs_assert(user_data);
-//end 3
+
             user_data = ogs_mstrcatf(user_data, "%s", 
                         ogs_diam_cx_xml_tp_e); 
             ogs_assert(user_data);

--- a/src/hss/hss-context.h
+++ b/src/hss/hss-context.h
@@ -38,6 +38,7 @@ extern int __hss_log_domain;
 typedef struct _hss_context_t {
     const char          *diam_conf_path;/* HSS Diameter conf path */
     ogs_diam_config_t   *diam_config;   /* HSS Diameter config */
+    const char          *sms_over_ims;  /* SMS over IMS */
 
     ogs_thread_mutex_t  db_lock;
     ogs_thread_mutex_t  cx_lock;


### PR DESCRIPTION
Functionality for send sms with using IMS service, for all subscribers, which registered to IMS.

Below is the profile added to user-cx-data field of CX - interface:
```
<InitialFilterCriteria>
 <Priority>2</Priority>
 <TriggerPoint>
  <ConditionTypeCNF>1</ConditionTypeCNF>
  <SPT>
   <ConditionNegated>0</ConditionNegated>
   <Group>1</Group>
   <Method>MESSAGE</Method>
   <Extension>
    <RegistrationType>0</RegistrationType>
   </Extension>
  </SPT>
  <SPT>
   <ConditionNegated>0</ConditionNegated>
   <Group>2</Group>
   <SIPHeader>
    <Header>Content-Type</Header>
    <Content>application/vnd.3gpp.sms</Content>
   </SIPHeader>
   <Extension>
    <RegistrationType>0</RegistrationType>
   </Extension>
  </SPT>
  <SPT>
   <ConditionNegated>0</ConditionNegated>
   <Group>3</Group>
   <SessionCase>0</SessionCase>
   <Extension>
    <RegistrationType>0</RegistrationType>
   </Extension>
  </SPT>
 </TriggerPoint>
 <ApplicationServer>
  <ServerName>sip:smsc.epc.mnc001.mcc001.3gppnetwork.org:7060;transport=tcp</ServerName>
  <DefaultHandling>0</DefaultHandling>
 </ApplicationServer>
</InitialFilterCriteria>
```
This Filter created by using information from project FoHSS and maybe not optimal.

Value for  <ServerName> setting in conf-file hss.yaml:
```
hss:
    freeDiameter: /etc/freeDiameter/hss.conf
    sms_over_ims: "sip:smsc.epc.mnc001.mcc001.3gppnetwork.org:7060;transport=tcp"
```

This commit checked with kamailio 5.3 from [trunk](https://github.com/herlesupreeth/kamailio), which using by open5gs for VoLTE.

[dia_cx_data.zip](https://github.com/open5gs/open5gs/files/8451916/dia_cx_data.zip)
[sms2.zip](https://github.com/open5gs/open5gs/files/8451970/sms2.zip)
