### PR TITLE
Rename GTPv2C specifics to gtp2 prefix

### DIFF
--- a/lib/gtp/context.c
+++ b/lib/gtp/context.c
@@ -548,7 +548,7 @@ void ogs_gtp_node_free(ogs_gtp_node_t *node)
 }
 
 ogs_gtp_node_t *ogs_gtp_node_add_by_f_teid(
-        ogs_list_t *list, ogs_gtp_f_teid_t *f_teid, uint16_t port)
+        ogs_list_t *list, ogs_gtp2_f_teid_t *f_teid, uint16_t port)
 {
     int rv;
     ogs_gtp_node_t *node = NULL;
@@ -558,7 +558,7 @@ ogs_gtp_node_t *ogs_gtp_node_add_by_f_teid(
     ogs_assert(f_teid);
     ogs_assert(port);
 
-    rv = ogs_gtp_f_teid_to_sockaddr(f_teid, port, &addr);
+    rv = ogs_gtp2_f_teid_to_sockaddr(f_teid, port, &addr);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
 
     rv = ogs_filter_ip_version(
@@ -576,7 +576,7 @@ ogs_gtp_node_t *ogs_gtp_node_add_by_f_teid(
     node = ogs_gtp_node_new(addr);
     ogs_assert(node);
 
-    rv = ogs_gtp_f_teid_to_ip(f_teid, &node->ip);
+    rv = ogs_gtp2_f_teid_to_ip(f_teid, &node->ip);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
 
     ogs_list_add(list, node);
@@ -637,7 +637,7 @@ ogs_gtp_node_t *ogs_gtp_node_find_by_addr(
 }
 
 ogs_gtp_node_t *ogs_gtp_node_find_by_f_teid(
-        ogs_list_t *list, ogs_gtp_f_teid_t *f_teid)
+        ogs_list_t *list, ogs_gtp2_f_teid_t *f_teid)
 {
     int rv;
     ogs_gtp_node_t *node = NULL;
@@ -646,7 +646,7 @@ ogs_gtp_node_t *ogs_gtp_node_find_by_f_teid(
     ogs_assert(list);
     ogs_assert(f_teid);
 
-    rv = ogs_gtp_f_teid_to_ip(f_teid, &ip);
+    rv = ogs_gtp2_f_teid_to_ip(f_teid, &ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_list_for_each(list, node) {

--- a/lib/gtp/context.h
+++ b/lib/gtp/context.h
@@ -92,7 +92,7 @@ ogs_gtp_node_t *ogs_gtp_node_new(ogs_sockaddr_t *sa_list);
 void ogs_gtp_node_free(ogs_gtp_node_t *node);
 
 ogs_gtp_node_t *ogs_gtp_node_add_by_f_teid(
-        ogs_list_t *list, ogs_gtp_f_teid_t *f_teid, uint16_t port);
+        ogs_list_t *list, ogs_gtp2_f_teid_t *f_teid, uint16_t port);
 ogs_gtp_node_t *ogs_gtp_node_add_by_addr(
         ogs_list_t *list, ogs_sockaddr_t *addr);
 void ogs_gtp_node_remove(ogs_list_t *list, ogs_gtp_node_t *node);
@@ -101,7 +101,7 @@ void ogs_gtp_node_remove_all(ogs_list_t *list);
 ogs_gtp_node_t *ogs_gtp_node_find_by_addr(
         ogs_list_t *list, ogs_sockaddr_t *addr);
 ogs_gtp_node_t *ogs_gtp_node_find_by_f_teid(
-        ogs_list_t *list, ogs_gtp_f_teid_t *f_teid);
+        ogs_list_t *list, ogs_gtp2_f_teid_t *f_teid);
 
 ogs_gtp_node_t *ogs_gtp_node_add_by_ip(
         ogs_list_t *list, ogs_ip_t *ip, uint16_t port);

--- a/lib/gtp/util.c
+++ b/lib/gtp/util.c
@@ -21,14 +21,14 @@
 
 int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf)
 {
-    ogs_gtp_header_t *gtp_h = NULL;
+    ogs_gtp2_header_t *gtp_h = NULL;
     uint8_t *ext_h = NULL;
     uint16_t len = 0;
 
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->data);
 
-    gtp_h = (ogs_gtp_header_t *)pkbuf->data;
+    gtp_h = (ogs_gtp2_header_t *)pkbuf->data;
 
     len = OGS_GTPV1U_HEADER_LEN;
     if (pkbuf->len < len) return -1;

--- a/lib/gtp/v1/types.h
+++ b/lib/gtp/v1/types.h
@@ -192,9 +192,9 @@ int16_t ogs_gtp1_build_uli(ogs_tlv_octet_t *octet,
 #define OGS_GTP_GSN_ADDRESS_IPV6_LEN    OGS_IPV6_LEN
 typedef struct ogs_gtp1_gsn_addr_s {
     union {
-        /* OGS_GTP_F_TEID_IPV4 */
+        /* OGS_GTP2_F_TEID_IPV4 */
         uint32_t addr;
-        /* OGS_GTP_F_TEID_IPV6 */
+        /* OGS_GTP2_F_TEID_IPV6 */
         uint8_t addr6[OGS_IPV6_LEN];
     };
 } __attribute__ ((packed)) ogs_gtp1_gsn_addr_t;

--- a/lib/gtp/v2/build.c
+++ b/lib/gtp/v2/build.c
@@ -19,14 +19,14 @@
 
 #include "ogs-gtp.h"
 
-ogs_pkbuf_t *ogs_gtp_build_echo_request(
+ogs_pkbuf_t *ogs_gtp2_build_echo_request(
         uint8_t type, uint8_t recovery, uint8_t features)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_echo_request_t *req = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_echo_request_t *req = NULL;
 
     req = &gtp_message.echo_request;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     req->recovery.presence = 1;
     req->recovery.u8 = recovery;
@@ -35,17 +35,17 @@ ogs_pkbuf_t *ogs_gtp_build_echo_request(
     req->sending_node_features.u8 = features;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
-ogs_pkbuf_t *ogs_gtp_build_echo_response(
+ogs_pkbuf_t *ogs_gtp2_build_echo_response(
         uint8_t type, uint8_t recovery, uint8_t features)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_echo_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_echo_response_t *rsp = NULL;
 
     rsp = &gtp_message.echo_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     rsp->recovery.presence = 1;
     rsp->recovery.u8 = recovery;
@@ -54,10 +54,10 @@ ogs_pkbuf_t *ogs_gtp_build_echo_response(
     rsp->sending_node_features.u8 = features;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
-ogs_pkbuf_t *ogs_gtp_build_error_indication(
+ogs_pkbuf_t *ogs_gtp2_build_error_indication(
         uint32_t teid, ogs_sockaddr_t *addr)
 {
     ogs_pkbuf_t *pkbuf = NULL;

--- a/lib/gtp/v2/build.h
+++ b/lib/gtp/v2/build.h
@@ -21,23 +21,23 @@
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_GTP_BUILD_H
-#define OGS_GTP_BUILD_H
+#ifndef OGS_GTP2_BUILD_H
+#define OGS_GTP2_BUILD_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-ogs_pkbuf_t *ogs_gtp_build_echo_request(
+ogs_pkbuf_t *ogs_gtp2_build_echo_request(
         uint8_t type, uint8_t recovery, uint8_t features);
-ogs_pkbuf_t *ogs_gtp_build_echo_response(
+ogs_pkbuf_t *ogs_gtp2_build_echo_response(
         uint8_t type, uint8_t recovery, uint8_t features);
 
-ogs_pkbuf_t *ogs_gtp_build_error_indication(
+ogs_pkbuf_t *ogs_gtp2_build_error_indication(
         uint32_t teid, ogs_sockaddr_t *addr);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OGS_GTP_BUILD_H */
+#endif /* OGS_GTP2_BUILD_H */

--- a/lib/gtp/v2/conv.c
+++ b/lib/gtp/v2/conv.c
@@ -19,8 +19,8 @@
 
 #include "ogs-gtp.h"
 
-int ogs_gtp_f_teid_to_sockaddr(
-    ogs_gtp_f_teid_t *f_teid, uint16_t port, ogs_sockaddr_t **list)
+int ogs_gtp2_f_teid_to_sockaddr(
+    ogs_gtp2_f_teid_t *f_teid, uint16_t port, ogs_sockaddr_t **list)
 {
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
 
@@ -64,8 +64,8 @@ int ogs_gtp_f_teid_to_sockaddr(
     return OGS_OK;
 }
 
-int ogs_gtp_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
-        ogs_gtp_f_teid_t *f_teid, int *len)
+int ogs_gtp2_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
+        ogs_gtp2_f_teid_t *f_teid, int *len)
 {
     ogs_assert(f_teid);
 
@@ -74,17 +74,17 @@ int ogs_gtp_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
         f_teid->both.addr = addr->sin.sin_addr.s_addr;
         f_teid->ipv6 = 1;
         memcpy(f_teid->both.addr6, addr6->sin6.sin6_addr.s6_addr, OGS_IPV6_LEN);
-        *len = OGS_GTP_F_TEID_IPV4V6_LEN;
+        *len = OGS_GTP2_F_TEID_IPV4V6_LEN;
     } else if (addr) {
         f_teid->ipv4 = 1;
         f_teid->ipv6 = 0;
         f_teid->addr = addr->sin.sin_addr.s_addr;
-        *len = OGS_GTP_F_TEID_IPV4_LEN;
+        *len = OGS_GTP2_F_TEID_IPV4_LEN;
     } else if (addr6) {
         f_teid->ipv4 = 0;
         f_teid->ipv6 = 1;
         memcpy(f_teid->addr6, addr6->sin6.sin6_addr.s6_addr, OGS_IPV6_LEN);
-        *len = OGS_GTP_F_TEID_IPV6_LEN;
+        *len = OGS_GTP2_F_TEID_IPV6_LEN;
     } else {
         ogs_error("No IPv4 or IPv6");
         return OGS_ERROR;
@@ -93,7 +93,7 @@ int ogs_gtp_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
     return OGS_OK;
 }
 
-int ogs_gtp_f_teid_to_ip(ogs_gtp_f_teid_t *f_teid, ogs_ip_t *ip)
+int ogs_gtp2_f_teid_to_ip(ogs_gtp2_f_teid_t *f_teid, ogs_ip_t *ip)
 {
     ogs_assert(ip);
     ogs_assert(f_teid);
@@ -121,7 +121,7 @@ int ogs_gtp_f_teid_to_ip(ogs_gtp_f_teid_t *f_teid, ogs_ip_t *ip)
     return OGS_OK;
 }
 
-int ogs_gtp_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp_f_teid_t *f_teid, int *len)
+int ogs_gtp2_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp2_f_teid_t *f_teid, int *len)
 {
     ogs_assert(ip);
     ogs_assert(f_teid);
@@ -132,13 +132,13 @@ int ogs_gtp_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp_f_teid_t *f_teid, int *len)
     if (f_teid->ipv4 && f_teid->ipv6) {
         f_teid->both.addr = ip->addr;
         memcpy(f_teid->both.addr6, ip->addr6, OGS_IPV6_LEN);
-        *len = OGS_GTP_F_TEID_IPV4V6_LEN;
+        *len = OGS_GTP2_F_TEID_IPV4V6_LEN;
     } else if (f_teid->ipv4) {
         f_teid->addr = ip->addr;
-        *len = OGS_GTP_F_TEID_IPV4_LEN;
+        *len = OGS_GTP2_F_TEID_IPV4_LEN;
     } else if (f_teid->ipv6) {
         memcpy(f_teid->addr6, ip->addr6, OGS_IPV6_LEN);
-        *len = OGS_GTP_F_TEID_IPV6_LEN;
+        *len = OGS_GTP2_F_TEID_IPV6_LEN;
     } else {
         ogs_error("No IPv4 or IPv6");
         return OGS_ERROR;
@@ -147,7 +147,7 @@ int ogs_gtp_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp_f_teid_t *f_teid, int *len)
     return OGS_OK;
 }
 
-int ogs_gtp_paa_to_ip(ogs_paa_t *paa, ogs_ip_t *ip)
+int ogs_gtp2_paa_to_ip(ogs_paa_t *paa, ogs_ip_t *ip)
 {
     ogs_assert(paa);
     ogs_assert(ip);

--- a/lib/gtp/v2/conv.h
+++ b/lib/gtp/v2/conv.h
@@ -21,21 +21,21 @@
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_GTP_CONV_H
-#define OGS_GTP_CONV_H
+#ifndef OGS_GTP2_CONV_H
+#define OGS_GTP2_CONV_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int ogs_gtp_f_teid_to_sockaddr(
-    ogs_gtp_f_teid_t *f_teid, uint16_t port, ogs_sockaddr_t **list);
-int ogs_gtp_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
-    ogs_gtp_f_teid_t *f_teid, int *len);
-int ogs_gtp_f_teid_to_ip(ogs_gtp_f_teid_t *f_teid, ogs_ip_t *ip);
-int ogs_gtp_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp_f_teid_t *f_teid, int *len);
+int ogs_gtp2_f_teid_to_sockaddr(
+    ogs_gtp2_f_teid_t *f_teid, uint16_t port, ogs_sockaddr_t **list);
+int ogs_gtp2_sockaddr_to_f_teid(ogs_sockaddr_t *addr, ogs_sockaddr_t *addr6,
+    ogs_gtp2_f_teid_t *f_teid, int *len);
+int ogs_gtp2_f_teid_to_ip(ogs_gtp2_f_teid_t *f_teid, ogs_ip_t *ip);
+int ogs_gtp2_ip_to_f_teid(ogs_ip_t *ip, ogs_gtp2_f_teid_t *f_teid, int *len);
 
-int ogs_gtp_paa_to_ip(ogs_paa_t *paa, ogs_ip_t *ip);
+int ogs_gtp2_paa_to_ip(ogs_paa_t *paa, ogs_ip_t *ip);
 
 #ifdef __cplusplus
 }

--- a/lib/gtp/v2/message.c
+++ b/lib/gtp/v2/message.c
@@ -20,2565 +20,2565 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2021-10-16 16:32:20.655097 by acetcom
+ * Created on: 2022-04-12 14:16:09.777673 by pespin
  * from 29274-g30.docx
  ******************************************************************************/
 
 #include "ogs-gtp.h"
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_imsi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_imsi_0 =
 {
     OGS_TLV_VAR_STR,
     "IMSI",
-    OGS_GTP_IMSI_TYPE,
+    OGS_GTP2_IMSI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_imsi_t),
+    sizeof(ogs_gtp2_tlv_imsi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_cause_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_cause_0 =
 {
     OGS_TLV_VAR_STR,
     "Cause",
-    OGS_GTP_CAUSE_TYPE,
+    OGS_GTP2_CAUSE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_cause_t),
+    sizeof(ogs_gtp2_tlv_cause_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_recovery_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_recovery_0 =
 {
     OGS_TLV_UINT8,
     "Recovery",
-    OGS_GTP_RECOVERY_TYPE,
+    OGS_GTP2_RECOVERY_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_recovery_t),
+    sizeof(ogs_gtp2_tlv_recovery_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_stn_sr_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_stn_sr_0 =
 {
     OGS_TLV_VAR_STR,
     "STN-SR",
-    OGS_GTP_STN_SR_TYPE,
+    OGS_GTP2_STN_SR_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_stn_sr_t),
+    sizeof(ogs_gtp2_tlv_stn_sr_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_0 =
 {
     OGS_TLV_VAR_STR,
     "APN",
-    OGS_GTP_APN_TYPE,
+    OGS_GTP2_APN_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_apn_t),
+    sizeof(ogs_gtp2_tlv_apn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ambr_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ambr_0 =
 {
     OGS_TLV_VAR_STR,
     "AMBR",
-    OGS_GTP_AMBR_TYPE,
+    OGS_GTP2_AMBR_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ambr_t),
+    sizeof(ogs_gtp2_tlv_ambr_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ebi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ebi_0 =
 {
     OGS_TLV_UINT8,
     "EBI",
-    OGS_GTP_EBI_TYPE,
+    OGS_GTP2_EBI_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_ebi_t),
+    sizeof(ogs_gtp2_tlv_ebi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ebi_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ebi_1 =
 {
     OGS_TLV_UINT8,
     "EBI",
-    OGS_GTP_EBI_TYPE,
+    OGS_GTP2_EBI_TYPE,
     1,
     1,
-    sizeof(ogs_gtp_tlv_ebi_t),
+    sizeof(ogs_gtp2_tlv_ebi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_0 =
 {
     OGS_TLV_VAR_STR,
     "IP Address",
-    OGS_GTP_IP_ADDRESS_TYPE,
+    OGS_GTP2_IP_ADDRESS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ip_address_t),
+    sizeof(ogs_gtp2_tlv_ip_address_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_1 =
 {
     OGS_TLV_VAR_STR,
     "IP Address",
-    OGS_GTP_IP_ADDRESS_TYPE,
+    OGS_GTP2_IP_ADDRESS_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_ip_address_t),
+    sizeof(ogs_gtp2_tlv_ip_address_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_2 =
 {
     OGS_TLV_VAR_STR,
     "IP Address",
-    OGS_GTP_IP_ADDRESS_TYPE,
+    OGS_GTP2_IP_ADDRESS_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_ip_address_t),
+    sizeof(ogs_gtp2_tlv_ip_address_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_3 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_3 =
 {
     OGS_TLV_VAR_STR,
     "IP Address",
-    OGS_GTP_IP_ADDRESS_TYPE,
+    OGS_GTP2_IP_ADDRESS_TYPE,
     0,
     3,
-    sizeof(ogs_gtp_tlv_ip_address_t),
+    sizeof(ogs_gtp2_tlv_ip_address_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mei_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mei_0 =
 {
     OGS_TLV_VAR_STR,
     "MEI",
-    OGS_GTP_MEI_TYPE,
+    OGS_GTP2_MEI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mei_t),
+    sizeof(ogs_gtp2_tlv_mei_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_msisdn_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_msisdn_0 =
 {
     OGS_TLV_VAR_STR,
     "MSISDN",
-    OGS_GTP_MSISDN_TYPE,
+    OGS_GTP2_MSISDN_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_msisdn_t),
+    sizeof(ogs_gtp2_tlv_msisdn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_indication_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_indication_0 =
 {
     OGS_TLV_VAR_STR,
     "Indication",
-    OGS_GTP_INDICATION_TYPE,
+    OGS_GTP2_INDICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_indication_t),
+    sizeof(ogs_gtp2_tlv_indication_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pco_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pco_0 =
 {
     OGS_TLV_VAR_STR,
     "PCO",
-    OGS_GTP_PCO_TYPE,
+    OGS_GTP2_PCO_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pco_t),
+    sizeof(ogs_gtp2_tlv_pco_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_paa_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_paa_0 =
 {
     OGS_TLV_VAR_STR,
     "PAA",
-    OGS_GTP_PAA_TYPE,
+    OGS_GTP2_PAA_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_paa_t),
+    sizeof(ogs_gtp2_tlv_paa_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_qos_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_qos_0 =
 {
     OGS_TLV_VAR_STR,
     "Bearer QoS",
-    OGS_GTP_BEARER_QOS_TYPE,
+    OGS_GTP2_BEARER_QOS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_bearer_qos_t),
+    sizeof(ogs_gtp2_tlv_bearer_qos_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_flow_qos_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_flow_qos_0 =
 {
     OGS_TLV_VAR_STR,
     "Flow QoS",
-    OGS_GTP_FLOW_QOS_TYPE,
+    OGS_GTP2_FLOW_QOS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_flow_qos_t),
+    sizeof(ogs_gtp2_tlv_flow_qos_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_rat_type_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_rat_type_0 =
 {
     OGS_TLV_UINT8,
     "RAT Type",
-    OGS_GTP_RAT_TYPE_TYPE,
+    OGS_GTP2_RAT_TYPE_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_rat_type_t),
+    sizeof(ogs_gtp2_tlv_rat_type_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_serving_network_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_serving_network_0 =
 {
     OGS_TLV_VAR_STR,
     "Serving Network",
-    OGS_GTP_SERVING_NETWORK_TYPE,
+    OGS_GTP2_SERVING_NETWORK_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_serving_network_t),
+    sizeof(ogs_gtp2_tlv_serving_network_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_tft_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_tft_0 =
 {
     OGS_TLV_VAR_STR,
     "Bearer TFT",
-    OGS_GTP_BEARER_TFT_TYPE,
+    OGS_GTP2_BEARER_TFT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_bearer_tft_t),
+    sizeof(ogs_gtp2_tlv_bearer_tft_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_tad_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_tad_0 =
 {
     OGS_TLV_VAR_STR,
     "TAD",
-    OGS_GTP_TAD_TYPE,
+    OGS_GTP2_TAD_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_tad_t),
+    sizeof(ogs_gtp2_tlv_tad_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_0 =
 {
     OGS_TLV_VAR_STR,
     "ULI",
-    OGS_GTP_ULI_TYPE,
+    OGS_GTP2_ULI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_uli_t),
+    sizeof(ogs_gtp2_tlv_uli_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_1 =
 {
     OGS_TLV_VAR_STR,
     "ULI",
-    OGS_GTP_ULI_TYPE,
+    OGS_GTP2_ULI_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_uli_t),
+    sizeof(ogs_gtp2_tlv_uli_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_0 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_1 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_2 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_3 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_3 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     3,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_4 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_4 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     4,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_5 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_5 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     5,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_6 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_6 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     6,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_7 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_7 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     7,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_8 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_8 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     8,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_9 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_9 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     9,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_10 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_10 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     10,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_11 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_11 =
 {
     OGS_TLV_VAR_STR,
     "F-TEID",
-    OGS_GTP_F_TEID_TYPE,
+    OGS_GTP2_F_TEID_TYPE,
     0,
     11,
-    sizeof(ogs_gtp_tlv_f_teid_t),
+    sizeof(ogs_gtp2_tlv_f_teid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_tmsi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_tmsi_0 =
 {
     OGS_TLV_VAR_STR,
     "TMSI",
-    OGS_GTP_TMSI_TYPE,
+    OGS_GTP2_TMSI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_tmsi_t),
+    sizeof(ogs_gtp2_tlv_tmsi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_global_cn_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_global_cn_id_0 =
 {
     OGS_TLV_VAR_STR,
     "Global CN-Id",
-    OGS_GTP_GLOBAL_CN_ID_TYPE,
+    OGS_GTP2_GLOBAL_CN_ID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_global_cn_id_t),
+    sizeof(ogs_gtp2_tlv_global_cn_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_s103pdf_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_s103pdf_0 =
 {
     OGS_TLV_VAR_STR,
     "S103PDF",
-    OGS_GTP_S103PDF_TYPE,
+    OGS_GTP2_S103PDF_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_s103pdf_t),
+    sizeof(ogs_gtp2_tlv_s103pdf_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_s1udf_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_s1udf_0 =
 {
     OGS_TLV_VAR_STR,
     "S1UDF",
-    OGS_GTP_S1UDF_TYPE,
+    OGS_GTP2_S1UDF_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_s1udf_t),
+    sizeof(ogs_gtp2_tlv_s1udf_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delay_value_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delay_value_0 =
 {
     OGS_TLV_UINT8,
     "Delay Value",
-    OGS_GTP_DELAY_VALUE_TYPE,
+    OGS_GTP2_DELAY_VALUE_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_delay_value_t),
+    sizeof(ogs_gtp2_tlv_delay_value_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_charging_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_charging_id_0 =
 {
     OGS_TLV_UINT32,
     "Charging ID",
-    OGS_GTP_CHARGING_ID_TYPE,
+    OGS_GTP2_CHARGING_ID_TYPE,
     4,
     0,
-    sizeof(ogs_gtp_tlv_charging_id_t),
+    sizeof(ogs_gtp2_tlv_charging_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_charging_characteristics_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_charging_characteristics_0 =
 {
     OGS_TLV_VAR_STR,
     "Charging Characteristics",
-    OGS_GTP_CHARGING_CHARACTERISTICS_TYPE,
+    OGS_GTP2_CHARGING_CHARACTERISTICS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_charging_characteristics_t),
+    sizeof(ogs_gtp2_tlv_charging_characteristics_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Trace Information",
-    OGS_GTP_TRACE_INFORMATION_TYPE,
+    OGS_GTP2_TRACE_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_trace_information_t),
+    sizeof(ogs_gtp2_tlv_trace_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_flags_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_flags_0 =
 {
     OGS_TLV_VAR_STR,
     "Bearer Flags",
-    OGS_GTP_BEARER_FLAGS_TYPE,
+    OGS_GTP2_BEARER_FLAGS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_bearer_flags_t),
+    sizeof(ogs_gtp2_tlv_bearer_flags_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_type_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdn_type_0 =
 {
     OGS_TLV_UINT8,
     "PDN Type",
-    OGS_GTP_PDN_TYPE_TYPE,
+    OGS_GTP2_PDN_TYPE_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_pdn_type_t),
+    sizeof(ogs_gtp2_tlv_pdn_type_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pti_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pti_0 =
 {
     OGS_TLV_UINT8,
     "PTI",
-    OGS_GTP_PTI_TYPE,
+    OGS_GTP2_PTI_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_pti_t),
+    sizeof(ogs_gtp2_tlv_pti_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mm_context_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mm_context_0 =
 {
     OGS_TLV_VAR_STR,
     "MM Context",
-    OGS_GTP_MM_CONTEXT_TYPE,
+    OGS_GTP2_MM_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mm_context_t),
+    sizeof(ogs_gtp2_tlv_mm_context_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pdu_numbers_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdu_numbers_0 =
 {
     OGS_TLV_VAR_STR,
     "PDU Numbers",
-    OGS_GTP_PDU_NUMBERS_TYPE,
+    OGS_GTP2_PDU_NUMBERS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pdu_numbers_t),
+    sizeof(ogs_gtp2_tlv_pdu_numbers_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_p_tmsi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_p_tmsi_0 =
 {
     OGS_TLV_VAR_STR,
     "P-TMSI",
-    OGS_GTP_P_TMSI_TYPE,
+    OGS_GTP2_P_TMSI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_p_tmsi_t),
+    sizeof(ogs_gtp2_tlv_p_tmsi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_p_tmsi_signature_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_p_tmsi_signature_0 =
 {
     OGS_TLV_VAR_STR,
     "P-TMSI Signature",
-    OGS_GTP_P_TMSI_SIGNATURE_TYPE,
+    OGS_GTP2_P_TMSI_SIGNATURE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_p_tmsi_signature_t),
+    sizeof(ogs_gtp2_tlv_p_tmsi_signature_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_hop_counter_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_hop_counter_0 =
 {
     OGS_TLV_VAR_STR,
     "Hop Counter",
-    OGS_GTP_HOP_COUNTER_TYPE,
+    OGS_GTP2_HOP_COUNTER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_hop_counter_t),
+    sizeof(ogs_gtp2_tlv_hop_counter_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ue_time_zone_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ue_time_zone_0 =
 {
     OGS_TLV_VAR_STR,
     "UE Time Zone",
-    OGS_GTP_UE_TIME_ZONE_TYPE,
+    OGS_GTP2_UE_TIME_ZONE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ue_time_zone_t),
+    sizeof(ogs_gtp2_tlv_ue_time_zone_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_reference_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_reference_0 =
 {
     OGS_TLV_VAR_STR,
     "Trace Reference",
-    OGS_GTP_TRACE_REFERENCE_TYPE,
+    OGS_GTP2_TRACE_REFERENCE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_trace_reference_t),
+    sizeof(ogs_gtp2_tlv_trace_reference_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_complete_request_message_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_complete_request_message_0 =
 {
     OGS_TLV_VAR_STR,
     "Complete Request Message",
-    OGS_GTP_COMPLETE_REQUEST_MESSAGE_TYPE,
+    OGS_GTP2_COMPLETE_REQUEST_MESSAGE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_complete_request_message_t),
+    sizeof(ogs_gtp2_tlv_complete_request_message_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_guti_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_guti_0 =
 {
     OGS_TLV_VAR_STR,
     "GUTI",
-    OGS_GTP_GUTI_TYPE,
+    OGS_GTP2_GUTI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_guti_t),
+    sizeof(ogs_gtp2_tlv_guti_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_container_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_container_0 =
 {
     OGS_TLV_VAR_STR,
     "F-Container",
-    OGS_GTP_F_CONTAINER_TYPE,
+    OGS_GTP2_F_CONTAINER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_f_container_t),
+    sizeof(ogs_gtp2_tlv_f_container_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_f_cause_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_cause_0 =
 {
     OGS_TLV_VAR_STR,
     "F-Cause",
-    OGS_GTP_F_CAUSE_TYPE,
+    OGS_GTP2_F_CAUSE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_f_cause_t),
+    sizeof(ogs_gtp2_tlv_f_cause_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_plmn_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_plmn_id_0 =
 {
     OGS_TLV_VAR_STR,
     "PLMN ID",
-    OGS_GTP_PLMN_ID_TYPE,
+    OGS_GTP2_PLMN_ID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_plmn_id_t),
+    sizeof(ogs_gtp2_tlv_plmn_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_target_identification_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_target_identification_0 =
 {
     OGS_TLV_VAR_STR,
     "Target Identification",
-    OGS_GTP_TARGET_IDENTIFICATION_TYPE,
+    OGS_GTP2_TARGET_IDENTIFICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_target_identification_t),
+    sizeof(ogs_gtp2_tlv_target_identification_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_packet_flow_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_packet_flow_id_0 =
 {
     OGS_TLV_VAR_STR,
     "Packet Flow ID",
-    OGS_GTP_PACKET_FLOW_ID_TYPE,
+    OGS_GTP2_PACKET_FLOW_ID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_packet_flow_id_t),
+    sizeof(ogs_gtp2_tlv_packet_flow_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_rab_context_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_rab_context_0 =
 {
     OGS_TLV_VAR_STR,
     "RAB Context",
-    OGS_GTP_RAB_CONTEXT_TYPE,
+    OGS_GTP2_RAB_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_rab_context_t),
+    sizeof(ogs_gtp2_tlv_rab_context_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_source_rnc_pdcp_context_info_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_source_rnc_pdcp_context_info_0 =
 {
     OGS_TLV_VAR_STR,
     "Source RNC PDCP Context Info",
-    OGS_GTP_SOURCE_RNC_PDCP_CONTEXT_INFO_TYPE,
+    OGS_GTP2_SOURCE_RNC_PDCP_CONTEXT_INFO_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_source_rnc_pdcp_context_info_t),
+    sizeof(ogs_gtp2_tlv_source_rnc_pdcp_context_info_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_0 =
 {
     OGS_TLV_UINT16,
     "Port Number",
-    OGS_GTP_PORT_NUMBER_TYPE,
+    OGS_GTP2_PORT_NUMBER_TYPE,
     2,
     0,
-    sizeof(ogs_gtp_tlv_port_number_t),
+    sizeof(ogs_gtp2_tlv_port_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_1 =
 {
     OGS_TLV_UINT16,
     "Port Number",
-    OGS_GTP_PORT_NUMBER_TYPE,
+    OGS_GTP2_PORT_NUMBER_TYPE,
     2,
     1,
-    sizeof(ogs_gtp_tlv_port_number_t),
+    sizeof(ogs_gtp2_tlv_port_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_2 =
 {
     OGS_TLV_UINT16,
     "Port Number",
-    OGS_GTP_PORT_NUMBER_TYPE,
+    OGS_GTP2_PORT_NUMBER_TYPE,
     2,
     2,
-    sizeof(ogs_gtp_tlv_port_number_t),
+    sizeof(ogs_gtp2_tlv_port_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_restriction_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_restriction_0 =
 {
     OGS_TLV_UINT8,
     "APN Restriction",
-    OGS_GTP_APN_RESTRICTION_TYPE,
+    OGS_GTP2_APN_RESTRICTION_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_apn_restriction_t),
+    sizeof(ogs_gtp2_tlv_apn_restriction_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_selection_mode_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_selection_mode_0 =
 {
     OGS_TLV_UINT8,
     "Selection Mode",
-    OGS_GTP_SELECTION_MODE_TYPE,
+    OGS_GTP2_SELECTION_MODE_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_selection_mode_t),
+    sizeof(ogs_gtp2_tlv_selection_mode_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_source_identification_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_source_identification_0 =
 {
     OGS_TLV_VAR_STR,
     "Source Identification",
-    OGS_GTP_SOURCE_IDENTIFICATION_TYPE,
+    OGS_GTP2_SOURCE_IDENTIFICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_source_identification_t),
+    sizeof(ogs_gtp2_tlv_source_identification_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_change_reporting_action_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_reporting_action_0 =
 {
     OGS_TLV_VAR_STR,
     "Change Reporting Action",
-    OGS_GTP_CHANGE_REPORTING_ACTION_TYPE,
+    OGS_GTP2_CHANGE_REPORTING_ACTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_change_reporting_action_t),
+    sizeof(ogs_gtp2_tlv_change_reporting_action_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_0 =
 {
     OGS_TLV_VAR_STR,
     "FQ-CSID",
-    OGS_GTP_FQ_CSID_TYPE,
+    OGS_GTP2_FQ_CSID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_fq_csid_t),
+    sizeof(ogs_gtp2_tlv_fq_csid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_1 =
 {
     OGS_TLV_VAR_STR,
     "FQ-CSID",
-    OGS_GTP_FQ_CSID_TYPE,
+    OGS_GTP2_FQ_CSID_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_fq_csid_t),
+    sizeof(ogs_gtp2_tlv_fq_csid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_2 =
 {
     OGS_TLV_VAR_STR,
     "FQ-CSID",
-    OGS_GTP_FQ_CSID_TYPE,
+    OGS_GTP2_FQ_CSID_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_fq_csid_t),
+    sizeof(ogs_gtp2_tlv_fq_csid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_3 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_3 =
 {
     OGS_TLV_VAR_STR,
     "FQ-CSID",
-    OGS_GTP_FQ_CSID_TYPE,
+    OGS_GTP2_FQ_CSID_TYPE,
     0,
     3,
-    sizeof(ogs_gtp_tlv_fq_csid_t),
+    sizeof(ogs_gtp2_tlv_fq_csid_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_channel_needed_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_channel_needed_0 =
 {
     OGS_TLV_VAR_STR,
     "Channel needed",
-    OGS_GTP_CHANNEL_NEEDED_TYPE,
+    OGS_GTP2_CHANNEL_NEEDED_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_channel_needed_t),
+    sizeof(ogs_gtp2_tlv_channel_needed_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_emlpp_priority_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_emlpp_priority_0 =
 {
     OGS_TLV_VAR_STR,
     "eMLPP Priority",
-    OGS_GTP_EMLPP_PRIORITY_TYPE,
+    OGS_GTP2_EMLPP_PRIORITY_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_emlpp_priority_t),
+    sizeof(ogs_gtp2_tlv_emlpp_priority_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_node_type_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_type_0 =
 {
     OGS_TLV_UINT8,
     "Node Type",
-    OGS_GTP_NODE_TYPE_TYPE,
+    OGS_GTP2_NODE_TYPE_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_node_type_t),
+    sizeof(ogs_gtp2_tlv_node_type_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fqdn_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fqdn_0 =
 {
     OGS_TLV_VAR_STR,
     "FQDN",
-    OGS_GTP_FQDN_TYPE,
+    OGS_GTP2_FQDN_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_fqdn_t),
+    sizeof(ogs_gtp2_tlv_fqdn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_fqdn_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_fqdn_1 =
 {
     OGS_TLV_VAR_STR,
     "FQDN",
-    OGS_GTP_FQDN_TYPE,
+    OGS_GTP2_FQDN_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_fqdn_t),
+    sizeof(ogs_gtp2_tlv_fqdn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ti_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ti_0 =
 {
     OGS_TLV_VAR_STR,
     "TI",
-    OGS_GTP_TI_TYPE,
+    OGS_GTP2_TI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ti_t),
+    sizeof(ogs_gtp2_tlv_ti_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_session_duration_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_session_duration_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Session Duration",
-    OGS_GTP_MBMS_SESSION_DURATION_TYPE,
+    OGS_GTP2_MBMS_SESSION_DURATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_session_duration_t),
+    sizeof(ogs_gtp2_tlv_mbms_session_duration_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_service_area_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_service_area_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Service Area",
-    OGS_GTP_MBMS_SERVICE_AREA_TYPE,
+    OGS_GTP2_MBMS_SERVICE_AREA_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_service_area_t),
+    sizeof(ogs_gtp2_tlv_mbms_service_area_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_session_identifier_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_session_identifier_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Session Identifier",
-    OGS_GTP_MBMS_SESSION_IDENTIFIER_TYPE,
+    OGS_GTP2_MBMS_SESSION_IDENTIFIER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_session_identifier_t),
+    sizeof(ogs_gtp2_tlv_mbms_session_identifier_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_flow_identifier_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_flow_identifier_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Flow Identifier",
-    OGS_GTP_MBMS_FLOW_IDENTIFIER_TYPE,
+    OGS_GTP2_MBMS_FLOW_IDENTIFIER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_flow_identifier_t),
+    sizeof(ogs_gtp2_tlv_mbms_flow_identifier_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_ip_multicast_distribution_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_ip_multicast_distribution_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS IP Multicast Distribution",
-    OGS_GTP_MBMS_IP_MULTICAST_DISTRIBUTION_TYPE,
+    OGS_GTP2_MBMS_IP_MULTICAST_DISTRIBUTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_ip_multicast_distribution_t),
+    sizeof(ogs_gtp2_tlv_mbms_ip_multicast_distribution_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_distribution_acknowledge_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_distribution_acknowledge_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Distribution Acknowledge",
-    OGS_GTP_MBMS_DISTRIBUTION_ACKNOWLEDGE_TYPE,
+    OGS_GTP2_MBMS_DISTRIBUTION_ACKNOWLEDGE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_distribution_acknowledge_t),
+    sizeof(ogs_gtp2_tlv_mbms_distribution_acknowledge_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_rfsp_index_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_rfsp_index_0 =
 {
     OGS_TLV_VAR_STR,
     "RFSP Index",
-    OGS_GTP_RFSP_INDEX_TYPE,
+    OGS_GTP2_RFSP_INDEX_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_rfsp_index_t),
+    sizeof(ogs_gtp2_tlv_rfsp_index_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_uci_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_uci_0 =
 {
     OGS_TLV_VAR_STR,
     "UCI",
-    OGS_GTP_UCI_TYPE,
+    OGS_GTP2_UCI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_uci_t),
+    sizeof(ogs_gtp2_tlv_uci_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_csg_information_reporting_action_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_csg_information_reporting_action_0 =
 {
     OGS_TLV_VAR_STR,
     "CSG Information Reporting Action",
-    OGS_GTP_CSG_INFORMATION_REPORTING_ACTION_TYPE,
+    OGS_GTP2_CSG_INFORMATION_REPORTING_ACTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_csg_information_reporting_action_t),
+    sizeof(ogs_gtp2_tlv_csg_information_reporting_action_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_csg_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_csg_id_0 =
 {
     OGS_TLV_VAR_STR,
     "CSG ID",
-    OGS_GTP_CSG_ID_TYPE,
+    OGS_GTP2_CSG_ID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_csg_id_t),
+    sizeof(ogs_gtp2_tlv_csg_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_cmi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_cmi_0 =
 {
     OGS_TLV_VAR_STR,
     "CMI",
-    OGS_GTP_CMI_TYPE,
+    OGS_GTP2_CMI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_cmi_t),
+    sizeof(ogs_gtp2_tlv_cmi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_service_indicator_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_service_indicator_0 =
 {
     OGS_TLV_VAR_STR,
     "Service indicator",
-    OGS_GTP_SERVICE_INDICATOR_TYPE,
+    OGS_GTP2_SERVICE_INDICATOR_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_service_indicator_t),
+    sizeof(ogs_gtp2_tlv_service_indicator_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_detach_type_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_detach_type_0 =
 {
     OGS_TLV_VAR_STR,
     "Detach Type",
-    OGS_GTP_DETACH_TYPE_TYPE,
+    OGS_GTP2_DETACH_TYPE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_detach_type_t),
+    sizeof(ogs_gtp2_tlv_detach_type_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_0 =
 {
     OGS_TLV_VAR_STR,
     "LDN",
-    OGS_GTP_LDN_TYPE,
+    OGS_GTP2_LDN_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ldn_t),
+    sizeof(ogs_gtp2_tlv_ldn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_1 =
 {
     OGS_TLV_VAR_STR,
     "LDN",
-    OGS_GTP_LDN_TYPE,
+    OGS_GTP2_LDN_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_ldn_t),
+    sizeof(ogs_gtp2_tlv_ldn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_2 =
 {
     OGS_TLV_VAR_STR,
     "LDN",
-    OGS_GTP_LDN_TYPE,
+    OGS_GTP2_LDN_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_ldn_t),
+    sizeof(ogs_gtp2_tlv_ldn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_3 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_3 =
 {
     OGS_TLV_VAR_STR,
     "LDN",
-    OGS_GTP_LDN_TYPE,
+    OGS_GTP2_LDN_TYPE,
     0,
     3,
-    sizeof(ogs_gtp_tlv_ldn_t),
+    sizeof(ogs_gtp2_tlv_ldn_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_node_features_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_features_0 =
 {
     OGS_TLV_UINT8,
     "Node Features",
-    OGS_GTP_NODE_FEATURES_TYPE,
+    OGS_GTP2_NODE_FEATURES_TYPE,
     1,
     0,
-    sizeof(ogs_gtp_tlv_node_features_t),
+    sizeof(ogs_gtp2_tlv_node_features_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_time_to_data_transfer_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_time_to_data_transfer_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Time to Data Transfer",
-    OGS_GTP_MBMS_TIME_TO_DATA_TRANSFER_TYPE,
+    OGS_GTP2_MBMS_TIME_TO_DATA_TRANSFER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_time_to_data_transfer_t),
+    sizeof(ogs_gtp2_tlv_mbms_time_to_data_transfer_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_throttling_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_throttling_0 =
 {
     OGS_TLV_VAR_STR,
     "Throttling",
-    OGS_GTP_THROTTLING_TYPE,
+    OGS_GTP2_THROTTLING_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_throttling_t),
+    sizeof(ogs_gtp2_tlv_throttling_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_arp_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_arp_0 =
 {
     OGS_TLV_VAR_STR,
     "ARP",
-    OGS_GTP_ARP_TYPE,
+    OGS_GTP2_ARP_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_arp_t),
+    sizeof(ogs_gtp2_tlv_arp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_epc_timer_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_epc_timer_0 =
 {
     OGS_TLV_VAR_STR,
     "EPC Timer",
-    OGS_GTP_EPC_TIMER_TYPE,
+    OGS_GTP2_EPC_TIMER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_epc_timer_t),
+    sizeof(ogs_gtp2_tlv_epc_timer_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_signalling_priority_indication_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_signalling_priority_indication_0 =
 {
     OGS_TLV_VAR_STR,
     "Signalling Priority Indication",
-    OGS_GTP_SIGNALLING_PRIORITY_INDICATION_TYPE,
+    OGS_GTP2_SIGNALLING_PRIORITY_INDICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_signalling_priority_indication_t),
+    sizeof(ogs_gtp2_tlv_signalling_priority_indication_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_tmgi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_tmgi_0 =
 {
     OGS_TLV_VAR_STR,
     "TMGI",
-    OGS_GTP_TMGI_TYPE,
+    OGS_GTP2_TMGI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_tmgi_t),
+    sizeof(ogs_gtp2_tlv_tmgi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_mm_context_for_srvcc_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_mm_context_for_srvcc_0 =
 {
     OGS_TLV_VAR_STR,
     "Additional MM context for SRVCC",
-    OGS_GTP_ADDITIONAL_MM_CONTEXT_FOR_SRVCC_TYPE,
+    OGS_GTP2_ADDITIONAL_MM_CONTEXT_FOR_SRVCC_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_additional_mm_context_for_srvcc_t),
+    sizeof(ogs_gtp2_tlv_additional_mm_context_for_srvcc_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_flags_for_srvcc_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_flags_for_srvcc_0 =
 {
     OGS_TLV_VAR_STR,
     "Additional flags for SRVCC",
-    OGS_GTP_ADDITIONAL_FLAGS_FOR_SRVCC_TYPE,
+    OGS_GTP2_ADDITIONAL_FLAGS_FOR_SRVCC_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_additional_flags_for_srvcc_t),
+    sizeof(ogs_gtp2_tlv_additional_flags_for_srvcc_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mdt_configuration_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mdt_configuration_0 =
 {
     OGS_TLV_VAR_STR,
     "MDT Configuration",
-    OGS_GTP_MDT_CONFIGURATION_TYPE,
+    OGS_GTP2_MDT_CONFIGURATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mdt_configuration_t),
+    sizeof(ogs_gtp2_tlv_mdt_configuration_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_apco_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_apco_0 =
 {
     OGS_TLV_VAR_STR,
     "APCO",
-    OGS_GTP_APCO_TYPE,
+    OGS_GTP2_APCO_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_apco_t),
+    sizeof(ogs_gtp2_tlv_apco_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_absolute_time_of_mbms_data_transfer_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_absolute_time_of_mbms_data_transfer_0 =
 {
     OGS_TLV_VAR_STR,
     "Absolute Time of MBMS Data Transfer",
-    OGS_GTP_ABSOLUTE_TIME_OF_MBMS_DATA_TRANSFER_TYPE,
+    OGS_GTP2_ABSOLUTE_TIME_OF_MBMS_DATA_TRANSFER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_absolute_time_of_mbms_data_transfer_t),
+    sizeof(ogs_gtp2_tlv_absolute_time_of_mbms_data_transfer_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_enb_information_reporting_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_enb_information_reporting_0 =
 {
     OGS_TLV_VAR_STR,
     "eNB Information Reporting",
-    OGS_GTP_ENB_INFORMATION_REPORTING_TYPE,
+    OGS_GTP2_ENB_INFORMATION_REPORTING_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_enb_information_reporting_t),
+    sizeof(ogs_gtp2_tlv_enb_information_reporting_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ip4cp_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip4cp_0 =
 {
     OGS_TLV_VAR_STR,
     "IP4CP",
-    OGS_GTP_IP4CP_TYPE,
+    OGS_GTP2_IP4CP_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ip4cp_t),
+    sizeof(ogs_gtp2_tlv_ip4cp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_change_to_report_flags_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_to_report_flags_0 =
 {
     OGS_TLV_VAR_STR,
     "Change to Report Flags",
-    OGS_GTP_CHANGE_TO_REPORT_FLAGS_TYPE,
+    OGS_GTP2_CHANGE_TO_REPORT_FLAGS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_change_to_report_flags_t),
+    sizeof(ogs_gtp2_tlv_change_to_report_flags_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_action_indication_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_action_indication_0 =
 {
     OGS_TLV_VAR_STR,
     "Action Indication",
-    OGS_GTP_ACTION_INDICATION_TYPE,
+    OGS_GTP2_ACTION_INDICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_action_indication_t),
+    sizeof(ogs_gtp2_tlv_action_indication_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_0 =
 {
     OGS_TLV_VAR_STR,
     "TWAN Identifier",
-    OGS_GTP_TWAN_IDENTIFIER_TYPE,
+    OGS_GTP2_TWAN_IDENTIFIER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_twan_identifier_t),
+    sizeof(ogs_gtp2_tlv_twan_identifier_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_1 =
 {
     OGS_TLV_VAR_STR,
     "TWAN Identifier",
-    OGS_GTP_TWAN_IDENTIFIER_TYPE,
+    OGS_GTP2_TWAN_IDENTIFIER_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_twan_identifier_t),
+    sizeof(ogs_gtp2_tlv_twan_identifier_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_timestamp_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_timestamp_0 =
 {
     OGS_TLV_VAR_STR,
     "ULI Timestamp",
-    OGS_GTP_ULI_TIMESTAMP_TYPE,
+    OGS_GTP2_ULI_TIMESTAMP_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_uli_timestamp_t),
+    sizeof(ogs_gtp2_tlv_uli_timestamp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_flags_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_flags_0 =
 {
     OGS_TLV_VAR_STR,
     "MBMS Flags",
-    OGS_GTP_MBMS_FLAGS_TYPE,
+    OGS_GTP2_MBMS_FLAGS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mbms_flags_t),
+    sizeof(ogs_gtp2_tlv_mbms_flags_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ran_nas_cause_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ran_nas_cause_0 =
 {
     OGS_TLV_VAR_STR,
     "RAN/NAS Cause",
-    OGS_GTP_RAN_NAS_CAUSE_TYPE,
+    OGS_GTP2_RAN_NAS_CAUSE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ran_nas_cause_t),
+    sizeof(ogs_gtp2_tlv_ran_nas_cause_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_cn_operator_selection_entity_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_cn_operator_selection_entity_0 =
 {
     OGS_TLV_VAR_STR,
     "CN Operator Selection Entity",
-    OGS_GTP_CN_OPERATOR_SELECTION_ENTITY_TYPE,
+    OGS_GTP2_CN_OPERATOR_SELECTION_ENTITY_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_cn_operator_selection_entity_t),
+    sizeof(ogs_gtp2_tlv_cn_operator_selection_entity_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_twmi_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_twmi_0 =
 {
     OGS_TLV_VAR_STR,
     "TWMI",
-    OGS_GTP_TWMI_TYPE,
+    OGS_GTP2_TWMI_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_twmi_t),
+    sizeof(ogs_gtp2_tlv_twmi_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_node_number_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_number_0 =
 {
     OGS_TLV_VAR_STR,
     "Node Number",
-    OGS_GTP_NODE_NUMBER_TYPE,
+    OGS_GTP2_NODE_NUMBER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_node_number_t),
+    sizeof(ogs_gtp2_tlv_node_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_node_identifier_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_identifier_0 =
 {
     OGS_TLV_VAR_STR,
     "Node Identifier",
-    OGS_GTP_NODE_IDENTIFIER_TYPE,
+    OGS_GTP2_NODE_IDENTIFIER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_node_identifier_t),
+    sizeof(ogs_gtp2_tlv_node_identifier_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_presence_reporting_area_action_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_presence_reporting_area_action_0 =
 {
     OGS_TLV_VAR_STR,
     "Presence Reporting Area Action",
-    OGS_GTP_PRESENCE_REPORTING_AREA_ACTION_TYPE,
+    OGS_GTP2_PRESENCE_REPORTING_AREA_ACTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_presence_reporting_area_action_t),
+    sizeof(ogs_gtp2_tlv_presence_reporting_area_action_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_presence_reporting_area_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_presence_reporting_area_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Presence Reporting Area Information",
-    OGS_GTP_PRESENCE_REPORTING_AREA_INFORMATION_TYPE,
+    OGS_GTP2_PRESENCE_REPORTING_AREA_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_presence_reporting_area_information_t),
+    sizeof(ogs_gtp2_tlv_presence_reporting_area_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_timestamp_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_timestamp_0 =
 {
     OGS_TLV_VAR_STR,
     "TWAN Identifier Timestamp",
-    OGS_GTP_TWAN_IDENTIFIER_TIMESTAMP_TYPE,
+    OGS_GTP2_TWAN_IDENTIFIER_TIMESTAMP_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_twan_identifier_timestamp_t),
+    sizeof(ogs_gtp2_tlv_twan_identifier_timestamp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_timestamp_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_timestamp_1 =
 {
     OGS_TLV_VAR_STR,
     "TWAN Identifier Timestamp",
-    OGS_GTP_TWAN_IDENTIFIER_TIMESTAMP_TYPE,
+    OGS_GTP2_TWAN_IDENTIFIER_TIMESTAMP_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_twan_identifier_timestamp_t),
+    sizeof(ogs_gtp2_tlv_twan_identifier_timestamp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_metric_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_metric_0 =
 {
     OGS_TLV_VAR_STR,
     "Metric",
-    OGS_GTP_METRIC_TYPE,
+    OGS_GTP2_METRIC_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_metric_t),
+    sizeof(ogs_gtp2_tlv_metric_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_sequence_number_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_sequence_number_0 =
 {
     OGS_TLV_VAR_STR,
     "Sequence Number",
-    OGS_GTP_SEQUENCE_NUMBER_TYPE,
+    OGS_GTP2_SEQUENCE_NUMBER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_sequence_number_t),
+    sizeof(ogs_gtp2_tlv_sequence_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_and_relative_capacity_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_and_relative_capacity_0 =
 {
     OGS_TLV_VAR_STR,
     "APN and Relative Capacity",
-    OGS_GTP_APN_AND_RELATIVE_CAPACITY_TYPE,
+    OGS_GTP2_APN_AND_RELATIVE_CAPACITY_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_apn_and_relative_capacity_t),
+    sizeof(ogs_gtp2_tlv_apn_and_relative_capacity_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_wlan_offloadability_indication_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_wlan_offloadability_indication_0 =
 {
     OGS_TLV_VAR_STR,
     "WLAN Offloadability Indication",
-    OGS_GTP_WLAN_OFFLOADABILITY_INDICATION_TYPE,
+    OGS_GTP2_WLAN_OFFLOADABILITY_INDICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_wlan_offloadability_indication_t),
+    sizeof(ogs_gtp2_tlv_wlan_offloadability_indication_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_paging_and_service_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_paging_and_service_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Paging and Service Information",
-    OGS_GTP_PAGING_AND_SERVICE_INFORMATION_TYPE,
+    OGS_GTP2_PAGING_AND_SERVICE_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_paging_and_service_information_t),
+    sizeof(ogs_gtp2_tlv_paging_and_service_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_integer_number_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_integer_number_0 =
 {
     OGS_TLV_VAR_STR,
     "Integer Number",
-    OGS_GTP_INTEGER_NUMBER_TYPE,
+    OGS_GTP2_INTEGER_NUMBER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_integer_number_t),
+    sizeof(ogs_gtp2_tlv_integer_number_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_millisecond_time_stamp_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_millisecond_time_stamp_0 =
 {
     OGS_TLV_VAR_STR,
     "Millisecond Time Stamp",
-    OGS_GTP_MILLISECOND_TIME_STAMP_TYPE,
+    OGS_GTP2_MILLISECOND_TIME_STAMP_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_millisecond_time_stamp_t),
+    sizeof(ogs_gtp2_tlv_millisecond_time_stamp_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_monitoring_event_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_monitoring_event_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Monitoring Event Information",
-    OGS_GTP_MONITORING_EVENT_INFORMATION_TYPE,
+    OGS_GTP2_MONITORING_EVENT_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_monitoring_event_information_t),
+    sizeof(ogs_gtp2_tlv_monitoring_event_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ecgi_list_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ecgi_list_0 =
 {
     OGS_TLV_VAR_STR,
     "ECGI List",
-    OGS_GTP_ECGI_LIST_TYPE,
+    OGS_GTP2_ECGI_LIST_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ecgi_list_t),
+    sizeof(ogs_gtp2_tlv_ecgi_list_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_user_id_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_user_id_0 =
 {
     OGS_TLV_VAR_STR,
     "Remote User ID",
-    OGS_GTP_REMOTE_USER_ID_TYPE,
+    OGS_GTP2_REMOTE_USER_ID_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_remote_user_id_t),
+    sizeof(ogs_gtp2_tlv_remote_user_id_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_ip_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_ip_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Remote UE IP Information",
-    OGS_GTP_REMOTE_UE_IP_INFORMATION_TYPE,
+    OGS_GTP2_REMOTE_UE_IP_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_remote_ue_ip_information_t),
+    sizeof(ogs_gtp2_tlv_remote_ue_ip_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_ciot_optimizations_support_indication_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_ciot_optimizations_support_indication_0 =
 {
     OGS_TLV_VAR_STR,
     "CIoT Optimizations Support Indication",
-    OGS_GTP_CIOT_OPTIMIZATIONS_SUPPORT_INDICATION_TYPE,
+    OGS_GTP2_CIOT_OPTIMIZATIONS_SUPPORT_INDICATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_ciot_optimizations_support_indication_t),
+    sizeof(ogs_gtp2_tlv_ciot_optimizations_support_indication_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_header_compression_configuration_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_header_compression_configuration_0 =
 {
     OGS_TLV_VAR_STR,
     "Header Compression Configuration",
-    OGS_GTP_HEADER_COMPRESSION_CONFIGURATION_TYPE,
+    OGS_GTP2_HEADER_COMPRESSION_CONFIGURATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_header_compression_configuration_t),
+    sizeof(ogs_gtp2_tlv_header_compression_configuration_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_epco_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_epco_0 =
 {
     OGS_TLV_VAR_STR,
     "ePCO",
-    OGS_GTP_EPCO_TYPE,
+    OGS_GTP2_EPCO_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_epco_t),
+    sizeof(ogs_gtp2_tlv_epco_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_serving_plmn_rate_control_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_serving_plmn_rate_control_0 =
 {
     OGS_TLV_VAR_STR,
     "Serving PLMN Rate Control",
-    OGS_GTP_SERVING_PLMN_RATE_CONTROL_TYPE,
+    OGS_GTP2_SERVING_PLMN_RATE_CONTROL_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_serving_plmn_rate_control_t),
+    sizeof(ogs_gtp2_tlv_serving_plmn_rate_control_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_counter_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_counter_0 =
 {
     OGS_TLV_VAR_STR,
     "Counter",
-    OGS_GTP_COUNTER_TYPE,
+    OGS_GTP2_COUNTER_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_counter_t),
+    sizeof(ogs_gtp2_tlv_counter_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_mapped_ue_usage_type_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_mapped_ue_usage_type_0 =
 {
     OGS_TLV_VAR_STR,
     "Mapped UE Usage Type",
-    OGS_GTP_MAPPED_UE_USAGE_TYPE_TYPE,
+    OGS_GTP2_MAPPED_UE_USAGE_TYPE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_mapped_ue_usage_type_t),
+    sizeof(ogs_gtp2_tlv_mapped_ue_usage_type_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0 =
 {
     OGS_TLV_VAR_STR,
     "Secondary RAT Usage Data Report",
-    OGS_GTP_SECONDARY_RAT_USAGE_DATA_REPORT_TYPE,
+    OGS_GTP2_SECONDARY_RAT_USAGE_DATA_REPORT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_secondary_rat_usage_data_report_t),
+    sizeof(ogs_gtp2_tlv_secondary_rat_usage_data_report_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_up_function_selection_indication_flags_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_up_function_selection_indication_flags_0 =
 {
     OGS_TLV_VAR_STR,
     "UP Function Selection Indication Flags",
-    OGS_GTP_UP_FUNCTION_SELECTION_INDICATION_FLAGS_TYPE,
+    OGS_GTP2_UP_FUNCTION_SELECTION_INDICATION_FLAGS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_up_function_selection_indication_flags_t),
+    sizeof(ogs_gtp2_tlv_up_function_selection_indication_flags_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_maximum_packet_loss_rate_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_maximum_packet_loss_rate_0 =
 {
     OGS_TLV_VAR_STR,
     "Maximum Packet Loss Rate",
-    OGS_GTP_MAXIMUM_PACKET_LOSS_RATE_TYPE,
+    OGS_GTP2_MAXIMUM_PACKET_LOSS_RATE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_maximum_packet_loss_rate_t),
+    sizeof(ogs_gtp2_tlv_maximum_packet_loss_rate_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_rate_control_status_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_rate_control_status_0 =
 {
     OGS_TLV_VAR_STR,
     "APN Rate Control Status",
-    OGS_GTP_APN_RATE_CONTROL_STATUS_TYPE,
+    OGS_GTP2_APN_RATE_CONTROL_STATUS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_apn_rate_control_status_t),
+    sizeof(ogs_gtp2_tlv_apn_rate_control_status_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_extended_trace_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_extended_trace_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Extended Trace Information",
-    OGS_GTP_EXTENDED_TRACE_INFORMATION_TYPE,
+    OGS_GTP2_EXTENDED_TRACE_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_extended_trace_information_t),
+    sizeof(ogs_gtp2_tlv_extended_trace_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_monitoring_event_extension_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_monitoring_event_extension_information_0 =
 {
     OGS_TLV_VAR_STR,
     "Monitoring Event Extension Information",
-    OGS_GTP_MONITORING_EVENT_EXTENSION_INFORMATION_TYPE,
+    OGS_GTP2_MONITORING_EVENT_EXTENSION_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_monitoring_event_extension_information_t),
+    sizeof(ogs_gtp2_tlv_monitoring_event_extension_information_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_rrm_policy_index_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_rrm_policy_index_0 =
 {
     OGS_TLV_VAR_STR,
     "Additional RRM Policy Index",
-    OGS_GTP_ADDITIONAL_RRM_POLICY_INDEX_TYPE,
+    OGS_GTP2_ADDITIONAL_RRM_POLICY_INDEX_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_additional_rrm_policy_index_t),
+    sizeof(ogs_gtp2_tlv_additional_rrm_policy_index_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_services_authorized_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_services_authorized_0 =
 {
     OGS_TLV_VAR_STR,
     "Services Authorized",
-    OGS_GTP_SERVICES_AUTHORIZED_TYPE,
+    OGS_GTP2_SERVICES_AUTHORIZED_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_services_authorized_t),
+    sizeof(ogs_gtp2_tlv_services_authorized_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_services_authorized_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_services_authorized_1 =
 {
     OGS_TLV_VAR_STR,
     "Services Authorized",
-    OGS_GTP_SERVICES_AUTHORIZED_TYPE,
+    OGS_GTP2_SERVICES_AUTHORIZED_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_services_authorized_t),
+    sizeof(ogs_gtp2_tlv_services_authorized_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bit_rate_0 =
 {
     OGS_TLV_VAR_STR,
     "Bit Rate",
-    OGS_GTP_BIT_RATE_TYPE,
+    OGS_GTP2_BIT_RATE_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_bit_rate_t),
+    sizeof(ogs_gtp2_tlv_bit_rate_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bit_rate_1 =
 {
     OGS_TLV_VAR_STR,
     "Bit Rate",
-    OGS_GTP_BIT_RATE_TYPE,
+    OGS_GTP2_BIT_RATE_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_bit_rate_t),
+    sizeof(ogs_gtp2_tlv_bit_rate_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_flow_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pc5_qos_flow_0 =
 {
     OGS_TLV_VAR_STR,
     "PC5 QoS Flow",
-    OGS_GTP_PC5_QOS_FLOW_TYPE,
+    OGS_GTP2_PC5_QOS_FLOW_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pc5_qos_flow_t),
+    sizeof(ogs_gtp2_tlv_pc5_qos_flow_t),
     { NULL }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pc5_qos_parameters_0 =
 {
     OGS_TLV_COMPOUND,
     "PC5 QoS Parameters",
-    OGS_GTP_PC5_QOS_PARAMETERS_TYPE,
+    OGS_GTP2_PC5_QOS_PARAMETERS_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pc5_qos_parameters_t),
+    sizeof(ogs_gtp2_tlv_pc5_qos_parameters_t),
     {
-        &ogs_gtp_tlv_desc_pc5_qos_flow_0,
-        &ogs_gtp_tlv_desc_bit_rate_0,
+        &ogs_gtp2_tlv_desc_pc5_qos_flow_0,
+        &ogs_gtp2_tlv_desc_bit_rate_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_context_0 =
 {
     OGS_TLV_COMPOUND,
     "Remote UE Context",
-    OGS_GTP_REMOTE_UE_CONTEXT_TYPE,
+    OGS_GTP2_REMOTE_UE_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_remote_ue_context_t),
+    sizeof(ogs_gtp2_tlv_remote_ue_context_t),
     {
-        &ogs_gtp_tlv_desc_remote_user_id_0,
-        &ogs_gtp_tlv_desc_remote_ue_ip_information_0,
+        &ogs_gtp2_tlv_desc_remote_user_id_0,
+        &ogs_gtp2_tlv_desc_remote_ue_ip_information_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_v2x_context_0 =
 {
     OGS_TLV_COMPOUND,
     "V2X Context",
-    OGS_GTP_V2X_CONTEXT_TYPE,
+    OGS_GTP2_V2X_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_v2x_context_t),
+    sizeof(ogs_gtp2_tlv_v2x_context_t),
     {
-        &ogs_gtp_tlv_desc_services_authorized_0,
-        &ogs_gtp_tlv_desc_services_authorized_1,
-        &ogs_gtp_tlv_desc_bit_rate_0,
-        &ogs_gtp_tlv_desc_bit_rate_1,
-        &ogs_gtp_tlv_desc_pc5_qos_parameters_0,
+        &ogs_gtp2_tlv_desc_services_authorized_0,
+        &ogs_gtp2_tlv_desc_services_authorized_1,
+        &ogs_gtp2_tlv_desc_bit_rate_0,
+        &ogs_gtp2_tlv_desc_bit_rate_1,
+        &ogs_gtp2_tlv_desc_pc5_qos_parameters_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_context_0 =
 {
     OGS_TLV_COMPOUND,
     "Bearer Context",
-    OGS_GTP_BEARER_CONTEXT_TYPE,
+    OGS_GTP2_BEARER_CONTEXT_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_bearer_context_t),
+    sizeof(ogs_gtp2_tlv_bearer_context_t),
     {
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_tft_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_f_teid_1,
-        &ogs_gtp_tlv_desc_f_teid_2,
-        &ogs_gtp_tlv_desc_f_teid_3,
-        &ogs_gtp_tlv_desc_f_teid_4,
-        &ogs_gtp_tlv_desc_f_teid_5,
-        &ogs_gtp_tlv_desc_f_teid_6,
-        &ogs_gtp_tlv_desc_bearer_qos_0,
-        &ogs_gtp_tlv_desc_f_teid_7,
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_charging_id_0,
-        &ogs_gtp_tlv_desc_bearer_flags_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
-        &ogs_gtp_tlv_desc_f_teid_8,
-        &ogs_gtp_tlv_desc_f_teid_9,
-        &ogs_gtp_tlv_desc_f_teid_10,
-        &ogs_gtp_tlv_desc_f_teid_11,
-        &ogs_gtp_tlv_desc_ran_nas_cause_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_ti_0,
-        &ogs_gtp_tlv_desc_packet_flow_id_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_bearer_tft_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_f_teid_1,
+        &ogs_gtp2_tlv_desc_f_teid_2,
+        &ogs_gtp2_tlv_desc_f_teid_3,
+        &ogs_gtp2_tlv_desc_f_teid_4,
+        &ogs_gtp2_tlv_desc_f_teid_5,
+        &ogs_gtp2_tlv_desc_f_teid_6,
+        &ogs_gtp2_tlv_desc_bearer_qos_0,
+        &ogs_gtp2_tlv_desc_f_teid_7,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_charging_id_0,
+        &ogs_gtp2_tlv_desc_bearer_flags_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_maximum_packet_loss_rate_0,
+        &ogs_gtp2_tlv_desc_f_teid_8,
+        &ogs_gtp2_tlv_desc_f_teid_9,
+        &ogs_gtp2_tlv_desc_f_teid_10,
+        &ogs_gtp2_tlv_desc_f_teid_11,
+        &ogs_gtp2_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp2_tlv_desc_apco_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_ti_0,
+        &ogs_gtp2_tlv_desc_packet_flow_id_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_context_1 =
 {
     OGS_TLV_COMPOUND,
     "Bearer Context",
-    OGS_GTP_BEARER_CONTEXT_TYPE,
+    OGS_GTP2_BEARER_CONTEXT_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_bearer_context_t),
+    sizeof(ogs_gtp2_tlv_bearer_context_t),
     {
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_tft_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_f_teid_1,
-        &ogs_gtp_tlv_desc_f_teid_2,
-        &ogs_gtp_tlv_desc_f_teid_3,
-        &ogs_gtp_tlv_desc_f_teid_4,
-        &ogs_gtp_tlv_desc_f_teid_5,
-        &ogs_gtp_tlv_desc_f_teid_6,
-        &ogs_gtp_tlv_desc_bearer_qos_0,
-        &ogs_gtp_tlv_desc_f_teid_7,
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_charging_id_0,
-        &ogs_gtp_tlv_desc_bearer_flags_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_maximum_packet_loss_rate_0,
-        &ogs_gtp_tlv_desc_f_teid_8,
-        &ogs_gtp_tlv_desc_f_teid_9,
-        &ogs_gtp_tlv_desc_f_teid_10,
-        &ogs_gtp_tlv_desc_f_teid_11,
-        &ogs_gtp_tlv_desc_ran_nas_cause_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_ti_0,
-        &ogs_gtp_tlv_desc_packet_flow_id_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_bearer_tft_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_f_teid_1,
+        &ogs_gtp2_tlv_desc_f_teid_2,
+        &ogs_gtp2_tlv_desc_f_teid_3,
+        &ogs_gtp2_tlv_desc_f_teid_4,
+        &ogs_gtp2_tlv_desc_f_teid_5,
+        &ogs_gtp2_tlv_desc_f_teid_6,
+        &ogs_gtp2_tlv_desc_bearer_qos_0,
+        &ogs_gtp2_tlv_desc_f_teid_7,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_charging_id_0,
+        &ogs_gtp2_tlv_desc_bearer_flags_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_maximum_packet_loss_rate_0,
+        &ogs_gtp2_tlv_desc_f_teid_8,
+        &ogs_gtp2_tlv_desc_f_teid_9,
+        &ogs_gtp2_tlv_desc_f_teid_10,
+        &ogs_gtp2_tlv_desc_f_teid_11,
+        &ogs_gtp2_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp2_tlv_desc_apco_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_ti_0,
+        &ogs_gtp2_tlv_desc_packet_flow_id_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdn_connection_0 =
 {
     OGS_TLV_COMPOUND,
     "PDN Connection",
-    OGS_GTP_PDN_CONNECTION_TYPE,
+    OGS_GTP2_PDN_CONNECTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_pdn_connection_t),
+    sizeof(ogs_gtp2_tlv_pdn_connection_t),
     {
-        &ogs_gtp_tlv_desc_apn_0,
-        &ogs_gtp_tlv_desc_apn_restriction_0,
-        &ogs_gtp_tlv_desc_selection_mode_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_ip_address_1,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_fqdn_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_charging_characteristics_0,
-        &ogs_gtp_tlv_desc_change_reporting_action_0,
-        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
-        &ogs_gtp_tlv_desc_enb_information_reporting_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_signalling_priority_indication_0,
-        &ogs_gtp_tlv_desc_change_to_report_flags_0,
-        &ogs_gtp_tlv_desc_fqdn_1,
-        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_wlan_offloadability_indication_0,
-        &ogs_gtp_tlv_desc_remote_ue_context_0,
-        &ogs_gtp_tlv_desc_pdn_type_0,
-        &ogs_gtp_tlv_desc_header_compression_configuration_0,
+        &ogs_gtp2_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_apn_restriction_0,
+        &ogs_gtp2_tlv_desc_selection_mode_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_ip_address_1,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_fqdn_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_charging_characteristics_0,
+        &ogs_gtp2_tlv_desc_change_reporting_action_0,
+        &ogs_gtp2_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp2_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_signalling_priority_indication_0,
+        &ogs_gtp2_tlv_desc_change_to_report_flags_0,
+        &ogs_gtp2_tlv_desc_fqdn_1,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp2_tlv_desc_wlan_offloadability_indication_0,
+        &ogs_gtp2_tlv_desc_remote_ue_context_0,
+        &ogs_gtp2_tlv_desc_pdn_type_0,
+        &ogs_gtp2_tlv_desc_header_compression_configuration_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_0 =
 {
     OGS_TLV_COMPOUND,
     "Overload Control Information",
-    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_OVERLOAD_CONTROL_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_overload_control_information_t),
+    sizeof(ogs_gtp2_tlv_overload_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_epc_timer_0,
+        &ogs_gtp2_tlv_desc_apn_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_1 =
 {
     OGS_TLV_COMPOUND,
     "Overload Control Information",
-    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_OVERLOAD_CONTROL_INFORMATION_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_overload_control_information_t),
+    sizeof(ogs_gtp2_tlv_overload_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_epc_timer_0,
+        &ogs_gtp2_tlv_desc_apn_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_2 =
 {
     OGS_TLV_COMPOUND,
     "Overload Control Information",
-    OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_OVERLOAD_CONTROL_INFORMATION_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_overload_control_information_t),
+    sizeof(ogs_gtp2_tlv_overload_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_epc_timer_0,
+        &ogs_gtp2_tlv_desc_apn_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_0 =
 {
     OGS_TLV_COMPOUND,
     "Load Control Information",
-    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_LOAD_CONTROL_INFORMATION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_load_control_information_t),
+    sizeof(ogs_gtp2_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_1 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_1 =
 {
     OGS_TLV_COMPOUND,
     "Load Control Information",
-    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_LOAD_CONTROL_INFORMATION_TYPE,
     0,
     1,
-    sizeof(ogs_gtp_tlv_load_control_information_t),
+    sizeof(ogs_gtp2_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_2 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_2 =
 {
     OGS_TLV_COMPOUND,
     "Load Control Information",
-    OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE,
+    OGS_GTP2_LOAD_CONTROL_INFORMATION_TYPE,
     0,
     2,
-    sizeof(ogs_gtp_tlv_load_control_information_t),
+    sizeof(ogs_gtp2_tlv_load_control_information_t),
     {
-        &ogs_gtp_tlv_desc_sequence_number_0,
-        &ogs_gtp_tlv_desc_metric_0,
-        &ogs_gtp_tlv_desc_apn_and_relative_capacity_0,
+        &ogs_gtp2_tlv_desc_sequence_number_0,
+        &ogs_gtp2_tlv_desc_metric_0,
+        &ogs_gtp2_tlv_desc_apn_and_relative_capacity_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection_0 =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_scef_pdn_connection_0 =
 {
     OGS_TLV_COMPOUND,
     "SCEF PDN Connection",
-    OGS_GTP_SCEF_PDN_CONNECTION_TYPE,
+    OGS_GTP2_SCEF_PDN_CONNECTION_TYPE,
     0,
     0,
-    sizeof(ogs_gtp_tlv_scef_pdn_connection_t),
+    sizeof(ogs_gtp2_tlv_scef_pdn_connection_t),
     {
-        &ogs_gtp_tlv_desc_apn_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_node_identifier_0,
+        &ogs_gtp2_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_node_identifier_0,
         NULL,
     }
 };
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_echo_request =
 {
     OGS_TLV_MESSAGE,
     "Echo Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_node_features_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_node_features_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_echo_response =
 {
     OGS_TLV_MESSAGE,
     "Echo Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_node_features_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_node_features_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_session_request =
 {
     OGS_TLV_MESSAGE,
     "Create Session Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_imsi_0,
-        &ogs_gtp_tlv_desc_msisdn_0,
-        &ogs_gtp_tlv_desc_mei_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_serving_network_0,
-        &ogs_gtp_tlv_desc_rat_type_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_f_teid_1,
-        &ogs_gtp_tlv_desc_apn_0,
-        &ogs_gtp_tlv_desc_selection_mode_0,
-        &ogs_gtp_tlv_desc_pdn_type_0,
-        &ogs_gtp_tlv_desc_paa_0,
-        &ogs_gtp_tlv_desc_apn_restriction_0,
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_twmi_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_trace_information_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_fq_csid_2,
-        &ogs_gtp_tlv_desc_fq_csid_3,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_uci_0,
-        &ogs_gtp_tlv_desc_charging_characteristics_0,
-        &ogs_gtp_tlv_desc_ldn_0,
-        &ogs_gtp_tlv_desc_ldn_1,
-        &ogs_gtp_tlv_desc_ldn_2,
-        &ogs_gtp_tlv_desc_ldn_3,
-        &ogs_gtp_tlv_desc_signalling_priority_indication_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_ip_address_1,
-        &ogs_gtp_tlv_desc_port_number_1,
-        &ogs_gtp_tlv_desc_ip_address_2,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_ip_address_3,
-        &ogs_gtp_tlv_desc_cn_operator_selection_entity_0,
-        &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_millisecond_time_stamp_0,
-        &ogs_gtp_tlv_desc_integer_number_0,
-        &ogs_gtp_tlv_desc_twan_identifier_1,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_remote_ue_context_0,
-        &ogs_gtp_tlv_desc_node_identifier_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_serving_plmn_rate_control_0,
-        &ogs_gtp_tlv_desc_counter_0,
-        &ogs_gtp_tlv_desc_port_number_2,
-        &ogs_gtp_tlv_desc_mapped_ue_usage_type_0,
-        &ogs_gtp_tlv_desc_uli_1,
-        &ogs_gtp_tlv_desc_fqdn_0,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
-        &ogs_gtp_tlv_desc_up_function_selection_indication_flags_0,
-        &ogs_gtp_tlv_desc_apn_rate_control_status_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_msisdn_0,
+        &ogs_gtp2_tlv_desc_mei_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_serving_network_0,
+        &ogs_gtp2_tlv_desc_rat_type_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_f_teid_1,
+        &ogs_gtp2_tlv_desc_apn_0,
+        &ogs_gtp2_tlv_desc_selection_mode_0,
+        &ogs_gtp2_tlv_desc_pdn_type_0,
+        &ogs_gtp2_tlv_desc_paa_0,
+        &ogs_gtp2_tlv_desc_apn_restriction_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_twmi_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_trace_information_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_fq_csid_2,
+        &ogs_gtp2_tlv_desc_fq_csid_3,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_uci_0,
+        &ogs_gtp2_tlv_desc_charging_characteristics_0,
+        &ogs_gtp2_tlv_desc_ldn_0,
+        &ogs_gtp2_tlv_desc_ldn_1,
+        &ogs_gtp2_tlv_desc_ldn_2,
+        &ogs_gtp2_tlv_desc_ldn_3,
+        &ogs_gtp2_tlv_desc_signalling_priority_indication_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_apco_0,
+        &ogs_gtp2_tlv_desc_ip_address_1,
+        &ogs_gtp2_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_ip_address_2,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_ip_address_3,
+        &ogs_gtp2_tlv_desc_cn_operator_selection_entity_0,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_millisecond_time_stamp_0,
+        &ogs_gtp2_tlv_desc_integer_number_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_remote_ue_context_0,
+        &ogs_gtp2_tlv_desc_node_identifier_0,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_serving_plmn_rate_control_0,
+        &ogs_gtp2_tlv_desc_counter_0,
+        &ogs_gtp2_tlv_desc_port_number_2,
+        &ogs_gtp2_tlv_desc_mapped_ue_usage_type_0,
+        &ogs_gtp2_tlv_desc_uli_1,
+        &ogs_gtp2_tlv_desc_fqdn_0,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_up_function_selection_indication_flags_0,
+        &ogs_gtp2_tlv_desc_apn_rate_control_status_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_session_response =
 {
     OGS_TLV_MESSAGE,
     "Create Session Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_change_reporting_action_0,
-        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
-        &ogs_gtp_tlv_desc_enb_information_reporting_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_f_teid_1,
-        &ogs_gtp_tlv_desc_paa_0,
-        &ogs_gtp_tlv_desc_apn_restriction_0,
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_fqdn_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_ldn_0,
-        &ogs_gtp_tlv_desc_ldn_1,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_apco_0,
-        &ogs_gtp_tlv_desc_ip4cp_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_charging_id_0,
-        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_change_reporting_action_0,
+        &ogs_gtp2_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp2_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_f_teid_1,
+        &ogs_gtp2_tlv_desc_paa_0,
+        &ogs_gtp2_tlv_desc_apn_restriction_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_fqdn_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_ldn_0,
+        &ogs_gtp2_tlv_desc_ldn_1,
+        &ogs_gtp2_tlv_desc_epc_timer_0,
+        &ogs_gtp2_tlv_desc_apco_0,
+        &ogs_gtp2_tlv_desc_ip4cp_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_charging_id_0,
+        &ogs_gtp2_tlv_desc_epco_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_request =
 {
     OGS_TLV_MESSAGE,
     "Modify Bearer Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_mei_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_serving_network_0,
-        &ogs_gtp_tlv_desc_rat_type_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_delay_value_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_uci_0,
-        &ogs_gtp_tlv_desc_ip_address_1,
-        &ogs_gtp_tlv_desc_port_number_1,
-        &ogs_gtp_tlv_desc_ldn_0,
-        &ogs_gtp_tlv_desc_ldn_1,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_ip_address_2,
-        &ogs_gtp_tlv_desc_cn_operator_selection_entity_0,
-        &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_serving_plmn_rate_control_0,
-        &ogs_gtp_tlv_desc_counter_0,
-        &ogs_gtp_tlv_desc_imsi_0,
-        &ogs_gtp_tlv_desc_uli_1,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_mei_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_serving_network_0,
+        &ogs_gtp2_tlv_desc_rat_type_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_delay_value_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_uci_0,
+        &ogs_gtp2_tlv_desc_ip_address_1,
+        &ogs_gtp2_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_ldn_0,
+        &ogs_gtp2_tlv_desc_ldn_1,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_ip_address_2,
+        &ogs_gtp2_tlv_desc_cn_operator_selection_entity_0,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_serving_plmn_rate_control_0,
+        &ogs_gtp2_tlv_desc_counter_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_uli_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_0,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_response =
 {
     OGS_TLV_MESSAGE,
     "Modify Bearer Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_msisdn_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_apn_restriction_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_change_reporting_action_0,
-        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
-        &ogs_gtp_tlv_desc_enb_information_reporting_0,
-        &ogs_gtp_tlv_desc_fqdn_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_ldn_0,
-        &ogs_gtp_tlv_desc_ldn_1,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_charging_id_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_msisdn_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_apn_restriction_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_change_reporting_action_0,
+        &ogs_gtp2_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp2_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp2_tlv_desc_fqdn_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_ldn_0,
+        &ogs_gtp2_tlv_desc_ldn_1,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_charging_id_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_session_request =
 {
     OGS_TLV_MESSAGE,
     "Delete Session Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_node_type_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_uli_timestamp_0,
-        &ogs_gtp_tlv_desc_ran_nas_cause_0,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_twan_identifier_1,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_port_number_1,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_node_type_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_uli_timestamp_0,
+        &ogs_gtp2_tlv_desc_ran_nas_cause_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_twan_identifier_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_1,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_session_response =
 {
     OGS_TLV_MESSAGE,
     "Delete Session Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_apn_rate_control_status_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_apn_rate_control_status_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_command =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_command =
 {
     OGS_TLV_MESSAGE,
     "Modify Bearer Command",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_f_teid_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_failure_indication =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_failure_indication =
 {
     OGS_TLV_MESSAGE,
     "Modify Bearer Failure Indication",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_command =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_command =
 {
     OGS_TLV_MESSAGE,
     "Delete Bearer Command",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_uli_timestamp_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_uli_timestamp_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_failure_indication =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_failure_indication =
 {
     OGS_TLV_MESSAGE,
     "Delete Bearer Failure Indication",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_command =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_resource_command =
 {
     OGS_TLV_MESSAGE,
     "Bearer Resource Command",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_pti_0,
-        &ogs_gtp_tlv_desc_flow_qos_0,
-        &ogs_gtp_tlv_desc_tad_0,
-        &ogs_gtp_tlv_desc_rat_type_0,
-        &ogs_gtp_tlv_desc_serving_network_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_ebi_1,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_f_teid_1,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_signalling_priority_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_epco_0,
-        &ogs_gtp_tlv_desc_f_teid_2,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_pti_0,
+        &ogs_gtp2_tlv_desc_flow_qos_0,
+        &ogs_gtp2_tlv_desc_tad_0,
+        &ogs_gtp2_tlv_desc_rat_type_0,
+        &ogs_gtp2_tlv_desc_serving_network_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_ebi_1,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_f_teid_1,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_signalling_priority_indication_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_f_teid_2,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_failure_indication =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_resource_failure_indication =
 {
     OGS_TLV_MESSAGE,
     "Bearer Resource Failure Indication",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_pti_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_pti_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification_failure_indication =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification_failure_indication =
 {
     OGS_TLV_MESSAGE,
     "Downlink Data Notification Failure Indication",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_node_type_0,
-        &ogs_gtp_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_node_type_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_bearer_request =
 {
     OGS_TLV_MESSAGE,
     "Create Bearer Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_pti_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_change_reporting_action_0,
-        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
-        &ogs_gtp_tlv_desc_enb_information_reporting_0,
-        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_pti_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_change_reporting_action_0,
+        &ogs_gtp2_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp2_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_container_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_bearer_response =
 {
     OGS_TLV_MESSAGE,
     "Create Bearer Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_2,
-        &ogs_gtp_tlv_desc_fq_csid_3,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_twan_identifier_1,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_2,
+        &ogs_gtp2_tlv_desc_fq_csid_3,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_information_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_twan_identifier_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_1,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_port_number_1,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_bearer_request =
 {
     OGS_TLV_MESSAGE,
     "Update Bearer Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_pti_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_ambr_0,
-        &ogs_gtp_tlv_desc_change_reporting_action_0,
-        &ogs_gtp_tlv_desc_csg_information_reporting_action_0,
-        &ogs_gtp_tlv_desc_enb_information_reporting_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_presence_reporting_area_action_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_pti_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_ambr_0,
+        &ogs_gtp2_tlv_desc_change_reporting_action_0,
+        &ogs_gtp2_tlv_desc_csg_information_reporting_action_0,
+        &ogs_gtp2_tlv_desc_enb_information_reporting_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_action_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_container_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_bearer_response =
 {
     OGS_TLV_MESSAGE,
     "Update Bearer Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_fq_csid_2,
-        &ogs_gtp_tlv_desc_fq_csid_3,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_presence_reporting_area_information_0,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_twan_identifier_1,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_fq_csid_2,
+        &ogs_gtp2_tlv_desc_fq_csid_3,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_presence_reporting_area_information_0,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_twan_identifier_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_1,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_port_number_1,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_request =
 {
     OGS_TLV_MESSAGE,
     "Delete Bearer Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_ebi_1,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_pti_0,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_load_control_information_1,
-        &ogs_gtp_tlv_desc_load_control_information_2,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_apn_rate_control_status_0,
-        &ogs_gtp_tlv_desc_epco_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_ebi_1,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_pti_0,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_load_control_information_1,
+        &ogs_gtp2_tlv_desc_load_control_information_2,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_apn_rate_control_status_0,
+        &ogs_gtp2_tlv_desc_epco_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_response =
 {
     OGS_TLV_MESSAGE,
     "Delete Bearer Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_fq_csid_0,
-        &ogs_gtp_tlv_desc_fq_csid_1,
-        &ogs_gtp_tlv_desc_fq_csid_2,
-        &ogs_gtp_tlv_desc_fq_csid_3,
-        &ogs_gtp_tlv_desc_pco_0,
-        &ogs_gtp_tlv_desc_ue_time_zone_0,
-        &ogs_gtp_tlv_desc_uli_0,
-        &ogs_gtp_tlv_desc_uli_timestamp_0,
-        &ogs_gtp_tlv_desc_twan_identifier_0,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_1,
-        &ogs_gtp_tlv_desc_ip_address_0,
-        &ogs_gtp_tlv_desc_overload_control_information_2,
-        &ogs_gtp_tlv_desc_twan_identifier_1,
-        &ogs_gtp_tlv_desc_twan_identifier_timestamp_1,
-        &ogs_gtp_tlv_desc_port_number_0,
-        &ogs_gtp_tlv_desc_f_container_0,
-        &ogs_gtp_tlv_desc_port_number_1,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_fq_csid_0,
+        &ogs_gtp2_tlv_desc_fq_csid_1,
+        &ogs_gtp2_tlv_desc_fq_csid_2,
+        &ogs_gtp2_tlv_desc_fq_csid_3,
+        &ogs_gtp2_tlv_desc_pco_0,
+        &ogs_gtp2_tlv_desc_ue_time_zone_0,
+        &ogs_gtp2_tlv_desc_uli_0,
+        &ogs_gtp2_tlv_desc_uli_timestamp_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_0,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_1,
+        &ogs_gtp2_tlv_desc_ip_address_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_2,
+        &ogs_gtp2_tlv_desc_twan_identifier_1,
+        &ogs_gtp2_tlv_desc_twan_identifier_timestamp_1,
+        &ogs_gtp2_tlv_desc_port_number_0,
+        &ogs_gtp2_tlv_desc_f_container_0,
+        &ogs_gtp2_tlv_desc_port_number_1,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_request =
 {
     OGS_TLV_MESSAGE,
     "Create Indirect Data Forwarding Tunnel Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_imsi_0,
-        &ogs_gtp_tlv_desc_mei_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_mei_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
         &ogs_tlv_desc_more8,
-        &ogs_gtp_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_response =
 {
     OGS_TLV_MESSAGE,
     "Create Indirect Data Forwarding Tunnel Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
         &ogs_tlv_desc_more8,
-        &ogs_gtp_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_request =
 {
     OGS_TLV_MESSAGE,
     "Delete Indirect Data Forwarding Tunnel Request",
@@ -2586,124 +2586,124 @@ ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_request =
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_response =
 {
     OGS_TLV_MESSAGE,
     "Delete Indirect Data Forwarding Tunnel Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_release_access_bearers_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_release_access_bearers_request =
 {
     OGS_TLV_MESSAGE,
     "Release Access Bearers Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_node_type_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_node_type_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_release_access_bearers_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_release_access_bearers_response =
 {
     OGS_TLV_MESSAGE,
     "Release Access Bearers Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification =
 {
     OGS_TLV_MESSAGE,
     "Downlink Data Notification",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_ebi_0,
-        &ogs_gtp_tlv_desc_arp_0,
-        &ogs_gtp_tlv_desc_imsi_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
-        &ogs_gtp_tlv_desc_paging_and_service_information_0,
-        &ogs_gtp_tlv_desc_integer_number_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_ebi_0,
+        &ogs_gtp2_tlv_desc_arp_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_paging_and_service_information_0,
+        &ogs_gtp2_tlv_desc_integer_number_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification_acknowledge =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification_acknowledge =
 {
     OGS_TLV_MESSAGE,
     "Downlink Data Notification Acknowledge",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_delay_value_0,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_throttling_0,
-        &ogs_gtp_tlv_desc_imsi_0,
-        &ogs_gtp_tlv_desc_epc_timer_0,
-        &ogs_gtp_tlv_desc_integer_number_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_delay_value_0,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_throttling_0,
+        &ogs_gtp2_tlv_desc_imsi_0,
+        &ogs_gtp2_tlv_desc_epc_timer_0,
+        &ogs_gtp2_tlv_desc_integer_number_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_request =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_access_bearers_request =
 {
     OGS_TLV_MESSAGE,
     "Modify Access Bearers Request",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_f_teid_0,
-        &ogs_gtp_tlv_desc_delay_value_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_f_teid_0,
+        &ogs_gtp2_tlv_desc_delay_value_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0,
     NULL,
 }};
 
-ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_response =
+ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_access_bearers_response =
 {
     OGS_TLV_MESSAGE,
     "Modify Access Bearers Response",
     0, 0, 0, 0, {
-        &ogs_gtp_tlv_desc_cause_0,
-        &ogs_gtp_tlv_desc_bearer_context_0,
-        &ogs_gtp_tlv_desc_bearer_context_1,
-        &ogs_gtp_tlv_desc_recovery_0,
-        &ogs_gtp_tlv_desc_indication_0,
-        &ogs_gtp_tlv_desc_load_control_information_0,
-        &ogs_gtp_tlv_desc_overload_control_information_0,
+        &ogs_gtp2_tlv_desc_cause_0,
+        &ogs_gtp2_tlv_desc_bearer_context_0,
+        &ogs_gtp2_tlv_desc_bearer_context_1,
+        &ogs_gtp2_tlv_desc_recovery_0,
+        &ogs_gtp2_tlv_desc_indication_0,
+        &ogs_gtp2_tlv_desc_load_control_information_0,
+        &ogs_gtp2_tlv_desc_overload_control_information_0,
     NULL,
 }};
 
 
-int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
+int ogs_gtp2_parse_msg(ogs_gtp2_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
 {
     int rv = OGS_ERROR;
-    ogs_gtp_header_t *h = NULL;
+    ogs_gtp2_header_t *h = NULL;
     uint16_t size = 0;
 
     ogs_assert(gtp_message);
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->len);
 
-    h = (ogs_gtp_header_t *)pkbuf->data;
+    h = (ogs_gtp2_header_t *)pkbuf->data;
     ogs_assert(h);
-    
-    memset(gtp_message, 0, sizeof(ogs_gtp_message_t));
+
+    memset(gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     if (h->teid_presence)
         size = OGS_GTPV2C_HEADER_LEN;
     else
-        size = OGS_GTPV2C_HEADER_LEN-OGS_GTP_TEID_LEN;
+        size = OGS_GTPV2C_HEADER_LEN-OGS_GTP2_TEID_LEN;
 
     ogs_assert(ogs_pkbuf_pull(pkbuf, size));
     memcpy(&gtp_message->h, pkbuf->data - size, size);
@@ -2717,129 +2717,129 @@ int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
     }
 
     switch(gtp_message->h.type) {
-    case OGS_GTP_ECHO_REQUEST_TYPE:
+    case OGS_GTP2_ECHO_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->echo_request,
-                &ogs_gtp_tlv_desc_echo_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_echo_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_ECHO_RESPONSE_TYPE:
+    case OGS_GTP2_ECHO_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->echo_response,
-                &ogs_gtp_tlv_desc_echo_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_echo_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_session_request,
-                &ogs_gtp_tlv_desc_create_session_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_session_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_SESSION_RESPONSE_TYPE:
+    case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_session_response,
-                &ogs_gtp_tlv_desc_create_session_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_session_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_bearer_request,
-                &ogs_gtp_tlv_desc_modify_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE:
+    case OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_bearer_response,
-                &ogs_gtp_tlv_desc_modify_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_session_request,
-                &ogs_gtp_tlv_desc_delete_session_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_session_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
+    case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_session_response,
-                &ogs_gtp_tlv_desc_delete_session_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_session_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_COMMAND_TYPE:
+    case OGS_GTP2_MODIFY_BEARER_COMMAND_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_bearer_command,
-                &ogs_gtp_tlv_desc_modify_bearer_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_bearer_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_FAILURE_INDICATION_TYPE:
+    case OGS_GTP2_MODIFY_BEARER_FAILURE_INDICATION_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_bearer_failure_indication,
-                &ogs_gtp_tlv_desc_modify_bearer_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_bearer_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_COMMAND_TYPE:
+    case OGS_GTP2_DELETE_BEARER_COMMAND_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_bearer_command,
-                &ogs_gtp_tlv_desc_delete_bearer_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_bearer_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_FAILURE_INDICATION_TYPE:
+    case OGS_GTP2_DELETE_BEARER_FAILURE_INDICATION_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_bearer_failure_indication,
-                &ogs_gtp_tlv_desc_delete_bearer_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_bearer_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
+    case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->bearer_resource_command,
-                &ogs_gtp_tlv_desc_bearer_resource_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_bearer_resource_command, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
+    case OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->bearer_resource_failure_indication,
-                &ogs_gtp_tlv_desc_bearer_resource_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_bearer_resource_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE:
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->downlink_data_notification_failure_indication,
-                &ogs_gtp_tlv_desc_downlink_data_notification_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_downlink_data_notification_failure_indication, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_bearer_request,
-                &ogs_gtp_tlv_desc_create_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_BEARER_RESPONSE_TYPE:
+    case OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_bearer_response,
-                &ogs_gtp_tlv_desc_create_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_UPDATE_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->update_bearer_request,
-                &ogs_gtp_tlv_desc_update_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_update_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE:
+    case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->update_bearer_response,
-                &ogs_gtp_tlv_desc_update_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_update_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_bearer_request,
-                &ogs_gtp_tlv_desc_delete_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_bearer_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_RESPONSE_TYPE:
+    case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_bearer_response,
-                &ogs_gtp_tlv_desc_delete_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_bearer_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_indirect_data_forwarding_tunnel_request,
-                &ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->create_indirect_data_forwarding_tunnel_response,
-                &ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_indirect_data_forwarding_tunnel_request,
-                &ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+    case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->delete_indirect_data_forwarding_tunnel_response,
-                &ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
+    case OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->release_access_bearers_request,
-                &ogs_gtp_tlv_desc_release_access_bearers_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_release_access_bearers_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
+    case OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->release_access_bearers_response,
-                &ogs_gtp_tlv_desc_release_access_bearers_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_release_access_bearers_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE:
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->downlink_data_notification,
-                &ogs_gtp_tlv_desc_downlink_data_notification, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_downlink_data_notification, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->downlink_data_notification_acknowledge,
-                &ogs_gtp_tlv_desc_downlink_data_notification_acknowledge, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_downlink_data_notification_acknowledge, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_ACCESS_BEARERS_REQUEST_TYPE:
+    case OGS_GTP2_MODIFY_ACCESS_BEARERS_REQUEST_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_access_bearers_request,
-                &ogs_gtp_tlv_desc_modify_access_bearers_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_access_bearers_request, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE:
+    case OGS_GTP2_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE:
         rv = ogs_tlv_parse_msg(&gtp_message->modify_access_bearers_response,
-                &ogs_gtp_tlv_desc_modify_access_bearers_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
+                &ogs_gtp2_tlv_desc_modify_access_bearers_response, pkbuf, OGS_TLV_MODE_T1_L2_I1);
         break;
     default:
         ogs_warn("Not implmeneted(type:%d)", gtp_message->h.type);
@@ -2851,134 +2851,134 @@ int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
     return rv;
 }
 
-ogs_pkbuf_t *ogs_gtp_build_msg(ogs_gtp_message_t *gtp_message)
+ogs_pkbuf_t *ogs_gtp2_build_msg(ogs_gtp2_message_t *gtp_message)
 {
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(gtp_message);
     switch(gtp_message->h.type) {
-    case OGS_GTP_ECHO_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_echo_request,
+    case OGS_GTP2_ECHO_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_echo_request,
                 &gtp_message->echo_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_ECHO_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_echo_response,
+    case OGS_GTP2_ECHO_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_echo_response,
                 &gtp_message->echo_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_session_request,
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_session_request,
                 &gtp_message->create_session_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_SESSION_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_session_response,
+    case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_session_response,
                 &gtp_message->create_session_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_bearer_request,
+    case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_bearer_request,
                 &gtp_message->modify_bearer_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_bearer_response,
+    case OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_bearer_response,
                 &gtp_message->modify_bearer_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_session_request,
+    case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_session_request,
                 &gtp_message->delete_session_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_session_response,
+    case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_session_response,
                 &gtp_message->delete_session_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_COMMAND_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_bearer_command,
+    case OGS_GTP2_MODIFY_BEARER_COMMAND_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_bearer_command,
                 &gtp_message->modify_bearer_command, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_BEARER_FAILURE_INDICATION_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_bearer_failure_indication,
+    case OGS_GTP2_MODIFY_BEARER_FAILURE_INDICATION_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_bearer_failure_indication,
                 &gtp_message->modify_bearer_failure_indication, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_COMMAND_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_bearer_command,
+    case OGS_GTP2_DELETE_BEARER_COMMAND_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_bearer_command,
                 &gtp_message->delete_bearer_command, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_FAILURE_INDICATION_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_bearer_failure_indication,
+    case OGS_GTP2_DELETE_BEARER_FAILURE_INDICATION_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_bearer_failure_indication,
                 &gtp_message->delete_bearer_failure_indication, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_bearer_resource_command,
+    case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_bearer_resource_command,
                 &gtp_message->bearer_resource_command, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_bearer_resource_failure_indication,
+    case OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_bearer_resource_failure_indication,
                 &gtp_message->bearer_resource_failure_indication, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_downlink_data_notification_failure_indication,
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_downlink_data_notification_failure_indication,
                 &gtp_message->downlink_data_notification_failure_indication, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_bearer_request,
+    case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_bearer_request,
                 &gtp_message->create_bearer_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_BEARER_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_bearer_response,
+    case OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_bearer_response,
                 &gtp_message->create_bearer_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_UPDATE_BEARER_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_update_bearer_request,
+    case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_update_bearer_request,
                 &gtp_message->update_bearer_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_update_bearer_response,
+    case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_update_bearer_response,
                 &gtp_message->update_bearer_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_bearer_request,
+    case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_bearer_request,
                 &gtp_message->delete_bearer_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_BEARER_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_bearer_response,
+    case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_bearer_response,
                 &gtp_message->delete_bearer_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_request,
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_request,
                 &gtp_message->create_indirect_data_forwarding_tunnel_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_response,
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_response,
                 &gtp_message->create_indirect_data_forwarding_tunnel_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_request,
+    case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_request,
                 &gtp_message->delete_indirect_data_forwarding_tunnel_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_response,
+    case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_response,
                 &gtp_message->delete_indirect_data_forwarding_tunnel_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_release_access_bearers_request,
+    case OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_release_access_bearers_request,
                 &gtp_message->release_access_bearers_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_release_access_bearers_response,
+    case OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_release_access_bearers_response,
                 &gtp_message->release_access_bearers_response, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_downlink_data_notification,
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_downlink_data_notification,
                 &gtp_message->downlink_data_notification, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_downlink_data_notification_acknowledge,
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_downlink_data_notification_acknowledge,
                 &gtp_message->downlink_data_notification_acknowledge, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_ACCESS_BEARERS_REQUEST_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_access_bearers_request,
+    case OGS_GTP2_MODIFY_ACCESS_BEARERS_REQUEST_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_access_bearers_request,
                 &gtp_message->modify_access_bearers_request, OGS_TLV_MODE_T1_L2_I1);
         break;
-    case OGS_GTP_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE:
-        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_modify_access_bearers_response,
+    case OGS_GTP2_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE:
+        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_modify_access_bearers_response,
                 &gtp_message->modify_access_bearers_response, OGS_TLV_MODE_T1_L2_I1);
         break;
     default:
@@ -2988,4 +2988,3 @@ ogs_pkbuf_t *ogs_gtp_build_msg(ogs_gtp_message_t *gtp_message)
 
     return pkbuf;
 }
-

--- a/lib/gtp/v2/message.h
+++ b/lib/gtp/v2/message.h
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2021-10-16 16:32:20.650061 by acetcom
+ * Created on: 2022-04-12 14:16:09.770077 by pespin
  * from 29274-g30.docx
  ******************************************************************************/
 
@@ -28,8 +28,8 @@
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_GTP_MESSAGE_H
-#define OGS_GTP_MESSAGE_H
+#ifndef OGS_GTP2_MESSAGE_H
+#define OGS_GTP2_MESSAGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,12 +38,12 @@ extern "C" {
 /* 5.1 General format */
 #define OGS_GTPV1U_HEADER_LEN   8
 #define OGS_GTPV2C_HEADER_LEN   12
-#define OGS_GTP_TEID_LEN        4
-typedef struct ogs_gtp_header_s {
+#define OGS_GTP2_TEID_LEN        4
+typedef struct ogs_gtp2_header_s {
     union {
         struct {
-#define OGS_GTP_VERSION_0 0
-#define OGS_GTP_VERSION_1 1
+#define OGS_GTP2_VERSION_0 0
+#define OGS_GTP2_VERSION_1 1
         ED4(uint8_t version:3;,
             uint8_t piggybacked:1;,
             uint8_t teid_presence:1;,
@@ -70,1215 +70,1215 @@ typedef struct ogs_gtp_header_s {
         struct {
             uint32_t teid;
             /* sqn : 31bit ~ 8bit, spare : 7bit ~ 0bit */
-#define OGS_GTP_XID_TO_SQN(__xid) htobe32(((__xid) << 8))
-#define OGS_GTP_SQN_TO_XID(__sqn) (be32toh(__sqn) >> 8)
+#define OGS_GTP2_XID_TO_SQN(__xid) htobe32(((__xid) << 8))
+#define OGS_GTP2_SQN_TO_XID(__sqn) (be32toh(__sqn) >> 8)
             uint32_t sqn;
         };
         /* sqn : 31bit ~ 8bit, spare : 7bit ~ 0bit */
         uint32_t sqn_only;
     };
-} __attribute__ ((packed)) ogs_gtp_header_t;
+} __attribute__ ((packed)) ogs_gtp2_header_t;
 
 /* GTPv2-C message type */
-#define OGS_GTP_ECHO_REQUEST_TYPE 1
-#define OGS_GTP_ECHO_RESPONSE_TYPE 2
-#define OGS_GTP_VERSION_NOT_SUPPORTED_INDICATION_TYPE 3
-#define OGS_GTP_CREATE_SESSION_REQUEST_TYPE 32
-#define OGS_GTP_CREATE_SESSION_RESPONSE_TYPE 33
-#define OGS_GTP_MODIFY_BEARER_REQUEST_TYPE 34
-#define OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE 35
-#define OGS_GTP_DELETE_SESSION_REQUEST_TYPE 36
-#define OGS_GTP_DELETE_SESSION_RESPONSE_TYPE 37
-#define OGS_GTP_CHANGE_NOTIFICATION_REQUEST_TYPE 38
-#define OGS_GTP_CHANGE_NOTIFICATION_RESPONSE_TYPE 39
-#define OGS_GTP_REMOTE_UE_REPORT_NOTIFICATION_TYPE 40
-#define OGS_GTP_REMOTE_UE_REPORT_ACKNOWLEDGE_TYPE 41
-#define OGS_GTP_MODIFY_BEARER_COMMAND_TYPE 64
-#define OGS_GTP_MODIFY_BEARER_FAILURE_INDICATION_TYPE 65
-#define OGS_GTP_DELETE_BEARER_COMMAND_TYPE 66
-#define OGS_GTP_DELETE_BEARER_FAILURE_INDICATION_TYPE 67
-#define OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE 68
-#define OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE 69
-#define OGS_GTP_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE 70
-#define OGS_GTP_TRACE_SESSION_ACTIVATION_TYPE 71
-#define OGS_GTP_TRACE_SESSION_DEACTIVATION_TYPE 72
-#define OGS_GTP_STOP_PAGING_INDICATION_TYPE 73
-#define OGS_GTP_CREATE_BEARER_REQUEST_TYPE 95
-#define OGS_GTP_CREATE_BEARER_RESPONSE_TYPE 96
-#define OGS_GTP_UPDATE_BEARER_REQUEST_TYPE 97
-#define OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE 98
-#define OGS_GTP_DELETE_BEARER_REQUEST_TYPE 99
-#define OGS_GTP_DELETE_BEARER_RESPONSE_TYPE 100
-#define OGS_GTP_DELETE_PDN_CONNECTION_SET_REQUEST_TYPE 101
-#define OGS_GTP_DELETE_PDN_CONNECTION_SET_RESPONSE_TYPE 102
-#define OGS_GTP_PGW_DOWNLINK_TRIGGERING_NOTIFICATION_TYPE 103
-#define OGS_GTP_PGW_DOWNLINK_TRIGGERING_ACKNOWLEDGE_TYPE 104
-#define OGS_GTP_CREATE_FORWARDING_TUNNEL_REQUEST_TYPE 160
-#define OGS_GTP_CREATE_FORWARDING_TUNNEL_RESPONSE_TYPE 161
-#define OGS_GTP_SUSPEND_NOTIFICATION_TYPE 162
-#define OGS_GTP_SUSPEND_ACKNOWLEDGE_TYPE 163
-#define OGS_GTP_RESUME_NOTIFICATION_TYPE 164
-#define OGS_GTP_RESUME_ACKNOWLEDGE_TYPE 165
-#define OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE 166
-#define OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE 167
-#define OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE 168
-#define OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE 169
-#define OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE 170
-#define OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE 171
-#define OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE 176
-#define OGS_GTP_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE 177
-#define OGS_GTP_PGW_RESTART_NOTIFICATION_TYPE 179
-#define OGS_GTP_PGW_RESTART_NOTIFICATION_ACKNOWLEDGE_TYPE 180
-#define OGS_GTP_UPDATE_PDN_CONNECTION_SET_REQUEST_TYPE 200
-#define OGS_GTP_UPDATE_PDN_CONNECTION_SET_RESPONSE_TYPE 201
-#define OGS_GTP_MODIFY_ACCESS_BEARERS_REQUEST_TYPE 211
-#define OGS_GTP_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE 212
+#define OGS_GTP2_ECHO_REQUEST_TYPE 1
+#define OGS_GTP2_ECHO_RESPONSE_TYPE 2
+#define OGS_GTP2_VERSION_NOT_SUPPORTED_INDICATION_TYPE 3
+#define OGS_GTP2_CREATE_SESSION_REQUEST_TYPE 32
+#define OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE 33
+#define OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE 34
+#define OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE 35
+#define OGS_GTP2_DELETE_SESSION_REQUEST_TYPE 36
+#define OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE 37
+#define OGS_GTP2_CHANGE_NOTIFICATION_REQUEST_TYPE 38
+#define OGS_GTP2_CHANGE_NOTIFICATION_RESPONSE_TYPE 39
+#define OGS_GTP2_REMOTE_UE_REPORT_NOTIFICATION_TYPE 40
+#define OGS_GTP2_REMOTE_UE_REPORT_ACKNOWLEDGE_TYPE 41
+#define OGS_GTP2_MODIFY_BEARER_COMMAND_TYPE 64
+#define OGS_GTP2_MODIFY_BEARER_FAILURE_INDICATION_TYPE 65
+#define OGS_GTP2_DELETE_BEARER_COMMAND_TYPE 66
+#define OGS_GTP2_DELETE_BEARER_FAILURE_INDICATION_TYPE 67
+#define OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE 68
+#define OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE 69
+#define OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_FAILURE_INDICATION_TYPE 70
+#define OGS_GTP2_TRACE_SESSION_ACTIVATION_TYPE 71
+#define OGS_GTP2_TRACE_SESSION_DEACTIVATION_TYPE 72
+#define OGS_GTP2_STOP_PAGING_INDICATION_TYPE 73
+#define OGS_GTP2_CREATE_BEARER_REQUEST_TYPE 95
+#define OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE 96
+#define OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE 97
+#define OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE 98
+#define OGS_GTP2_DELETE_BEARER_REQUEST_TYPE 99
+#define OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE 100
+#define OGS_GTP2_DELETE_PDN_CONNECTION_SET_REQUEST_TYPE 101
+#define OGS_GTP2_DELETE_PDN_CONNECTION_SET_RESPONSE_TYPE 102
+#define OGS_GTP2_PGW_DOWNLINK_TRIGGERING_NOTIFICATION_TYPE 103
+#define OGS_GTP2_PGW_DOWNLINK_TRIGGERING_ACKNOWLEDGE_TYPE 104
+#define OGS_GTP2_CREATE_FORWARDING_TUNNEL_REQUEST_TYPE 160
+#define OGS_GTP2_CREATE_FORWARDING_TUNNEL_RESPONSE_TYPE 161
+#define OGS_GTP2_SUSPEND_NOTIFICATION_TYPE 162
+#define OGS_GTP2_SUSPEND_ACKNOWLEDGE_TYPE 163
+#define OGS_GTP2_RESUME_NOTIFICATION_TYPE 164
+#define OGS_GTP2_RESUME_ACKNOWLEDGE_TYPE 165
+#define OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE 166
+#define OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE 167
+#define OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE 168
+#define OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE 169
+#define OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE 170
+#define OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE 171
+#define OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE 176
+#define OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE 177
+#define OGS_GTP2_PGW_RESTART_NOTIFICATION_TYPE 179
+#define OGS_GTP2_PGW_RESTART_NOTIFICATION_ACKNOWLEDGE_TYPE 180
+#define OGS_GTP2_UPDATE_PDN_CONNECTION_SET_REQUEST_TYPE 200
+#define OGS_GTP2_UPDATE_PDN_CONNECTION_SET_RESPONSE_TYPE 201
+#define OGS_GTP2_MODIFY_ACCESS_BEARERS_REQUEST_TYPE 211
+#define OGS_GTP2_MODIFY_ACCESS_BEARERS_RESPONSE_TYPE 212
 
-#define OGS_GTP_IMSI_TYPE 1
-#define OGS_GTP_CAUSE_TYPE 2
-#define OGS_GTP_RECOVERY_TYPE 3
-#define OGS_GTP_STN_SR_TYPE 51
-#define OGS_GTP_APN_TYPE 71
-#define OGS_GTP_AMBR_TYPE 72
-#define OGS_GTP_EBI_TYPE 73
-#define OGS_GTP_IP_ADDRESS_TYPE 74
-#define OGS_GTP_MEI_TYPE 75
-#define OGS_GTP_MSISDN_TYPE 76
-#define OGS_GTP_INDICATION_TYPE 77
-#define OGS_GTP_PCO_TYPE 78
-#define OGS_GTP_PAA_TYPE 79
-#define OGS_GTP_BEARER_QOS_TYPE 80
-#define OGS_GTP_FLOW_QOS_TYPE 81
-#define OGS_GTP_RAT_TYPE_TYPE 82
-#define OGS_GTP_SERVING_NETWORK_TYPE 83
-#define OGS_GTP_BEARER_TFT_TYPE 84
-#define OGS_GTP_TAD_TYPE 85
-#define OGS_GTP_ULI_TYPE 86
-#define OGS_GTP_F_TEID_TYPE 87
-#define OGS_GTP_TMSI_TYPE 88
-#define OGS_GTP_GLOBAL_CN_ID_TYPE 89
-#define OGS_GTP_S103PDF_TYPE 90
-#define OGS_GTP_S1UDF_TYPE 91
-#define OGS_GTP_DELAY_VALUE_TYPE 92
-#define OGS_GTP_BEARER_CONTEXT_TYPE 93
-#define OGS_GTP_CHARGING_ID_TYPE 94
-#define OGS_GTP_CHARGING_CHARACTERISTICS_TYPE 95
-#define OGS_GTP_TRACE_INFORMATION_TYPE 96
-#define OGS_GTP_BEARER_FLAGS_TYPE 97
-#define OGS_GTP_PDN_TYPE_TYPE 99
-#define OGS_GTP_PTI_TYPE 100
-#define OGS_GTP_MM_CONTEXT_TYPE 107
-#define OGS_GTP_PDN_CONNECTION_TYPE 109
-#define OGS_GTP_PDU_NUMBERS_TYPE 110
-#define OGS_GTP_P_TMSI_TYPE 111
-#define OGS_GTP_P_TMSI_SIGNATURE_TYPE 112
-#define OGS_GTP_HOP_COUNTER_TYPE 113
-#define OGS_GTP_UE_TIME_ZONE_TYPE 114
-#define OGS_GTP_TRACE_REFERENCE_TYPE 115
-#define OGS_GTP_COMPLETE_REQUEST_MESSAGE_TYPE 116
-#define OGS_GTP_GUTI_TYPE 117
-#define OGS_GTP_F_CONTAINER_TYPE 118
-#define OGS_GTP_F_CAUSE_TYPE 119
-#define OGS_GTP_PLMN_ID_TYPE 120
-#define OGS_GTP_TARGET_IDENTIFICATION_TYPE 121
-#define OGS_GTP_PACKET_FLOW_ID_TYPE 123
-#define OGS_GTP_RAB_CONTEXT_TYPE 124
-#define OGS_GTP_SOURCE_RNC_PDCP_CONTEXT_INFO_TYPE 125
-#define OGS_GTP_PORT_NUMBER_TYPE 126
-#define OGS_GTP_APN_RESTRICTION_TYPE 127
-#define OGS_GTP_SELECTION_MODE_TYPE 128
-#define OGS_GTP_SOURCE_IDENTIFICATION_TYPE 129
-#define OGS_GTP_CHANGE_REPORTING_ACTION_TYPE 131
-#define OGS_GTP_FQ_CSID_TYPE 132
-#define OGS_GTP_CHANNEL_NEEDED_TYPE 133
-#define OGS_GTP_EMLPP_PRIORITY_TYPE 134
-#define OGS_GTP_NODE_TYPE_TYPE 135
-#define OGS_GTP_FQDN_TYPE 136
-#define OGS_GTP_TI_TYPE 137
-#define OGS_GTP_MBMS_SESSION_DURATION_TYPE 138
-#define OGS_GTP_MBMS_SERVICE_AREA_TYPE 139
-#define OGS_GTP_MBMS_SESSION_IDENTIFIER_TYPE 140
-#define OGS_GTP_MBMS_FLOW_IDENTIFIER_TYPE 141
-#define OGS_GTP_MBMS_IP_MULTICAST_DISTRIBUTION_TYPE 142
-#define OGS_GTP_MBMS_DISTRIBUTION_ACKNOWLEDGE_TYPE 143
-#define OGS_GTP_RFSP_INDEX_TYPE 144
-#define OGS_GTP_UCI_TYPE 145
-#define OGS_GTP_CSG_INFORMATION_REPORTING_ACTION_TYPE 146
-#define OGS_GTP_CSG_ID_TYPE 147
-#define OGS_GTP_CMI_TYPE 148
-#define OGS_GTP_SERVICE_INDICATOR_TYPE 149
-#define OGS_GTP_DETACH_TYPE_TYPE 150
-#define OGS_GTP_LDN_TYPE 151
-#define OGS_GTP_NODE_FEATURES_TYPE 152
-#define OGS_GTP_MBMS_TIME_TO_DATA_TRANSFER_TYPE 153
-#define OGS_GTP_THROTTLING_TYPE 154
-#define OGS_GTP_ARP_TYPE 155
-#define OGS_GTP_EPC_TIMER_TYPE 156
-#define OGS_GTP_SIGNALLING_PRIORITY_INDICATION_TYPE 157
-#define OGS_GTP_TMGI_TYPE 158
-#define OGS_GTP_ADDITIONAL_MM_CONTEXT_FOR_SRVCC_TYPE 159
-#define OGS_GTP_ADDITIONAL_FLAGS_FOR_SRVCC_TYPE 160
-#define OGS_GTP_MDT_CONFIGURATION_TYPE 162
-#define OGS_GTP_APCO_TYPE 163
-#define OGS_GTP_ABSOLUTE_TIME_OF_MBMS_DATA_TRANSFER_TYPE 164
-#define OGS_GTP_ENB_INFORMATION_REPORTING_TYPE 165
-#define OGS_GTP_IP4CP_TYPE 166
-#define OGS_GTP_CHANGE_TO_REPORT_FLAGS_TYPE 167
-#define OGS_GTP_ACTION_INDICATION_TYPE 168
-#define OGS_GTP_TWAN_IDENTIFIER_TYPE 169
-#define OGS_GTP_ULI_TIMESTAMP_TYPE 170
-#define OGS_GTP_MBMS_FLAGS_TYPE 171
-#define OGS_GTP_RAN_NAS_CAUSE_TYPE 172
-#define OGS_GTP_CN_OPERATOR_SELECTION_ENTITY_TYPE 173
-#define OGS_GTP_TWMI_TYPE 174
-#define OGS_GTP_NODE_NUMBER_TYPE 175
-#define OGS_GTP_NODE_IDENTIFIER_TYPE 176
-#define OGS_GTP_PRESENCE_REPORTING_AREA_ACTION_TYPE 177
-#define OGS_GTP_PRESENCE_REPORTING_AREA_INFORMATION_TYPE 178
-#define OGS_GTP_TWAN_IDENTIFIER_TIMESTAMP_TYPE 179
-#define OGS_GTP_OVERLOAD_CONTROL_INFORMATION_TYPE 180
-#define OGS_GTP_LOAD_CONTROL_INFORMATION_TYPE 181
-#define OGS_GTP_METRIC_TYPE 182
-#define OGS_GTP_SEQUENCE_NUMBER_TYPE 183
-#define OGS_GTP_APN_AND_RELATIVE_CAPACITY_TYPE 184
-#define OGS_GTP_WLAN_OFFLOADABILITY_INDICATION_TYPE 185
-#define OGS_GTP_PAGING_AND_SERVICE_INFORMATION_TYPE 186
-#define OGS_GTP_INTEGER_NUMBER_TYPE 187
-#define OGS_GTP_MILLISECOND_TIME_STAMP_TYPE 188
-#define OGS_GTP_MONITORING_EVENT_INFORMATION_TYPE 189
-#define OGS_GTP_ECGI_LIST_TYPE 190
-#define OGS_GTP_REMOTE_UE_CONTEXT_TYPE 191
-#define OGS_GTP_REMOTE_USER_ID_TYPE 192
-#define OGS_GTP_REMOTE_UE_IP_INFORMATION_TYPE 193
-#define OGS_GTP_CIOT_OPTIMIZATIONS_SUPPORT_INDICATION_TYPE 194
-#define OGS_GTP_SCEF_PDN_CONNECTION_TYPE 195
-#define OGS_GTP_HEADER_COMPRESSION_CONFIGURATION_TYPE 196
-#define OGS_GTP_EPCO_TYPE 197
-#define OGS_GTP_SERVING_PLMN_RATE_CONTROL_TYPE 198
-#define OGS_GTP_COUNTER_TYPE 199
-#define OGS_GTP_MAPPED_UE_USAGE_TYPE_TYPE 200
-#define OGS_GTP_SECONDARY_RAT_USAGE_DATA_REPORT_TYPE 201
-#define OGS_GTP_UP_FUNCTION_SELECTION_INDICATION_FLAGS_TYPE 202
-#define OGS_GTP_MAXIMUM_PACKET_LOSS_RATE_TYPE 203
-#define OGS_GTP_APN_RATE_CONTROL_STATUS_TYPE 204
-#define OGS_GTP_EXTENDED_TRACE_INFORMATION_TYPE 205
-#define OGS_GTP_MONITORING_EVENT_EXTENSION_INFORMATION_TYPE 206
-#define OGS_GTP_ADDITIONAL_RRM_POLICY_INDEX_TYPE 207
-#define OGS_GTP_V2X_CONTEXT_TYPE 208
-#define OGS_GTP_PC5_QOS_PARAMETERS_TYPE 209
-#define OGS_GTP_SERVICES_AUTHORIZED_TYPE 210
-#define OGS_GTP_BIT_RATE_TYPE 211
-#define OGS_GTP_PC5_QOS_FLOW_TYPE 212
+#define OGS_GTP2_IMSI_TYPE 1
+#define OGS_GTP2_CAUSE_TYPE 2
+#define OGS_GTP2_RECOVERY_TYPE 3
+#define OGS_GTP2_STN_SR_TYPE 51
+#define OGS_GTP2_APN_TYPE 71
+#define OGS_GTP2_AMBR_TYPE 72
+#define OGS_GTP2_EBI_TYPE 73
+#define OGS_GTP2_IP_ADDRESS_TYPE 74
+#define OGS_GTP2_MEI_TYPE 75
+#define OGS_GTP2_MSISDN_TYPE 76
+#define OGS_GTP2_INDICATION_TYPE 77
+#define OGS_GTP2_PCO_TYPE 78
+#define OGS_GTP2_PAA_TYPE 79
+#define OGS_GTP2_BEARER_QOS_TYPE 80
+#define OGS_GTP2_FLOW_QOS_TYPE 81
+#define OGS_GTP2_RAT_TYPE_TYPE 82
+#define OGS_GTP2_SERVING_NETWORK_TYPE 83
+#define OGS_GTP2_BEARER_TFT_TYPE 84
+#define OGS_GTP2_TAD_TYPE 85
+#define OGS_GTP2_ULI_TYPE 86
+#define OGS_GTP2_F_TEID_TYPE 87
+#define OGS_GTP2_TMSI_TYPE 88
+#define OGS_GTP2_GLOBAL_CN_ID_TYPE 89
+#define OGS_GTP2_S103PDF_TYPE 90
+#define OGS_GTP2_S1UDF_TYPE 91
+#define OGS_GTP2_DELAY_VALUE_TYPE 92
+#define OGS_GTP2_BEARER_CONTEXT_TYPE 93
+#define OGS_GTP2_CHARGING_ID_TYPE 94
+#define OGS_GTP2_CHARGING_CHARACTERISTICS_TYPE 95
+#define OGS_GTP2_TRACE_INFORMATION_TYPE 96
+#define OGS_GTP2_BEARER_FLAGS_TYPE 97
+#define OGS_GTP2_PDN_TYPE_TYPE 99
+#define OGS_GTP2_PTI_TYPE 100
+#define OGS_GTP2_MM_CONTEXT_TYPE 107
+#define OGS_GTP2_PDN_CONNECTION_TYPE 109
+#define OGS_GTP2_PDU_NUMBERS_TYPE 110
+#define OGS_GTP2_P_TMSI_TYPE 111
+#define OGS_GTP2_P_TMSI_SIGNATURE_TYPE 112
+#define OGS_GTP2_HOP_COUNTER_TYPE 113
+#define OGS_GTP2_UE_TIME_ZONE_TYPE 114
+#define OGS_GTP2_TRACE_REFERENCE_TYPE 115
+#define OGS_GTP2_COMPLETE_REQUEST_MESSAGE_TYPE 116
+#define OGS_GTP2_GUTI_TYPE 117
+#define OGS_GTP2_F_CONTAINER_TYPE 118
+#define OGS_GTP2_F_CAUSE_TYPE 119
+#define OGS_GTP2_PLMN_ID_TYPE 120
+#define OGS_GTP2_TARGET_IDENTIFICATION_TYPE 121
+#define OGS_GTP2_PACKET_FLOW_ID_TYPE 123
+#define OGS_GTP2_RAB_CONTEXT_TYPE 124
+#define OGS_GTP2_SOURCE_RNC_PDCP_CONTEXT_INFO_TYPE 125
+#define OGS_GTP2_PORT_NUMBER_TYPE 126
+#define OGS_GTP2_APN_RESTRICTION_TYPE 127
+#define OGS_GTP2_SELECTION_MODE_TYPE 128
+#define OGS_GTP2_SOURCE_IDENTIFICATION_TYPE 129
+#define OGS_GTP2_CHANGE_REPORTING_ACTION_TYPE 131
+#define OGS_GTP2_FQ_CSID_TYPE 132
+#define OGS_GTP2_CHANNEL_NEEDED_TYPE 133
+#define OGS_GTP2_EMLPP_PRIORITY_TYPE 134
+#define OGS_GTP2_NODE_TYPE_TYPE 135
+#define OGS_GTP2_FQDN_TYPE 136
+#define OGS_GTP2_TI_TYPE 137
+#define OGS_GTP2_MBMS_SESSION_DURATION_TYPE 138
+#define OGS_GTP2_MBMS_SERVICE_AREA_TYPE 139
+#define OGS_GTP2_MBMS_SESSION_IDENTIFIER_TYPE 140
+#define OGS_GTP2_MBMS_FLOW_IDENTIFIER_TYPE 141
+#define OGS_GTP2_MBMS_IP_MULTICAST_DISTRIBUTION_TYPE 142
+#define OGS_GTP2_MBMS_DISTRIBUTION_ACKNOWLEDGE_TYPE 143
+#define OGS_GTP2_RFSP_INDEX_TYPE 144
+#define OGS_GTP2_UCI_TYPE 145
+#define OGS_GTP2_CSG_INFORMATION_REPORTING_ACTION_TYPE 146
+#define OGS_GTP2_CSG_ID_TYPE 147
+#define OGS_GTP2_CMI_TYPE 148
+#define OGS_GTP2_SERVICE_INDICATOR_TYPE 149
+#define OGS_GTP2_DETACH_TYPE_TYPE 150
+#define OGS_GTP2_LDN_TYPE 151
+#define OGS_GTP2_NODE_FEATURES_TYPE 152
+#define OGS_GTP2_MBMS_TIME_TO_DATA_TRANSFER_TYPE 153
+#define OGS_GTP2_THROTTLING_TYPE 154
+#define OGS_GTP2_ARP_TYPE 155
+#define OGS_GTP2_EPC_TIMER_TYPE 156
+#define OGS_GTP2_SIGNALLING_PRIORITY_INDICATION_TYPE 157
+#define OGS_GTP2_TMGI_TYPE 158
+#define OGS_GTP2_ADDITIONAL_MM_CONTEXT_FOR_SRVCC_TYPE 159
+#define OGS_GTP2_ADDITIONAL_FLAGS_FOR_SRVCC_TYPE 160
+#define OGS_GTP2_MDT_CONFIGURATION_TYPE 162
+#define OGS_GTP2_APCO_TYPE 163
+#define OGS_GTP2_ABSOLUTE_TIME_OF_MBMS_DATA_TRANSFER_TYPE 164
+#define OGS_GTP2_ENB_INFORMATION_REPORTING_TYPE 165
+#define OGS_GTP2_IP4CP_TYPE 166
+#define OGS_GTP2_CHANGE_TO_REPORT_FLAGS_TYPE 167
+#define OGS_GTP2_ACTION_INDICATION_TYPE 168
+#define OGS_GTP2_TWAN_IDENTIFIER_TYPE 169
+#define OGS_GTP2_ULI_TIMESTAMP_TYPE 170
+#define OGS_GTP2_MBMS_FLAGS_TYPE 171
+#define OGS_GTP2_RAN_NAS_CAUSE_TYPE 172
+#define OGS_GTP2_CN_OPERATOR_SELECTION_ENTITY_TYPE 173
+#define OGS_GTP2_TWMI_TYPE 174
+#define OGS_GTP2_NODE_NUMBER_TYPE 175
+#define OGS_GTP2_NODE_IDENTIFIER_TYPE 176
+#define OGS_GTP2_PRESENCE_REPORTING_AREA_ACTION_TYPE 177
+#define OGS_GTP2_PRESENCE_REPORTING_AREA_INFORMATION_TYPE 178
+#define OGS_GTP2_TWAN_IDENTIFIER_TIMESTAMP_TYPE 179
+#define OGS_GTP2_OVERLOAD_CONTROL_INFORMATION_TYPE 180
+#define OGS_GTP2_LOAD_CONTROL_INFORMATION_TYPE 181
+#define OGS_GTP2_METRIC_TYPE 182
+#define OGS_GTP2_SEQUENCE_NUMBER_TYPE 183
+#define OGS_GTP2_APN_AND_RELATIVE_CAPACITY_TYPE 184
+#define OGS_GTP2_WLAN_OFFLOADABILITY_INDICATION_TYPE 185
+#define OGS_GTP2_PAGING_AND_SERVICE_INFORMATION_TYPE 186
+#define OGS_GTP2_INTEGER_NUMBER_TYPE 187
+#define OGS_GTP2_MILLISECOND_TIME_STAMP_TYPE 188
+#define OGS_GTP2_MONITORING_EVENT_INFORMATION_TYPE 189
+#define OGS_GTP2_ECGI_LIST_TYPE 190
+#define OGS_GTP2_REMOTE_UE_CONTEXT_TYPE 191
+#define OGS_GTP2_REMOTE_USER_ID_TYPE 192
+#define OGS_GTP2_REMOTE_UE_IP_INFORMATION_TYPE 193
+#define OGS_GTP2_CIOT_OPTIMIZATIONS_SUPPORT_INDICATION_TYPE 194
+#define OGS_GTP2_SCEF_PDN_CONNECTION_TYPE 195
+#define OGS_GTP2_HEADER_COMPRESSION_CONFIGURATION_TYPE 196
+#define OGS_GTP2_EPCO_TYPE 197
+#define OGS_GTP2_SERVING_PLMN_RATE_CONTROL_TYPE 198
+#define OGS_GTP2_COUNTER_TYPE 199
+#define OGS_GTP2_MAPPED_UE_USAGE_TYPE_TYPE 200
+#define OGS_GTP2_SECONDARY_RAT_USAGE_DATA_REPORT_TYPE 201
+#define OGS_GTP2_UP_FUNCTION_SELECTION_INDICATION_FLAGS_TYPE 202
+#define OGS_GTP2_MAXIMUM_PACKET_LOSS_RATE_TYPE 203
+#define OGS_GTP2_APN_RATE_CONTROL_STATUS_TYPE 204
+#define OGS_GTP2_EXTENDED_TRACE_INFORMATION_TYPE 205
+#define OGS_GTP2_MONITORING_EVENT_EXTENSION_INFORMATION_TYPE 206
+#define OGS_GTP2_ADDITIONAL_RRM_POLICY_INDEX_TYPE 207
+#define OGS_GTP2_V2X_CONTEXT_TYPE 208
+#define OGS_GTP2_PC5_QOS_PARAMETERS_TYPE 209
+#define OGS_GTP2_SERVICES_AUTHORIZED_TYPE 210
+#define OGS_GTP2_BIT_RATE_TYPE 211
+#define OGS_GTP2_PC5_QOS_FLOW_TYPE 212
 
 /* Information Element TLV Descriptor */
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_imsi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_cause_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_recovery_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_stn_sr_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ambr_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ebi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ebi_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ip_address_3;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mei_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_msisdn_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_indication_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pco_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_paa_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_qos_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_flow_qos_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_rat_type_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_serving_network_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_tft_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_tad_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_3;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_4;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_5;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_6;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_7;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_8;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_9;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_10;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_teid_11;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_tmsi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_global_cn_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_s103pdf_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_s1udf_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delay_value_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_charging_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_charging_characteristics_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_flags_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_type_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pti_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mm_context_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdu_numbers_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_p_tmsi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_p_tmsi_signature_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_hop_counter_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ue_time_zone_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_reference_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_complete_request_message_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_guti_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_container_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_f_cause_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_plmn_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_target_identification_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_packet_flow_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_rab_context_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_source_rnc_pdcp_context_info_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_port_number_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_restriction_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_selection_mode_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_source_identification_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_change_reporting_action_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fq_csid_3;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_channel_needed_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_emlpp_priority_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_node_type_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fqdn_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_fqdn_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ti_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_session_duration_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_service_area_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_session_identifier_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_flow_identifier_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_ip_multicast_distribution_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_distribution_acknowledge_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_rfsp_index_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_uci_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_csg_information_reporting_action_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_csg_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_cmi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_service_indicator_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_detach_type_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ldn_3;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_node_features_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_time_to_data_transfer_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_throttling_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_arp_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_epc_timer_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_signalling_priority_indication_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_tmgi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_mm_context_for_srvcc_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_flags_for_srvcc_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mdt_configuration_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_apco_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_absolute_time_of_mbms_data_transfer_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_enb_information_reporting_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ip4cp_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_change_to_report_flags_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_action_indication_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_uli_timestamp_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mbms_flags_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ran_nas_cause_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_cn_operator_selection_entity_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_twmi_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_node_number_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_node_identifier_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_presence_reporting_area_action_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_presence_reporting_area_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_timestamp_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_twan_identifier_timestamp_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_metric_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_sequence_number_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_and_relative_capacity_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_wlan_offloadability_indication_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_paging_and_service_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_integer_number_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_millisecond_time_stamp_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_monitoring_event_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ecgi_list_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_user_id_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_ip_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_ciot_optimizations_support_indication_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_header_compression_configuration_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_epco_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_serving_plmn_rate_control_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_counter_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_mapped_ue_usage_type_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_secondary_rat_usage_data_report_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_up_function_selection_indication_flags_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_maximum_packet_loss_rate_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_apn_rate_control_status_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_extended_trace_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_monitoring_event_extension_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_additional_rrm_policy_index_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_services_authorized_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_services_authorized_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bit_rate_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_flow_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_imsi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_cause_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_recovery_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_stn_sr_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ambr_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ebi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ebi_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip_address_3;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mei_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_msisdn_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_indication_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pco_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_paa_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_qos_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_flow_qos_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_rat_type_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_serving_network_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_tft_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_tad_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_3;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_4;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_5;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_6;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_7;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_8;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_9;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_10;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_teid_11;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_tmsi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_global_cn_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_s103pdf_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_s1udf_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delay_value_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_charging_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_charging_characteristics_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_flags_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdn_type_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pti_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mm_context_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdu_numbers_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_p_tmsi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_p_tmsi_signature_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_hop_counter_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ue_time_zone_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_reference_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_complete_request_message_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_guti_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_container_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_f_cause_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_plmn_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_target_identification_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_packet_flow_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_rab_context_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_source_rnc_pdcp_context_info_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_port_number_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_restriction_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_selection_mode_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_source_identification_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_reporting_action_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fq_csid_3;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_channel_needed_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_emlpp_priority_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_type_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fqdn_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_fqdn_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ti_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_session_duration_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_service_area_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_session_identifier_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_flow_identifier_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_ip_multicast_distribution_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_distribution_acknowledge_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_rfsp_index_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_uci_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_csg_information_reporting_action_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_csg_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_cmi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_service_indicator_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_detach_type_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ldn_3;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_features_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_time_to_data_transfer_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_throttling_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_arp_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_epc_timer_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_signalling_priority_indication_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_tmgi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_mm_context_for_srvcc_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_flags_for_srvcc_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mdt_configuration_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_apco_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_absolute_time_of_mbms_data_transfer_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_enb_information_reporting_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ip4cp_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_to_report_flags_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_action_indication_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_uli_timestamp_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mbms_flags_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ran_nas_cause_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_cn_operator_selection_entity_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_twmi_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_number_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_node_identifier_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_presence_reporting_area_action_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_presence_reporting_area_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_timestamp_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_twan_identifier_timestamp_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_metric_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_sequence_number_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_and_relative_capacity_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_wlan_offloadability_indication_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_paging_and_service_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_integer_number_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_millisecond_time_stamp_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_monitoring_event_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ecgi_list_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_user_id_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_ip_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_ciot_optimizations_support_indication_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_header_compression_configuration_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_epco_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_serving_plmn_rate_control_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_counter_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_mapped_ue_usage_type_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_secondary_rat_usage_data_report_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_up_function_selection_indication_flags_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_maximum_packet_loss_rate_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_apn_rate_control_status_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_extended_trace_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_monitoring_event_extension_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_additional_rrm_policy_index_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_services_authorized_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_services_authorized_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bit_rate_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bit_rate_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pc5_qos_flow_0;
 
 /* Group Information Element TLV Descriptor */
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pc5_qos_parameters_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_context_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_v2x_context_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_context_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pdn_connection_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_overload_control_information_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_0;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_1;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_load_control_information_2;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_scef_pdn_connection_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pc5_qos_parameters_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_context_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_v2x_context_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_context_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_context_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pdn_connection_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_overload_control_information_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_0;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_1;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_load_control_information_2;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_scef_pdn_connection_0;
 
 /* Message Descriptor */
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_echo_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_version_not_supported_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_session_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_session_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_change_notification_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_change_notification_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_report_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_remote_ue_report_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_command;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_bearer_failure_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_command;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_failure_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_command;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_bearer_resource_failure_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification_failure_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_session_activation;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_trace_session_deactivation;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_stop_paging_indication;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_bearer_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_update_bearer_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_bearer_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_pdn_connection_set_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_pdn_connection_set_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pgw_downlink_triggering_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pgw_downlink_triggering_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_forwarding_tunnel_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_forwarding_tunnel_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_suspend_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_suspend_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_resume_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_resume_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_create_indirect_data_forwarding_tunnel_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_delete_indirect_data_forwarding_tunnel_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_release_access_bearers_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_release_access_bearers_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_downlink_data_notification_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pgw_restart_notification;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_pgw_restart_notification_acknowledge;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_update_pdn_connection_set_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_update_pdn_connection_set_response;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_request;
-extern ogs_tlv_desc_t ogs_gtp_tlv_desc_modify_access_bearers_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_echo_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_echo_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_version_not_supported_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_session_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_session_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_session_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_session_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_notification_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_change_notification_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_report_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_remote_ue_report_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_command;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_bearer_failure_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_command;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_failure_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_resource_command;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_bearer_resource_failure_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification_failure_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_session_activation;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_trace_session_deactivation;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_stop_paging_indication;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_bearer_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_bearer_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_bearer_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_bearer_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_bearer_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_pdn_connection_set_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_pdn_connection_set_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pgw_downlink_triggering_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pgw_downlink_triggering_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_forwarding_tunnel_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_forwarding_tunnel_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_suspend_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_suspend_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_resume_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_resume_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_create_indirect_data_forwarding_tunnel_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_delete_indirect_data_forwarding_tunnel_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_release_access_bearers_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_release_access_bearers_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_downlink_data_notification_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pgw_restart_notification;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_pgw_restart_notification_acknowledge;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_pdn_connection_set_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_update_pdn_connection_set_response;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_access_bearers_request;
+extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_modify_access_bearers_response;
 
 /* Structure for Information Element */
-typedef ogs_tlv_octet_t ogs_gtp_tlv_imsi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_cause_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_recovery_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_stn_sr_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_apn_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ambr_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_ebi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ip_address_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mei_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_msisdn_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_indication_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_pco_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_paa_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_bearer_qos_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_flow_qos_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_rat_type_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_serving_network_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_bearer_tft_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_tad_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_uli_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_f_teid_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_tmsi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_global_cn_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_s103pdf_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_s1udf_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_delay_value_t;
-typedef ogs_tlv_uint32_t ogs_gtp_tlv_charging_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_charging_characteristics_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_trace_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_bearer_flags_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_pdn_type_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_pti_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mm_context_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_pdu_numbers_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_p_tmsi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_p_tmsi_signature_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_hop_counter_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ue_time_zone_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_trace_reference_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_complete_request_message_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_guti_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_f_container_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_f_cause_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_plmn_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_target_identification_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_packet_flow_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_rab_context_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_source_rnc_pdcp_context_info_t;
-typedef ogs_tlv_uint16_t ogs_gtp_tlv_port_number_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_apn_restriction_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_selection_mode_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_source_identification_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_change_reporting_action_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_fq_csid_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_channel_needed_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_emlpp_priority_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_node_type_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_fqdn_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ti_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_session_duration_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_service_area_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_session_identifier_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_flow_identifier_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_ip_multicast_distribution_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_distribution_acknowledge_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_rfsp_index_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_uci_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_csg_information_reporting_action_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_csg_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_cmi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_service_indicator_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_detach_type_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ldn_t;
-typedef ogs_tlv_uint8_t ogs_gtp_tlv_node_features_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_time_to_data_transfer_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_throttling_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_arp_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_epc_timer_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_signalling_priority_indication_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_tmgi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_additional_mm_context_for_srvcc_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_additional_flags_for_srvcc_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mdt_configuration_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_apco_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_absolute_time_of_mbms_data_transfer_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_enb_information_reporting_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ip4cp_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_change_to_report_flags_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_action_indication_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_twan_identifier_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_uli_timestamp_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mbms_flags_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ran_nas_cause_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_cn_operator_selection_entity_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_twmi_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_node_number_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_node_identifier_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_presence_reporting_area_action_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_presence_reporting_area_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_twan_identifier_timestamp_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_metric_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_sequence_number_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_apn_and_relative_capacity_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_wlan_offloadability_indication_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_paging_and_service_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_integer_number_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_millisecond_time_stamp_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_monitoring_event_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ecgi_list_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_remote_user_id_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_remote_ue_ip_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_ciot_optimizations_support_indication_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_header_compression_configuration_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_epco_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_serving_plmn_rate_control_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_counter_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_mapped_ue_usage_type_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_secondary_rat_usage_data_report_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_up_function_selection_indication_flags_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_maximum_packet_loss_rate_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_apn_rate_control_status_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_extended_trace_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_monitoring_event_extension_information_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_additional_rrm_policy_index_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_services_authorized_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_bit_rate_t;
-typedef ogs_tlv_octet_t ogs_gtp_tlv_pc5_qos_flow_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_imsi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_cause_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_recovery_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_stn_sr_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_apn_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ambr_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_ebi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ip_address_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mei_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_msisdn_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_indication_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_pco_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_paa_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_bearer_qos_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_flow_qos_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_rat_type_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_serving_network_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_bearer_tft_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_tad_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_uli_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_f_teid_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_tmsi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_global_cn_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_s103pdf_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_s1udf_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_delay_value_t;
+typedef ogs_tlv_uint32_t ogs_gtp2_tlv_charging_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_charging_characteristics_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_trace_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_bearer_flags_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_pdn_type_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_pti_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mm_context_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_pdu_numbers_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_p_tmsi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_p_tmsi_signature_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_hop_counter_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ue_time_zone_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_trace_reference_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_complete_request_message_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_guti_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_f_container_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_f_cause_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_plmn_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_target_identification_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_packet_flow_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_rab_context_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_source_rnc_pdcp_context_info_t;
+typedef ogs_tlv_uint16_t ogs_gtp2_tlv_port_number_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_apn_restriction_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_selection_mode_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_source_identification_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_change_reporting_action_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_fq_csid_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_channel_needed_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_emlpp_priority_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_node_type_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_fqdn_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ti_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_session_duration_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_service_area_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_session_identifier_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_flow_identifier_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_ip_multicast_distribution_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_distribution_acknowledge_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_rfsp_index_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_uci_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_csg_information_reporting_action_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_csg_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_cmi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_service_indicator_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_detach_type_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ldn_t;
+typedef ogs_tlv_uint8_t ogs_gtp2_tlv_node_features_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_time_to_data_transfer_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_throttling_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_arp_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_epc_timer_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_signalling_priority_indication_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_tmgi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_additional_mm_context_for_srvcc_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_additional_flags_for_srvcc_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mdt_configuration_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_apco_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_absolute_time_of_mbms_data_transfer_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_enb_information_reporting_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ip4cp_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_change_to_report_flags_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_action_indication_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_twan_identifier_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_uli_timestamp_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mbms_flags_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ran_nas_cause_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_cn_operator_selection_entity_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_twmi_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_node_number_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_node_identifier_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_presence_reporting_area_action_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_presence_reporting_area_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_twan_identifier_timestamp_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_metric_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_sequence_number_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_apn_and_relative_capacity_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_wlan_offloadability_indication_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_paging_and_service_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_integer_number_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_millisecond_time_stamp_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_monitoring_event_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ecgi_list_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_remote_user_id_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_remote_ue_ip_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_ciot_optimizations_support_indication_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_header_compression_configuration_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_epco_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_serving_plmn_rate_control_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_counter_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_mapped_ue_usage_type_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_secondary_rat_usage_data_report_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_up_function_selection_indication_flags_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_maximum_packet_loss_rate_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_apn_rate_control_status_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_extended_trace_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_monitoring_event_extension_information_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_additional_rrm_policy_index_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_services_authorized_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_bit_rate_t;
+typedef ogs_tlv_octet_t ogs_gtp2_tlv_pc5_qos_flow_t;
 
 /* Structure for Group Information Element */
-typedef struct ogs_gtp_tlv_pc5_qos_parameters_s {
+typedef struct ogs_gtp2_tlv_pc5_qos_parameters_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_pc5_qos_flow_t pc5_qos_flows;
-    ogs_gtp_tlv_bit_rate_t pc5_link_aggregated_bit_rates;
-} ogs_gtp_tlv_pc5_qos_parameters_t;
+    ogs_gtp2_tlv_pc5_qos_flow_t pc5_qos_flows;
+    ogs_gtp2_tlv_bit_rate_t pc5_link_aggregated_bit_rates;
+} ogs_gtp2_tlv_pc5_qos_parameters_t;
 
-typedef struct ogs_gtp_tlv_remote_ue_context_s {
+typedef struct ogs_gtp2_tlv_remote_ue_context_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_remote_user_id_t remote_user_id;
-    ogs_gtp_tlv_remote_ue_ip_information_t remote_ue_ip_information;
-} ogs_gtp_tlv_remote_ue_context_t;
+    ogs_gtp2_tlv_remote_user_id_t remote_user_id;
+    ogs_gtp2_tlv_remote_ue_ip_information_t remote_ue_ip_information;
+} ogs_gtp2_tlv_remote_ue_context_t;
 
-typedef struct ogs_gtp_tlv_v2x_context_s {
+typedef struct ogs_gtp2_tlv_v2x_context_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_services_authorized_t lte_v2x_services_authorized;
-    ogs_gtp_tlv_services_authorized_t nr_v2x_services_authorized;
-    ogs_gtp_tlv_bit_rate_t lte_ue_sidelink_aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_bit_rate_t nr_ue_sidelink_aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_pc5_qos_parameters_t pc5_qos_parameters;
-} ogs_gtp_tlv_v2x_context_t;
+    ogs_gtp2_tlv_services_authorized_t lte_v2x_services_authorized;
+    ogs_gtp2_tlv_services_authorized_t nr_v2x_services_authorized;
+    ogs_gtp2_tlv_bit_rate_t lte_ue_sidelink_aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_bit_rate_t nr_ue_sidelink_aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_pc5_qos_parameters_t pc5_qos_parameters;
+} ogs_gtp2_tlv_v2x_context_t;
 
-typedef struct ogs_gtp_tlv_bearer_context_s {
+typedef struct ogs_gtp2_tlv_bearer_context_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_ebi_t eps_bearer_id;
-    ogs_gtp_tlv_bearer_tft_t tft;
-    ogs_gtp_tlv_f_teid_t s1_u_enodeb_f_teid; /* Instance : 0 */
-    ogs_gtp_tlv_f_teid_t s4_u_sgsn_f_teid; /* Instance : 1 */
-    ogs_gtp_tlv_f_teid_t s5_s8_u_sgw_f_teid; /* Instance : 2 */
-    ogs_gtp_tlv_f_teid_t s5_s8_u_pgw_f_teid; /* Instance : 3 */
-    ogs_gtp_tlv_f_teid_t s12_rnc_f_teid; /* Instance : 4 */
-    ogs_gtp_tlv_f_teid_t s2b_u_epdg_f_teid_5; /* Instance : 5 */
-    ogs_gtp_tlv_f_teid_t s2a_u_twan_f_teid_6; /* Instance : 6 */
-    ogs_gtp_tlv_bearer_qos_t bearer_level_qos;
-    ogs_gtp_tlv_f_teid_t s11_u_mme_f_teid; /* Instance : 7 */
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_charging_id_t charging_id;
-    ogs_gtp_tlv_bearer_flags_t bearer_flags;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-    ogs_gtp_tlv_maximum_packet_loss_rate_t maximum_packet_loss_rate;
-    ogs_gtp_tlv_f_teid_t s2b_u_epdg_f_teid_8; /* Instance : 8 */
-    ogs_gtp_tlv_f_teid_t s2b_u_pgw_f_teid; /* Instance : 9 */
-    ogs_gtp_tlv_f_teid_t s2a_u_twan_f_teid_10; /* Instance : 10 */
-    ogs_gtp_tlv_f_teid_t s2a_u_pgw_f_teid; /* Instance : 11 */
-    ogs_gtp_tlv_ran_nas_cause_t ran_nas_cause;
-    ogs_gtp_tlv_apco_t additional_protocol_configuration_options;
-    ogs_gtp_tlv_f_container_t bss_container;
-    ogs_gtp_tlv_ti_t transaction_identifier;
-    ogs_gtp_tlv_packet_flow_id_t packet_flow_id;
-} ogs_gtp_tlv_bearer_context_t;
+    ogs_gtp2_tlv_ebi_t eps_bearer_id;
+    ogs_gtp2_tlv_bearer_tft_t tft;
+    ogs_gtp2_tlv_f_teid_t s1_u_enodeb_f_teid; /* Instance : 0 */
+    ogs_gtp2_tlv_f_teid_t s4_u_sgsn_f_teid; /* Instance : 1 */
+    ogs_gtp2_tlv_f_teid_t s5_s8_u_sgw_f_teid; /* Instance : 2 */
+    ogs_gtp2_tlv_f_teid_t s5_s8_u_pgw_f_teid; /* Instance : 3 */
+    ogs_gtp2_tlv_f_teid_t s12_rnc_f_teid; /* Instance : 4 */
+    ogs_gtp2_tlv_f_teid_t s2b_u_epdg_f_teid_5; /* Instance : 5 */
+    ogs_gtp2_tlv_f_teid_t s2a_u_twan_f_teid_6; /* Instance : 6 */
+    ogs_gtp2_tlv_bearer_qos_t bearer_level_qos;
+    ogs_gtp2_tlv_f_teid_t s11_u_mme_f_teid; /* Instance : 7 */
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_charging_id_t charging_id;
+    ogs_gtp2_tlv_bearer_flags_t bearer_flags;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp2_tlv_maximum_packet_loss_rate_t maximum_packet_loss_rate;
+    ogs_gtp2_tlv_f_teid_t s2b_u_epdg_f_teid_8; /* Instance : 8 */
+    ogs_gtp2_tlv_f_teid_t s2b_u_pgw_f_teid; /* Instance : 9 */
+    ogs_gtp2_tlv_f_teid_t s2a_u_twan_f_teid_10; /* Instance : 10 */
+    ogs_gtp2_tlv_f_teid_t s2a_u_pgw_f_teid; /* Instance : 11 */
+    ogs_gtp2_tlv_ran_nas_cause_t ran_nas_cause;
+    ogs_gtp2_tlv_apco_t additional_protocol_configuration_options;
+    ogs_gtp2_tlv_f_container_t bss_container;
+    ogs_gtp2_tlv_ti_t transaction_identifier;
+    ogs_gtp2_tlv_packet_flow_id_t packet_flow_id;
+} ogs_gtp2_tlv_bearer_context_t;
 
-typedef struct ogs_gtp_tlv_pdn_connection_s {
+typedef struct ogs_gtp2_tlv_pdn_connection_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_apn_t apn;
-    ogs_gtp_tlv_apn_restriction_t apn_restriction;
-    ogs_gtp_tlv_selection_mode_t selection_mode;
-    ogs_gtp_tlv_ip_address_t ipv4_address;
-    ogs_gtp_tlv_ip_address_t ipv6_address;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_f_teid_t pgw_s5_s8_ip_address_for_control_plane_or_pmip; /* Instance : 0 */
-    ogs_gtp_tlv_fqdn_t pgw_node_name;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_;
-    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_charging_characteristics_t charging_characteristics;
-    ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
-    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
-    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting_;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_signalling_priority_indication_t signalling_priority_indication__;
-    ogs_gtp_tlv_change_to_report_flags_t change_to_report_flags;
-    ogs_gtp_tlv_fqdn_t local_home_network_id;
-    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_wlan_offloadability_indication_t wlan_offloadability_indication;
-    ogs_gtp_tlv_remote_ue_context_t remote_ue_context_connected;
-    ogs_gtp_tlv_pdn_type_t pdn_type;
-    ogs_gtp_tlv_header_compression_configuration_t header_compression_configuration;
-} ogs_gtp_tlv_pdn_connection_t;
+    ogs_gtp2_tlv_apn_t apn;
+    ogs_gtp2_tlv_apn_restriction_t apn_restriction;
+    ogs_gtp2_tlv_selection_mode_t selection_mode;
+    ogs_gtp2_tlv_ip_address_t ipv4_address;
+    ogs_gtp2_tlv_ip_address_t ipv6_address;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_f_teid_t pgw_s5_s8_ip_address_for_control_plane_or_pmip; /* Instance : 0 */
+    ogs_gtp2_tlv_fqdn_t pgw_node_name;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_;
+    ogs_gtp2_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_charging_characteristics_t charging_characteristics;
+    ogs_gtp2_tlv_change_reporting_action_t change_reporting_action;
+    ogs_gtp2_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp2_tlv_enb_information_reporting_t hnb_information_reporting_;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_signalling_priority_indication_t signalling_priority_indication__;
+    ogs_gtp2_tlv_change_to_report_flags_t change_to_report_flags;
+    ogs_gtp2_tlv_fqdn_t local_home_network_id;
+    ogs_gtp2_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp2_tlv_wlan_offloadability_indication_t wlan_offloadability_indication;
+    ogs_gtp2_tlv_remote_ue_context_t remote_ue_context_connected;
+    ogs_gtp2_tlv_pdn_type_t pdn_type;
+    ogs_gtp2_tlv_header_compression_configuration_t header_compression_configuration;
+} ogs_gtp2_tlv_pdn_connection_t;
 
-typedef struct ogs_gtp_tlv_overload_control_information_s {
+typedef struct ogs_gtp2_tlv_overload_control_information_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_sequence_number_t overload_control_sequence_number;
-    ogs_gtp_tlv_metric_t overload_reduction_metric;
-    ogs_gtp_tlv_epc_timer_t period_of_validity;
-    ogs_gtp_tlv_apn_t list_of_access_point_name;
-} ogs_gtp_tlv_overload_control_information_t;
+    ogs_gtp2_tlv_sequence_number_t overload_control_sequence_number;
+    ogs_gtp2_tlv_metric_t overload_reduction_metric;
+    ogs_gtp2_tlv_epc_timer_t period_of_validity;
+    ogs_gtp2_tlv_apn_t list_of_access_point_name;
+} ogs_gtp2_tlv_overload_control_information_t;
 
-typedef struct ogs_gtp_tlv_load_control_information_s {
+typedef struct ogs_gtp2_tlv_load_control_information_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_sequence_number_t load_control_sequence_number;
-    ogs_gtp_tlv_metric_t load_metric;
-    ogs_gtp_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
-} ogs_gtp_tlv_load_control_information_t;
+    ogs_gtp2_tlv_sequence_number_t load_control_sequence_number;
+    ogs_gtp2_tlv_metric_t load_metric;
+    ogs_gtp2_tlv_apn_and_relative_capacity_t list_of_apn_and_relative_capacity;
+} ogs_gtp2_tlv_load_control_information_t;
 
-typedef struct ogs_gtp_tlv_scef_pdn_connection_s {
+typedef struct ogs_gtp2_tlv_scef_pdn_connection_s {
     ogs_tlv_presence_t presence;
-    ogs_gtp_tlv_apn_t apn;
-    ogs_gtp_tlv_ebi_t default_eps_bearer_id;
-    ogs_gtp_tlv_node_identifier_t scef_id;
-} ogs_gtp_tlv_scef_pdn_connection_t;
+    ogs_gtp2_tlv_apn_t apn;
+    ogs_gtp2_tlv_ebi_t default_eps_bearer_id;
+    ogs_gtp2_tlv_node_identifier_t scef_id;
+} ogs_gtp2_tlv_scef_pdn_connection_t;
 
 /* Structure for Message */
-typedef struct ogs_gtp_echo_request_s {
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_node_features_t sending_node_features;
-} ogs_gtp_echo_request_t;
+typedef struct ogs_gtp2_echo_request_s {
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_node_features_t sending_node_features;
+} ogs_gtp2_echo_request_t;
 
-typedef struct ogs_gtp_echo_response_s {
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_node_features_t sending_node_features;
-} ogs_gtp_echo_response_t;
+typedef struct ogs_gtp2_echo_response_s {
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_node_features_t sending_node_features;
+} ogs_gtp2_echo_response_t;
 
-typedef struct ogs_gtp_create_session_request_s {
-    ogs_gtp_tlv_imsi_t imsi;
-    ogs_gtp_tlv_msisdn_t msisdn;
-    ogs_gtp_tlv_mei_t me_identity;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_serving_network_t serving_network;
-    ogs_gtp_tlv_rat_type_t rat_type;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_f_teid_t pgw_s5_s8_address_for_control_plane_or_pmip;
-    ogs_gtp_tlv_apn_t access_point_name;
-    ogs_gtp_tlv_selection_mode_t selection_mode;
-    ogs_gtp_tlv_pdn_type_t pdn_type;
-    ogs_gtp_tlv_paa_t pdn_address_allocation;
-    ogs_gtp_tlv_apn_restriction_t maximum_apn_restriction;
-    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_twmi_t trusted_wlan_mode_indication;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_created;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
-    ogs_gtp_tlv_trace_information_t trace_information;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_fq_csid_t mme_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t epdg_fq_csid;
-    ogs_gtp_tlv_fq_csid_t twan_fq_csid;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_uci_t user_csg_information;
-    ogs_gtp_tlv_charging_characteristics_t charging_characteristics;
-    ogs_gtp_tlv_ldn_t mme_s4_sgsn_ldn;
-    ogs_gtp_tlv_ldn_t sgw_ldn;
-    ogs_gtp_tlv_ldn_t epdg_ldn;
-    ogs_gtp_tlv_ldn_t twan_ldn;
-    ogs_gtp_tlv_signalling_priority_indication_t signalling_priority_indication;
-    ogs_gtp_tlv_ip_address_t ue_local_ip_address;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_apco_t additional_protocol_configuration_options;
-    ogs_gtp_tlv_ip_address_t hnb_local_ip_address;
-    ogs_gtp_tlv_port_number_t hnb_udp_port;
-    ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_ip_address_t epdg_ip_address;
-    ogs_gtp_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
-    ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_millisecond_time_stamp_t origination_time_stamp;
-    ogs_gtp_tlv_integer_number_t maximum_wait_time;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_remote_ue_context_t remote_ue_context_connected;
-    ogs_gtp_tlv_node_identifier_t _aaa_server_identifier;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-    ogs_gtp_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
-    ogs_gtp_tlv_counter_t mo_exception_data_counter;
-    ogs_gtp_tlv_port_number_t ue_tcp_port;
-    ogs_gtp_tlv_mapped_ue_usage_type_t mapped_ue_usage_type;
-    ogs_gtp_tlv_uli_t user_location_information_for_sgw_;
-    ogs_gtp_tlv_fqdn_t sgw_u_node_name;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-    ogs_gtp_tlv_up_function_selection_indication_flags_t up_function_selection_indication_flags;
-    ogs_gtp_tlv_apn_rate_control_status_t apn_rate_control_status;
-} ogs_gtp_create_session_request_t;
+typedef struct ogs_gtp2_create_session_request_s {
+    ogs_gtp2_tlv_imsi_t imsi;
+    ogs_gtp2_tlv_msisdn_t msisdn;
+    ogs_gtp2_tlv_mei_t me_identity;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_serving_network_t serving_network;
+    ogs_gtp2_tlv_rat_type_t rat_type;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_f_teid_t pgw_s5_s8_address_for_control_plane_or_pmip;
+    ogs_gtp2_tlv_apn_t access_point_name;
+    ogs_gtp2_tlv_selection_mode_t selection_mode;
+    ogs_gtp2_tlv_pdn_type_t pdn_type;
+    ogs_gtp2_tlv_paa_t pdn_address_allocation;
+    ogs_gtp2_tlv_apn_restriction_t maximum_apn_restriction;
+    ogs_gtp2_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_twmi_t trusted_wlan_mode_indication;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_created;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp2_tlv_trace_information_t trace_information;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_fq_csid_t mme_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t epdg_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t twan_fq_csid;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_uci_t user_csg_information;
+    ogs_gtp2_tlv_charging_characteristics_t charging_characteristics;
+    ogs_gtp2_tlv_ldn_t mme_s4_sgsn_ldn;
+    ogs_gtp2_tlv_ldn_t sgw_ldn;
+    ogs_gtp2_tlv_ldn_t epdg_ldn;
+    ogs_gtp2_tlv_ldn_t twan_ldn;
+    ogs_gtp2_tlv_signalling_priority_indication_t signalling_priority_indication;
+    ogs_gtp2_tlv_ip_address_t ue_local_ip_address;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_apco_t additional_protocol_configuration_options;
+    ogs_gtp2_tlv_ip_address_t hnb_local_ip_address;
+    ogs_gtp2_tlv_port_number_t hnb_udp_port;
+    ogs_gtp2_tlv_ip_address_t mme_s4_sgsn_identifier;
+    ogs_gtp2_tlv_twan_identifier_t twan_identifier;
+    ogs_gtp2_tlv_ip_address_t epdg_ip_address;
+    ogs_gtp2_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
+    ogs_gtp2_tlv_presence_reporting_area_information_t presence_reporting_area_information;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_millisecond_time_stamp_t origination_time_stamp;
+    ogs_gtp2_tlv_integer_number_t maximum_wait_time;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_remote_ue_context_t remote_ue_context_connected;
+    ogs_gtp2_tlv_node_identifier_t _aaa_server_identifier;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp2_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
+    ogs_gtp2_tlv_counter_t mo_exception_data_counter;
+    ogs_gtp2_tlv_port_number_t ue_tcp_port;
+    ogs_gtp2_tlv_mapped_ue_usage_type_t mapped_ue_usage_type;
+    ogs_gtp2_tlv_uli_t user_location_information_for_sgw_;
+    ogs_gtp2_tlv_fqdn_t sgw_u_node_name;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+    ogs_gtp2_tlv_up_function_selection_indication_flags_t up_function_selection_indication_flags;
+    ogs_gtp2_tlv_apn_rate_control_status_t apn_rate_control_status;
+} ogs_gtp2_create_session_request_t;
 
-typedef struct ogs_gtp_create_session_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_change_reporting_action_t change_reporting_action_;
-    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
-    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_f_teid_t pgw_s5_s8__s2a_s2b_f_teid_for_pmip_based_interface_or_for_gtp_based_control_plane_interface;
-    ogs_gtp_tlv_paa_t pdn_address_allocation;
-    ogs_gtp_tlv_apn_restriction_t apn_restriction;
-    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_created;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_fqdn_t charging_gateway_name;
-    ogs_gtp_tlv_ip_address_t charging_gateway_address;
-    ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_ldn_t sgw_ldn;
-    ogs_gtp_tlv_ldn_t pgw_ldn;
-    ogs_gtp_tlv_epc_timer_t pgw_back_off_time;
-    ogs_gtp_tlv_apco_t additional_protocol_configuration_options;
-    ogs_gtp_tlv_ip4cp_t trusted_wlan_ipv4_parameters_;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_charging_id_t pdn_connection_charging_id;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-} ogs_gtp_create_session_response_t;
+typedef struct ogs_gtp2_create_session_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_change_reporting_action_t change_reporting_action_;
+    ogs_gtp2_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp2_tlv_enb_information_reporting_t hnb_information_reporting;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_f_teid_t pgw_s5_s8__s2a_s2b_f_teid_for_pmip_based_interface_or_for_gtp_based_control_plane_interface;
+    ogs_gtp2_tlv_paa_t pdn_address_allocation;
+    ogs_gtp2_tlv_apn_restriction_t apn_restriction;
+    ogs_gtp2_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_created;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_fqdn_t charging_gateway_name;
+    ogs_gtp2_tlv_ip_address_t charging_gateway_address;
+    ogs_gtp2_tlv_fq_csid_t pgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_ldn_t sgw_ldn;
+    ogs_gtp2_tlv_ldn_t pgw_ldn;
+    ogs_gtp2_tlv_epc_timer_t pgw_back_off_time;
+    ogs_gtp2_tlv_apco_t additional_protocol_configuration_options;
+    ogs_gtp2_tlv_ip4cp_t trusted_wlan_ipv4_parameters_;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_charging_id_t pdn_connection_charging_id;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+} ogs_gtp2_create_session_response_t;
 
-typedef struct ogs_gtp_modify_bearer_request_s {
-    ogs_gtp_tlv_mei_t me_identity;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_serving_network_t serving_network;
-    ogs_gtp_tlv_rat_type_t rat_type;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_delay_value_t delay_downlink_packet_notification_request;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_fq_csid_t mme_fq_csid;
-    ogs_gtp_tlv_uci_t user_csg_information;
-    ogs_gtp_tlv_ip_address_t ue_local_ip_address;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_ldn_t mme_s4_sgsn_ldn;
-    ogs_gtp_tlv_ldn_t sgw_ldn;
-    ogs_gtp_tlv_ip_address_t hnb_local_ip_address;
-    ogs_gtp_tlv_port_number_t hnb_udp_port;
-    ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
-    ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t epdg_s_overload_control_information;
-    ogs_gtp_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
-    ogs_gtp_tlv_counter_t mo_exception_data_counter;
-    ogs_gtp_tlv_imsi_t imsi;
-    ogs_gtp_tlv_uli_t user_location_information_for_sgw_;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_modify_bearer_request_t;
+typedef struct ogs_gtp2_modify_bearer_request_s {
+    ogs_gtp2_tlv_mei_t me_identity;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_serving_network_t serving_network;
+    ogs_gtp2_tlv_rat_type_t rat_type;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_delay_value_t delay_downlink_packet_notification_request;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_modified;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_fq_csid_t mme_fq_csid;
+    ogs_gtp2_tlv_uci_t user_csg_information;
+    ogs_gtp2_tlv_ip_address_t ue_local_ip_address;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_ldn_t mme_s4_sgsn_ldn;
+    ogs_gtp2_tlv_ldn_t sgw_ldn;
+    ogs_gtp2_tlv_ip_address_t hnb_local_ip_address;
+    ogs_gtp2_tlv_port_number_t hnb_udp_port;
+    ogs_gtp2_tlv_ip_address_t mme_s4_sgsn_identifier;
+    ogs_gtp2_tlv_cn_operator_selection_entity_t cn_operator_selection_entity;
+    ogs_gtp2_tlv_presence_reporting_area_information_t presence_reporting_area_information;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t epdg_s_overload_control_information;
+    ogs_gtp2_tlv_serving_plmn_rate_control_t serving_plmn_rate_control;
+    ogs_gtp2_tlv_counter_t mo_exception_data_counter;
+    ogs_gtp2_tlv_imsi_t imsi;
+    ogs_gtp2_tlv_uli_t user_location_information_for_sgw_;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_modify_bearer_request_t;
 
-typedef struct ogs_gtp_modify_bearer_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_msisdn_t msisdn;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_apn_restriction_t apn_restriction;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
-    ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
-    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
-    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting_;
-    ogs_gtp_tlv_fqdn_t charging_gateway_name;
-    ogs_gtp_tlv_ip_address_t charging_gateway_address;
-    ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_ldn_t sgw_ldn;
-    ogs_gtp_tlv_ldn_t pgw_ldn;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_charging_id_t pdn_connection_charging_id;
-} ogs_gtp_modify_bearer_response_t;
+typedef struct ogs_gtp2_modify_bearer_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_msisdn_t msisdn;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_apn_restriction_t apn_restriction;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_modified;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp2_tlv_change_reporting_action_t change_reporting_action;
+    ogs_gtp2_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp2_tlv_enb_information_reporting_t hnb_information_reporting_;
+    ogs_gtp2_tlv_fqdn_t charging_gateway_name;
+    ogs_gtp2_tlv_ip_address_t charging_gateway_address;
+    ogs_gtp2_tlv_fq_csid_t pgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_ldn_t sgw_ldn;
+    ogs_gtp2_tlv_ldn_t pgw_ldn;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_charging_id_t pdn_connection_charging_id;
+} ogs_gtp2_modify_bearer_response_t;
 
-typedef struct ogs_gtp_delete_session_request_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_node_type_t originating_node;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_uli_timestamp_t uli_timestamp;
-    ogs_gtp_tlv_ran_nas_cause_t ran_nas_release_cause;
-    ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_ip_address_t ue_local_ip_address;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-    ogs_gtp_tlv_port_number_t ue_tcp_port;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_delete_session_request_t;
+typedef struct ogs_gtp2_delete_session_request_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_node_type_t originating_node;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_uli_timestamp_t uli_timestamp;
+    ogs_gtp2_tlv_ran_nas_cause_t ran_nas_release_cause;
+    ogs_gtp2_tlv_twan_identifier_t twan_identifier;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_ip_address_t ue_local_ip_address;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp2_tlv_port_number_t ue_tcp_port;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_delete_session_request_t;
 
-typedef struct ogs_gtp_delete_session_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-    ogs_gtp_tlv_apn_rate_control_status_t apn_rate_control_status;
-} ogs_gtp_delete_session_response_t;
+typedef struct ogs_gtp2_delete_session_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp2_tlv_apn_rate_control_status_t apn_rate_control_status;
+} ogs_gtp2_delete_session_response_t;
 
-typedef struct ogs_gtp_modify_bearer_command_s {
-    ogs_gtp_tlv_ambr_t apn_aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_bearer_context_t bearer_context;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-} ogs_gtp_modify_bearer_command_t;
+typedef struct ogs_gtp2_modify_bearer_command_s {
+    ogs_gtp2_tlv_ambr_t apn_aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_bearer_context_t bearer_context;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+} ogs_gtp2_modify_bearer_command_t;
 
-typedef struct ogs_gtp_modify_bearer_failure_indication_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-} ogs_gtp_modify_bearer_failure_indication_t;
+typedef struct ogs_gtp2_modify_bearer_failure_indication_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+} ogs_gtp2_modify_bearer_failure_indication_t;
 
-typedef struct ogs_gtp_delete_bearer_command_s {
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_uli_timestamp_t uli_timestamp;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_delete_bearer_command_t;
+typedef struct ogs_gtp2_delete_bearer_command_s {
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_uli_timestamp_t uli_timestamp;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_delete_bearer_command_t;
 
-typedef struct ogs_gtp_delete_bearer_failure_indication_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_context;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-} ogs_gtp_delete_bearer_failure_indication_t;
+typedef struct ogs_gtp2_delete_bearer_failure_indication_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_bearer_context_t bearer_context;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+} ogs_gtp2_delete_bearer_failure_indication_t;
 
-typedef struct ogs_gtp_bearer_resource_command_s {
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_pti_t procedure_transaction_id;
-    ogs_gtp_tlv_flow_qos_t flow_quality_of_service;
-    ogs_gtp_tlv_tad_t traffic_aggregate_description;
-    ogs_gtp_tlv_rat_type_t rat_type;
-    ogs_gtp_tlv_serving_network_t serving_network;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_ebi_t eps_bearer_id;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_f_teid_t s4_u_sgsn_f_teid;
-    ogs_gtp_tlv_f_teid_t s12_rnc_f_teid;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_signalling_priority_indication_t signalling_priority_indication__;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-} ogs_gtp_bearer_resource_command_t;
+typedef struct ogs_gtp2_bearer_resource_command_s {
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_pti_t procedure_transaction_id;
+    ogs_gtp2_tlv_flow_qos_t flow_quality_of_service;
+    ogs_gtp2_tlv_tad_t traffic_aggregate_description;
+    ogs_gtp2_tlv_rat_type_t rat_type;
+    ogs_gtp2_tlv_serving_network_t serving_network;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_ebi_t eps_bearer_id;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_f_teid_t s4_u_sgsn_f_teid;
+    ogs_gtp2_tlv_f_teid_t s12_rnc_f_teid;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_signalling_priority_indication_t signalling_priority_indication__;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+} ogs_gtp2_bearer_resource_command_t;
 
-typedef struct ogs_gtp_bearer_resource_failure_indication_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_pti_t procedure_transaction_id;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-} ogs_gtp_bearer_resource_failure_indication_t;
+typedef struct ogs_gtp2_bearer_resource_failure_indication_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_pti_t procedure_transaction_id;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+} ogs_gtp2_bearer_resource_failure_indication_t;
 
-typedef struct ogs_gtp_downlink_data_notification_failure_indication_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_node_type_t originating_node;
-    ogs_gtp_tlv_imsi_t imsi;
-} ogs_gtp_downlink_data_notification_failure_indication_t;
+typedef struct ogs_gtp2_downlink_data_notification_failure_indication_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_node_type_t originating_node;
+    ogs_gtp2_tlv_imsi_t imsi;
+} ogs_gtp2_downlink_data_notification_failure_indication_t;
 
-typedef struct ogs_gtp_create_bearer_request_s {
-    ogs_gtp_tlv_pti_t procedure_transaction_id;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
-    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
-    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting;
-    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-} ogs_gtp_create_bearer_request_t;
+typedef struct ogs_gtp2_create_bearer_request_s {
+    ogs_gtp2_tlv_pti_t procedure_transaction_id;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_fq_csid_t pgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_change_reporting_action_t change_reporting_action;
+    ogs_gtp2_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp2_tlv_enb_information_reporting_t hnb_information_reporting;
+    ogs_gtp2_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+} ogs_gtp2_create_bearer_request_t;
 
-typedef struct ogs_gtp_create_bearer_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_fq_csid_t mme_fq_csid;
-    ogs_gtp_tlv_fq_csid_t epdg_fq_csid;
-    ogs_gtp_tlv_fq_csid_t twan_fq_csid;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_port_number_t ue_tcp_port;
-} ogs_gtp_create_bearer_response_t;
+typedef struct ogs_gtp2_create_bearer_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_fq_csid_t mme_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t epdg_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t twan_fq_csid;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_twan_identifier_t twan_identifier;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_presence_reporting_area_information_t presence_reporting_area_information;
+    ogs_gtp2_tlv_ip_address_t mme_s4_sgsn_identifier;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_port_number_t ue_tcp_port;
+} ogs_gtp2_create_bearer_response_t;
 
-typedef struct ogs_gtp_update_bearer_request_s {
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_pti_t procedure_transaction_id;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_ambr_t aggregate_maximum_bit_rate;
-    ogs_gtp_tlv_change_reporting_action_t change_reporting_action;
-    ogs_gtp_tlv_csg_information_reporting_action_t csg_information_reporting_action;
-    ogs_gtp_tlv_enb_information_reporting_t hnb_information_reporting_;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_presence_reporting_area_action_t presence_reporting_area_action;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-} ogs_gtp_update_bearer_request_t;
+typedef struct ogs_gtp2_update_bearer_request_s {
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_pti_t procedure_transaction_id;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_ambr_t aggregate_maximum_bit_rate;
+    ogs_gtp2_tlv_change_reporting_action_t change_reporting_action;
+    ogs_gtp2_tlv_csg_information_reporting_action_t csg_information_reporting_action;
+    ogs_gtp2_tlv_enb_information_reporting_t hnb_information_reporting_;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_fq_csid_t pgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_presence_reporting_area_action_t presence_reporting_area_action;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+} ogs_gtp2_update_bearer_request_t;
 
-typedef struct ogs_gtp_update_bearer_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_fq_csid_t mme_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t epdg_fq_csid;
-    ogs_gtp_tlv_fq_csid_t twan_fq_csid;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_presence_reporting_area_information_t presence_reporting_area_information;
-    ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_port_number_t ue_tcp_port;
-} ogs_gtp_update_bearer_response_t;
+typedef struct ogs_gtp2_update_bearer_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_fq_csid_t mme_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t epdg_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t twan_fq_csid;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_twan_identifier_t twan_identifier;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_presence_reporting_area_information_t presence_reporting_area_information;
+    ogs_gtp2_tlv_ip_address_t mme_s4_sgsn_identifier;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_port_number_t ue_tcp_port;
+} ogs_gtp2_update_bearer_response_t;
 
-typedef struct ogs_gtp_delete_bearer_request_s {
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_ebi_t eps_bearer_ids;
-    ogs_gtp_tlv_bearer_context_t failed_bearer_contexts;
-    ogs_gtp_tlv_pti_t procedure_transaction_id;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_fq_csid_t pgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t pgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t pgw_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_apn_rate_control_status_t apn_rate_control_status;
-    ogs_gtp_tlv_epco_t extended_protocol_configuration_options;
-} ogs_gtp_delete_bearer_request_t;
+typedef struct ogs_gtp2_delete_bearer_request_s {
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_ebi_t eps_bearer_ids;
+    ogs_gtp2_tlv_bearer_context_t failed_bearer_contexts;
+    ogs_gtp2_tlv_pti_t procedure_transaction_id;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_fq_csid_t pgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t pgw_s_apn_level_load_control_information;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t pgw_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_apn_rate_control_status_t apn_rate_control_status;
+    ogs_gtp2_tlv_epco_t extended_protocol_configuration_options;
+} ogs_gtp2_delete_bearer_request_t;
 
-typedef struct ogs_gtp_delete_bearer_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_ebi_t linked_eps_bearer_id;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_fq_csid_t mme_fq_csid;
-    ogs_gtp_tlv_fq_csid_t sgw_fq_csid;
-    ogs_gtp_tlv_fq_csid_t epdg_fq_csid;
-    ogs_gtp_tlv_fq_csid_t twan_fq_csid;
-    ogs_gtp_tlv_pco_t protocol_configuration_options;
-    ogs_gtp_tlv_ue_time_zone_t ue_time_zone;
-    ogs_gtp_tlv_uli_t user_location_information;
-    ogs_gtp_tlv_uli_timestamp_t uli_timestamp;
-    ogs_gtp_tlv_twan_identifier_t twan_identifier;
-    ogs_gtp_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
-    ogs_gtp_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_ip_address_t mme_s4_sgsn_identifier;
-    ogs_gtp_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
-    ogs_gtp_tlv_twan_identifier_t wlan_location_information;
-    ogs_gtp_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
-    ogs_gtp_tlv_port_number_t ue_udp_port;
-    ogs_gtp_tlv_f_container_t nbifom_container;
-    ogs_gtp_tlv_port_number_t ue_tcp_port;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_delete_bearer_response_t;
+typedef struct ogs_gtp2_delete_bearer_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_ebi_t linked_eps_bearer_id;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_fq_csid_t mme_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t sgw_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t epdg_fq_csid;
+    ogs_gtp2_tlv_fq_csid_t twan_fq_csid;
+    ogs_gtp2_tlv_pco_t protocol_configuration_options;
+    ogs_gtp2_tlv_ue_time_zone_t ue_time_zone;
+    ogs_gtp2_tlv_uli_t user_location_information;
+    ogs_gtp2_tlv_uli_timestamp_t uli_timestamp;
+    ogs_gtp2_tlv_twan_identifier_t twan_identifier;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t twan_identifier_timestamp;
+    ogs_gtp2_tlv_overload_control_information_t mme_s4_sgsn_s_overload_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_ip_address_t mme_s4_sgsn_identifier;
+    ogs_gtp2_tlv_overload_control_information_t twan_epdg_s_overload_control_information;
+    ogs_gtp2_tlv_twan_identifier_t wlan_location_information;
+    ogs_gtp2_tlv_twan_identifier_timestamp_t wlan_location_timestamp;
+    ogs_gtp2_tlv_port_number_t ue_udp_port;
+    ogs_gtp2_tlv_f_container_t nbifom_container;
+    ogs_gtp2_tlv_port_number_t ue_tcp_port;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_delete_bearer_response_t;
 
-typedef struct ogs_gtp_create_indirect_data_forwarding_tunnel_request_s {
-    ogs_gtp_tlv_imsi_t imsi;
-    ogs_gtp_tlv_mei_t me_identity;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts[8];
-    ogs_gtp_tlv_recovery_t recovery;
-} ogs_gtp_create_indirect_data_forwarding_tunnel_request_t;
+typedef struct ogs_gtp2_create_indirect_data_forwarding_tunnel_request_s {
+    ogs_gtp2_tlv_imsi_t imsi;
+    ogs_gtp2_tlv_mei_t me_identity;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts[8];
+    ogs_gtp2_tlv_recovery_t recovery;
+} ogs_gtp2_create_indirect_data_forwarding_tunnel_request_t;
 
-typedef struct ogs_gtp_create_indirect_data_forwarding_tunnel_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts[8];
-    ogs_gtp_tlv_recovery_t recovery;
-} ogs_gtp_create_indirect_data_forwarding_tunnel_response_t;
+typedef struct ogs_gtp2_create_indirect_data_forwarding_tunnel_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts[8];
+    ogs_gtp2_tlv_recovery_t recovery;
+} ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t;
 
-typedef struct ogs_gtp_delete_indirect_data_forwarding_tunnel_request_s {
-} ogs_gtp_delete_indirect_data_forwarding_tunnel_request_t;
+typedef struct ogs_gtp2_delete_indirect_data_forwarding_tunnel_request_s {
+} ogs_gtp2_delete_indirect_data_forwarding_tunnel_request_t;
 
-typedef struct ogs_gtp_delete_indirect_data_forwarding_tunnel_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_recovery_t recovery;
-} ogs_gtp_delete_indirect_data_forwarding_tunnel_response_t;
+typedef struct ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_recovery_t recovery;
+} ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t;
 
-typedef struct ogs_gtp_release_access_bearers_request_s {
-    ogs_gtp_tlv_ebi_t list_of_rabs;
-    ogs_gtp_tlv_node_type_t originating_node;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_release_access_bearers_request_t;
+typedef struct ogs_gtp2_release_access_bearers_request_s {
+    ogs_gtp2_tlv_ebi_t list_of_rabs;
+    ogs_gtp2_tlv_node_type_t originating_node;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_release_access_bearers_request_t;
 
-typedef struct ogs_gtp_release_access_bearers_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-} ogs_gtp_release_access_bearers_response_t;
+typedef struct ogs_gtp2_release_access_bearers_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+} ogs_gtp2_release_access_bearers_response_t;
 
-typedef struct ogs_gtp_downlink_data_notification_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_ebi_t eps_bearer_id;
-    ogs_gtp_tlv_arp_t allocation_retention_priority;
-    ogs_gtp_tlv_imsi_t imsi;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-    ogs_gtp_tlv_paging_and_service_information_t paging_and_service_information;
-    ogs_gtp_tlv_integer_number_t dl_data_packets_size;
-} ogs_gtp_downlink_data_notification_t;
+typedef struct ogs_gtp2_downlink_data_notification_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_ebi_t eps_bearer_id;
+    ogs_gtp2_tlv_arp_t allocation_retention_priority;
+    ogs_gtp2_tlv_imsi_t imsi;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+    ogs_gtp2_tlv_paging_and_service_information_t paging_and_service_information;
+    ogs_gtp2_tlv_integer_number_t dl_data_packets_size;
+} ogs_gtp2_downlink_data_notification_t;
 
-typedef struct ogs_gtp_downlink_data_notification_acknowledge_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_delay_value_t data_notification_delay;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_throttling_t dl_low_priority_traffic_throttling_;
-    ogs_gtp_tlv_imsi_t imsi;
-    ogs_gtp_tlv_epc_timer_t dl_buffering_duration;
-    ogs_gtp_tlv_integer_number_t dl_buffering_suggested_packet_count;
-} ogs_gtp_downlink_data_notification_acknowledge_t;
+typedef struct ogs_gtp2_downlink_data_notification_acknowledge_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_delay_value_t data_notification_delay;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_throttling_t dl_low_priority_traffic_throttling_;
+    ogs_gtp2_tlv_imsi_t imsi;
+    ogs_gtp2_tlv_epc_timer_t dl_buffering_duration;
+    ogs_gtp2_tlv_integer_number_t dl_buffering_suggested_packet_count;
+} ogs_gtp2_downlink_data_notification_acknowledge_t;
 
-typedef struct ogs_gtp_modify_access_bearers_request_s {
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_f_teid_t sender_f_teid_for_control_plane;
-    ogs_gtp_tlv_delay_value_t delay_downlink_packet_notification_request;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_to_be_removed;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
-} ogs_gtp_modify_access_bearers_request_t;
+typedef struct ogs_gtp2_modify_access_bearers_request_s {
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_f_teid_t sender_f_teid_for_control_plane;
+    ogs_gtp2_tlv_delay_value_t delay_downlink_packet_notification_request;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_modified;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_to_be_removed;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_secondary_rat_usage_data_report_t secondary_rat_usage_data_report;
+} ogs_gtp2_modify_access_bearers_request_t;
 
-typedef struct ogs_gtp_modify_access_bearers_response_s {
-    ogs_gtp_tlv_cause_t cause;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_modified;
-    ogs_gtp_tlv_bearer_context_t bearer_contexts_marked_for_removal;
-    ogs_gtp_tlv_recovery_t recovery;
-    ogs_gtp_tlv_indication_t indication_flags;
-    ogs_gtp_tlv_load_control_information_t sgw_s_node_level_load_control_information;
-    ogs_gtp_tlv_overload_control_information_t sgw_s_overload_control_information;
-} ogs_gtp_modify_access_bearers_response_t;
+typedef struct ogs_gtp2_modify_access_bearers_response_s {
+    ogs_gtp2_tlv_cause_t cause;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_modified;
+    ogs_gtp2_tlv_bearer_context_t bearer_contexts_marked_for_removal;
+    ogs_gtp2_tlv_recovery_t recovery;
+    ogs_gtp2_tlv_indication_t indication_flags;
+    ogs_gtp2_tlv_load_control_information_t sgw_s_node_level_load_control_information;
+    ogs_gtp2_tlv_overload_control_information_t sgw_s_overload_control_information;
+} ogs_gtp2_modify_access_bearers_response_t;
 
-typedef struct ogs_gtp_message_s {
-   ogs_gtp_header_t h;
+typedef struct ogs_gtp2_message_s {
+   ogs_gtp2_header_t h;
    union {
-        ogs_gtp_echo_request_t echo_request;
-        ogs_gtp_echo_response_t echo_response;
-        ogs_gtp_create_session_request_t create_session_request;
-        ogs_gtp_create_session_response_t create_session_response;
-        ogs_gtp_modify_bearer_request_t modify_bearer_request;
-        ogs_gtp_modify_bearer_response_t modify_bearer_response;
-        ogs_gtp_delete_session_request_t delete_session_request;
-        ogs_gtp_delete_session_response_t delete_session_response;
-        ogs_gtp_modify_bearer_command_t modify_bearer_command;
-        ogs_gtp_modify_bearer_failure_indication_t modify_bearer_failure_indication;
-        ogs_gtp_delete_bearer_command_t delete_bearer_command;
-        ogs_gtp_delete_bearer_failure_indication_t delete_bearer_failure_indication;
-        ogs_gtp_bearer_resource_command_t bearer_resource_command;
-        ogs_gtp_bearer_resource_failure_indication_t bearer_resource_failure_indication;
-        ogs_gtp_downlink_data_notification_failure_indication_t downlink_data_notification_failure_indication;
-        ogs_gtp_create_bearer_request_t create_bearer_request;
-        ogs_gtp_create_bearer_response_t create_bearer_response;
-        ogs_gtp_update_bearer_request_t update_bearer_request;
-        ogs_gtp_update_bearer_response_t update_bearer_response;
-        ogs_gtp_delete_bearer_request_t delete_bearer_request;
-        ogs_gtp_delete_bearer_response_t delete_bearer_response;
-        ogs_gtp_create_indirect_data_forwarding_tunnel_request_t create_indirect_data_forwarding_tunnel_request;
-        ogs_gtp_create_indirect_data_forwarding_tunnel_response_t create_indirect_data_forwarding_tunnel_response;
-        ogs_gtp_delete_indirect_data_forwarding_tunnel_request_t delete_indirect_data_forwarding_tunnel_request;
-        ogs_gtp_delete_indirect_data_forwarding_tunnel_response_t delete_indirect_data_forwarding_tunnel_response;
-        ogs_gtp_release_access_bearers_request_t release_access_bearers_request;
-        ogs_gtp_release_access_bearers_response_t release_access_bearers_response;
-        ogs_gtp_downlink_data_notification_t downlink_data_notification;
-        ogs_gtp_downlink_data_notification_acknowledge_t downlink_data_notification_acknowledge;
-        ogs_gtp_modify_access_bearers_request_t modify_access_bearers_request;
-        ogs_gtp_modify_access_bearers_response_t modify_access_bearers_response;
+        ogs_gtp2_echo_request_t echo_request;
+        ogs_gtp2_echo_response_t echo_response;
+        ogs_gtp2_create_session_request_t create_session_request;
+        ogs_gtp2_create_session_response_t create_session_response;
+        ogs_gtp2_modify_bearer_request_t modify_bearer_request;
+        ogs_gtp2_modify_bearer_response_t modify_bearer_response;
+        ogs_gtp2_delete_session_request_t delete_session_request;
+        ogs_gtp2_delete_session_response_t delete_session_response;
+        ogs_gtp2_modify_bearer_command_t modify_bearer_command;
+        ogs_gtp2_modify_bearer_failure_indication_t modify_bearer_failure_indication;
+        ogs_gtp2_delete_bearer_command_t delete_bearer_command;
+        ogs_gtp2_delete_bearer_failure_indication_t delete_bearer_failure_indication;
+        ogs_gtp2_bearer_resource_command_t bearer_resource_command;
+        ogs_gtp2_bearer_resource_failure_indication_t bearer_resource_failure_indication;
+        ogs_gtp2_downlink_data_notification_failure_indication_t downlink_data_notification_failure_indication;
+        ogs_gtp2_create_bearer_request_t create_bearer_request;
+        ogs_gtp2_create_bearer_response_t create_bearer_response;
+        ogs_gtp2_update_bearer_request_t update_bearer_request;
+        ogs_gtp2_update_bearer_response_t update_bearer_response;
+        ogs_gtp2_delete_bearer_request_t delete_bearer_request;
+        ogs_gtp2_delete_bearer_response_t delete_bearer_response;
+        ogs_gtp2_create_indirect_data_forwarding_tunnel_request_t create_indirect_data_forwarding_tunnel_request;
+        ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t create_indirect_data_forwarding_tunnel_response;
+        ogs_gtp2_delete_indirect_data_forwarding_tunnel_request_t delete_indirect_data_forwarding_tunnel_request;
+        ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t delete_indirect_data_forwarding_tunnel_response;
+        ogs_gtp2_release_access_bearers_request_t release_access_bearers_request;
+        ogs_gtp2_release_access_bearers_response_t release_access_bearers_response;
+        ogs_gtp2_downlink_data_notification_t downlink_data_notification;
+        ogs_gtp2_downlink_data_notification_acknowledge_t downlink_data_notification_acknowledge;
+        ogs_gtp2_modify_access_bearers_request_t modify_access_bearers_request;
+        ogs_gtp2_modify_access_bearers_response_t modify_access_bearers_response;
    };
-} ogs_gtp_message_t;
+} ogs_gtp2_message_t;
 
-int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf);
-ogs_pkbuf_t *ogs_gtp_build_msg(ogs_gtp_message_t *gtp_message);
+int ogs_gtp2_parse_msg(ogs_gtp2_message_t *gtp_message, ogs_pkbuf_t *pkbuf);
+ogs_pkbuf_t *ogs_gtp2_build_msg(ogs_gtp2_message_t *gtp_message);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OGS_GTP_MESSAGE_H */
+#endif /* OGS_GTP2_MESSAGE_H */

--- a/lib/gtp/v2/path.h
+++ b/lib/gtp/v2/path.h
@@ -30,19 +30,18 @@ extern "C" {
 
 typedef struct ogs_gtp_xact_s ogs_gtp_xact_t;
 
-
-int ogs_gtp_send_user_plane(
+int ogs_gtp2_send_user_plane(
         ogs_gtp_node_t *gnode,
-        ogs_gtp_header_t *gtp_hdesc, ogs_gtp_extension_header_t *ext_hdesc,
+        ogs_gtp2_header_t *gtp_hdesc, ogs_gtp2_extension_header_t *ext_hdesc,
         ogs_pkbuf_t *pkbuf);
 
-ogs_pkbuf_t *ogs_gtp_handle_echo_req(ogs_pkbuf_t *pkt);
+ogs_pkbuf_t *ogs_gtp2_handle_echo_req(ogs_pkbuf_t *pkt);
 void ogs_gtp2_send_error_message(
         ogs_gtp_xact_t *xact, uint32_t teid, uint8_t type, uint8_t cause_value);
 
-void ogs_gtp_send_echo_request(
+void ogs_gtp2_send_echo_request(
         ogs_gtp_node_t *gnode, uint8_t recovery, uint8_t features);
-void ogs_gtp_send_echo_response(ogs_gtp_xact_t *xact,
+void ogs_gtp2_send_echo_response(ogs_gtp_xact_t *xact,
         uint8_t recovery, uint8_t features);
 
 #ifdef __cplusplus

--- a/lib/gtp/v2/support/gtp-tlv.py
+++ b/lib/gtp/v2/support/gtp-tlv.py
@@ -440,8 +440,8 @@ f.write("""#if !defined(OGS_GTP_INSIDE) && !defined(OGS_GTP_COMPILATION)
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_GTP_MESSAGE_H
-#define OGS_GTP_MESSAGE_H
+#ifndef OGS_GTP2_MESSAGE_H
+#define OGS_GTP2_MESSAGE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -450,12 +450,12 @@ extern "C" {
 /* 5.1 General format */
 #define OGS_GTPV1U_HEADER_LEN   8
 #define OGS_GTPV2C_HEADER_LEN   12
-#define OGS_GTP_TEID_LEN        4
-typedef struct ogs_gtp_header_s {
+#define OGS_GTP2_TEID_LEN        4
+typedef struct ogs_gtp2_header_s {
     union {
         struct {
-#define OGS_GTP_VERSION_0 0
-#define OGS_GTP_VERSION_1 1
+#define OGS_GTP2_VERSION_0 0
+#define OGS_GTP2_VERSION_1 1
         ED4(uint8_t version:3;,
             uint8_t piggybacked:1;,
             uint8_t teid_presence:1;,
@@ -482,14 +482,14 @@ typedef struct ogs_gtp_header_s {
         struct {
             uint32_t teid;
             /* sqn : 31bit ~ 8bit, spare : 7bit ~ 0bit */
-#define OGS_GTP_XID_TO_SQN(__xid) htobe32(((__xid) << 8))
-#define OGS_GTP_SQN_TO_XID(__sqn) (be32toh(__sqn) >> 8)
+#define OGS_GTP2_XID_TO_SQN(__xid) htobe32(((__xid) << 8))
+#define OGS_GTP2_SQN_TO_XID(__sqn) (be32toh(__sqn) >> 8)
             uint32_t sqn;
         };
         /* sqn : 31bit ~ 8bit, spare : 7bit ~ 0bit */
         uint32_t sqn_only;
     };
-} __attribute__ ((packed)) ogs_gtp_header_t;
+} __attribute__ ((packed)) ogs_gtp2_header_t;
 
 /* GTPv2-C message type */
 """)
@@ -497,13 +497,13 @@ typedef struct ogs_gtp_header_s {
 tmp = [(k, v["type"]) for k, v in msg_list.items()]
 sorted_msg_list = sorted(tmp, key=lambda tup: int(tup[1]))
 for (k, v) in sorted_msg_list:
-    f.write("#define OGS_GTP_" + v_upper(k) + "_TYPE " + v + "\n")
+    f.write("#define OGS_GTP2_" + v_upper(k) + "_TYPE " + v + "\n")
 f.write("\n")
 
 tmp = [(k, v["type"]) for k, v in type_list.items()]
 sorted_type_list = sorted(tmp, key=lambda tup: int(tup[1]))
 for (k, v) in sorted_type_list:
-    f.write("#define OGS_GTP_" + v_upper(k) + "_TYPE " + v + "\n")
+    f.write("#define OGS_GTP2_" + v_upper(k) + "_TYPE " + v + "\n")
 f.write("\n")
 
 f.write("/* Information Element TLV Descriptor */\n")
@@ -511,7 +511,7 @@ for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
     for instance in range(0, int(type_list[k]["max_instance"])+1):
-        f.write("extern ogs_tlv_desc_t ogs_gtp_tlv_desc_" + v_lower(k))
+        f.write("extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_" + v_lower(k))
         f.write("_" + str(instance) + ";\n")
 f.write("\n")
 
@@ -527,13 +527,13 @@ sorted_group_list = sorted(tmp, key=lambda tup: int(tup[1]))
 f.write("/* Group Information Element TLV Descriptor */\n")
 for (k, v) in sorted_group_list:
     for instance in range(0, int(type_list[k]["max_instance"])+1):
-        f.write("extern ogs_tlv_desc_t ogs_gtp_tlv_desc_" + v_lower(k))
+        f.write("extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_" + v_lower(k))
         f.write("_" + str(instance) + ";\n")
 f.write("\n")
 
 f.write("/* Message Descriptor */\n")
 for (k, v) in sorted_msg_list:
-    f.write("extern ogs_tlv_desc_t ogs_gtp_tlv_desc_" + v_lower(k) + ";\n")
+    f.write("extern ogs_tlv_desc_t ogs_gtp2_tlv_desc_" + v_lower(k) + ";\n")
 f.write("\n")
 
 f.write("/* Structure for Information Element */\n")
@@ -542,25 +542,25 @@ for (k, v) in sorted_type_list:
         continue
     if "size" in type_list[k]:
         if type_list[k]["size"] == 1:
-            f.write("typedef ogs_tlv_uint8_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+            f.write("typedef ogs_tlv_uint8_t ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
         elif type_list[k]["size"] == 2:
-            f.write("typedef ogs_tlv_uint16_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+            f.write("typedef ogs_tlv_uint16_t ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
         elif type_list[k]["size"] == 3:
-            f.write("typedef ogs_tlv_uint24_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+            f.write("typedef ogs_tlv_uint24_t ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
         elif type_list[k]["size"] == 4:
-            f.write("typedef ogs_tlv_uint32_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+            f.write("typedef ogs_tlv_uint32_t ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
         else:
             assert False, "Unknown size = %d for key = %s" % (type_list[k]["size"], k)
     else:
-        f.write("typedef ogs_tlv_octet_t ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+        f.write("typedef ogs_tlv_octet_t ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
 f.write("\n")
 
 f.write("/* Structure for Group Information Element */\n")
 for (k, v) in sorted_group_list:
-    f.write("typedef struct ogs_gtp_tlv_" + v_lower(k) + "_s {\n")
+    f.write("typedef struct ogs_gtp2_tlv_" + v_lower(k) + "_s {\n")
     f.write("    ogs_tlv_presence_t presence;\n")
     for ies in group_list[k]["ies"]:
-        f.write("    ogs_gtp_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
+        f.write("    ogs_gtp2_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
                 v_lower(ies["ie_value"]))
         if ies["ie_type"] == "F-TEID":
             if ies["ie_value"] == "S2b-U ePDG F-TEID":
@@ -572,40 +572,40 @@ for (k, v) in sorted_group_list:
             f.write(" /* Instance : " + ies["instance"] + " */\n")
         else:
             f.write(";\n")
-    f.write("} ogs_gtp_tlv_" + v_lower(k) + "_t;\n")
+    f.write("} ogs_gtp2_tlv_" + v_lower(k) + "_t;\n")
     f.write("\n")
 
 f.write("/* Structure for Message */\n")
 for (k, v) in sorted_msg_list:
     if "ies" in msg_list[k]:
-        f.write("typedef struct ogs_gtp_" + v_lower(k) + "_s {\n")
+        f.write("typedef struct ogs_gtp2_" + v_lower(k) + "_s {\n")
         for ies in msg_list[k]["ies"]:
             if (k == 'Create Indirect Data Forwarding Tunnel Request' or k == 'Create Indirect Data Forwarding Tunnel Response') and ies["ie_value"] == 'Bearer Contexts':
-                f.write("    ogs_gtp_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
+                f.write("    ogs_gtp2_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
                         v_lower(ies["ie_value"]) + "[8];\n")
             else:
-                f.write("    ogs_gtp_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
+                f.write("    ogs_gtp2_tlv_" + v_lower(ies["ie_type"]) + "_t " + \
                         v_lower(ies["ie_value"]) + ";\n")
-        f.write("} ogs_gtp_" + v_lower(k) + "_t;\n")
+        f.write("} ogs_gtp2_" + v_lower(k) + "_t;\n")
         f.write("\n")
 
-f.write("typedef struct ogs_gtp_message_s {\n")
-f.write("   ogs_gtp_header_t h;\n")
+f.write("typedef struct ogs_gtp2_message_s {\n")
+f.write("   ogs_gtp2_header_t h;\n")
 f.write("   union {\n")
 for (k, v) in sorted_msg_list:
     if "ies" in msg_list[k]:
-        f.write("        ogs_gtp_" + v_lower(k) + "_t " + v_lower(k) + ";\n");
+        f.write("        ogs_gtp2_" + v_lower(k) + "_t " + v_lower(k) + ";\n");
 f.write("   };\n");
-f.write("} ogs_gtp_message_t;\n\n")
+f.write("} ogs_gtp2_message_t;\n\n")
 
-f.write("""int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf);
-ogs_pkbuf_t *ogs_gtp_build_msg(ogs_gtp_message_t *gtp_message);
+f.write("""int ogs_gtp2_parse_msg(ogs_gtp2_message_t *gtp_message, ogs_pkbuf_t *pkbuf);
+ogs_pkbuf_t *ogs_gtp2_build_msg(ogs_gtp2_message_t *gtp_message);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OGS_GTP_MESSAGE_H */
+#endif /* OGS_GTP2_MESSAGE_H */
 """)
 f.close()
 
@@ -619,7 +619,7 @@ for (k, v) in sorted_type_list:
     if k in group_list.keys():
         continue
     for instance in range(0, int(type_list[k]["max_instance"])+1):
-        f.write("ogs_tlv_desc_t ogs_gtp_tlv_desc_%s_%d =\n" % (v_lower(k), instance))
+        f.write("ogs_tlv_desc_t ogs_gtp2_tlv_desc_%s_%d =\n" % (v_lower(k), instance))
         f.write("{\n")
         if "size" in type_list[k]:
             if type_list[k]["size"] == 1:
@@ -635,89 +635,89 @@ for (k, v) in sorted_type_list:
         else:
             f.write("    OGS_TLV_VAR_STR,\n")
         f.write("    \"%s\",\n" % k)
-        f.write("    OGS_GTP_%s_TYPE,\n" % v_upper(k))
+        f.write("    OGS_GTP2_%s_TYPE,\n" % v_upper(k))
         if "size" in type_list[k]:
             f.write("    %d,\n" % type_list[k]["size"])
         else:
             f.write("    0,\n")
         f.write("    %d,\n" % instance)
-        f.write("    sizeof(ogs_gtp_tlv_%s_t),\n" % v_lower(k))
+        f.write("    sizeof(ogs_gtp2_tlv_%s_t),\n" % v_lower(k))
         f.write("    { NULL }\n")
         f.write("};\n\n")
 
 for (k, v) in sorted_group_list:
     for instance in range(0, int(type_list[k]["max_instance"])+1):
-        f.write("ogs_tlv_desc_t ogs_gtp_tlv_desc_%s_%d =\n" % (v_lower(k), instance))
+        f.write("ogs_tlv_desc_t ogs_gtp2_tlv_desc_%s_%d =\n" % (v_lower(k), instance))
         f.write("{\n")
         f.write("    OGS_TLV_COMPOUND,\n")
         f.write("    \"%s\",\n" % k)
-        f.write("    OGS_GTP_%s_TYPE,\n" % v_upper(k))
+        f.write("    OGS_GTP2_%s_TYPE,\n" % v_upper(k))
         f.write("    0,\n")
         f.write("    %d,\n" % instance)
-        f.write("    sizeof(ogs_gtp_tlv_%s_t),\n" % v_lower(k))
+        f.write("    sizeof(ogs_gtp2_tlv_%s_t),\n" % v_lower(k))
         f.write("    {\n")
         for ies in group_list[k]["ies"]:
-                f.write("        &ogs_gtp_tlv_desc_%s_%s,\n" % (v_lower(ies["ie_type"]), v_lower(ies["instance"])))
+                f.write("        &ogs_gtp2_tlv_desc_%s_%s,\n" % (v_lower(ies["ie_type"]), v_lower(ies["instance"])))
         f.write("        NULL,\n")
         f.write("    }\n")
         f.write("};\n\n")
 
 for (k, v) in sorted_msg_list:
     if "ies" in msg_list[k]:
-        f.write("ogs_tlv_desc_t ogs_gtp_tlv_desc_%s =\n" % v_lower(k))
+        f.write("ogs_tlv_desc_t ogs_gtp2_tlv_desc_%s =\n" % v_lower(k))
         f.write("{\n")
         f.write("    OGS_TLV_MESSAGE,\n")
         f.write("    \"%s\",\n" % k)
         f.write("    0, 0, 0, 0, {\n")
         for ies in msg_list[k]["ies"]:
-            f.write("        &ogs_gtp_tlv_desc_%s_%s,\n" % (v_lower(ies["ie_type"]), v_lower(ies["instance"])))
+            f.write("        &ogs_gtp2_tlv_desc_%s_%s,\n" % (v_lower(ies["ie_type"]), v_lower(ies["instance"])))
             if (k == 'Create Indirect Data Forwarding Tunnel Request' or k == 'Create Indirect Data Forwarding Tunnel Response') and ies["ie_value"] == 'Bearer Contexts':
                 f.write("        &ogs_tlv_desc_more8,\n")
         f.write("    NULL,\n")
         f.write("}};\n\n")
 f.write("\n")
 
-f.write("""int ogs_gtp_parse_msg(ogs_gtp_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
+f.write("""int ogs_gtp2_parse_msg(ogs_gtp2_message_t *gtp_message, ogs_pkbuf_t *pkbuf)
 {
     int rv = OGS_ERROR;
-    ogs_gtp_header_t *h = NULL;
+    ogs_gtp2_header_t *h = NULL;
     uint16_t size = 0;
 
-    ogs_assert(gtp_message);
+    ogs_assert(gtp2_message);
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->len);
 
-    h = (ogs_gtp_header_t *)pkbuf->data;
+    h = (ogs_gtp2_header_t *)pkbuf->data;
     ogs_assert(h);
     
-    memset(gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(gtp2_message, 0, sizeof(ogs_gtp2_message_t));
 
     if (h->teid_presence)
         size = OGS_GTPV2C_HEADER_LEN;
     else
-        size = OGS_GTPV2C_HEADER_LEN-OGS_GTP_TEID_LEN;
+        size = OGS_GTPV2C_HEADER_LEN-OGS_GTP2_TEID_LEN;
 
     ogs_assert(ogs_pkbuf_pull(pkbuf, size));
-    memcpy(&gtp_message->h, pkbuf->data - size, size);
+    memcpy(&gtp2_message->h, pkbuf->data - size, size);
 
     if (h->teid_presence)
-        gtp_message->h.teid = be32toh(gtp_message->h.teid);
+        gtp2_message->h.teid = be32toh(gtp_message->h.teid);
 
     if (pkbuf->len == 0) {
         ogs_assert(ogs_pkbuf_push(pkbuf, size));
         return OGS_OK;
     }
 
-    switch(gtp_message->h.type) {
+    switch(gtp2_message->h.type) {
 """)
 for (k, v) in sorted_msg_list:
     if "ies" in msg_list[k]:
-        f.write("    case OGS_GTP_%s_TYPE:\n" % v_upper(k))
-        f.write("        rv = ogs_tlv_parse_msg(&gtp_message->%s,\n" % v_lower(k))
-        f.write("                &ogs_gtp_tlv_desc_%s, pkbuf, OGS_TLV_MODE_T1_L2_I1);\n" % v_lower(k))
+        f.write("    case OGS_GTP2_%s_TYPE:\n" % v_upper(k))
+        f.write("        rv = ogs_tlv_parse_msg(&gtp2_message->%s,\n" % v_lower(k))
+        f.write("                &ogs_gtp2_tlv_desc_%s, pkbuf, OGS_TLV_MODE_T1_L2_I1);\n" % v_lower(k))
         f.write("        break;\n")
 f.write("""    default:
-        ogs_warn("Not implmeneted(type:%d)", gtp_message->h.type);
+        ogs_warn("Not implmeneted(type:%d)", gtp2_message->h.type);
         break;
     }
 
@@ -728,21 +728,21 @@ f.write("""    default:
 
 """)
 
-f.write("""ogs_pkbuf_t *ogs_gtp_build_msg(ogs_gtp_message_t *gtp_message)
+f.write("""ogs_pkbuf_t *ogs_gtp2_build_msg(ogs_gtp2_message_t *gtp_message)
 {
     ogs_pkbuf_t *pkbuf = NULL;
 
-    ogs_assert(gtp_message);
-    switch(gtp_message->h.type) {
+    ogs_assert(gtp2_message);
+    switch(gtp2_message->h.type) {
 """)
 for (k, v) in sorted_msg_list:
     if "ies" in msg_list[k]:
-        f.write("    case OGS_GTP_%s_TYPE:\n" % v_upper(k))
-        f.write("        pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_%s,\n" % v_lower(k))
-        f.write("                &gtp_message->%s, OGS_TLV_MODE_T1_L2_I1);\n" % v_lower(k))
+        f.write("    case OGS_GTP2_%s_TYPE:\n" % v_upper(k))
+        f.write("        pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_%s,\n" % v_lower(k))
+        f.write("                &gtp2_message->%s, OGS_TLV_MODE_T1_L2_I1);\n" % v_lower(k))
         f.write("        break;\n")
 f.write("""    default:
-        ogs_warn("Not implmeneted(type:%d)", gtp_message->h.type);
+        ogs_warn("Not implmeneted(type:%d)", gtp2_message->h.type);
         break;
     }
 

--- a/lib/gtp/v2/types.c
+++ b/lib/gtp/v2/types.c
@@ -23,17 +23,17 @@
  * 10.5.6.3 Protocol configuration options in 3GPP TS 24.008 */
 
 /* 8.15 Bearer Quality of Service (Bearer QoS) */
-int16_t ogs_gtp_parse_bearer_qos(
-    ogs_gtp_bearer_qos_t *bearer_qos, ogs_tlv_octet_t *octet)
+int16_t ogs_gtp2_parse_bearer_qos(
+    ogs_gtp2_bearer_qos_t *bearer_qos, ogs_tlv_octet_t *octet)
 {
-    ogs_gtp_bearer_qos_t *source = (ogs_gtp_bearer_qos_t *)octet->data;
+    ogs_gtp2_bearer_qos_t *source = (ogs_gtp2_bearer_qos_t *)octet->data;
     int16_t size = 0;
 
     ogs_assert(bearer_qos);
     ogs_assert(octet);
-    ogs_assert(octet->len == GTP_BEARER_QOS_LEN);
+    ogs_assert(octet->len == GTP2_BEARER_QOS_LEN);
 
-    memset(bearer_qos, 0, sizeof(ogs_gtp_bearer_qos_t));
+    memset(bearer_qos, 0, sizeof(ogs_gtp2_bearer_qos_t));
 
     bearer_qos->pre_emption_capability = source->pre_emption_capability;
     bearer_qos->priority_level = source->priority_level;
@@ -66,19 +66,19 @@ int16_t ogs_gtp_parse_bearer_qos(
     
     return size;
 }
-int16_t ogs_gtp_build_bearer_qos(ogs_tlv_octet_t *octet,
-        ogs_gtp_bearer_qos_t *bearer_qos, void *data, int data_len)
+int16_t ogs_gtp2_build_bearer_qos(ogs_tlv_octet_t *octet,
+        ogs_gtp2_bearer_qos_t *bearer_qos, void *data, int data_len)
 {
-    ogs_gtp_bearer_qos_t target;
+    ogs_gtp2_bearer_qos_t target;
     int16_t size = 0;
 
     ogs_assert(bearer_qos);
     ogs_assert(octet);
     ogs_assert(data);
-    ogs_assert(data_len >= GTP_BEARER_QOS_LEN);
+    ogs_assert(data_len >= GTP2_BEARER_QOS_LEN);
 
     octet->data = data;
-    memcpy(&target, bearer_qos, sizeof(ogs_gtp_bearer_qos_t));
+    memcpy(&target, bearer_qos, sizeof(ogs_gtp2_bearer_qos_t));
 
     memcpy((unsigned char *)octet->data + size, &target, 2);
     size += 2;
@@ -108,7 +108,7 @@ int16_t ogs_gtp_build_bearer_qos(ogs_tlv_octet_t *octet,
 }
 
 /* 8.16 Flow Quality of Service (Flow QoS) */
-uint64_t ogs_gtp_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2)
+uint64_t ogs_gtp2_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2)
 {
     /*
      * Octet 12 : 00000000
@@ -198,17 +198,17 @@ uint64_t ogs_gtp_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2)
     return 0;
 }
 
-int16_t ogs_gtp_parse_flow_qos(
-    ogs_gtp_flow_qos_t *flow_qos, ogs_tlv_octet_t *octet)
+int16_t ogs_gtp2_parse_flow_qos(
+    ogs_gtp2_flow_qos_t *flow_qos, ogs_tlv_octet_t *octet)
 {
-    ogs_gtp_flow_qos_t *source = (ogs_gtp_flow_qos_t *)octet->data;
+    ogs_gtp2_flow_qos_t *source = (ogs_gtp2_flow_qos_t *)octet->data;
     int16_t size = 0;
 
     ogs_assert(flow_qos);
     ogs_assert(octet);
-    ogs_assert(octet->len == GTP_FLOW_QOS_LEN);
+    ogs_assert(octet->len == GTP2_FLOW_QOS_LEN);
 
-    memset(flow_qos, 0, sizeof(ogs_gtp_flow_qos_t));
+    memset(flow_qos, 0, sizeof(ogs_gtp2_flow_qos_t));
 
     flow_qos->qci = source->qci;
     size++;
@@ -236,19 +236,19 @@ int16_t ogs_gtp_parse_flow_qos(
     
     return size;
 }
-int16_t ogs_gtp_build_flow_qos(ogs_tlv_octet_t *octet,
-        ogs_gtp_flow_qos_t *flow_qos, void *data, int data_len)
+int16_t ogs_gtp2_build_flow_qos(ogs_tlv_octet_t *octet,
+        ogs_gtp2_flow_qos_t *flow_qos, void *data, int data_len)
 {
-    ogs_gtp_flow_qos_t target;
+    ogs_gtp2_flow_qos_t target;
     int16_t size = 0;
 
     ogs_assert(flow_qos);
     ogs_assert(octet);
     ogs_assert(data);
-    ogs_assert(data_len >= GTP_FLOW_QOS_LEN);
+    ogs_assert(data_len >= GTP2_FLOW_QOS_LEN);
 
     octet->data = data;
-    memcpy(&target, flow_qos, sizeof(ogs_gtp_flow_qos_t));
+    memcpy(&target, flow_qos, sizeof(ogs_gtp2_flow_qos_t));
 
     memcpy((unsigned char *)octet->data + size, &target, 2);
     size += 1;
@@ -279,7 +279,7 @@ int16_t ogs_gtp_build_flow_qos(ogs_tlv_octet_t *octet,
 
 /* 8.19 EPS Bearer Level Traffic Flow Template (Bearer TFT) 
  * See subclause 10.5.6.12 in 3GPP TS 24.008 [13]. */
-int16_t ogs_gtp_parse_tft(ogs_gtp_tft_t *tft, ogs_tlv_octet_t *octet)
+int16_t ogs_gtp2_parse_tft(ogs_gtp2_tft_t *tft, ogs_tlv_octet_t *octet)
 {
     int16_t size = 0;
     int i, j, len = 0;
@@ -287,19 +287,19 @@ int16_t ogs_gtp_parse_tft(ogs_gtp_tft_t *tft, ogs_tlv_octet_t *octet)
     ogs_assert(tft);
     ogs_assert(octet);
 
-    memset(tft, 0, sizeof(ogs_gtp_tft_t));
+    memset(tft, 0, sizeof(ogs_gtp2_tft_t));
 
     ogs_assert(size+sizeof(tft->flags) <= octet->len);
     memcpy(&tft->flags, (unsigned char *)octet->data+size, sizeof(tft->flags));
     size++;
 
-    if (tft->code == OGS_GTP_TFT_CODE_IGNORE_THIS_IE) {
+    if (tft->code == OGS_GTP2_TFT_CODE_IGNORE_THIS_IE) {
         ogs_error("Invalid TFT Code(Spare)");
         return size;
     }
 
-    if (tft->code == OGS_GTP_TFT_CODE_NO_TFT_OPERATION ||
-        tft->code == OGS_GTP_TFT_CODE_DELETE_EXISTING_TFT)
+    if (tft->code == OGS_GTP2_TFT_CODE_NO_TFT_OPERATION ||
+        tft->code == OGS_GTP2_TFT_CODE_DELETE_EXISTING_TFT)
         return size;
 
     for (i = 0; i < tft->num_of_packet_filter &&
@@ -309,7 +309,7 @@ int16_t ogs_gtp_parse_tft(ogs_gtp_tft_t *tft, ogs_tlv_octet_t *octet)
                 sizeof(tft->pf[i].flags));
         size += sizeof(tft->pf[i].flags);
 
-        if (tft->code == OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING)
+        if (tft->code == OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING)
             continue;
 
         ogs_assert(size+sizeof(tft->pf[i].precedence) <= octet->len);
@@ -443,30 +443,30 @@ int16_t ogs_gtp_parse_tft(ogs_gtp_tft_t *tft, ogs_tlv_octet_t *octet)
 
     return size;
 }
-int16_t ogs_gtp_build_tft(
-    ogs_tlv_octet_t *octet, ogs_gtp_tft_t *tft, void *data, int data_len)
+int16_t ogs_gtp2_build_tft(
+    ogs_tlv_octet_t *octet, ogs_gtp2_tft_t *tft, void *data, int data_len)
 {
-    ogs_gtp_tft_t target;
+    ogs_gtp2_tft_t target;
     uint16_t size = 0;
     int i, j;
 
     ogs_assert(tft);
     ogs_assert(octet);
     ogs_assert(data);
-    ogs_assert(data_len >= OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE);
+    ogs_assert(data_len >= OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE);
 
-    ogs_assert(tft->code != OGS_GTP_TFT_CODE_IGNORE_THIS_IE);
+    ogs_assert(tft->code != OGS_GTP2_TFT_CODE_IGNORE_THIS_IE);
 
     octet->data = data;
-    memcpy(&target, tft, sizeof(ogs_gtp_tft_t));
+    memcpy(&target, tft, sizeof(ogs_gtp2_tft_t));
 
     ogs_assert(size + sizeof(target.flags) <= data_len);
     memcpy((unsigned char *)octet->data + size, &target.flags,
             sizeof(target.flags));
     size += sizeof(target.flags);
 
-    if (tft->code == OGS_GTP_TFT_CODE_NO_TFT_OPERATION ||
-        tft->code == OGS_GTP_TFT_CODE_DELETE_EXISTING_TFT)
+    if (tft->code == OGS_GTP2_TFT_CODE_NO_TFT_OPERATION ||
+        tft->code == OGS_GTP2_TFT_CODE_DELETE_EXISTING_TFT)
         return size;
 
     for (i = 0; i < target.num_of_packet_filter &&
@@ -476,7 +476,7 @@ int16_t ogs_gtp_build_tft(
                 sizeof(target.pf[i].flags));
         size += sizeof(target.pf[i].flags);
 
-        if (tft->code == OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING)
+        if (tft->code == OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING)
             continue;
 
         ogs_assert(size + sizeof(target.pf[i].precedence) <= data_len);
@@ -615,15 +615,15 @@ int16_t ogs_gtp_build_tft(
 
 
 /* 8.21 User Location Information (ULI) */
-int16_t ogs_gtp_parse_uli(ogs_gtp_uli_t *uli, ogs_tlv_octet_t *octet)
+int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
 {
-    ogs_gtp_uli_t *source = (ogs_gtp_uli_t *)octet->data;
+    ogs_gtp2_uli_t *source = (ogs_gtp2_uli_t *)octet->data;
     int16_t size = 0;
 
     ogs_assert(uli);
     ogs_assert(octet);
 
-    memset(uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(uli, 0, sizeof(ogs_gtp2_uli_t));
 
     uli->flags = source->flags;
     size++;
@@ -678,10 +678,10 @@ int16_t ogs_gtp_parse_uli(ogs_gtp_uli_t *uli, ogs_tlv_octet_t *octet)
 
     return size;
 }
-int16_t ogs_gtp_build_uli(
-        ogs_tlv_octet_t *octet, ogs_gtp_uli_t *uli, void *data, int data_len)
+int16_t ogs_gtp2_build_uli(
+        ogs_tlv_octet_t *octet, ogs_gtp2_uli_t *uli, void *data, int data_len)
 {
-    ogs_gtp_uli_t target;
+    ogs_gtp2_uli_t target;
     int16_t size = 0;
 
     ogs_assert(uli);
@@ -690,7 +690,7 @@ int16_t ogs_gtp_build_uli(
     ogs_assert(data_len);
 
     octet->data = data;
-    memcpy(&target, uli, sizeof(ogs_gtp_uli_t));
+    memcpy(&target, uli, sizeof(ogs_gtp2_uli_t));
 
     ogs_assert(size + sizeof(target.flags) <= data_len);
     memcpy((unsigned char *)octet->data + size,

--- a/lib/gtp/v2/types.h
+++ b/lib/gtp/v2/types.h
@@ -21,14 +21,14 @@
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_GTP_TYPES_H
-#define OGS_GTP_TYPES_H
+#ifndef OGS_GTP2_TYPES_H
+#define OGS_GTP2_TYPES_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define OGS_GTP_MAX_INDIRECT_TUNNEL 8
+#define OGS_GTP2_MAX_INDIRECT_TUNNEL 8
 
 #define OGS_GTPV1U_5GC_HEADER_LEN 16
 /*
@@ -50,120 +50,120 @@ extern "C" {
  */
 
 #define OGS_GTPV1U_EXTENSION_HEADER_LEN 4
-typedef struct ogs_gtp_extension_header_s {
-#define OGS_GTP_EXTENSION_HEADER_TYPE_UDP_PORT 0x40
-#define OGS_GTP_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER 0x85
-#define OGS_GTP_EXTENSION_HEADER_TYPE_NO_MORE_EXTENSION_HEADERS 0x0
+typedef struct ogs_gtp2_extension_header_s {
+#define OGS_GTP2_EXTENSION_HEADER_TYPE_UDP_PORT 0x40
+#define OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER 0x85
+#define OGS_GTP2_EXTENSION_HEADER_TYPE_NO_MORE_EXTENSION_HEADERS 0x0
     uint16_t sequence_number;
     uint8_t n_pdu_number;
     uint8_t type;
     uint8_t len;
-#define OGS_GTP_EXTENSION_HEADER_PDU_TYPE_DL_PDU_SESSION_INFORMATION 0
-#define OGS_GTP_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION 1
+#define OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_DL_PDU_SESSION_INFORMATION 0
+#define OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION 1
     ED2(uint8_t pdu_type:4;,
         uint8_t spare1:4;);
     ED3(uint8_t paging_policy_presence:1;,
         uint8_t reflective_qos_indicator:1;,
         uint8_t qos_flow_identifier:6;);
     uint8_t next_type;
-} __attribute__ ((packed)) ogs_gtp_extension_header_t;
+} __attribute__ ((packed)) ogs_gtp2_extension_header_t;
 
 /* 8.4 Cause */
-#define OGS_GTP_CAUSE_UNDEFINED_VALUE 0
-#define OGS_GTP_CAUSE_LOCAL_DETACH 2
-#define OGS_GTP_CAUSE_COMPLETE_DETACH_3
-#define OGS_GTP_CAUSE_RAT_CHANGED_FROM_3GPP_TO_NON_3GPP 4
-#define OGS_GTP_CAUSE_ISR_DEACTIVATION 5
-#define OGS_GTP_CAUSE_ERROR_INDICATION_RECEIVED 6
-#define OGS_GTP_CAUSE_IMSI_DETACH_ONLY 7
-#define OGS_GTP_CAUSE_REACTIVATION_REQUESTED 8
-#define OGS_GTP_CAUSE_PDN_RECONNECTION_TO_THIS_APN_DISALLOWED 9
-#define OGS_GTP_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP  10
-#define OGS_GTP_CAUSE_PDN_CONNECTION_INACTIVITY_TIMER_EXPIRES 11
-#define OGS_GTP_CAUSE_PGW_NOT_RESPONDING 12
-#define OGS_GTP_CAUSE_NETWORK_FAILURE 13
-#define OGS_GTP_CAUSE_QOS_PARAMETER_MISMATCH 14
-#define OGS_GTP_CAUSE_REQUEST_ACCEPTED 16
-#define OGS_GTP_CAUSE_REQUEST_ACCEPTED_PARTIALLY 17
-#define OGS_GTP_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE 18
-#define OGS_GTP_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY 19
-#define OGS_GTP_CAUSE_CONTEXT_NOT_FOUND 64
-#define OGS_GTP_CAUSE_INVALID_MESSAGE_FORMAT 65
-#define OGS_GTP_CAUSE_VERSION_NOT_SUPPORTED_BY_NEXT_PEER 66
-#define OGS_GTP_CAUSE_INVALID_LENGTH 67
-#define OGS_GTP_CAUSE_SERVICE_NOT_SUPPORTED 68
-#define OGS_GTP_CAUSE_MANDATORY_IE_INCORRECT 69
-#define OGS_GTP_CAUSE_MANDATORY_IE_MISSING  70
-#define OGS_GTP_CAUSE_SYSTEM_FAILURE 72
-#define OGS_GTP_CAUSE_NO_RESOURCES_AVAILABLE 73
-#define OGS_GTP_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION 74
-#define OGS_GTP_CAUSE_SYNTACTIC_ERROR_IN_THE_TFT_OPERATION  75
-#define OGS_GTP_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER 76
-#define OGS_GTP_CAUSE_SYNTACTIC_ERRORS_IN_PACKET_FILTER  77
-#define OGS_GTP_CAUSE_MISSING_OR_UNKNOWN_APN 78
-#define OGS_GTP_CAUSE_GRE_KEY_NOT_FOUND 80
-#define OGS_GTP_CAUSE_RELOCATION_FAILURE 81
-#define OGS_GTP_CAUSE_DENIED_IN_RAT 82
-#define OGS_GTP_CAUSE_PREFERRED_PDN_TYPE_NOT_SUPPORTED  83
-#define OGS_GTP_CAUSE_ALL_DYNAMIC_ADDRESSES_ARE_OCCUPIED 84
-#define OGS_GTP_CAUSE_UE_CONTEXT_WITHOUT_TFT_ALREADY_ACTIVATED 85
-#define OGS_GTP_CAUSE_PROTOCOL_TYPE_NOT_SUPPORTED 86
-#define OGS_GTP_CAUSE_UE_NOT_RESPONDING 87
-#define OGS_GTP_CAUSE_UE_REFUSES 88
-#define OGS_GTP_CAUSE_SERVICE_DENIED 89
-#define OGS_GTP_CAUSE_UNABLE_TO_PAGE_UE 90
-#define OGS_GTP_CAUSE_NO_MEMORY_AVAILABLE 91
-#define OGS_GTP_CAUSE_USER_AUTHENTICATION_FAILED 92
-#define OGS_GTP_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION 93
-#define OGS_GTP_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED 94
-#define OGS_GTP_CAUSE_P_TMSI_SIGNATURE_MISMATCH 95
-#define OGS_GTP_CAUSE_IMSI_IMEI_NOT_KNOWN 96
-#define OGS_GTP_CAUSE_SEMANTIC_ERROR_IN_THE_TAD_OPERATION 97
-#define OGS_GTP_CAUSE_SYNTACTIC_ERROR_IN_THE_TAD_OPERATION 98
-#define OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING 100
-#define OGS_GTP_CAUSE_COLLISION_WITH_NETWORK_INITIATED_REQUEST  101
-#define OGS_GTP_CAUSE_UNABLE_TO_PAGE_UE_DUE_TO_SUSPENSION 102
-#define OGS_GTP_CAUSE_CONDITIONAL_IE_MISSING 103
-#define OGS_GTP_CAUSE_APN_RESTRICTION_TYPE_INCOMPATIBLE 104
-#define OGS_GTP_CAUSE_INVALID_OVERALL_LENGTH 105
-#define OGS_GTP_CAUSE_DATA_FORWARDING_NOT_SUPPORTED 106
-#define OGS_GTP_CAUSE_INVALID_REPLY_FROM_REMOTE_PEER 107
-#define OGS_GTP_CAUSE_FALLBACK_TO_GTPV1 108
-#define OGS_GTP_CAUSE_INVALID_PEER 109
-#define OGS_GTP_CAUSE_TEMPORARILY_REJECTED_DUE_TO_HANDOVER_IN_PROGRESS 110
-#define OGS_GTP_CAUSE_MODIFICATIONS_NOT_LIMITED_TO_S1_U_BEARERS 111
-#define OGS_GTP_CAUSE_REQUEST_REJECTED_FOR_A_PMIPV6_REASON 112
-#define OGS_GTP_CAUSE_APN_CONGESTION 113
-#define OGS_GTP_CAUSE_BEARER_HANDLING_NOT_SUPPORTED 114
-#define OGS_GTP_CAUSE_UE_ALREADY_RE_ATTACHED 115
-#define OGS_GTP_CAUSE_MULTIPLE_PDN_CONNECTIONS_FOR_A_GIVEN_APN_NOT_ALLOWED  116
-#define OGS_GTP_CAUSE_TARGET_ACCESS_RESTRICTED_FOR_THE_SUBSCRIBER 117
-#define OGS_GTP_CAUSE_MME_SGSN_REFUSES_DUE_TO_VPLMN_POLICY  119
-#define OGS_GTP_CAUSE_GTP_C_ENTITY_CONGESTION 120
-#define OGS_GTP_CAUSE_LATE_OVERLAPPING_REQUEST  121
-#define OGS_GTP_CAUSE_TIMED_OUT_REQUEST 122
-#define OGS_GTP_CAUSE_UE_IS_TEMPORARILY_NOT_REACHABLE_DUE_TO_POWER_SAVING 123
-#define OGS_GTP_CAUSE_RELOCATION_FAILURE_DUE_TO_NAS_MESSAGE_REDIRECTION 124
-#define OGS_GTP_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER 125
-#define OGS_GTP_CAUSE_MULTIPLE_ACCESSES_TO_A_PDN_CONNECTION_NOT_ALLOWED 126
-#define OGS_GTP_CAUSE_REQUEST_REJECTED_DUE_TO_UE_CAPABILITY 127
+#define OGS_GTP2_CAUSE_UNDEFINED_VALUE 0
+#define OGS_GTP2_CAUSE_LOCAL_DETACH 2
+#define OGS_GTP2_CAUSE_COMPLETE_DETACH_3
+#define OGS_GTP2_CAUSE_RAT_CHANGED_FROM_3GPP_TO_NON_3GPP 4
+#define OGS_GTP2_CAUSE_ISR_DEACTIVATION 5
+#define OGS_GTP2_CAUSE_ERROR_INDICATION_RECEIVED 6
+#define OGS_GTP2_CAUSE_IMSI_DETACH_ONLY 7
+#define OGS_GTP2_CAUSE_REACTIVATION_REQUESTED 8
+#define OGS_GTP2_CAUSE_PDN_RECONNECTION_TO_THIS_APN_DISALLOWED 9
+#define OGS_GTP2_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP  10
+#define OGS_GTP2_CAUSE_PDN_CONNECTION_INACTIVITY_TIMER_EXPIRES 11
+#define OGS_GTP2_CAUSE_PGW_NOT_RESPONDING 12
+#define OGS_GTP2_CAUSE_NETWORK_FAILURE 13
+#define OGS_GTP2_CAUSE_QOS_PARAMETER_MISMATCH 14
+#define OGS_GTP2_CAUSE_REQUEST_ACCEPTED 16
+#define OGS_GTP2_CAUSE_REQUEST_ACCEPTED_PARTIALLY 17
+#define OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE 18
+#define OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY 19
+#define OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND 64
+#define OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT 65
+#define OGS_GTP2_CAUSE_VERSION_NOT_SUPPORTED_BY_NEXT_PEER 66
+#define OGS_GTP2_CAUSE_INVALID_LENGTH 67
+#define OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED 68
+#define OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT 69
+#define OGS_GTP2_CAUSE_MANDATORY_IE_MISSING  70
+#define OGS_GTP2_CAUSE_SYSTEM_FAILURE 72
+#define OGS_GTP2_CAUSE_NO_RESOURCES_AVAILABLE 73
+#define OGS_GTP2_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION 74
+#define OGS_GTP2_CAUSE_SYNTACTIC_ERROR_IN_THE_TFT_OPERATION  75
+#define OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER 76
+#define OGS_GTP2_CAUSE_SYNTACTIC_ERRORS_IN_PACKET_FILTER  77
+#define OGS_GTP2_CAUSE_MISSING_OR_UNKNOWN_APN 78
+#define OGS_GTP2_CAUSE_GRE_KEY_NOT_FOUND 80
+#define OGS_GTP2_CAUSE_RELOCATION_FAILURE 81
+#define OGS_GTP2_CAUSE_DENIED_IN_RAT 82
+#define OGS_GTP2_CAUSE_PREFERRED_PDN_TYPE_NOT_SUPPORTED  83
+#define OGS_GTP2_CAUSE_ALL_DYNAMIC_ADDRESSES_ARE_OCCUPIED 84
+#define OGS_GTP2_CAUSE_UE_CONTEXT_WITHOUT_TFT_ALREADY_ACTIVATED 85
+#define OGS_GTP2_CAUSE_PROTOCOL_TYPE_NOT_SUPPORTED 86
+#define OGS_GTP2_CAUSE_UE_NOT_RESPONDING 87
+#define OGS_GTP2_CAUSE_UE_REFUSES 88
+#define OGS_GTP2_CAUSE_SERVICE_DENIED 89
+#define OGS_GTP2_CAUSE_UNABLE_TO_PAGE_UE 90
+#define OGS_GTP2_CAUSE_NO_MEMORY_AVAILABLE 91
+#define OGS_GTP2_CAUSE_USER_AUTHENTICATION_FAILED 92
+#define OGS_GTP2_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION 93
+#define OGS_GTP2_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED 94
+#define OGS_GTP2_CAUSE_P_TMSI_SIGNATURE_MISMATCH 95
+#define OGS_GTP2_CAUSE_IMSI_IMEI_NOT_KNOWN 96
+#define OGS_GTP2_CAUSE_SEMANTIC_ERROR_IN_THE_TAD_OPERATION 97
+#define OGS_GTP2_CAUSE_SYNTACTIC_ERROR_IN_THE_TAD_OPERATION 98
+#define OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING 100
+#define OGS_GTP2_CAUSE_COLLISION_WITH_NETWORK_INITIATED_REQUEST  101
+#define OGS_GTP2_CAUSE_UNABLE_TO_PAGE_UE_DUE_TO_SUSPENSION 102
+#define OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING 103
+#define OGS_GTP2_CAUSE_APN_RESTRICTION_TYPE_INCOMPATIBLE 104
+#define OGS_GTP2_CAUSE_INVALID_OVERALL_LENGTH 105
+#define OGS_GTP2_CAUSE_DATA_FORWARDING_NOT_SUPPORTED 106
+#define OGS_GTP2_CAUSE_INVALID_REPLY_FROM_REMOTE_PEER 107
+#define OGS_GTP2_CAUSE_FALLBACK_TO_GTPV1 108
+#define OGS_GTP2_CAUSE_INVALID_PEER 109
+#define OGS_GTP2_CAUSE_TEMPORARILY_REJECTED_DUE_TO_HANDOVER_IN_PROGRESS 110
+#define OGS_GTP2_CAUSE_MODIFICATIONS_NOT_LIMITED_TO_S1_U_BEARERS 111
+#define OGS_GTP2_CAUSE_REQUEST_REJECTED_FOR_A_PMIPV6_REASON 112
+#define OGS_GTP2_CAUSE_APN_CONGESTION 113
+#define OGS_GTP2_CAUSE_BEARER_HANDLING_NOT_SUPPORTED 114
+#define OGS_GTP2_CAUSE_UE_ALREADY_RE_ATTACHED 115
+#define OGS_GTP2_CAUSE_MULTIPLE_PDN_CONNECTIONS_FOR_A_GIVEN_APN_NOT_ALLOWED  116
+#define OGS_GTP2_CAUSE_TARGET_ACCESS_RESTRICTED_FOR_THE_SUBSCRIBER 117
+#define OGS_GTP2_CAUSE_MME_SGSN_REFUSES_DUE_TO_VPLMN_POLICY  119
+#define OGS_GTP2_CAUSE_GTP_C_ENTITY_CONGESTION 120
+#define OGS_GTP2_CAUSE_LATE_OVERLAPPING_REQUEST  121
+#define OGS_GTP2_CAUSE_TIMED_OUT_REQUEST 122
+#define OGS_GTP2_CAUSE_UE_IS_TEMPORARILY_NOT_REACHABLE_DUE_TO_POWER_SAVING 123
+#define OGS_GTP2_CAUSE_RELOCATION_FAILURE_DUE_TO_NAS_MESSAGE_REDIRECTION 124
+#define OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER 125
+#define OGS_GTP2_CAUSE_MULTIPLE_ACCESSES_TO_A_PDN_CONNECTION_NOT_ALLOWED 126
+#define OGS_GTP2_CAUSE_REQUEST_REJECTED_DUE_TO_UE_CAPABILITY 127
 
-typedef struct ogs_gtp_cause_s {
+typedef struct ogs_gtp2_cause_s {
     uint8_t value;
 ED4(uint8_t spare:5;,
     uint8_t pce:1;,
     uint8_t bce:1;,
     uint8_t cs:1;)
-} __attribute__ ((packed)) ogs_gtp_cause_t;
+} __attribute__ ((packed)) ogs_gtp2_cause_t;
 
 /* 8.7 Aggregate Maximum Bit Rate (AMBR) */
-typedef struct ogs_gtp_ambr_s {
+typedef struct ogs_gtp2_ambr_s {
     uint32_t uplink;
     uint32_t downlink;
-} __attribute__ ((packed)) ogs_gtp_ambr_t;
+} __attribute__ ((packed)) ogs_gtp2_ambr_t;
 
 /* 8.12 Indication */
-typedef struct ogs_gtp_indication_s {
+typedef struct ogs_gtp2_indication_s {
 ED8(uint8_t dual_address_bearer_flag:1;,
     uint8_t direct_tunnel_flag:1;,
     uint8_t handover_indication:1;,
@@ -244,7 +244,7 @@ ED8(uint8_t spare1:1;,
     uint8_t notify_source_enodeb_indication:1;,
     uint8_t indirect_data_forwarding_with_upf_indication:1;,
     uint8_t emergency_pdu_session_indication:1;)
-} __attribute__ ((packed)) ogs_gtp_indication_t;
+} __attribute__ ((packed)) ogs_gtp2_indication_t;
 
 /* 8.13 Protocol Configuration Options (PCO)
  * 10.5.6.3 Protocol configuration options in 3GPP TS 24.008
@@ -252,8 +252,8 @@ ED8(uint8_t spare1:1;,
  * RFC 1661 [102] */
 
 /* 8.15 Bearer Quality of Service (Bearer QoS) */
-#define GTP_BEARER_QOS_LEN 22
-typedef struct ogs_gtp_bearer_qos_s {
+#define GTP2_BEARER_QOS_LEN 22
+typedef struct ogs_gtp2_bearer_qos_s {
 ED5(uint8_t spare1:1;,
     /* See 3GPP TS 29.212[29], clause 5.3.46 Pre-emption-Capability AVP. */
     uint8_t pre_emption_capability:1;,
@@ -274,16 +274,16 @@ ED5(uint8_t spare1:1;,
 
     /* NOTE : The encoding in 3GPP TS 24.301 [23] and 3GPP TS 36.413 [10]
      * is different from the encoding within this specification.  */
-} __attribute__ ((packed)) ogs_gtp_bearer_qos_t;
+} __attribute__ ((packed)) ogs_gtp2_bearer_qos_t;
 
-int16_t ogs_gtp_parse_bearer_qos(
-    ogs_gtp_bearer_qos_t *bearer_qos, ogs_tlv_octet_t *octet);
-int16_t ogs_gtp_build_bearer_qos(ogs_tlv_octet_t *octet,
-    ogs_gtp_bearer_qos_t *bearer_qos, void *data, int data_len);
+int16_t ogs_gtp2_parse_bearer_qos(
+    ogs_gtp2_bearer_qos_t *bearer_qos, ogs_tlv_octet_t *octet);
+int16_t ogs_gtp2_build_bearer_qos(ogs_tlv_octet_t *octet,
+    ogs_gtp2_bearer_qos_t *bearer_qos, void *data, int data_len);
 
 /* 8.16 Flow Quality of Service (Flow QoS) */
-#define GTP_FLOW_QOS_LEN 21
-typedef struct ogs_gtp_flow_qos_s {
+#define GTP2_FLOW_QOS_LEN 21
+typedef struct ogs_gtp2_flow_qos_s {
     uint8_t qci; /* specified in 3GPP TS 23.203 [48]. */
 
     /* specified in 3GPP TS 36.413 [10]. */
@@ -294,42 +294,42 @@ typedef struct ogs_gtp_flow_qos_s {
 
     /* NOTE : The encoding in 3GPP TS 24.301 [23] and 3GPP TS 36.413 [10]
      * is different from the encoding within this specification.  */
-} __attribute__ ((packed)) ogs_gtp_flow_qos_t;
+} __attribute__ ((packed)) ogs_gtp2_flow_qos_t;
 
-#define ogs_gtp_qos_to_bps(br, extended, extended2) \
-    ogs_gtp_qos_to_kbps(br, extended, extended2) * 1024;
+#define ogs_gtp2_qos_to_bps(br, extended, extended2) \
+    ogs_gtp2_qos_to_kbps(br, extended, extended2) * 1024;
 
-uint64_t ogs_gtp_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2);
+uint64_t ogs_gtp2_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2);
 
-int16_t ogs_gtp_parse_flow_qos(
-    ogs_gtp_flow_qos_t *flow_qos, ogs_tlv_octet_t *octet);
-int16_t ogs_gtp_build_flow_qos(ogs_tlv_octet_t *octet,
-    ogs_gtp_flow_qos_t *flow_qos, void *data, int data_len);
+int16_t ogs_gtp2_parse_flow_qos(
+    ogs_gtp2_flow_qos_t *flow_qos, ogs_tlv_octet_t *octet);
+int16_t ogs_gtp2_build_flow_qos(ogs_tlv_octet_t *octet,
+    ogs_gtp2_flow_qos_t *flow_qos, void *data, int data_len);
 
 /* 8.17 RAT Type */
-#define OGS_GTP_RAT_TYPE_UTRAN                                  1
-#define OGS_GTP_RAT_TYPE_GERAN                                  2
-#define OGS_GTP_RAT_TYPE_WLAN                                   3
-#define OGS_GTP_RAT_TYPE_GAN                                    4
-#define OGS_GTP_RAT_TYPE_HSPA_EVOLUTION                         5
-#define OGS_GTP_RAT_TYPE_EUTRAN                                 6
-#define OGS_GTP_RAT_TYPE_VIRTUAL                                7
-#define OGS_GTP_RAT_TYPE_EUTRAN_NB_IOT                          8
+#define OGS_GTP2_RAT_TYPE_UTRAN                                  1
+#define OGS_GTP2_RAT_TYPE_GERAN                                  2
+#define OGS_GTP2_RAT_TYPE_WLAN                                   3
+#define OGS_GTP2_RAT_TYPE_GAN                                    4
+#define OGS_GTP2_RAT_TYPE_HSPA_EVOLUTION                         5
+#define OGS_GTP2_RAT_TYPE_EUTRAN                                 6
+#define OGS_GTP2_RAT_TYPE_VIRTUAL                                7
+#define OGS_GTP2_RAT_TYPE_EUTRAN_NB_IOT                          8
 
 /* 8.19 EPS Bearer Level Traffic Flow Template (Bearer TFT)
  * See subclause 10.5.6.12 in 3GPP TS 24.008 [13]. */
-#define OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE 255
+#define OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE 255
 
-typedef struct ogs_gtp_tft_s {
+typedef struct ogs_gtp2_tft_s {
     union {
         struct {
-#define OGS_GTP_TFT_CODE_IGNORE_THIS_IE                         0
-#define OGS_GTP_TFT_CODE_CREATE_NEW_TFT                         1
-#define OGS_GTP_TFT_CODE_DELETE_EXISTING_TFT                    2
-#define OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT     3
-#define OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING     4
-#define OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING    5
-#define OGS_GTP_TFT_CODE_NO_TFT_OPERATION                       6
+#define OGS_GTP2_TFT_CODE_IGNORE_THIS_IE                         0
+#define OGS_GTP2_TFT_CODE_CREATE_NEW_TFT                         1
+#define OGS_GTP2_TFT_CODE_DELETE_EXISTING_TFT                    2
+#define OGS_GTP2_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT     3
+#define OGS_GTP2_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING     4
+#define OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING    5
+#define OGS_GTP2_TFT_CODE_NO_TFT_OPERATION                       6
 ED3(uint8_t code:3;,
     uint8_t e_bit:1;,
     uint8_t num_of_packet_filter:4;)
@@ -348,48 +348,48 @@ ED3(uint8_t code:3;,
         uint8_t precedence;
         ogs_pf_content_t content;
     } pf[OGS_MAX_NUM_OF_FLOW_IN_GTP];
-} ogs_gtp_tft_t;
+} ogs_gtp2_tft_t;
 
-int16_t ogs_gtp_parse_tft(ogs_gtp_tft_t *tft, ogs_tlv_octet_t *octet);
-int16_t ogs_gtp_build_tft(
-    ogs_tlv_octet_t *octet, ogs_gtp_tft_t *tft, void *data, int data_len);
+int16_t ogs_gtp2_parse_tft(ogs_gtp2_tft_t *tft, ogs_tlv_octet_t *octet);
+int16_t ogs_gtp2_build_tft(
+    ogs_tlv_octet_t *octet, ogs_gtp2_tft_t *tft, void *data, int data_len);
 
 /* 8.21 User Location Information (ULI) */
-#define OGS_GTP_MAX_ULI_LEN sizeof(ogs_gtp_uli_t)
-typedef struct ogs_gtp_uli_cgi_s {
+#define OGS_GTP2_MAX_ULI_LEN sizeof(ogs_gtp2_uli_t)
+typedef struct ogs_gtp2_uli_cgi_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint16_t lac;
     uint16_t ci;
-} __attribute__ ((packed)) ogs_gtp_uli_cgi_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_cgi_t;
 
-typedef struct ogs_gtp_uli_sai_s {
+typedef struct ogs_gtp2_uli_sai_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint16_t lac;
     uint16_t sac;
-} __attribute__ ((packed)) ogs_gtp_uli_sai_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_sai_t;
 
-typedef struct ogs_gtp_uli_rai_s {
+typedef struct ogs_gtp2_uli_rai_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint16_t lac;
     uint16_t rac;
-} __attribute__ ((packed)) ogs_gtp_uli_rai_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_rai_t;
 
-typedef struct ogs_gtp_uli_lai_s {
+typedef struct ogs_gtp2_uli_lai_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint16_t lac;
-} __attribute__ ((packed)) ogs_gtp_uli_lai_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_lai_t;
 
-typedef struct ogs_gtp_uli_tai_s {
+typedef struct ogs_gtp2_uli_tai_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint16_t tac;
-} __attribute__ ((packed)) ogs_gtp_uli_tai_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_tai_t;
 
-typedef struct ogs_gtp_uli_e_cgi_s {
+typedef struct ogs_gtp2_uli_e_cgi_s {
     ogs_nas_plmn_id_t nas_plmn_id;
     uint32_t cell_id;
-} __attribute__ ((packed)) ogs_gtp_uli_e_cgi_t;
+} __attribute__ ((packed)) ogs_gtp2_uli_e_cgi_t;
 
-typedef struct ogs_gtp_uli_s {
+typedef struct ogs_gtp2_uli_s {
     struct {
     ED7(uint8_t spare:2;,
         uint8_t lai:1;,
@@ -399,94 +399,94 @@ typedef struct ogs_gtp_uli_s {
         uint8_t sai:1;,
         uint8_t cgi:1;)
     } flags;
-    ogs_gtp_uli_cgi_t cgi;
-    ogs_gtp_uli_sai_t sai;
-    ogs_gtp_uli_rai_t rai;
-    ogs_gtp_uli_tai_t tai;
-    ogs_gtp_uli_e_cgi_t e_cgi;
-    ogs_gtp_uli_lai_t lai;
-} ogs_gtp_uli_t;
+    ogs_gtp2_uli_cgi_t cgi;
+    ogs_gtp2_uli_sai_t sai;
+    ogs_gtp2_uli_rai_t rai;
+    ogs_gtp2_uli_tai_t tai;
+    ogs_gtp2_uli_e_cgi_t e_cgi;
+    ogs_gtp2_uli_lai_t lai;
+} ogs_gtp2_uli_t;
 
-int16_t ogs_gtp_parse_uli(ogs_gtp_uli_t *uli, ogs_tlv_octet_t *octet);
-int16_t ogs_gtp_build_uli(ogs_tlv_octet_t *octet,
-        ogs_gtp_uli_t *uli, void *data, int data_len);
+int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet);
+int16_t ogs_gtp2_build_uli(ogs_tlv_octet_t *octet,
+        ogs_gtp2_uli_t *uli, void *data, int data_len);
 
 /* 8.22 Fully Qualified TEID (F-TEID) */
-#define OGS_GTP_F_TEID_S1_U_ENODEB_GTP_U                        0
-#define OGS_GTP_F_TEID_S1_U_SGW_GTP_U                           1
-#define OGS_GTP_F_TEID_S12_RNC_GTP_U                            2
-#define OGS_GTP_F_TEID_S12_SGW_GTP_U                            3
-#define OGS_GTP_F_TEID_S5_S8_SGW_GTP_U                          4
-#define OGS_GTP_F_TEID_S5_S8_PGW_GTP_U                          5
-#define OGS_GTP_F_TEID_S5_S8_SGW_GTP_C                          6
-#define OGS_GTP_F_TEID_S5_S8_PGW_GTP_C                          7
-#define OGS_GTP_F_TEID_S5_S8_SGW_PMIPV6                         8
-#define OGS_GTP_F_TEID_S5_S8_PGW_PMIPV6                         9
-#define OGS_GTP_F_TEID_S11_MME_GTP_C                            10
-#define OGS_GTP_F_TEID_S11_S4_SGW_GTP_C                         11
-#define OGS_GTP_F_TEID_S10_MME_GTP_C                            12
-#define OGS_GTP_F_TEID_S3_MME_GTP_C                             13
-#define OGS_GTP_F_TEID_S3_SGSN_GTP_C                            14
-#define OGS_GTP_F_TEID_S4_SGSN_GTP_U                            15
-#define OGS_GTP_F_TEID_S4_SGW_GTP_U                             16
-#define OGS_GTP_F_TEID_S4_SGSN_GTP_C                            17
-#define OGS_GTP_F_TEID_S16_SGSN_GTP_C                           18
-#define OGS_GTP_F_TEID_ENODEB_GTP_U_FOR_DL_DATA_FORWARDING      19
-#define OGS_GTP_F_TEID_ENODEB_GTP_U_FOR_UL_DATA_FORWARDING      20
-#define OGS_GTP_F_TEID_RNC_GTP_U_FOR_DATA_FORWARDING            21
-#define OGS_GTP_F_TEID_SGSN_GTP_U_FOR_DATA_FORWARDING           22
-#define OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING         23
-#define OGS_GTP_F_TEID_SM_MBMS_GW_GTP_C                         24
-#define OGS_GTP_F_TEID_SN_MBMS_GW_GTP_C                         25
-#define OGS_GTP_F_TEID_SM_MME_GTP_C                             26
-#define OGS_GTP_F_TEID_SN_SGSN_GTP_C                            27
-#define OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING         28
-#define OGS_GTP_F_TEID_SN_SGSN_GTP_U                            29
-#define OGS_GTP_F_TEID_S2B_EPDG_GTP_C                           30
-#define OGS_GTP_F_TEID_S2B_U_EPDG_GTP_U                         31
-#define OGS_GTP_F_TEID_S2B_PGW_GTP_C                            32
-#define OGS_GTP_F_TEID_S2B_U_PGW_GTP_U                          33
-#define OGS_GTP_F_TEID_S2A_TWAN_GTP_U                           34
-#define OGS_GTP_F_TEID_S2A_TWAN_GTP_C                           35
-#define OGS_GTP_F_TEID_S2A_PGW_GTP_C                            36
-#define OGS_GTP_F_TEID_S2A_PGW_GTP_U                            37
-#define OGS_GTP_F_TEID_S11_MME_GTP_U                            38
-#define OGS_GTP_F_TEID_S11_SGW_GTP_U                            39
+#define OGS_GTP2_F_TEID_S1_U_ENODEB_GTP_U                        0
+#define OGS_GTP2_F_TEID_S1_U_SGW_GTP_U                           1
+#define OGS_GTP2_F_TEID_S12_RNC_GTP_U                            2
+#define OGS_GTP2_F_TEID_S12_SGW_GTP_U                            3
+#define OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U                          4
+#define OGS_GTP2_F_TEID_S5_S8_PGW_GTP_U                          5
+#define OGS_GTP2_F_TEID_S5_S8_SGW_GTP_C                          6
+#define OGS_GTP2_F_TEID_S5_S8_PGW_GTP_C                          7
+#define OGS_GTP2_F_TEID_S5_S8_SGW_PMIPV6                         8
+#define OGS_GTP2_F_TEID_S5_S8_PGW_PMIPV6                         9
+#define OGS_GTP2_F_TEID_S11_MME_GTP_C                            10
+#define OGS_GTP2_F_TEID_S11_S4_SGW_GTP_C                         11
+#define OGS_GTP2_F_TEID_S10_MME_GTP_C                            12
+#define OGS_GTP2_F_TEID_S3_MME_GTP_C                             13
+#define OGS_GTP2_F_TEID_S3_SGSN_GTP_C                            14
+#define OGS_GTP2_F_TEID_S4_SGSN_GTP_U                            15
+#define OGS_GTP2_F_TEID_S4_SGW_GTP_U                             16
+#define OGS_GTP2_F_TEID_S4_SGSN_GTP_C                            17
+#define OGS_GTP2_F_TEID_S16_SGSN_GTP_C                           18
+#define OGS_GTP2_F_TEID_ENODEB_GTP_U_FOR_DL_DATA_FORWARDING      19
+#define OGS_GTP2_F_TEID_ENODEB_GTP_U_FOR_UL_DATA_FORWARDING      20
+#define OGS_GTP2_F_TEID_RNC_GTP_U_FOR_DATA_FORWARDING            21
+#define OGS_GTP2_F_TEID_SGSN_GTP_U_FOR_DATA_FORWARDING           22
+#define OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING         23
+#define OGS_GTP2_F_TEID_SM_MBMS_GW_GTP_C                         24
+#define OGS_GTP2_F_TEID_SN_MBMS_GW_GTP_C                         25
+#define OGS_GTP2_F_TEID_SM_MME_GTP_C                             26
+#define OGS_GTP2_F_TEID_SN_SGSN_GTP_C                            27
+#define OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING         28
+#define OGS_GTP2_F_TEID_SN_SGSN_GTP_U                            29
+#define OGS_GTP2_F_TEID_S2B_EPDG_GTP_C                           30
+#define OGS_GTP2_F_TEID_S2B_U_EPDG_GTP_U                         31
+#define OGS_GTP2_F_TEID_S2B_PGW_GTP_C                            32
+#define OGS_GTP2_F_TEID_S2B_U_PGW_GTP_U                          33
+#define OGS_GTP2_F_TEID_S2A_TWAN_GTP_U                           34
+#define OGS_GTP2_F_TEID_S2A_TWAN_GTP_C                           35
+#define OGS_GTP2_F_TEID_S2A_PGW_GTP_C                            36
+#define OGS_GTP2_F_TEID_S2A_PGW_GTP_U                            37
+#define OGS_GTP2_F_TEID_S11_MME_GTP_U                            38
+#define OGS_GTP2_F_TEID_S11_SGW_GTP_U                            39
 
-#define OGS_GTP_F_TEID_HDR_LEN          5
-#define OGS_GTP_F_TEID_IPV4_LEN         OGS_IPV4_LEN+OGS_GTP_F_TEID_HDR_LEN
-#define OGS_GTP_F_TEID_IPV6_LEN         OGS_IPV6_LEN+OGS_GTP_F_TEID_HDR_LEN
-#define OGS_GTP_F_TEID_IPV4V6_LEN       OGS_IPV4V6_LEN+OGS_GTP_F_TEID_HDR_LEN
-typedef struct ogs_gtp_f_teid_s {
+#define OGS_GTP2_F_TEID_HDR_LEN          5
+#define OGS_GTP2_F_TEID_IPV4_LEN         OGS_IPV4_LEN+OGS_GTP2_F_TEID_HDR_LEN
+#define OGS_GTP2_F_TEID_IPV6_LEN         OGS_IPV6_LEN+OGS_GTP2_F_TEID_HDR_LEN
+#define OGS_GTP2_F_TEID_IPV4V6_LEN       OGS_IPV4V6_LEN+OGS_GTP2_F_TEID_HDR_LEN
+typedef struct ogs_gtp2_f_teid_s {
 ED3(uint8_t       ipv4:1;,
     uint8_t       ipv6:1;,
     uint8_t       interface_type:6;)
     uint32_t      teid;
     union {
-        /* OGS_GTP_F_TEID_IPV4 */
+        /* OGS_GTP2_F_TEID_IPV4 */
         uint32_t addr;
 
-        /* OGS_GTP_F_TEID_IPV6 */
+        /* OGS_GTP2_F_TEID_IPV6 */
         uint8_t addr6[OGS_IPV6_LEN];
 
-        /* OGS_GTP_F_TEID_BOTH */
+        /* OGS_GTP2_F_TEID_BOTH */
         struct {
             uint32_t addr;
             uint8_t addr6[OGS_IPV6_LEN];
         } both;
     };
-} __attribute__ ((packed)) ogs_gtp_f_teid_t;
+} __attribute__ ((packed)) ogs_gtp2_f_teid_t;
 
 /* 8.44 UE Time Zone */
-#define OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME 0
-#define OGS_GTP_UE_TIME_ZONE_1_HOUR_FOR_DAYLIGHT_SAVING_TIME        1
-#define OGS_GTP_UE_TIME_ZONE_2_HOUR_FOR_DAYLIGHT_SAVING_TIME        2
+#define OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME 0
+#define OGS_GTP2_UE_TIME_ZONE_1_HOUR_FOR_DAYLIGHT_SAVING_TIME        1
+#define OGS_GTP2_UE_TIME_ZONE_2_HOUR_FOR_DAYLIGHT_SAVING_TIME        2
 /* Time Zone" IE in 3GPP TS 24.008 [5].
  * This field uses the same format as the Timezone field used in the
  * TP-Service-Centre-Time-Stamp, which is defined in 3GPP TS 23.040 [90],
  * and its value shall be set as defined in 3GPP TS 22.042 */
-typedef struct ogs_gtp_ue_timezone_s {
-#define OGS_GTP_TIME_TO_BCD(x) OGS_TIME_TO_BCD(x)
+typedef struct ogs_gtp2_ue_timezone_s {
+#define OGS_GTP2_TIME_TO_BCD(x) OGS_TIME_TO_BCD(x)
     /* The Time Zone indicates the difference, expressed in quarters of an hour,
      * between the local time and GMT. In the first of the two semi-octets,
      * the first bit (bit 3 of the seventh octet of
@@ -495,36 +495,36 @@ typedef struct ogs_gtp_ue_timezone_s {
     uint8_t timezone;
 ED2(uint8_t spare:6;,
     uint8_t daylight_saving_time:2;)
-} __attribute__ ((packed)) ogs_gtp_ue_timezone_t;
+} __attribute__ ((packed)) ogs_gtp2_ue_timezone_t;
 
 /* 8.57 APN Restriction */
-#define OGS_GTP_APN_NO_RESTRICTION                              0
-#define OGS_GTP_APN_RESTRICTION_PUBLIC_1                        1
-#define OGS_GTP_APN_RESTRICTION_PUBLIC_2                        2
-#define OGS_GTP_APN_RESTRICTION_PRIVATE_1                       3
-#define OGS_GTP_APN_RESTRICTION_PRIVATE_2                       4
+#define OGS_GTP2_APN_NO_RESTRICTION                              0
+#define OGS_GTP2_APN_RESTRICTION_PUBLIC_1                        1
+#define OGS_GTP2_APN_RESTRICTION_PUBLIC_2                        2
+#define OGS_GTP2_APN_RESTRICTION_PRIVATE_1                       3
+#define OGS_GTP2_APN_RESTRICTION_PRIVATE_2                       4
 
 /* 8.58 Selection Mode */
-#define OGS_GTP_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN       0
-#define OGS_GTP_SELECTION_MODE_MS_PROVIDED_APN                  1
-#define OGS_GTP_SELECTION_MODE_NETWORK_PROVIDED_APN             2
+#define OGS_GTP2_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN       0
+#define OGS_GTP2_SELECTION_MODE_MS_PROVIDED_APN                  1
+#define OGS_GTP2_SELECTION_MODE_NETWORK_PROVIDED_APN             2
 
 /* 8.65 Node Type */
-#define OGS_GTP_NODE_TYPE_MME                                   0
-#define OGS_GTP_NODE_TYPE_SGSN                                  1
+#define OGS_GTP2_NODE_TYPE_MME                                   0
+#define OGS_GTP2_NODE_TYPE_SGSN                                  1
 
 /* 8.86 Allocation/Retention Priority (ARP) */
-typedef struct ogs_gtp_arp_s {
-#define OGS_GTP_TIME_TO_BCD(x) OGS_TIME_TO_BCD(x)
+typedef struct ogs_gtp2_arp_s {
+#define OGS_GTP2_TIME_TO_BCD(x) OGS_TIME_TO_BCD(x)
 ED5(uint8_t spare1:1;,
     uint8_t pre_emption_vulnerability:1;,
     uint8_t priority_level:4;,
     uint8_t spare2:1;,
     uint8_t pre_emption_capability:1;)
-} __attribute__ ((packed)) ogs_gtp_arp_t;
+} __attribute__ ((packed)) ogs_gtp2_arp_t;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OGS_GTP_TYPES_H */
+#endif /* OGS_GTP2_TYPES_H */

--- a/lib/gtp/xact.h
+++ b/lib/gtp/xact.h
@@ -121,7 +121,7 @@ ogs_gtp_xact_t *ogs_gtp1_xact_local_create(ogs_gtp_node_t *gnode,
         ogs_gtp1_header_t *hdesc, ogs_pkbuf_t *pkbuf,
         void (*cb)(ogs_gtp_xact_t *xact, void *data), void *data);
 ogs_gtp_xact_t *ogs_gtp_xact_local_create(ogs_gtp_node_t *gnode,
-        ogs_gtp_header_t *hdesc, ogs_pkbuf_t *pkbuf,
+        ogs_gtp2_header_t *hdesc, ogs_pkbuf_t *pkbuf,
         void (*cb)(ogs_gtp_xact_t *xact, void *data), void *data);
 
 ogs_gtp_xact_t *ogs_gtp_xact_cycle(ogs_gtp_xact_t *xact);
@@ -130,14 +130,14 @@ void ogs_gtp_xact_delete_all(ogs_gtp_node_t *gnode);
 int ogs_gtp1_xact_update_tx(ogs_gtp_xact_t *xact,
         ogs_gtp1_header_t *hdesc, ogs_pkbuf_t *pkbuf);
 int ogs_gtp_xact_update_tx(ogs_gtp_xact_t *xact,
-        ogs_gtp_header_t *hdesc, ogs_pkbuf_t *pkbuf);
+        ogs_gtp2_header_t *hdesc, ogs_pkbuf_t *pkbuf);
 
 int ogs_gtp_xact_commit(ogs_gtp_xact_t *xact);
 
 int ogs_gtp1_xact_receive(ogs_gtp_node_t *gnode,
         ogs_gtp1_header_t *h, ogs_gtp_xact_t **xact);
 int ogs_gtp_xact_receive(ogs_gtp_node_t *gnode,
-        ogs_gtp_header_t *h, ogs_gtp_xact_t **xact);
+        ogs_gtp2_header_t *h, ogs_gtp_xact_t **xact);
 
 void ogs_gtp_xact_associate(ogs_gtp_xact_t *xact1, ogs_gtp_xact_t *xact2);
 void ogs_gtp_xact_deassociate(ogs_gtp_xact_t *xact1, ogs_gtp_xact_t *xact2);

--- a/lib/pfcp/path.c
+++ b/lib/pfcp/path.c
@@ -279,8 +279,8 @@ void ogs_pfcp_send_g_pdu(ogs_pfcp_pdr_t *pdr, ogs_pkbuf_t *sendbuf)
     ogs_gtp_node_t *gnode = NULL;
     ogs_pfcp_far_t *far = NULL;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_assert(pdr);
     ogs_assert(sendbuf);
@@ -310,7 +310,7 @@ void ogs_pfcp_send_g_pdu(ogs_pfcp_pdr_t *pdr, ogs_pkbuf_t *sendbuf)
     if (pdr->qer && pdr->qer->qfi)
         ext_hdesc.qos_flow_identifier = pdr->qer->qfi;
 
-    ogs_gtp_send_user_plane(gnode, &gtp_hdesc, &ext_hdesc, sendbuf);
+    ogs_gtp2_send_user_plane(gnode, &gtp_hdesc, &ext_hdesc, sendbuf);
 }
 
 int ogs_pfcp_send_end_marker(ogs_pfcp_pdr_t *pdr)
@@ -320,8 +320,8 @@ int ogs_pfcp_send_end_marker(ogs_pfcp_pdr_t *pdr)
 
     ogs_pkbuf_t *sendbuf = NULL;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_assert(pdr);
     far = pdr->far;
@@ -349,7 +349,7 @@ int ogs_pfcp_send_end_marker(ogs_pfcp_pdr_t *pdr)
     if (pdr->qer && pdr->qer->qfi)
         ext_hdesc.qos_flow_identifier = pdr->qer->qfi;
 
-    ogs_gtp_send_user_plane(gnode, &gtp_hdesc, &ext_hdesc, sendbuf);
+    ogs_gtp2_send_user_plane(gnode, &gtp_hdesc, &ext_hdesc, sendbuf);
 
     return OGS_OK;
 }

--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -587,7 +587,7 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e)
                         mme_ue->imsi_bcd);
                 CLEAR_MME_UE_TIMER(mme_ue->t3413);
 
-                mme_send_after_paging(mme_ue, OGS_GTP_CAUSE_UNABLE_TO_PAGE_UE);
+                mme_send_after_paging(mme_ue, OGS_GTP2_CAUSE_UNABLE_TO_PAGE_UE);
 
                 if (CS_CALL_SERVICE_INDICATOR(mme_ue) ||
                     SMS_SERVICE_INDICATOR(mme_ue)) {

--- a/src/mme/esm-sm.c
+++ b/src/mme/esm-sm.c
@@ -36,18 +36,18 @@ static uint8_t gtp_cause_from_esm(uint8_t esm_cause)
 {
     switch (esm_cause) {
     case ESM_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION:
-        return OGS_GTP_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
+        return OGS_GTP2_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
     case ESM_CAUSE_SYNTACTICAL_ERROR_IN_THE_TFT_OPERATION:
-        return OGS_GTP_CAUSE_SYNTACTIC_ERROR_IN_THE_TFT_OPERATION;
+        return OGS_GTP2_CAUSE_SYNTACTIC_ERROR_IN_THE_TFT_OPERATION;
     case ESM_CAUSE_SYNTACTICAL_ERROR_IN_PACKET_FILTERS:
-        return OGS_GTP_CAUSE_SYNTACTIC_ERRORS_IN_PACKET_FILTER;
+        return OGS_GTP2_CAUSE_SYNTACTIC_ERRORS_IN_PACKET_FILTER;
     case ESM_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTERS:
-        return OGS_GTP_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER;
+        return OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER;
     default:
         break;
     }
 
-    return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+    return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
 }
 
 void esm_state_initial(ogs_fsm_t *s, mme_event_t *e)
@@ -195,7 +195,7 @@ void esm_state_inactive(ogs_fsm_t *s, mme_event_t *e)
             if (MME_HAVE_ENB_S1U_PATH(bearer)) {
                 ogs_assert(OGS_OK ==
                     mme_gtp_send_create_bearer_response(
-                        bearer, OGS_GTP_CAUSE_REQUEST_ACCEPTED));
+                        bearer, OGS_GTP2_CAUSE_REQUEST_ACCEPTED));
             }
 
             OGS_FSM_TRAN(s, esm_state_active);
@@ -318,7 +318,7 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
 
             ogs_assert(OGS_OK ==
                 mme_gtp_send_update_bearer_response(
-                    bearer, OGS_GTP_CAUSE_REQUEST_ACCEPTED));
+                    bearer, OGS_GTP2_CAUSE_REQUEST_ACCEPTED));
             break;
         case OGS_NAS_EPS_DEACTIVATE_EPS_BEARER_CONTEXT_ACCEPT:
             ogs_debug("Deactivate EPS bearer "
@@ -327,7 +327,7 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
                     mme_ue->imsi_bcd, sess->pti, bearer->ebi);
             ogs_assert(OGS_OK ==
                 mme_gtp_send_delete_bearer_response(
-                    bearer, OGS_GTP_CAUSE_REQUEST_ACCEPTED));
+                    bearer, OGS_GTP2_CAUSE_REQUEST_ACCEPTED));
             OGS_FSM_TRAN(s, esm_state_bearer_deactivated);
             break;
         case OGS_NAS_EPS_BEARER_RESOURCE_ALLOCATION_REQUEST:

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -86,21 +86,21 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
     type = xact->seq[0].type;
 
     switch (type) {
-    case OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
-    case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
-    case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+    case OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
         mme_ue = data;
         ogs_assert(mme_ue);
         break;
-    case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
-    case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
         sess = data;
         ogs_assert(sess);
         mme_ue = sess->mme_ue;
         ogs_assert(mme_ue);
         break;
-    case OGS_GTP_MODIFY_BEARER_REQUEST_TYPE:
-    case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
+    case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
         bearer = data;
         ogs_assert(bearer);
         sess = bearer->sess;
@@ -117,7 +117,7 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
     ogs_assert(mme_ue);
 
     switch (type) {
-    case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
         /*
          * If SESSION_CONTEXT_WILL_DELETED(MME_UE) is not cleared,
          * The MME cannot send Delete-Session-Request to the SGW-C.
@@ -139,7 +139,7 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
             ogs_warn("No S1 Context");
         }
         break;
-    case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
+    case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
         /* Nothing to do */
         break;
     default:
@@ -202,7 +202,7 @@ void mme_gtp_close(void)
 int mme_gtp_send_create_session_request(mme_sess_t *sess, bool esm_piggybacked)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
@@ -210,8 +210,8 @@ int mme_gtp_send_create_session_request(mme_sess_t *sess, bool esm_piggybacked)
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_CREATE_SESSION_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_session_request(h.type, sess);
@@ -234,15 +234,15 @@ int mme_gtp_send_modify_bearer_request(mme_bearer_t *bearer, int uli_presence)
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
     mme_ue = bearer->mme_ue;
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_MODIFY_BEARER_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_modify_bearer_request(h.type, bearer, uli_presence);
@@ -261,7 +261,7 @@ int mme_gtp_send_delete_session_request(mme_sess_t *sess, int action)
 {
     int rv;
     ogs_pkbuf_t *s11buf = NULL;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
@@ -270,8 +270,8 @@ int mme_gtp_send_delete_session_request(mme_sess_t *sess, int action)
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DELETE_SESSION_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     s11buf = mme_s11_build_delete_session_request(h.type, sess);
@@ -332,7 +332,7 @@ int mme_gtp_send_create_bearer_response(
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
@@ -341,8 +341,8 @@ int mme_gtp_send_create_bearer_response(
     xact = ogs_gtp_xact_cycle(bearer->create.xact);
     ogs_assert(xact);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_CREATE_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_bearer_response(h.type, bearer, cause_value);
@@ -365,7 +365,7 @@ int mme_gtp_send_update_bearer_response(
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
@@ -374,8 +374,8 @@ int mme_gtp_send_update_bearer_response(
     xact = ogs_gtp_xact_cycle(bearer->update.xact);
     ogs_assert(xact);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_update_bearer_response(h.type, bearer, cause_value);
@@ -398,7 +398,7 @@ int mme_gtp_send_delete_bearer_response(
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
@@ -407,8 +407,8 @@ int mme_gtp_send_delete_bearer_response(
     xact = ogs_gtp_xact_cycle(bearer->delete.xact);
     ogs_assert(xact);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DELETE_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_delete_bearer_response(h.type, bearer, cause_value);
@@ -426,15 +426,15 @@ int mme_gtp_send_delete_bearer_response(
 int mme_gtp_send_release_access_bearers_request(mme_ue_t *mme_ue, int action)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(action);
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_release_access_bearers_request(h.type);
@@ -485,7 +485,7 @@ int mme_gtp_send_downlink_data_notification_ack(
     mme_ue_t *mme_ue = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *s11buf = NULL;
 
     ogs_assert(bearer);
@@ -495,8 +495,8 @@ int mme_gtp_send_downlink_data_notification_ack(
     ogs_assert(mme_ue);
 
     /* Build Downlink data notification ack */
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     s11buf = mme_s11_build_downlink_data_notification_ack(h.type, cause_value);
@@ -515,14 +515,14 @@ int mme_gtp_send_create_indirect_data_forwarding_tunnel_request(
         mme_ue_t *mme_ue)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_indirect_data_forwarding_tunnel_request(
@@ -542,15 +542,15 @@ int mme_gtp_send_delete_indirect_data_forwarding_tunnel_request(
         mme_ue_t *mme_ue, int action)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(action);
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = ogs_pkbuf_alloc(NULL, OGS_TLV_MAX_HEADROOM);
@@ -571,7 +571,7 @@ int mme_gtp_send_bearer_resource_command(
         mme_bearer_t *bearer, ogs_nas_eps_message_t *nas_message)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
@@ -581,8 +581,8 @@ int mme_gtp_send_bearer_resource_command(
     mme_ue = bearer->mme_ue;
     ogs_assert(mme_ue);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE;
     h.teid = mme_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_bearer_resource_command(h.type, bearer, nas_message);

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -97,13 +97,13 @@ void mme_send_after_paging(mme_ue_t *mme_ue, uint8_t cause_value)
                 type = xact->seq[xact->step-1].type;
 
                 switch (type) {
-                case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE:
+                case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
                     ogs_assert(OGS_OK ==
                         mme_gtp_send_downlink_data_notification_ack(
                             bearer, cause_value));
                     break;
-                case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
-                    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+                case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
+                    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                         ogs_assert(OGS_OK ==
                         nas_eps_send_activate_dedicated_bearer_context_request(
                                 bearer));
@@ -113,8 +113,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, uint8_t cause_value)
                                 bearer, cause_value));
                     }
                     break;
-                case OGS_GTP_UPDATE_BEARER_REQUEST_TYPE:
-                    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+                case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
+                    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                         ogs_assert(OGS_OK ==
                             nas_eps_send_modify_bearer_context_request(bearer,
                                 (xact->update_flags &
@@ -127,8 +127,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, uint8_t cause_value)
                                 bearer, cause_value));
                     }
                     break;
-                case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
-                    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+                case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
+                    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                         ogs_assert(OGS_OK ==
                         nas_eps_send_deactivate_bearer_context_request(bearer));
                     } else {

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -28,22 +28,22 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     ogs_session_t *session = NULL;
     mme_ue_t *mme_ue = NULL;
     mme_bearer_t *bearer = NULL;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_session_request_t *req = &gtp_message.create_session_request;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_session_request_t *req = &gtp_message.create_session_request;
 
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_f_teid_t mme_s11_teid, pgw_s5c_teid;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_f_teid_t mme_s11_teid, pgw_s5c_teid;
     int len;
-    ogs_gtp_ambr_t ambr;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
-    ogs_gtp_ue_timezone_t ue_timezone;
+    ogs_gtp2_ambr_t ambr;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
+    ogs_gtp2_ue_timezone_t ue_timezone;
     struct timeval now;
     struct tm time_exp;
     char apn[OGS_MAX_APN_LEN+1];
 	
-    ogs_gtp_indication_t indication;
+    ogs_gtp2_indication_t indication;
 
     ogs_assert(sess);
     session = sess->session;
@@ -57,7 +57,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     ogs_debug("Create Session Request");
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     ogs_assert(mme_ue->imsi_len);
     req->imsi.presence = 1;
@@ -76,7 +76,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
         req->msisdn.len = mme_ue->msisdn_len;
     }
 
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -84,20 +84,20 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
     req->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&req->user_location_information, &uli, 
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&req->user_location_information, &uli, 
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
     req->serving_network.presence = 1;
     req->serving_network.data = &uli.tai.nas_plmn_id;
     req->serving_network.len = sizeof(uli.tai.nas_plmn_id);
 
     req->rat_type.presence = 1;
-    req->rat_type.u8 = OGS_GTP_RAT_TYPE_EUTRAN;
+    req->rat_type.u8 = OGS_GTP2_RAT_TYPE_EUTRAN;
 
-    memset(&mme_s11_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    mme_s11_teid.interface_type = OGS_GTP_F_TEID_S11_MME_GTP_C;
+    memset(&mme_s11_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    mme_s11_teid.interface_type = OGS_GTP2_F_TEID_S11_MME_GTP_C;
     mme_s11_teid.teid = htobe32(mme_ue->mme_s11_teid);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             ogs_gtp_self()->gtpc_addr, ogs_gtp_self()->gtpc_addr6,
             &mme_s11_teid, &len);
     ogs_assert(rv == OGS_OK);
@@ -105,8 +105,8 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     req->sender_f_teid_for_control_plane.data = &mme_s11_teid;
     req->sender_f_teid_for_control_plane.len = len;
 
-    memset(&pgw_s5c_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    pgw_s5c_teid.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_C;
+    memset(&pgw_s5c_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    pgw_s5c_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_C;
     if (session->smf_ip.ipv4 || session->smf_ip.ipv6) {
         pgw_s5c_teid.ipv4 = session->smf_ip.ipv4;
         pgw_s5c_teid.ipv6 = session->smf_ip.ipv6;
@@ -115,16 +115,16 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
             memcpy(pgw_s5c_teid.both.addr6, session->smf_ip.addr6,
                     sizeof session->smf_ip.addr6);
             req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
-                OGS_GTP_F_TEID_IPV4V6_LEN;
+                OGS_GTP2_F_TEID_IPV4V6_LEN;
         } else if (pgw_s5c_teid.ipv4) {
             pgw_s5c_teid.addr = session->smf_ip.addr;
             req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
-                OGS_GTP_F_TEID_IPV4_LEN;
+                OGS_GTP2_F_TEID_IPV4_LEN;
         } else if (pgw_s5c_teid.ipv6) {
             memcpy(pgw_s5c_teid.addr6, session->smf_ip.addr6,
                     sizeof session->smf_ip.addr6);
             req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
-                OGS_GTP_F_TEID_IPV6_LEN;
+                OGS_GTP2_F_TEID_IPV6_LEN;
         }
         req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
         req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
@@ -142,7 +142,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
             pgw_addr6 = mme_self()->pgw_addr6;
         }
 
-        rv = ogs_gtp_sockaddr_to_f_teid(
+        rv = ogs_gtp2_sockaddr_to_f_teid(
                 pgw_addr, pgw_addr6, &pgw_s5c_teid, &len);
         ogs_assert(rv == OGS_OK);
         req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
@@ -157,7 +157,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
 
     req->selection_mode.presence = 1;
     req->selection_mode.u8 = 
-        OGS_GTP_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN;
+        OGS_GTP2_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN;
 
     ogs_assert(sess->request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV4 ||
             sess->request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV6 ||
@@ -193,10 +193,10 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
 	    memcpy(session->paa.addr6, &addr, OGS_IPV6_LEN);
     }
 
-    memset(&indication, 0, sizeof(ogs_gtp_indication_t));
+    memset(&indication, 0, sizeof(ogs_gtp2_indication_t));
     req->indication_flags.presence = 1;
     req->indication_flags.data = &indication;
-    req->indication_flags.len = sizeof(ogs_gtp_indication_t);
+    req->indication_flags.len = sizeof(ogs_gtp2_indication_t);
 
     indication.change_reporting_support_indication = 1;
     indication.enb_change_reporting_support_indication = 1;
@@ -223,7 +223,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     req->pdn_address_allocation.presence = 1;
 
     req->maximum_apn_restriction.presence = 1;
-    req->maximum_apn_restriction.u8 = OGS_GTP_APN_NO_RESTRICTION;
+    req->maximum_apn_restriction.u8 = OGS_GTP2_APN_NO_RESTRICTION;
 
     if (session->ambr.uplink || session->ambr.downlink) {
         /*
@@ -233,7 +233,7 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
          * but it shall be encoded as shown in Figure 8.7-1 as
          * Unsigned32 binary integer values in kbps (1000 bits per second).
          */
-        memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+        memset(&ambr, 0, sizeof(ogs_gtp2_ambr_t));
         ambr.uplink = htobe32(session->ambr.uplink / 1000);
         ambr.downlink = htobe32(session->ambr.downlink / 1000);
         req->aggregate_maximum_bit_rate.presence = 1;
@@ -258,23 +258,23 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     bearer_qos.pre_emption_vulnerability =
         session->qos.arp.pre_emption_vulnerability;
     req->bearer_contexts_to_be_created.bearer_level_qos.presence = 1;
-    ogs_gtp_build_bearer_qos(
+    ogs_gtp2_build_bearer_qos(
             &req->bearer_contexts_to_be_created.bearer_level_qos,
-            &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+            &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
 
     /* UE Time Zone */
     memset(&ue_timezone, 0, sizeof(ue_timezone));
     ogs_gettimeofday(&now);
     ogs_localtime(now.tv_sec, &time_exp);
     if (time_exp.tm_gmtoff >= 0) {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
     } else {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
         ue_timezone.timezone |= 0x08;
     }
     /* quarters of an hour */
     ue_timezone.daylight_saving_time = 
-        OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
+        OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
     req->ue_time_zone.presence = 1;
     req->ue_time_zone.data = &ue_timezone;
     req->ue_time_zone.len = sizeof(ue_timezone);
@@ -284,22 +284,22 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     req->charging_characteristics.len = 2;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
         uint8_t type, mme_bearer_t *bearer, int uli_presence)
 {
     int rv;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_modify_bearer_request_t *req = &gtp_message.modify_bearer_request;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_modify_bearer_request_t *req = &gtp_message.modify_bearer_request;
 
-    ogs_gtp_f_teid_t enb_s1u_teid;
+    ogs_gtp2_f_teid_t enb_s1u_teid;
     int len;
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
 
-    ogs_gtp_indication_t indication;
+    ogs_gtp2_indication_t indication;
 
     mme_ue_t *mme_ue = NULL;
     mme_sess_t *sess = NULL;
@@ -316,14 +316,14 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
     ogs_debug("    ENB_S1U_TEID[%d] SGW_S1U_TEID[%d]",
         bearer->enb_s1u_teid, bearer->sgw_s1u_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     if (sess->request_type.value == OGS_NAS_EPS_REQUEST_TYPE_HANDOVER) {
-	    memset(&indication, 0, sizeof(ogs_gtp_indication_t));
+	    memset(&indication, 0, sizeof(ogs_gtp2_indication_t));
 	    indication.handover_indication = 1;
 	    req->indication_flags.presence = 1;
 	    req->indication_flags.data = &indication;
-	    req->indication_flags.len = sizeof(ogs_gtp_indication_t);
+	    req->indication_flags.len = sizeof(ogs_gtp2_indication_t);
     }
 
     /* Bearer Context : EBI */
@@ -332,10 +332,10 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
     req->bearer_contexts_to_be_modified.eps_bearer_id.u8 = bearer->ebi;
 
     /* Data Plane(DL) : ENB-S1U */
-    memset(&enb_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    enb_s1u_teid.interface_type = OGS_GTP_F_TEID_S1_U_ENODEB_GTP_U;
+    memset(&enb_s1u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    enb_s1u_teid.interface_type = OGS_GTP2_F_TEID_S1_U_ENODEB_GTP_U;
     enb_s1u_teid.teid = htobe32(bearer->enb_s1u_teid);
-    rv = ogs_gtp_ip_to_f_teid(&bearer->enb_s1u_ip, &enb_s1u_teid, &len);
+    rv = ogs_gtp2_ip_to_f_teid(&bearer->enb_s1u_ip, &enb_s1u_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
     req->bearer_contexts_to_be_modified.s1_u_enodeb_f_teid.presence = 1;
     req->bearer_contexts_to_be_modified.s1_u_enodeb_f_teid.data = &enb_s1u_teid;
@@ -343,7 +343,7 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
 
     if (uli_presence) {
         /* User Location Information(ULI) */
-        memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+        memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
         uli.flags.e_cgi = 1;
         uli.flags.tai = 1;
         ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -351,8 +351,8 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
         ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
         uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
         req->user_location_information.presence = 1;
-        ogs_gtp_build_uli(&req->user_location_information, &uli, 
-                uli_buf, OGS_GTP_MAX_ULI_LEN);
+        ogs_gtp2_build_uli(&req->user_location_information, &uli, 
+                uli_buf, OGS_GTP2_MAX_ULI_LEN);
     }
 
     /*
@@ -375,18 +375,18 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_delete_session_request(
         uint8_t type, mme_sess_t *sess)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_session_request_t *req = &gtp_message.delete_session_request;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_session_request_t *req = &gtp_message.delete_session_request;
 
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_indication_t indication;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_indication_t indication;
 
     mme_bearer_t *bearer = NULL;
     mme_ue_t *mme_ue = NULL;
@@ -401,13 +401,13 @@ ogs_pkbuf_t *mme_s11_build_delete_session_request(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     req->linked_eps_bearer_id.presence = 1;
     req->linked_eps_bearer_id.u8 = bearer->ebi;
 
     /* User Location Information(ULI) */
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -415,32 +415,32 @@ ogs_pkbuf_t *mme_s11_build_delete_session_request(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
     req->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&req->user_location_information, &uli,
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&req->user_location_information, &uli,
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
-    memset(&indication, 0, sizeof(ogs_gtp_indication_t));
+    memset(&indication, 0, sizeof(ogs_gtp2_indication_t));
     indication.operation_indication = 1;
     req->indication_flags.presence = 1;
     req->indication_flags.data = &indication;
-    req->indication_flags.len = sizeof(ogs_gtp_indication_t);
+    req->indication_flags.len = sizeof(ogs_gtp2_indication_t);
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_create_bearer_response(
         uint8_t type, mme_bearer_t *bearer, uint8_t cause_value)
 {
     int rv;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_bearer_response_t *rsp = &gtp_message.create_bearer_response;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_bearer_response_t *rsp = &gtp_message.create_bearer_response;
 
-    ogs_gtp_cause_t cause;
-    ogs_gtp_f_teid_t enb_s1u_teid, sgw_s1u_teid;
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_f_teid_t enb_s1u_teid, sgw_s1u_teid;
     int len;
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_ue_timezone_t ue_timezone;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_ue_timezone_t ue_timezone;
     struct timeval now;
     struct tm time_exp;
 
@@ -454,7 +454,7 @@ ogs_pkbuf_t *mme_s11_build_create_bearer_response(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Set Cause */
     memset(&cause, 0, sizeof(cause));
@@ -463,31 +463,31 @@ ogs_pkbuf_t *mme_s11_build_create_bearer_response(
     rsp->cause.len = sizeof(cause);
     rsp->cause.data = &cause;
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         /* Bearer Context : EBI */
         rsp->bearer_contexts.presence = 1;
         rsp->bearer_contexts.eps_bearer_id.presence = 1;
         rsp->bearer_contexts.eps_bearer_id.u8 = bearer->ebi;
 
         /* Data Plane(DL) : ENB-S1U */
-        memset(&enb_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-        enb_s1u_teid.interface_type = OGS_GTP_F_TEID_S1_U_ENODEB_GTP_U;
+        memset(&enb_s1u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+        enb_s1u_teid.interface_type = OGS_GTP2_F_TEID_S1_U_ENODEB_GTP_U;
         enb_s1u_teid.teid = htobe32(bearer->enb_s1u_teid);
-        rv = ogs_gtp_ip_to_f_teid(&bearer->enb_s1u_ip, &enb_s1u_teid, &len);
+        rv = ogs_gtp2_ip_to_f_teid(&bearer->enb_s1u_ip, &enb_s1u_teid, &len);
         ogs_expect_or_return_val(rv == OGS_OK, NULL);
         rsp->bearer_contexts.s1_u_enodeb_f_teid.presence = 1;
         rsp->bearer_contexts.s1_u_enodeb_f_teid.data = &enb_s1u_teid;
         rsp->bearer_contexts.s1_u_enodeb_f_teid.len = len;
 
         /* Data Plane(UL) : SGW-S1U */
-        memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-        sgw_s1u_teid.interface_type = OGS_GTP_F_TEID_S1_U_SGW_GTP_U;
+        memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+        sgw_s1u_teid.interface_type = OGS_GTP2_F_TEID_S1_U_SGW_GTP_U;
         sgw_s1u_teid.teid = htobe32(bearer->sgw_s1u_teid);
-        rv = ogs_gtp_ip_to_f_teid(&bearer->sgw_s1u_ip, &sgw_s1u_teid, &len);
+        rv = ogs_gtp2_ip_to_f_teid(&bearer->sgw_s1u_ip, &sgw_s1u_teid, &len);
         ogs_expect_or_return_val(rv == OGS_OK, NULL);
         rsp->bearer_contexts.s4_u_sgsn_f_teid.presence = 1;
         rsp->bearer_contexts.s4_u_sgsn_f_teid.data = &sgw_s1u_teid;
-        rsp->bearer_contexts.s4_u_sgsn_f_teid.len = OGS_GTP_F_TEID_IPV4_LEN;
+        rsp->bearer_contexts.s4_u_sgsn_f_teid.len = OGS_GTP2_F_TEID_IPV4_LEN;
 
         /* Bearer Context : Cause */
         rsp->bearer_contexts.cause.presence = 1;
@@ -496,7 +496,7 @@ ogs_pkbuf_t *mme_s11_build_create_bearer_response(
     }
 
     /* User Location Information(ULI) */
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -504,39 +504,39 @@ ogs_pkbuf_t *mme_s11_build_create_bearer_response(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
     rsp->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&rsp->user_location_information, &uli, 
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&rsp->user_location_information, &uli, 
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
     /* UE Time Zone */
     memset(&ue_timezone, 0, sizeof(ue_timezone));
     ogs_gettimeofday(&now);
     ogs_localtime(now.tv_sec, &time_exp);
     if (time_exp.tm_gmtoff >= 0) {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
     } else {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
         ue_timezone.timezone |= 0x08;
     }
     ue_timezone.daylight_saving_time = 
-        OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
+        OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
     rsp->ue_time_zone.presence = 1;
     rsp->ue_time_zone.data = &ue_timezone;
     rsp->ue_time_zone.len = sizeof(ue_timezone);
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_update_bearer_response(
         uint8_t type, mme_bearer_t *bearer, uint8_t cause_value)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_update_bearer_response_t *rsp = &gtp_message.update_bearer_response;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_update_bearer_response_t *rsp = &gtp_message.update_bearer_response;
 
-    ogs_gtp_cause_t cause;
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_ue_timezone_t ue_timezone;
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_ue_timezone_t ue_timezone;
     struct timeval now;
     struct tm time_exp;
 
@@ -550,7 +550,7 @@ ogs_pkbuf_t *mme_s11_build_update_bearer_response(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Set Cause */
     memset(&cause, 0, sizeof(cause));
@@ -559,7 +559,7 @@ ogs_pkbuf_t *mme_s11_build_update_bearer_response(
     rsp->cause.len = sizeof(cause);
     rsp->cause.data = &cause;
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         /* Bearer Context : EBI */
         rsp->bearer_contexts.presence = 1;
         rsp->bearer_contexts.eps_bearer_id.presence = 1;
@@ -572,7 +572,7 @@ ogs_pkbuf_t *mme_s11_build_update_bearer_response(
     }
 
     /* User Location Information(ULI) */
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -580,39 +580,39 @@ ogs_pkbuf_t *mme_s11_build_update_bearer_response(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
     rsp->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&rsp->user_location_information, &uli, 
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&rsp->user_location_information, &uli, 
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
     /* UE Time Zone */
     memset(&ue_timezone, 0, sizeof(ue_timezone));
     ogs_gettimeofday(&now);
     ogs_localtime(now.tv_sec, &time_exp);
     if (time_exp.tm_gmtoff >= 0) {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
     } else {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
         ue_timezone.timezone |= 0x08;
     }
     ue_timezone.daylight_saving_time = 
-        OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
+        OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
     rsp->ue_time_zone.presence = 1;
     rsp->ue_time_zone.data = &ue_timezone;
     rsp->ue_time_zone.len = sizeof(ue_timezone);
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
         uint8_t type, mme_bearer_t *bearer, uint8_t cause_value)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_bearer_response_t *rsp = &gtp_message.delete_bearer_response;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_bearer_response_t *rsp = &gtp_message.delete_bearer_response;
 
-    ogs_gtp_cause_t cause;
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_ue_timezone_t ue_timezone;
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_ue_timezone_t ue_timezone;
     struct timeval now;
     struct tm time_exp;
 
@@ -626,7 +626,7 @@ ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Set Cause */
     memset(&cause, 0, sizeof(cause));
@@ -635,7 +635,7 @@ ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
     rsp->cause.len = sizeof(cause);
     rsp->cause.data = &cause;
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         mme_bearer_t *linked_bearer = mme_linked_bearer(bearer);
         ogs_assert(linked_bearer);
 
@@ -680,7 +680,7 @@ ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
     }
 
     /* User Location Information(ULI) */
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &mme_ue->tai.plmn_id);
@@ -688,57 +688,57 @@ ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &mme_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = mme_ue->e_cgi.cell_id;
     rsp->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&rsp->user_location_information, &uli, 
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&rsp->user_location_information, &uli, 
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
     /* UE Time Zone */
     memset(&ue_timezone, 0, sizeof(ue_timezone));
     ogs_gettimeofday(&now);
     ogs_localtime(now.tv_sec, &time_exp);
     if (time_exp.tm_gmtoff >= 0) {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD(time_exp.tm_gmtoff / 900);
     } else {
-        ue_timezone.timezone = OGS_GTP_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
+        ue_timezone.timezone = OGS_GTP2_TIME_TO_BCD((-time_exp.tm_gmtoff) / 900);
         ue_timezone.timezone |= 0x08;
     }
     ue_timezone.daylight_saving_time = 
-        OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
+        OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
     rsp->ue_time_zone.presence = 1;
     rsp->ue_time_zone.data = &ue_timezone;
     rsp->ue_time_zone.len = sizeof(ue_timezone);
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_release_access_bearers_request(uint8_t type)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_release_access_bearers_request_t *req = 
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_release_access_bearers_request_t *req = 
         &gtp_message.release_access_bearers_request;
 
     ogs_debug("Release Access Bearers Request");
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     req->originating_node.presence = 1;
-    req->originating_node.u8 = OGS_GTP_NODE_TYPE_MME;
+    req->originating_node.u8 = OGS_GTP2_NODE_TYPE_MME;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_downlink_data_notification_ack(
         uint8_t type, uint8_t cause_value)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_downlink_data_notification_acknowledge_t *ack = 
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_downlink_data_notification_acknowledge_t *ack = 
         &gtp_message.downlink_data_notification_acknowledge;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
 
     ogs_debug("Downlink Data Notification Ackknowledge");
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     memset(&cause, 0, sizeof(cause));
     cause.value = cause_value;
@@ -751,7 +751,7 @@ ogs_pkbuf_t *mme_s11_build_downlink_data_notification_ack(
     ack->data_notification_delay.u8 = 0;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
@@ -763,12 +763,12 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_indirect_data_forwarding_tunnel_request_t *req =
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_indirect_data_forwarding_tunnel_request_t *req =
         &gtp_message.create_indirect_data_forwarding_tunnel_request;
     
-    ogs_gtp_f_teid_t dl_teid[OGS_GTP_MAX_INDIRECT_TUNNEL];
-    ogs_gtp_f_teid_t ul_teid[OGS_GTP_MAX_INDIRECT_TUNNEL];
+    ogs_gtp2_f_teid_t dl_teid[OGS_GTP2_MAX_INDIRECT_TUNNEL];
+    ogs_gtp2_f_teid_t ul_teid[OGS_GTP2_MAX_INDIRECT_TUNNEL];
     int len;
 
     ogs_assert(mme_ue);
@@ -777,7 +777,7 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
             mme_ue->mme_s11_teid, mme_ue->sgw_s11_teid);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     i = 0;
     sess = mme_sess_first(mme_ue);
@@ -785,11 +785,11 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
         bearer = mme_bearer_first(sess);
         while (bearer != NULL) {
             if (MME_HAVE_ENB_DL_INDIRECT_TUNNEL(bearer)) {
-                memset(&dl_teid[i], 0, sizeof(ogs_gtp_f_teid_t));
+                memset(&dl_teid[i], 0, sizeof(ogs_gtp2_f_teid_t));
                 dl_teid[i].interface_type =
-                    OGS_GTP_F_TEID_ENODEB_GTP_U_FOR_DL_DATA_FORWARDING;
+                    OGS_GTP2_F_TEID_ENODEB_GTP_U_FOR_DL_DATA_FORWARDING;
                 dl_teid[i].teid = htobe32(bearer->enb_dl_teid);
-                rv = ogs_gtp_ip_to_f_teid(
+                rv = ogs_gtp2_ip_to_f_teid(
                         &bearer->enb_dl_ip, &dl_teid[i], &len);
                 ogs_expect_or_return_val(rv == OGS_OK, NULL);
                 req->bearer_contexts[i].s1_u_enodeb_f_teid.presence = 1;
@@ -798,11 +798,11 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
             }
 
             if (MME_HAVE_ENB_UL_INDIRECT_TUNNEL(bearer)) {
-                memset(&ul_teid[i], 0, sizeof(ogs_gtp_f_teid_t));
+                memset(&ul_teid[i], 0, sizeof(ogs_gtp2_f_teid_t));
                 ul_teid[i].interface_type =
-                    OGS_GTP_F_TEID_ENODEB_GTP_U_FOR_UL_DATA_FORWARDING;
+                    OGS_GTP2_F_TEID_ENODEB_GTP_U_FOR_UL_DATA_FORWARDING;
                 ul_teid[i].teid = htobe32(bearer->enb_ul_teid);
-                rv = ogs_gtp_ip_to_f_teid(
+                rv = ogs_gtp2_ip_to_f_teid(
                         &bearer->enb_ul_ip, &ul_teid[i], &len);
                 ogs_expect_or_return_val(rv == OGS_OK, NULL);
                 req->bearer_contexts[i].s12_rnc_f_teid.presence = 1;
@@ -824,14 +824,14 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
         uint8_t type, mme_bearer_t *bearer, ogs_nas_eps_message_t *nas_message)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_bearer_resource_command_t *cmd =
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_bearer_resource_command_t *cmd =
         &gtp_message.bearer_resource_command;
     ogs_nas_eps_bearer_resource_allocation_request_t *allocation = NULL;
     ogs_nas_eps_bearer_resource_modification_request_t *modification = NULL;
@@ -839,8 +839,8 @@ ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
     ogs_nas_eps_quality_of_service_t *qos = NULL;
     ogs_nas_traffic_flow_aggregate_description_t *tad = NULL;
 
-    ogs_gtp_flow_qos_t flow_qos;
-    char flow_qos_buf[GTP_FLOW_QOS_LEN];
+    ogs_gtp2_flow_qos_t flow_qos;
+    char flow_qos_buf[GTP2_FLOW_QOS_LEN];
 
     mme_ue_t *mme_ue = NULL;
     mme_sess_t *sess = NULL;
@@ -879,7 +879,7 @@ ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
     linked_bearer = mme_linked_bearer(bearer);
     ogs_assert(linked_bearer);
 
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Linked Bearer Context : EBI */
     cmd->linked_eps_bearer_id.presence = 1;
@@ -903,21 +903,21 @@ ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
          * 00000000 Reserved
          */
         flow_qos.ul_mbr = qos->ul_mbr == 0 ? bearer->qos.mbr.uplink :
-            ogs_gtp_qos_to_bps(
+            ogs_gtp2_qos_to_bps(
                 qos->ul_mbr, qos->ul_mbr_extended, qos->ul_mbr_extended2);
         flow_qos.dl_mbr = qos->dl_mbr == 0 ? bearer->qos.mbr.downlink :
-            ogs_gtp_qos_to_bps(
+            ogs_gtp2_qos_to_bps(
                 qos->dl_mbr, qos->dl_mbr_extended, qos->dl_mbr_extended2);
         flow_qos.ul_gbr = qos->ul_gbr == 0 ? bearer->qos.gbr.uplink :
-            ogs_gtp_qos_to_bps(
+            ogs_gtp2_qos_to_bps(
                 qos->ul_gbr, qos->ul_gbr_extended, qos->ul_gbr_extended2);
         flow_qos.dl_gbr = qos->dl_gbr == 0 ? bearer->qos.gbr.downlink :
-            ogs_gtp_qos_to_bps(
+            ogs_gtp2_qos_to_bps(
                 qos->dl_gbr, qos->dl_gbr_extended, qos->dl_gbr_extended2);
 
-        ogs_gtp_build_flow_qos(
+        ogs_gtp2_build_flow_qos(
                 &cmd->flow_quality_of_service,
-                &flow_qos, flow_qos_buf, GTP_FLOW_QOS_LEN);
+                &flow_qos, flow_qos_buf, GTP2_FLOW_QOS_LEN);
         cmd->flow_quality_of_service.presence = 1;
     }
 
@@ -940,5 +940,5 @@ ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }

--- a/src/mme/mme-s11-handler.h
+++ b/src/mme/mme-s11-handler.h
@@ -27,44 +27,44 @@ extern "C" {
 #endif
 
 void mme_s11_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_request_t *req);
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req);
 void mme_s11_handle_echo_response(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_response_t *rsp);
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *rsp);
 void mme_s11_handle_create_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_create_session_response_t *rsp);
+        ogs_gtp2_create_session_response_t *rsp);
 void mme_s11_handle_modify_bearer_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_modify_bearer_response_t *rsp);
+        ogs_gtp2_modify_bearer_response_t *rsp);
 void mme_s11_handle_delete_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_delete_session_response_t *rsp);
+        ogs_gtp2_delete_session_response_t *rsp);
 void mme_s11_handle_create_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_create_bearer_request_t *rsp);
+        ogs_gtp2_create_bearer_request_t *rsp);
 void mme_s11_handle_update_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_update_bearer_request_t *rsp);
+        ogs_gtp2_update_bearer_request_t *rsp);
 void mme_s11_handle_delete_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_delete_bearer_request_t *rsp);
+        ogs_gtp2_delete_bearer_request_t *rsp);
 
 void mme_s11_handle_release_access_bearers_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_release_access_bearers_response_t *rsp);
+        ogs_gtp2_release_access_bearers_response_t *rsp);
 void mme_s11_handle_downlink_data_notification(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_downlink_data_notification_t *noti);
+        ogs_gtp2_downlink_data_notification_t *noti);
 void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_create_indirect_data_forwarding_tunnel_response_t *rsp);
+        ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t *rsp);
 void mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_delete_indirect_data_forwarding_tunnel_response_t *rsp);
+        ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t *rsp);
 
 void mme_s11_handle_bearer_resource_failure_indication(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp_bearer_resource_failure_indication_t *ind);
+        ogs_gtp2_bearer_resource_failure_indication_t *ind);
 
 #ifdef __cplusplus
 }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -123,7 +123,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
 
     ogs_gtp_node_t *gnode = NULL;
     ogs_gtp_xact_t *xact = NULL;
-    ogs_gtp_message_t gtp_message;
+    ogs_gtp2_message_t gtp_message;
 
     mme_vlr_t *vlr = NULL;
 
@@ -243,7 +243,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             ogs_warn("Cannot decode S1AP message");
             ogs_assert(OGS_OK ==
                 s1ap_send_error_indication(
-                    enb, NULL, NULL, S1AP_Cause_PR_protocol, 
+                    enb, NULL, NULL, S1AP_Cause_PR_protocol,
                     S1AP_CauseProtocol_abstract_syntax_error_falsely_constructed_message));
         }
 
@@ -299,7 +299,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             } else {
                 /* Here, if the MME_UE Context is found,
                  * the integrity check is not performed
-                 * For example, ATTACH_REQUEST, 
+                 * For example, ATTACH_REQUEST,
                  * TRACKING_AREA_UPDATE_REQUEST message
                  *
                  * Now, We will check the MAC in the NAS message*/
@@ -307,7 +307,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
                 h.type = e->nas_type;
                 if (h.integrity_protected) {
                     /* Decryption was performed in S1AP handler.
-                     * So, we disabled 'ciphered' 
+                     * So, we disabled 'ciphered'
                      * not to decrypt NAS message */
                     h.ciphered = 0;
                     if (nas_eps_security_decode(mme_ue, h, pkbuf) != OGS_OK) {
@@ -407,7 +407,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
 
         } else if (OGS_FSM_CHECK(&bearer->sm, esm_state_exception)) {
 
-            /* 
+            /*
              * The UE requested the wrong APN.
              *
              * From the Issues #568, MME need to accept further service request.
@@ -514,8 +514,8 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         pkbuf = e->pkbuf;
         ogs_assert(pkbuf);
 
-        if (ogs_gtp_parse_msg(&gtp_message, pkbuf) != OGS_OK) {
-            ogs_error("ogs_gtp_parse_msg() failed");
+        if (ogs_gtp2_parse_msg(&gtp_message, pkbuf) != OGS_OK) {
+            ogs_error("ogs_gtp2_parse_msg() failed");
             ogs_pkbuf_free(pkbuf);
             break;
         }
@@ -570,41 +570,41 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         }
 
         switch (gtp_message.h.type) {
-        case OGS_GTP_ECHO_REQUEST_TYPE:
+        case OGS_GTP2_ECHO_REQUEST_TYPE:
             mme_s11_handle_echo_request(xact, &gtp_message.echo_request);
             break;
-        case OGS_GTP_ECHO_RESPONSE_TYPE:
+        case OGS_GTP2_ECHO_RESPONSE_TYPE:
             mme_s11_handle_echo_response(xact, &gtp_message.echo_response);
             break;
-        case OGS_GTP_CREATE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
             mme_s11_handle_create_session_response(
                 xact, mme_ue, &gtp_message.create_session_response);
             break;
-        case OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE:
             mme_s11_handle_modify_bearer_response(
                 xact, mme_ue, &gtp_message.modify_bearer_response);
             break;
-        case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
             mme_s11_handle_delete_session_response(
                 xact, mme_ue, &gtp_message.delete_session_response);
             break;
-        case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
             mme_s11_handle_create_bearer_request(
                 xact, mme_ue, &gtp_message.create_bearer_request);
             break;
-        case OGS_GTP_UPDATE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
             mme_s11_handle_update_bearer_request(
                 xact, mme_ue, &gtp_message.update_bearer_request);
             break;
-        case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
             mme_s11_handle_delete_bearer_request(
                 xact, mme_ue, &gtp_message.delete_bearer_request);
             break;
-        case OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
+        case OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE:
             mme_s11_handle_release_access_bearers_response(
                 xact, mme_ue, &gtp_message.release_access_bearers_response);
             break;
-        case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE:
+        case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
             if (!mme_ue) {
                 if (gtp_message.h.teid_presence)
                     ogs_warn("No Context : TEID[%d]", gtp_message.h.teid);
@@ -616,17 +616,17 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             mme_s11_handle_downlink_data_notification(
                 xact, mme_ue, &gtp_message.downlink_data_notification);
             break;
-        case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
             mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
                 xact, mme_ue,
                 &gtp_message.create_indirect_data_forwarding_tunnel_response);
             break;
-        case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
             mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
                 xact, mme_ue,
                 &gtp_message.delete_indirect_data_forwarding_tunnel_response);
             break;
-        case OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
+        case OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
             mme_s11_handle_bearer_resource_failure_indication(
                 xact, mme_ue,
                 &gtp_message.bearer_resource_failure_indication);
@@ -658,7 +658,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         vlr->max_num_of_ostreams =
                 ogs_min(max_num_of_ostreams, vlr->max_num_of_ostreams);
 
-        ogs_debug("VLR-SGs SCTP_COMM_UP[%s] Max Num of Outbound Streams[%d]", 
+        ogs_debug("VLR-SGs SCTP_COMM_UP[%s] Max Num of Outbound Streams[%d]",
             OGS_ADDR(vlr->addr, buf), vlr->max_num_of_ostreams);
 
         e->vlr = vlr;
@@ -684,7 +684,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             e->vlr = vlr;
             ogs_fsm_dispatch(&vlr->sm, e);
 
-            ogs_info("VLR-SGs[%s] connection refused!!!", 
+            ogs_info("VLR-SGs[%s] connection refused!!!",
                     OGS_ADDR(vlr->addr, buf));
 
         } else {

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -757,7 +757,7 @@ void s1ap_handle_initial_context_setup_response(
     }
 
     if (mme_ue->nas_eps.type != MME_EPS_TYPE_ATTACH_REQUEST)
-        mme_send_after_paging(mme_ue, OGS_GTP_CAUSE_REQUEST_ACCEPTED);
+        mme_send_after_paging(mme_ue, OGS_GTP2_CAUSE_REQUEST_ACCEPTED);
 
     if (SMS_SERVICE_INDICATOR(mme_ue)) {
         ogs_assert(OGS_OK ==
@@ -1218,7 +1218,7 @@ void s1ap_handle_e_rab_setup_response(
                 } else {
                 ogs_assert(OGS_OK ==
                     mme_gtp_send_create_bearer_response(
-                        bearer, OGS_GTP_CAUSE_REQUEST_ACCEPTED));
+                        bearer, OGS_GTP2_CAUSE_REQUEST_ACCEPTED));
                 }
             }
         }

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -136,10 +136,10 @@ int sgwc_context_parse_config(void)
     return OGS_OK;
 }
 
-sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp_message_t *message)
+sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp2_message_t *message)
 {
     sgwc_ue_t *sgwc_ue = NULL;
-    ogs_gtp_create_session_request_t *req = &message->create_session_request;
+    ogs_gtp2_create_session_request_t *req = &message->create_session_request;
 
     ogs_assert(message);
 
@@ -152,7 +152,7 @@ sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp_message_t *message)
     ogs_trace("sgwc_ue_add_by_message() - IMSI ");
     ogs_log_hexdump(OGS_LOG_TRACE, req->imsi.data, req->imsi.len);
 
-    /* 
+    /*
      * 7.2.1 in 3GPP TS 29.274 Release 15
      *
      * If the new Create Session Request received by the SGW collides with
@@ -418,7 +418,7 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
 void sgwc_sess_remove_all(sgwc_ue_t *sgwc_ue)
 {
     sgwc_sess_t *sess = NULL, *next_sess = NULL;
-    
+
     ogs_assert(sgwc_ue);
     ogs_list_for_each_safe(&sgwc_ue->sess_list, next_sess, sess)
         sgwc_sess_remove(sess);
@@ -489,15 +489,15 @@ sgwc_bearer_t *sgwc_bearer_add(sgwc_sess_t *sess)
     bearer->sess = sess;
 
     /* Downlink */
-    tunnel = sgwc_tunnel_add(bearer, OGS_GTP_F_TEID_S5_S8_SGW_GTP_U);
+    tunnel = sgwc_tunnel_add(bearer, OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U);
     ogs_assert(tunnel);
 
     /* Uplink */
-    tunnel = sgwc_tunnel_add(bearer, OGS_GTP_F_TEID_S1_U_SGW_GTP_U);
+    tunnel = sgwc_tunnel_add(bearer, OGS_GTP2_F_TEID_S1_U_SGW_GTP_U);
     ogs_assert(tunnel);
 
     ogs_list_add(&sess->bearer_list, bearer);
-    
+
     return bearer;
 }
 
@@ -539,7 +539,7 @@ sgwc_bearer_t *sgwc_bearer_find_by_ue_ebi(sgwc_ue_t *sgwc_ue, uint8_t ebi)
 {
     sgwc_sess_t *sess = NULL;
     sgwc_bearer_t *bearer = NULL;
-    
+
     ogs_assert(sgwc_ue);
     ogs_list_for_each(&sgwc_ue->sess_list, sess) {
         ogs_list_for_each(&sess->bearer_list, bearer) {
@@ -643,20 +643,20 @@ sgwc_tunnel_t *sgwc_tunnel_add(
 
     switch (interface_type) {
     /* Downlink */
-    case OGS_GTP_F_TEID_S5_S8_SGW_GTP_U:
+    case OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U:
         src_if = OGS_PFCP_INTERFACE_CORE;
         dst_if = OGS_PFCP_INTERFACE_ACCESS;
         break;
 
     /* Uplink */
-    case OGS_GTP_F_TEID_S1_U_SGW_GTP_U:
+    case OGS_GTP2_F_TEID_S1_U_SGW_GTP_U:
         src_if = OGS_PFCP_INTERFACE_ACCESS;
         dst_if = OGS_PFCP_INTERFACE_CORE;
         break;
 
     /* Indirect */
-    case OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING:
-    case OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING:
+    case OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING:
+    case OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING:
         src_if = OGS_PFCP_INTERFACE_ACCESS;
         dst_if = OGS_PFCP_INTERFACE_ACCESS;
         break;
@@ -848,13 +848,13 @@ sgwc_tunnel_t *sgwc_dl_tunnel_in_bearer(sgwc_bearer_t *bearer)
 {
     ogs_assert(bearer);
     return sgwc_tunnel_find_by_interface_type(bearer,
-            OGS_GTP_F_TEID_S5_S8_SGW_GTP_U);
+            OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U);
 }
 sgwc_tunnel_t *sgwc_ul_tunnel_in_bearer(sgwc_bearer_t *bearer)
 {
     ogs_assert(bearer);
     return sgwc_tunnel_find_by_interface_type(bearer,
-            OGS_GTP_F_TEID_S1_U_SGW_GTP_U);
+            OGS_GTP2_F_TEID_S1_U_SGW_GTP_U);
 }
 
 static void stats_add_sgwc_session(void)

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -142,7 +142,7 @@ sgwc_context_t *sgwc_self(void);
 
 int sgwc_context_parse_config(void);
 
-sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp_message_t *message);
+sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp2_message_t *message);
 sgwc_ue_t *sgwc_ue_find_by_imsi(uint8_t *imsi, int imsi_len);
 sgwc_ue_t *sgwc_ue_find_by_imsi_bcd(char *imsi_bcd);
 sgwc_ue_t *sgwc_ue_find_by_teid(uint32_t teid);

--- a/src/sgwc/event.h
+++ b/src/sgwc/event.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 typedef struct ogs_gtp_node_s ogs_gtp_node_t;
-typedef struct ogs_gtp_message_s ogs_gtp_message_t;
+typedef struct ogs_gtp2_message_s ogs_gtp2_message_t;
 typedef struct ogs_pfcp_node_s ogs_pfcp_node_t;
 typedef struct ogs_pfcp_xact_s ogs_pfcp_xact_t;
 typedef struct ogs_pfcp_message_s ogs_pfcp_message_t;
@@ -53,7 +53,7 @@ typedef struct sgwc_event_s {
     int timer_id;
 
     ogs_gtp_node_t *gnode;
-    ogs_gtp_message_t *gtp_message;
+    ogs_gtp2_message_t *gtp_message;
 
     ogs_pfcp_node_t *pfcp_node;
     ogs_pfcp_xact_t *pfcp_xact;

--- a/src/sgwc/gtp-path.c
+++ b/src/sgwc/gtp-path.c
@@ -150,7 +150,7 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
     type = xact->seq[0].type;
 
     switch (type) {
-    case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE:
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
         ogs_warn("[%s] No Downlink Data Notification ACK", sgwc_ue->imsi_bcd);
         break;
     default:
@@ -170,7 +170,7 @@ int sgwc_gtp_send_downlink_data_notification(
     ogs_gtp_xact_t *gtp_xact = NULL;
 
     ogs_pkbuf_t *pkbuf = NULL;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
 
     ogs_assert(bearer);
 
@@ -184,8 +184,8 @@ int sgwc_gtp_send_downlink_data_notification(
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
         sgwc_ue->mme_s11_teid, sgwc_ue->sgw_s11_teid);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE;
     h.teid = sgwc_ue->mme_s11_teid;
 
     pkbuf = sgwc_s11_build_downlink_data_notification(cause_value, bearer);

--- a/src/sgwc/s11-build.c
+++ b/src/sgwc/s11-build.c
@@ -22,10 +22,10 @@
 ogs_pkbuf_t *sgwc_s11_build_downlink_data_notification(
         uint8_t cause_value, sgwc_bearer_t *bearer)
 {
-    ogs_gtp_message_t message;
-    ogs_gtp_downlink_data_notification_t *noti = NULL;
-    ogs_gtp_cause_t cause;
-    ogs_gtp_arp_t arp;
+    ogs_gtp2_message_t message;
+    ogs_gtp2_downlink_data_notification_t *noti = NULL;
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_arp_t arp;
     sgwc_sess_t *sess = NULL;
 
     ogs_assert(bearer);
@@ -34,7 +34,7 @@ ogs_pkbuf_t *sgwc_s11_build_downlink_data_notification(
 
     /* Build downlink notification message */
     noti = &message.downlink_data_notification;
-    memset(&message, 0, sizeof(ogs_gtp_message_t));
+    memset(&message, 0, sizeof(ogs_gtp2_message_t));
 
     /*
      * TS29.274 8.4 Cause Value
@@ -42,7 +42,7 @@ ogs_pkbuf_t *sgwc_s11_build_downlink_data_notification(
      * 0 : Reserved. Shall not be sent and
      *     if received the Cause shall be treated as an invalid IE
      */
-    if (cause_value != OGS_GTP_CAUSE_UNDEFINED_VALUE) {
+    if (cause_value != OGS_GTP2_CAUSE_UNDEFINED_VALUE) {
         memset(&cause, 0, sizeof(cause));
         cause.value = cause_value;
         noti->cause.presence = 1;
@@ -63,6 +63,6 @@ ogs_pkbuf_t *sgwc_s11_build_downlink_data_notification(
     noti->allocation_retention_priority.data = &arp;
     noti->allocation_retention_priority.len = sizeof(arp);
 
-    message.h.type = OGS_GTP_DOWNLINK_DATA_NOTIFICATION_TYPE;
-    return ogs_gtp_build_msg(&message);
+    message.h.type = OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE;
+    return ogs_gtp2_build_msg(&message);
 }

--- a/src/sgwc/s11-handler.h
+++ b/src/sgwc/s11-handler.h
@@ -28,40 +28,40 @@ extern "C" {
 
 void sgwc_s11_handle_create_session_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_modify_bearer_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_delete_session_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_create_bearer_response(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_update_bearer_response(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_delete_bearer_response(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 
 void sgwc_s11_handle_release_access_bearers_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_downlink_data_notification_ack(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 
 void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 
 void sgwc_s11_handle_bearer_resource_command(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 
 #ifdef __cplusplus
 }

--- a/src/sgwc/s5c-handler.h
+++ b/src/sgwc/s5c-handler.h
@@ -28,25 +28,25 @@ extern "C" {
 
 void sgwc_s5c_handle_create_session_response(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_delete_session_response(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_modify_bearer_response(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_create_bearer_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_update_bearer_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_delete_bearer_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 void sgwc_s5c_handle_bearer_resource_failure_indication(
         sgwc_sess_t *sess, ogs_gtp_xact_t *s5c_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp_message_t *message);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message);
 
 #ifdef __cplusplus
 }

--- a/src/sgwc/sgwc-sm.c
+++ b/src/sgwc/sgwc-sm.c
@@ -24,7 +24,7 @@
 #include "pfcp-path.h"
 
 static void sgwc_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_request_t *req)
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req)
 {
     ogs_assert(xact);
     ogs_assert(req);
@@ -32,11 +32,11 @@ static void sgwc_handle_echo_request(
     ogs_debug("[SGW] Receiving Echo Request");
     /* FIXME : Before implementing recovery counter correctly,
      *         I'll re-use the recovery value in request message */
-    ogs_gtp_send_echo_response(xact, req->recovery.u8, 0);
+    ogs_gtp2_send_echo_response(xact, req->recovery.u8, 0);
 }
 
 static void sgwc_handle_echo_response(
-        ogs_gtp_xact_t *s11_xact, ogs_gtp_echo_response_t *rsp)
+        ogs_gtp_xact_t *s11_xact, ogs_gtp2_echo_response_t *rsp)
 {
     /* Not Implemented */
 }
@@ -67,7 +67,7 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
     sgwc_sess_t *sess = NULL;
 
     ogs_gtp_xact_t *gtp_xact = NULL;
-    ogs_gtp_message_t gtp_message;
+    ogs_gtp2_message_t gtp_message;
     ogs_gtp_node_t *gnode = NULL;
 
     ogs_pfcp_node_t *pfcp_node = NULL;
@@ -110,7 +110,7 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
 
         e->gtp_message = NULL;
         if (pfcp_xact->gtpbuf) {
-            rv = ogs_gtp_parse_msg(&gtp_message, pfcp_xact->gtpbuf);
+            rv = ogs_gtp2_parse_msg(&gtp_message, pfcp_xact->gtpbuf);
             e->gtp_message = &gtp_message;
         }
 
@@ -139,8 +139,8 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
 
-        if (ogs_gtp_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
-            ogs_error("ogs_gtp_parse_msg() failed");
+        if (ogs_gtp2_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
+            ogs_error("ogs_gtp2_parse_msg() failed");
             ogs_pkbuf_free(recvbuf);
             break;
         }
@@ -165,13 +165,13 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         }
 
         switch(gtp_message.h.type) {
-        case OGS_GTP_ECHO_REQUEST_TYPE:
+        case OGS_GTP2_ECHO_REQUEST_TYPE:
             sgwc_handle_echo_request(gtp_xact, &gtp_message.echo_request);
             break;
-        case OGS_GTP_ECHO_RESPONSE_TYPE:
+        case OGS_GTP2_ECHO_RESPONSE_TYPE:
             sgwc_handle_echo_response(gtp_xact, &gtp_message.echo_response);
             break;
-        case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
             if (gtp_message.h.teid == 0) {
                 ogs_expect(!sgwc_ue);
                 sgwc_ue = sgwc_ue_add_by_message(&gtp_message);
@@ -181,43 +181,43 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
             sgwc_s11_handle_create_session_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_MODIFY_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
             sgwc_s11_handle_modify_bearer_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
             sgwc_s11_handle_delete_session_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_CREATE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE:
             sgwc_s11_handle_create_bearer_response(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
             sgwc_s11_handle_update_bearer_response(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DELETE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
             sgwc_s11_handle_delete_bearer_response(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
+        case OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
             sgwc_s11_handle_release_access_bearers_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
+        case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE:
             sgwc_s11_handle_downlink_data_notification_ack(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
             sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
             sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
+        case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
             sgwc_s11_handle_bearer_resource_command(
                     sgwc_ue, gtp_xact, recvbuf, &gtp_message);
             break;
@@ -233,8 +233,8 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
 
-        if (ogs_gtp_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
-            ogs_error("ogs_gtp_parse_msg() failed");
+        if (ogs_gtp2_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
+            ogs_error("ogs_gtp2_parse_msg() failed");
             ogs_pkbuf_free(recvbuf);
             break;
         }
@@ -258,37 +258,37 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         }
 
         switch(gtp_message.h.type) {
-        case OGS_GTP_ECHO_REQUEST_TYPE:
+        case OGS_GTP2_ECHO_REQUEST_TYPE:
             sgwc_handle_echo_request(gtp_xact, &gtp_message.echo_request);
             break;
-        case OGS_GTP_ECHO_RESPONSE_TYPE:
+        case OGS_GTP2_ECHO_RESPONSE_TYPE:
             sgwc_handle_echo_response(gtp_xact, &gtp_message.echo_response);
             break;
-        case OGS_GTP_CREATE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
             sgwc_s5c_handle_create_session_response(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
             sgwc_s5c_handle_delete_session_response(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE:
             sgwc_s5c_handle_modify_bearer_response(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
             sgwc_s5c_handle_create_bearer_request(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_UPDATE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
             sgwc_s5c_handle_update_bearer_request(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
             sgwc_s5c_handle_delete_bearer_request(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;
-        case OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
+        case OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE:
             sgwc_s5c_handle_bearer_resource_failure_indication(
                     sess, gtp_xact, recvbuf, &gtp_message);
             break;

--- a/src/sgwc/sxa-build.c
+++ b/src/sgwc/sxa-build.c
@@ -141,16 +141,16 @@ ogs_pkbuf_t *sgwc_sxa_build_sess_modification_request(
                    OGS_PFCP_MODIFY_INDIRECT)) == 0) ||
 
                 ((modify_flags & OGS_PFCP_MODIFY_DL_ONLY) &&
-                 (tunnel->interface_type == OGS_GTP_F_TEID_S5_S8_SGW_GTP_U)) ||
+                 (tunnel->interface_type == OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U)) ||
 
                 ((modify_flags & OGS_PFCP_MODIFY_UL_ONLY) &&
-                 (tunnel->interface_type == OGS_GTP_F_TEID_S1_U_SGW_GTP_U)) ||
+                 (tunnel->interface_type == OGS_GTP2_F_TEID_S1_U_SGW_GTP_U)) ||
 
                 (((modify_flags & OGS_PFCP_MODIFY_INDIRECT) &&
                   ((tunnel->interface_type ==
-                      OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) ||
+                      OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) ||
                    (tunnel->interface_type ==
-                      OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING))))) {
+                      OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING))))) {
 
                 if (modify_flags & OGS_PFCP_MODIFY_REMOVE) {
                     pdr = tunnel->pdr;
@@ -261,16 +261,16 @@ ogs_pkbuf_t *sgwc_sxa_build_bearer_modification_request(
                OGS_PFCP_MODIFY_INDIRECT)) == 0) ||
 
             ((modify_flags & OGS_PFCP_MODIFY_DL_ONLY) &&
-             (tunnel->interface_type == OGS_GTP_F_TEID_S5_S8_SGW_GTP_U)) ||
+             (tunnel->interface_type == OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U)) ||
 
             ((modify_flags & OGS_PFCP_MODIFY_UL_ONLY) &&
-             (tunnel->interface_type == OGS_GTP_F_TEID_S1_U_SGW_GTP_U)) ||
+             (tunnel->interface_type == OGS_GTP2_F_TEID_S1_U_SGW_GTP_U)) ||
 
             (((modify_flags & OGS_PFCP_MODIFY_INDIRECT) &&
               ((tunnel->interface_type ==
-                  OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) ||
+                  OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) ||
                (tunnel->interface_type ==
-                  OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING))))) {
+                  OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING))))) {
 
             if (modify_flags & OGS_PFCP_MODIFY_REMOVE) {
                 pdr = tunnel->pdr;

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -25,39 +25,39 @@ static uint8_t gtp_cause_from_pfcp(uint8_t pfcp_cause)
 {
     switch (pfcp_cause) {
     case OGS_PFCP_CAUSE_REQUEST_ACCEPTED:
-        return OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+        return OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
     case OGS_PFCP_CAUSE_REQUEST_REJECTED:
-        return OGS_GTP_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED;
+        return OGS_GTP2_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED;
     case OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND:
-        return OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        return OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     case OGS_PFCP_CAUSE_MANDATORY_IE_MISSING:
-        return OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        return OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     case OGS_PFCP_CAUSE_CONDITIONAL_IE_MISSING:
-        return OGS_GTP_CAUSE_CONDITIONAL_IE_MISSING;
+        return OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
     case OGS_PFCP_CAUSE_INVALID_LENGTH:
-        return OGS_GTP_CAUSE_INVALID_LENGTH;
+        return OGS_GTP2_CAUSE_INVALID_LENGTH;
     case OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT:
-        return OGS_GTP_CAUSE_MANDATORY_IE_INCORRECT;
+        return OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
     case OGS_PFCP_CAUSE_INVALID_FORWARDING_POLICY:
     case OGS_PFCP_CAUSE_INVALID_F_TEID_ALLOCATION_OPTION:
-        return OGS_GTP_CAUSE_INVALID_MESSAGE_FORMAT;
+        return OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT;
     case OGS_PFCP_CAUSE_NO_ESTABLISHED_PFCP_ASSOCIATION:
-        return OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+        return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
     case OGS_PFCP_CAUSE_RULE_CREATION_MODIFICATION_FAILURE:
-        return OGS_GTP_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
+        return OGS_GTP2_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
     case OGS_PFCP_CAUSE_PFCP_ENTITY_IN_CONGESTION:
-        return OGS_GTP_CAUSE_GTP_C_ENTITY_CONGESTION;
+        return OGS_GTP2_CAUSE_GTP_C_ENTITY_CONGESTION;
     case OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE:
-        return OGS_GTP_CAUSE_NO_RESOURCES_AVAILABLE;
+        return OGS_GTP2_CAUSE_NO_RESOURCES_AVAILABLE;
     case OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED:
-        return OGS_GTP_CAUSE_SERVICE_NOT_SUPPORTED;
+        return OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED;
     case OGS_PFCP_CAUSE_SYSTEM_FAILURE:
-        return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+        return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
     default:
-        return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+        return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
     }
 
-    return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+    return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
 }
 
 static void sess_timeout(ogs_gtp_xact_t *xact, void *data)
@@ -74,7 +74,7 @@ static void sess_timeout(ogs_gtp_xact_t *xact, void *data)
     type = xact->seq[0].type;
 
     switch (type) {
-    case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
         ogs_error("[%s] No Create Session Response", sgwc_ue->imsi_bcd);
         if (!sgwc_sess_cycle(sess)) {
             ogs_warn("[%s] Session has already been removed",
@@ -107,7 +107,7 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
     type = xact->seq[0].type;
 
     switch (type) {
-    case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
+    case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Create Bearer Response", sgwc_ue->imsi_bcd);
         if (!sgwc_bearer_cycle(bearer)) {
             ogs_warn("[%s] Bearer has already been removed", sgwc_ue->imsi_bcd);
@@ -126,7 +126,7 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 
 void sgwc_sxa_handle_session_establishment_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *gtp_message,
+        ogs_gtp2_message_t *gtp_message,
         ogs_pfcp_session_establishment_response_t *pfcp_rsp)
 {
     int rv, len = 0;
@@ -134,8 +134,8 @@ void sgwc_sxa_handle_session_establishment_response(
 
     ogs_pfcp_f_seid_t *up_f_seid = NULL;
 
-    ogs_gtp_f_teid_t sgw_s5c_teid, sgw_s5u_teid;
-    ogs_gtp_f_teid_t *pgw_s5c_teid = NULL;
+    ogs_gtp2_f_teid_t sgw_s5c_teid, sgw_s5u_teid;
+    ogs_gtp2_f_teid_t *pgw_s5c_teid = NULL;
 
     ogs_gtp_xact_t *s11_xact = NULL, *s5c_xact = NULL;
     ogs_gtp_node_t *pgw = NULL;
@@ -144,7 +144,7 @@ void sgwc_sxa_handle_session_establishment_response(
     sgwc_bearer_t *bearer = NULL;
     sgwc_tunnel_t *dl_tunnel = NULL;
 
-    ogs_gtp_create_session_request_t *gtp_req = NULL;
+    ogs_gtp2_create_session_request_t *gtp_req = NULL;
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_debug("Session Establishment Response");
@@ -161,21 +161,21 @@ void sgwc_sxa_handle_session_establishment_response(
 
     ogs_pfcp_xact_commit(pfcp_xact);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (pfcp_rsp->up_f_seid.presence == 0) {
         ogs_error("No UP F-SEID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (pfcp_rsp->created_pdr[0].presence == 0) {
         ogs_error("No Created PDR");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (pfcp_rsp->cause.presence) {
@@ -185,10 +185,10 @@ void sgwc_sxa_handle_session_establishment_response(
         }
     } else {
         ogs_error("No Cause");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         int i;
 
         uint8_t pfcp_cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
@@ -238,11 +238,11 @@ void sgwc_sxa_handle_session_establishment_response(
         cause_value = gtp_cause_from_pfcp(pfcp_cause_value);
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (sess) sgwc_ue = sess->sgwc_ue;
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -257,8 +257,8 @@ void sgwc_sxa_handle_session_establishment_response(
         ogs_error("No UP F-TEID");
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE,
-                OGS_GTP_CAUSE_GRE_KEY_NOT_FOUND);
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                OGS_GTP2_CAUSE_GRE_KEY_NOT_FOUND);
         return;
     }
 
@@ -268,10 +268,10 @@ void sgwc_sxa_handle_session_establishment_response(
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
 
     /* Send Control Plane(DL) : SGW-S5C */
-    memset(&sgw_s5c_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    sgw_s5c_teid.interface_type = OGS_GTP_F_TEID_S5_S8_SGW_GTP_C;
+    memset(&sgw_s5c_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    sgw_s5c_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_SGW_GTP_C;
     sgw_s5c_teid.teid = htobe32(sess->sgw_s5c_teid);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             ogs_gtp_self()->gtpc_addr, ogs_gtp_self()->gtpc_addr6,
             &sgw_s5c_teid, &len);
     ogs_assert(rv == OGS_OK);
@@ -305,11 +305,11 @@ void sgwc_sxa_handle_session_establishment_response(
     gtp_req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 0;
 
     /* Data Plane(DL) : SGW-S5U */
-    memset(&sgw_s5u_teid, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&sgw_s5u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
     sgw_s5u_teid.teid = htobe32(dl_tunnel->local_teid);
     sgw_s5u_teid.interface_type = dl_tunnel->interface_type;
     ogs_assert(dl_tunnel->local_addr || dl_tunnel->local_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
         dl_tunnel->local_addr, dl_tunnel->local_addr6, &sgw_s5u_teid, &len);
     ogs_assert(rv == OGS_OK);
     gtp_req->bearer_contexts_to_be_created.s5_s8_u_sgw_f_teid.presence = 1;
@@ -317,10 +317,10 @@ void sgwc_sxa_handle_session_establishment_response(
         &sgw_s5u_teid;
     gtp_req->bearer_contexts_to_be_created.s5_s8_u_sgw_f_teid.len = len;
 
-    gtp_message->h.type = OGS_GTP_CREATE_SESSION_REQUEST_TYPE;
+    gtp_message->h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
     gtp_message->h.teid = sess->pgw_s5c_teid;
 
-    pkbuf = ogs_gtp_build_msg(gtp_message);
+    pkbuf = ogs_gtp2_build_msg(gtp_message);
     ogs_expect_or_return(pkbuf);
 
     ogs_assert(sess->gnode);
@@ -336,7 +336,7 @@ void sgwc_sxa_handle_session_establishment_response(
 
 void sgwc_sxa_handle_session_modification_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *recv_message,
+        ogs_gtp2_message_t *recv_message,
         ogs_pfcp_session_modification_response_t *pfcp_rsp)
 {
     int i, rv, len = 0;
@@ -346,7 +346,7 @@ void sgwc_sxa_handle_session_modification_response(
     ogs_gtp_xact_t *s11_xact = NULL;
     ogs_gtp_xact_t *s5c_xact = NULL;
 
-    ogs_gtp_message_t send_message;
+    ogs_gtp2_message_t send_message;
 
     sgwc_bearer_t *bearer = NULL;
     sgwc_tunnel_t *dl_tunnel = NULL, *ul_tunnel = NULL;
@@ -354,7 +354,7 @@ void sgwc_sxa_handle_session_modification_response(
 
     ogs_pkbuf_t *pkbuf = NULL;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
 
     ogs_debug("Session Modification Response");
 
@@ -364,7 +364,7 @@ void sgwc_sxa_handle_session_modification_response(
     flags = pfcp_xact->modify_flags;
     ogs_assert(flags);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (flags & OGS_PFCP_MODIFY_SESSION) {
         if (!sess) {
@@ -373,7 +373,7 @@ void sgwc_sxa_handle_session_modification_response(
             sess = pfcp_xact->data;
             ogs_assert(sess);
 
-            cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+            cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
         sgwc_ue = sess->sgwc_ue;
         ogs_assert(sgwc_ue);
@@ -388,7 +388,7 @@ void sgwc_sxa_handle_session_modification_response(
             sess = bearer->sess;
             ogs_assert(sess);
 
-            cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+            cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
 
         sgwc_ue = bearer->sgwc_ue;
@@ -402,10 +402,10 @@ void sgwc_sxa_handle_session_modification_response(
         }
     } else {
         ogs_error("No Cause");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         uint8_t pfcp_cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
         uint8_t offending_ie_value = 0;
 
@@ -453,7 +453,7 @@ void sgwc_sxa_handle_session_modification_response(
         cause_value = gtp_cause_from_pfcp(pfcp_cause_value);
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         /*
          * You should not change the following order to support
          * OGS_PFCP_MODIFY_REMOVE|OGS_PFCP_MODIFY_CREATE.
@@ -468,7 +468,7 @@ void sgwc_sxa_handle_session_modification_response(
             if (s5c_xact) {
                 ogs_gtp_send_error_message(
                         s5c_xact, sess ? sess->pgw_s5c_teid : 0,
-                        OGS_GTP_DELETE_BEARER_RESPONSE_TYPE, cause_value);
+                        OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE, cause_value);
             }
 
             sgwc_bearer_remove(bearer);
@@ -478,7 +478,7 @@ void sgwc_sxa_handle_session_modification_response(
 
             ogs_gtp_send_error_message(
                     s5c_xact, sess ? sess->pgw_s5c_teid : 0,
-                    OGS_GTP_CREATE_BEARER_RESPONSE_TYPE, cause_value);
+                    OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
 
 
         } else if (flags & OGS_PFCP_MODIFY_ACTIVATE) {
@@ -488,7 +488,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 ogs_gtp_send_error_message(
                         s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                        OGS_GTP_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+                        OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
 
             } else if (flags & OGS_PFCP_MODIFY_DL_ONLY) {
                 s11_xact = pfcp_xact->assoc_xact;
@@ -496,7 +496,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 ogs_gtp_send_error_message(
                         s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                        OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
+                        OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
             } else {
                 ogs_fatal("Invalid modify_flags[0x%llx]", (long long)flags);
                 ogs_assert_if_reached();
@@ -507,7 +507,7 @@ void sgwc_sxa_handle_session_modification_response(
 
             ogs_gtp_send_error_message(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
+                    OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
         }
 
         ogs_pfcp_xact_commit(pfcp_xact);
@@ -552,7 +552,7 @@ void sgwc_sxa_handle_session_modification_response(
 
             if (delete_indirect_tunnel_is_done == true) {
                 sgwc_tunnel_t *tunnel = NULL, *next_tunnel = NULL;
-                ogs_gtp_delete_indirect_data_forwarding_tunnel_response_t
+                ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t
                     *gtp_rsp = NULL;
 
                 ogs_list_for_each(&sgwc_ue->sess_list, sess) {
@@ -560,9 +560,9 @@ void sgwc_sxa_handle_session_modification_response(
                         ogs_list_for_each_safe(&bearer->tunnel_list,
                                 next_tunnel, tunnel) {
                             if (tunnel->interface_type ==
-                            OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING ||
+                            OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING ||
                                 tunnel->interface_type ==
-                            OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING) {
+                            OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING) {
                                 sgwc_tunnel_remove(tunnel);
                             }
                         }
@@ -573,20 +573,20 @@ void sgwc_sxa_handle_session_modification_response(
                     delete_indirect_data_forwarding_tunnel_response;
                 ogs_assert(gtp_rsp);
 
-                memset(&send_message, 0, sizeof(ogs_gtp_message_t));
+                memset(&send_message, 0, sizeof(ogs_gtp2_message_t));
 
                 memset(&cause, 0, sizeof(cause));
-                cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+                cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
                 gtp_rsp->cause.presence = 1;
                 gtp_rsp->cause.data = &cause;
                 gtp_rsp->cause.len = sizeof(cause);
 
                 send_message.h.type =
-                OGS_GTP_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
+                OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
-                pkbuf = ogs_gtp_build_msg(&send_message);
+                pkbuf = ogs_gtp2_build_msg(&send_message);
                 ogs_expect_or_return(pkbuf);
 
                 rv = ogs_gtp_xact_update_tx(s11_xact, &send_message.h, pkbuf);
@@ -601,10 +601,10 @@ void sgwc_sxa_handle_session_modification_response(
 
             if (s5c_xact) {
                 ogs_assert(recv_message);
-                recv_message->h.type = OGS_GTP_DELETE_BEARER_RESPONSE_TYPE;
+                recv_message->h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
                 recv_message->h.teid = sess->pgw_s5c_teid;
 
-                pkbuf = ogs_gtp_build_msg(recv_message);
+                pkbuf = ogs_gtp2_build_msg(recv_message);
                 ogs_expect_or_return(pkbuf);
 
                 rv = ogs_gtp_xact_update_tx(s5c_xact, &recv_message->h, pkbuf);
@@ -619,8 +619,8 @@ void sgwc_sxa_handle_session_modification_response(
 
     } else if (flags & OGS_PFCP_MODIFY_CREATE) {
         if (flags & OGS_PFCP_MODIFY_UL_ONLY) {
-            ogs_gtp_create_bearer_request_t *gtp_req = NULL;
-            ogs_gtp_f_teid_t sgw_s1u_teid;
+            ogs_gtp2_create_bearer_request_t *gtp_req = NULL;
+            ogs_gtp2_f_teid_t sgw_s1u_teid;
 
             s5c_xact = pfcp_xact->assoc_xact;
             ogs_assert(s5c_xact);
@@ -633,11 +633,11 @@ void sgwc_sxa_handle_session_modification_response(
             gtp_req->bearer_contexts.s4_u_sgsn_f_teid.presence = 0;
 
             /* Send Data Plane(UL) : SGW-S1U */
-            memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
+            memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
             sgw_s1u_teid.interface_type = ul_tunnel->interface_type;
             sgw_s1u_teid.teid = htobe32(ul_tunnel->local_teid);
             ogs_assert(ul_tunnel->local_addr || ul_tunnel->local_addr6);
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     ul_tunnel->local_addr, ul_tunnel->local_addr6,
                     &sgw_s1u_teid, &len);
             ogs_assert(rv == OGS_OK);
@@ -645,10 +645,10 @@ void sgwc_sxa_handle_session_modification_response(
             gtp_req->bearer_contexts.s1_u_enodeb_f_teid.data = &sgw_s1u_teid;
             gtp_req->bearer_contexts.s1_u_enodeb_f_teid.len = len;
 
-            recv_message->h.type = OGS_GTP_CREATE_BEARER_REQUEST_TYPE;
+            recv_message->h.type = OGS_GTP2_CREATE_BEARER_REQUEST_TYPE;
             recv_message->h.teid = sgwc_ue->mme_s11_teid;
 
-            pkbuf = ogs_gtp_build_msg(recv_message);
+            pkbuf = ogs_gtp2_build_msg(recv_message);
             ogs_expect_or_return(pkbuf);
 
             ogs_assert(sgwc_ue->gnode);
@@ -663,8 +663,8 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_expect(rv == OGS_OK);
 
         } else if (flags & OGS_PFCP_MODIFY_DL_ONLY) {
-            ogs_gtp_create_bearer_response_t *gtp_rsp = NULL;
-            ogs_gtp_f_teid_t sgw_s5u_teid, pgw_s5u_teid;
+            ogs_gtp2_create_bearer_response_t *gtp_rsp = NULL;
+            ogs_gtp2_f_teid_t sgw_s5u_teid, pgw_s5u_teid;
 
             s5c_xact = pfcp_xact->assoc_xact;
             ogs_assert(s5c_xact);
@@ -681,11 +681,11 @@ void sgwc_sxa_handle_session_modification_response(
 
             /* Data Plane(DL) : SGW-S5U */
             ogs_assert(dl_tunnel);
-            memset(&sgw_s5u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-            sgw_s5u_teid.interface_type = OGS_GTP_F_TEID_S5_S8_SGW_GTP_U;
+            memset(&sgw_s5u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+            sgw_s5u_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U;
             sgw_s5u_teid.teid = htobe32(dl_tunnel->local_teid);
             ogs_assert(dl_tunnel->local_addr || dl_tunnel->local_addr6);
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     dl_tunnel->local_addr, dl_tunnel->local_addr6,
                     &sgw_s5u_teid, &len);
             ogs_assert(rv == OGS_OK);
@@ -695,18 +695,18 @@ void sgwc_sxa_handle_session_modification_response(
 
             /* Data Plane(UL) : PGW-S5U */
             ogs_assert(ul_tunnel);
-            pgw_s5u_teid.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_U;
+            pgw_s5u_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_U;
             pgw_s5u_teid.teid = htobe32(ul_tunnel->remote_teid);
-            rv = ogs_gtp_ip_to_f_teid(
+            rv = ogs_gtp2_ip_to_f_teid(
                     &ul_tunnel->remote_ip, &pgw_s5u_teid, &len);
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.presence = 1;
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.data = &pgw_s5u_teid;
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.len = len;
 
-            recv_message->h.type = OGS_GTP_CREATE_BEARER_RESPONSE_TYPE;
+            recv_message->h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
             recv_message->h.teid = sess->pgw_s5c_teid;
 
-            pkbuf = ogs_gtp_build_msg(recv_message);
+            pkbuf = ogs_gtp2_build_msg(recv_message);
             ogs_expect_or_return(pkbuf);
 
             rv = ogs_gtp_xact_update_tx(s5c_xact, &recv_message->h, pkbuf);
@@ -732,13 +732,13 @@ void sgwc_sxa_handle_session_modification_response(
             if (create_indirect_tunnel_is_done == true) {
                 sgwc_tunnel_t *tunnel = NULL;
 
-                ogs_gtp_create_indirect_data_forwarding_tunnel_request_t
+                ogs_gtp2_create_indirect_data_forwarding_tunnel_request_t
                     *gtp_req = NULL;
-                ogs_gtp_create_indirect_data_forwarding_tunnel_response_t
+                ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t
                     *gtp_rsp = NULL;
 
-                ogs_gtp_f_teid_t rsp_dl_teid[OGS_GTP_MAX_INDIRECT_TUNNEL];
-                ogs_gtp_f_teid_t rsp_ul_teid[OGS_GTP_MAX_INDIRECT_TUNNEL];
+                ogs_gtp2_f_teid_t rsp_dl_teid[OGS_GTP2_MAX_INDIRECT_TUNNEL];
+                ogs_gtp2_f_teid_t rsp_ul_teid[OGS_GTP2_MAX_INDIRECT_TUNNEL];
 
                 ogs_assert(recv_message);
                 gtp_req = &recv_message->
@@ -748,10 +748,10 @@ void sgwc_sxa_handle_session_modification_response(
                     create_indirect_data_forwarding_tunnel_response;
                 ogs_assert(gtp_rsp);
 
-                memset(&send_message, 0, sizeof(ogs_gtp_message_t));
+                memset(&send_message, 0, sizeof(ogs_gtp2_message_t));
 
                 memset(&cause, 0, sizeof(cause));
-                cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+                cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
                 gtp_rsp->cause.presence = 1;
                 gtp_rsp->cause.data = &cause;
@@ -766,16 +766,16 @@ void sgwc_sxa_handle_session_modification_response(
 
                     ogs_list_for_each(&bearer->tunnel_list, tunnel) {
                         if (tunnel->interface_type ==
-                            OGS_GTP_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) {
+                            OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING) {
 
                             memset(&rsp_dl_teid[i],
-                                    0, sizeof(ogs_gtp_f_teid_t));
+                                    0, sizeof(ogs_gtp2_f_teid_t));
                             rsp_dl_teid[i].interface_type =
                                 tunnel->interface_type;
                             rsp_dl_teid[i].teid = htobe32(tunnel->local_teid);
                             ogs_assert(
                                     tunnel->local_addr || tunnel->local_addr6);
-                            rv = ogs_gtp_sockaddr_to_f_teid(
+                            rv = ogs_gtp2_sockaddr_to_f_teid(
                                 tunnel->local_addr, tunnel->local_addr6,
                                 &rsp_dl_teid[i], &len);
                             ogs_assert(rv == OGS_OK);
@@ -787,16 +787,16 @@ void sgwc_sxa_handle_session_modification_response(
                                 s4_u_sgsn_f_teid.len = len;
 
                         } else if (tunnel->interface_type ==
-                            OGS_GTP_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING) {
+                            OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING) {
 
                             memset(&rsp_ul_teid[i],
-                                0, sizeof(ogs_gtp_f_teid_t));
+                                0, sizeof(ogs_gtp2_f_teid_t));
                             rsp_ul_teid[i].teid = htobe32(tunnel->local_teid);
                             rsp_ul_teid[i].interface_type =
                                 tunnel->interface_type;
                             ogs_assert(
                                     tunnel->local_addr || tunnel->local_addr6);
-                            rv = ogs_gtp_sockaddr_to_f_teid(
+                            rv = ogs_gtp2_sockaddr_to_f_teid(
                                 tunnel->local_addr, tunnel->local_addr6,
                                 &rsp_ul_teid[i], &len);
                             ogs_assert(rv == OGS_OK);
@@ -828,10 +828,10 @@ void sgwc_sxa_handle_session_modification_response(
                 }
 
                 send_message.h.type =
-                OGS_GTP_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
+                OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
-                pkbuf = ogs_gtp_build_msg(&send_message);
+                pkbuf = ogs_gtp2_build_msg(&send_message);
                 ogs_expect_or_return(pkbuf);
 
                 rv = ogs_gtp_xact_update_tx(s11_xact, &send_message.h, pkbuf);
@@ -850,19 +850,19 @@ void sgwc_sxa_handle_session_modification_response(
         ogs_assert(s11_xact);
 
         if (flags & OGS_PFCP_MODIFY_UL_ONLY) {
-            ogs_gtp_create_session_response_t *gtp_rsp = NULL;
-            ogs_gtp_f_teid_t sgw_s11_teid;
-            ogs_gtp_f_teid_t sgw_s1u_teid;
+            ogs_gtp2_create_session_response_t *gtp_rsp = NULL;
+            ogs_gtp2_f_teid_t sgw_s11_teid;
+            ogs_gtp2_f_teid_t sgw_s1u_teid;
 
             ogs_assert(recv_message);
             gtp_rsp = &recv_message->create_session_response;
             ogs_assert(gtp_rsp);
 
             /* Send Control Plane(UL) : SGW-S11 */
-            memset(&sgw_s11_teid, 0, sizeof(ogs_gtp_f_teid_t));
-            sgw_s11_teid.interface_type = OGS_GTP_F_TEID_S11_S4_SGW_GTP_C;
+            memset(&sgw_s11_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+            sgw_s11_teid.interface_type = OGS_GTP2_F_TEID_S11_S4_SGW_GTP_C;
             sgw_s11_teid.teid = htobe32(sgwc_ue->sgw_s11_teid);
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     ogs_gtp_self()->gtpc_addr, ogs_gtp_self()->gtpc_addr6,
                     &sgw_s11_teid, &len);
             ogs_assert(rv == OGS_OK);
@@ -872,11 +872,11 @@ void sgwc_sxa_handle_session_modification_response(
 
             /* Send Data Plane(UL) : SGW-S1U */
             ogs_assert(ul_tunnel);
-            memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp_f_teid_t));
+            memset(&sgw_s1u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
             sgw_s1u_teid.interface_type = ul_tunnel->interface_type;
             sgw_s1u_teid.teid = htobe32(ul_tunnel->local_teid);
             ogs_assert(ul_tunnel->local_addr || ul_tunnel->local_addr6);
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                 ul_tunnel->local_addr, ul_tunnel->local_addr6,
                 &sgw_s1u_teid, &len);
             ogs_assert(rv == OGS_OK);
@@ -885,10 +885,10 @@ void sgwc_sxa_handle_session_modification_response(
                 &sgw_s1u_teid;
             gtp_rsp->bearer_contexts_created.s1_u_enodeb_f_teid.len = len;
 
-            recv_message->h.type = OGS_GTP_CREATE_SESSION_RESPONSE_TYPE;
+            recv_message->h.type = OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE;
             recv_message->h.teid = sgwc_ue->mme_s11_teid;
 
-            pkbuf = ogs_gtp_build_msg(recv_message);
+            pkbuf = ogs_gtp2_build_msg(recv_message);
             ogs_expect_or_return(pkbuf);
 
             rv = ogs_gtp_xact_update_tx(s11_xact, &recv_message->h, pkbuf);
@@ -898,10 +898,10 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_expect(rv == OGS_OK);
 
         } else if (flags & OGS_PFCP_MODIFY_DL_ONLY) {
-            ogs_gtp_modify_bearer_request_t *gtp_req = NULL;
-            ogs_gtp_modify_bearer_response_t *gtp_rsp = NULL;
+            ogs_gtp2_modify_bearer_request_t *gtp_req = NULL;
+            ogs_gtp2_modify_bearer_response_t *gtp_rsp = NULL;
 
-            ogs_gtp_indication_t *indication = NULL;
+            ogs_gtp2_indication_t *indication = NULL;
 
             ogs_assert(recv_message);
             gtp_req = &recv_message->modify_bearer_request;
@@ -914,10 +914,10 @@ void sgwc_sxa_handle_session_modification_response(
             }
 
             if (indication && indication->handover_indication) {
-                recv_message->h.type = OGS_GTP_MODIFY_BEARER_REQUEST_TYPE;
+                recv_message->h.type = OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE;
                 recv_message->h.teid = sess->pgw_s5c_teid;
 
-                pkbuf = ogs_gtp_build_msg(recv_message);
+                pkbuf = ogs_gtp2_build_msg(recv_message);
                 ogs_expect_or_return(pkbuf);
 
                 ogs_assert(sess->gnode);
@@ -935,10 +935,10 @@ void sgwc_sxa_handle_session_modification_response(
                 gtp_rsp = &send_message.modify_bearer_response;
                 ogs_assert(gtp_rsp);
 
-                memset(&send_message, 0, sizeof(ogs_gtp_message_t));
+                memset(&send_message, 0, sizeof(ogs_gtp2_message_t));
 
                 memset(&cause, 0, sizeof(cause));
-                cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+                cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
                 gtp_rsp->cause.presence = 1;
                 gtp_rsp->cause.data = &cause;
@@ -974,10 +974,10 @@ void sgwc_sxa_handle_session_modification_response(
                 gtp_rsp->bearer_contexts_modified.cause.len = sizeof(cause);
                 gtp_rsp->bearer_contexts_modified.cause.data = &cause;
 
-                send_message.h.type = OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE;
+                send_message.h.type = OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
-                pkbuf = ogs_gtp_build_msg(&send_message);
+                pkbuf = ogs_gtp2_build_msg(&send_message);
                 ogs_expect_or_return(pkbuf);
 
                 rv = ogs_gtp_xact_update_tx(s11_xact, &send_message.h, pkbuf);
@@ -1010,10 +1010,10 @@ void sgwc_sxa_handle_session_modification_response(
 
                 ogs_assert(OGS_OK ==
                     sgwc_gtp_send_downlink_data_notification(
-                        OGS_GTP_CAUSE_ERROR_INDICATION_RECEIVED, bearer));
+                        OGS_GTP2_CAUSE_ERROR_INDICATION_RECEIVED, bearer));
 
             } else {
-                ogs_gtp_release_access_bearers_response_t *gtp_rsp = NULL;
+                ogs_gtp2_release_access_bearers_response_t *gtp_rsp = NULL;
 
                 s11_xact = pfcp_xact->assoc_xact;
                 ogs_assert(s11_xact);
@@ -1021,20 +1021,20 @@ void sgwc_sxa_handle_session_modification_response(
                 gtp_rsp = &send_message.release_access_bearers_response;
                 ogs_assert(gtp_rsp);
 
-                memset(&send_message, 0, sizeof(ogs_gtp_message_t));
+                memset(&send_message, 0, sizeof(ogs_gtp2_message_t));
 
                 memset(&cause, 0, sizeof(cause));
-                cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+                cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
                 gtp_rsp->cause.presence = 1;
                 gtp_rsp->cause.data = &cause;
                 gtp_rsp->cause.len = sizeof(cause);
 
                 send_message.h.type =
-                    OGS_GTP_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE;
+                    OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
-                pkbuf = ogs_gtp_build_msg(&send_message);
+                pkbuf = ogs_gtp2_build_msg(&send_message);
                 ogs_expect_or_return(pkbuf);
 
                 rv = ogs_gtp_xact_update_tx(s11_xact, &send_message.h, pkbuf);
@@ -1054,7 +1054,7 @@ void sgwc_sxa_handle_session_modification_response(
 
 void sgwc_sxa_handle_session_deletion_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *gtp_message,
+        ogs_gtp2_message_t *gtp_message,
         ogs_pfcp_session_deletion_response_t *pfcp_rsp)
 {
     int rv;
@@ -1071,11 +1071,11 @@ void sgwc_sxa_handle_session_deletion_response(
     ogs_assert(pfcp_xact);
     ogs_assert(pfcp_rsp);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (pfcp_rsp->cause.presence) {
@@ -1085,7 +1085,7 @@ void sgwc_sxa_handle_session_deletion_response(
         }
     } else {
         ogs_error("No Cause");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     gtp_xact = pfcp_xact->assoc_xact;
@@ -1098,7 +1098,7 @@ void sgwc_sxa_handle_session_deletion_response(
     }
 
     switch (gtp_message->h.type) {
-    case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
+    case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
         /*
          * 1. MME sends Delete Session Request to SGW/SMF.
          * 2. SMF sends Delete Session Response to SGW/MME.
@@ -1106,7 +1106,7 @@ void sgwc_sxa_handle_session_deletion_response(
         if (sess) sgwc_ue = sess->sgwc_ue;
         teid = sgwc_ue ? sgwc_ue->mme_s11_teid : 0;
         break;
-    case OGS_GTP_DELETE_BEARER_RESPONSE_TYPE:
+    case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
         /*
          * 1. SMF sends Delete Bearer Request(DEFAULT BEARER) to SGW/MME.
          * 2. MME sends Delete Bearer Response to SGW/SMF.
@@ -1127,7 +1127,7 @@ void sgwc_sxa_handle_session_deletion_response(
         ogs_assert_if_reached();
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (gtp_xact) {
             ogs_gtp_send_error_message(
                     gtp_xact, teid, gtp_message->h.type, cause_value);
@@ -1141,15 +1141,15 @@ void sgwc_sxa_handle_session_deletion_response(
 
     if (gtp_xact) {
         /*
-         * If gtp_message->h.type == OGS_GTP_DELETE_SESSION_RESPONSE_TYPE
+         * If gtp_message->h.type == OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE
          * Then gtp_xact is S11-XACT
          *
-         * If gtp_message->h.type == OGS_GTP_DELETE_BEARER_RESPONSE_TYPE
+         * If gtp_message->h.type == OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE
          * Then gtp_xact is S5C-XACT
          */
         gtp_message->h.teid = teid;
 
-        pkbuf = ogs_gtp_build_msg(gtp_message);
+        pkbuf = ogs_gtp2_build_msg(gtp_message);
         ogs_expect_or_return(pkbuf);
 
         rv = ogs_gtp_xact_update_tx(gtp_xact, &gtp_message->h, pkbuf);
@@ -1180,7 +1180,7 @@ void sgwc_sxa_handle_session_report_request(
     ogs_assert(pfcp_xact);
     ogs_assert(pfcp_req);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
@@ -1189,10 +1189,10 @@ void sgwc_sxa_handle_session_report_request(
 
     if (pfcp_req->report_type.presence == 0) {
         ogs_error("No Report Type");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_pfcp_send_error_message(pfcp_xact, 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 cause_value, 0);
@@ -1236,7 +1236,7 @@ void sgwc_sxa_handle_session_report_request(
                 if (tunnel->pdr->id == pdr_id) {
                     ogs_assert(OGS_OK ==
                         sgwc_gtp_send_downlink_data_notification(
-                            OGS_GTP_CAUSE_UNDEFINED_VALUE, bearer));
+                            OGS_GTP2_CAUSE_UNDEFINED_VALUE, bearer));
                     return;
                 }
             }

--- a/src/sgwc/sxa-handler.h
+++ b/src/sgwc/sxa-handler.h
@@ -28,15 +28,15 @@ extern "C" {
 
 void sgwc_sxa_handle_session_establishment_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *gtp_message,
+        ogs_gtp2_message_t *gtp_message,
         ogs_pfcp_session_establishment_response_t *pfcp_rsp);
 void sgwc_sxa_handle_session_modification_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *gtp_message,
+        ogs_gtp2_message_t *gtp_message,
         ogs_pfcp_session_modification_response_t *pfcp_rsp);
 void sgwc_sxa_handle_session_deletion_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_gtp_message_t *gtp_message,
+        ogs_gtp2_message_t *gtp_message,
         ogs_pfcp_session_deletion_response_t *pfcp_rsp);
 void sgwc_sxa_handle_session_report_request(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,

--- a/src/sgwu/gtp-path.c
+++ b/src/sgwu/gtp-path.c
@@ -35,7 +35,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t from;
 
-    ogs_gtp_header_t *gtp_h = NULL;
+    ogs_gtp2_header_t *gtp_h = NULL;
     ogs_pfcp_user_plane_report_t report;
 
     uint32_t teid;
@@ -59,8 +59,8 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->len);
 
-    gtp_h = (ogs_gtp_header_t *)pkbuf->data;
-    if (gtp_h->version != OGS_GTP_VERSION_1) {
+    gtp_h = (ogs_gtp2_header_t *)pkbuf->data;
+    if (gtp_h->version != OGS_GTP2_VERSION_1) {
         ogs_error("[DROP] Invalid GTPU version [%d]", gtp_h->version);
         ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
         goto cleanup;
@@ -70,7 +70,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
         ogs_pkbuf_t *echo_rsp;
 
         ogs_debug("[RECV] Echo Request from [%s]", OGS_ADDR(&from, buf));
-        echo_rsp = ogs_gtp_handle_echo_req(pkbuf);
+        echo_rsp = ogs_gtp2_handle_echo_req(pkbuf);
         ogs_expect(echo_rsp);
         if (echo_rsp) {
             ssize_t sent;
@@ -103,13 +103,13 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
          * Note 4 : For a GTP-PDU with several Extension Headers, the PDU
          *          Session Container should be the first Extension Header
          */
-        ogs_gtp_extension_header_t *extension_header =
-            (ogs_gtp_extension_header_t *)(pkbuf->data + OGS_GTPV1U_HEADER_LEN);
+        ogs_gtp2_extension_header_t *extension_header =
+            (ogs_gtp2_extension_header_t *)(pkbuf->data + OGS_GTPV1U_HEADER_LEN);
         ogs_assert(extension_header);
         if (extension_header->type ==
-                OGS_GTP_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER) {
+                OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER) {
             if (extension_header->pdu_type ==
-                OGS_GTP_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
+                OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
                     ogs_debug("   QFI [0x%x]",
                             extension_header->qos_flow_identifier);
                     qfi = extension_header->qos_flow_identifier;

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -934,14 +934,14 @@ static bool compare_ue_info(ogs_pfcp_node_t *node, smf_sess_t *sess)
         if (ogs_strcasecmp(node->dnn[i], sess->session.name) == 0) return true;
 
     for (i = 0; i < node->num_of_e_cell_id; i++)
-        if (sess->gtp_rat_type == OGS_GTP_RAT_TYPE_EUTRAN &&
+        if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_EUTRAN &&
                 node->e_cell_id[i] == sess->e_cgi.cell_id) return true;
 
     for (i = 0; i < node->num_of_nr_cell_id; i++)
         if (node->nr_cell_id[i] == sess->nr_cgi.cell_id) return true;
 
     for (i = 0; i < node->num_of_tac; i++)
-        if ((sess->gtp_rat_type == OGS_GTP_RAT_TYPE_EUTRAN &&
+        if ((sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_EUTRAN &&
                 node->tac[i] == sess->e_tai.tac) ||
             (node->tac[i] == sess->nr_tai.tac.v)) return true;
 
@@ -1144,13 +1144,13 @@ smf_sess_t *smf_sess_add_by_gtp1_message(ogs_gtp1_message_t *message)
     return sess;
 }
 
-smf_sess_t *smf_sess_add_by_gtp_message(ogs_gtp_message_t *message)
+smf_sess_t *smf_sess_add_by_gtp_message(ogs_gtp2_message_t *message)
 {
     smf_ue_t *smf_ue = NULL;
     smf_sess_t *sess = NULL;
     char apn[OGS_MAX_APN_LEN+1];
 
-    ogs_gtp_create_session_request_t *req = &message->create_session_request;
+    ogs_gtp2_create_session_request_t *req = &message->create_session_request;
 
     if (req->imsi.presence == 0) {
         ogs_error("No IMSI");

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -395,7 +395,7 @@ smf_ue_t *smf_ue_find_by_supi(char *supi);
 smf_ue_t *smf_ue_find_by_imsi(uint8_t *imsi, int imsi_len);
 
 smf_sess_t *smf_sess_add_by_gtp1_message(ogs_gtp1_message_t *message);
-smf_sess_t *smf_sess_add_by_gtp_message(ogs_gtp_message_t *message);
+smf_sess_t *smf_sess_add_by_gtp_message(ogs_gtp2_message_t *message);
 smf_sess_t *smf_sess_add_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type);
 
 smf_sess_t *smf_sess_add_by_sbi_message(ogs_sbi_message_t *message);

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -164,7 +164,7 @@ ogs_pkbuf_t *smf_gn_build_create_pdp_context_response(
     rsp->charging_id.u32 = sess->charging.id;
 
     /* End User Address */
-    rv = ogs_gtp_paa_to_ip(&sess->session.paa, &ip_eua);
+    rv = ogs_gtp2_paa_to_ip(&sess->session.paa, &ip_eua);
     rv = ogs_gtp1_ip_to_eua(sess->session.paa.session_type, &ip_eua, &eua,
             &eua_len);
     rsp->end_user_address.presence = 1;

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -392,7 +392,7 @@ void smf_gn_handle_update_pdp_context_request(
      * https://github.com/open5gs/open5gs/issues/1367
      */
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP1_UPDATE_PDP_CONTEXT_RESPONSE_TYPE;
     h.teid = sess->sgw_s5c_teid;
 

--- a/src/smf/gx-handler.c
+++ b/src/smf/gx-handler.c
@@ -33,14 +33,14 @@ static uint8_t gtp_cause_from_diameter(
     if (dia_err) {
         switch (*dia_err) {
         case OGS_DIAM_UNKNOWN_SESSION_ID:
-            return OGS_GTP_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION;
+            return OGS_GTP2_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION;
         }
     }
 
     ogs_error("Unexpected Diameter Result Code %d/%d, defaulting to severe "
               "network failure",
               dia_err ? *dia_err : -1, dia_exp_err ? *dia_exp_err : -1);
-    return OGS_GTP_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
+    return OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
 }
 
 void smf_gx_handle_cca_initial_request(
@@ -76,8 +76,8 @@ void smf_gx_handle_cca_initial_request(
             ogs_gtp1_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE, cause_value);
         else
-            ogs_gtp_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -292,8 +292,8 @@ void smf_gx_handle_cca_initial_request(
                 OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE);
         else
             ogs_gtp2_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE,
-                OGS_GTP_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER);
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER);
         return;
     }
 }

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -361,13 +361,13 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_assert(ret == 0);
 
         switch (sess->gtp_rat_type) {
-        case OGS_GTP_RAT_TYPE_UTRAN:
-        case OGS_GTP_RAT_TYPE_GERAN:
-        case OGS_GTP_RAT_TYPE_HSPA_EVOLUTION:
-        case OGS_GTP_RAT_TYPE_EUTRAN:
+        case OGS_GTP2_RAT_TYPE_UTRAN:
+        case OGS_GTP2_RAT_TYPE_GERAN:
+        case OGS_GTP2_RAT_TYPE_HSPA_EVOLUTION:
+        case OGS_GTP2_RAT_TYPE_EUTRAN:
             val.i32 = OGS_DIAM_GX_IP_CAN_TYPE_3GPP_EPS;
             break;
-        case OGS_GTP_RAT_TYPE_WLAN:
+        case OGS_GTP2_RAT_TYPE_WLAN:
             val.i32 = OGS_DIAM_GX_IP_CAN_TYPE_NON_3GPP_EPS;
             break;
         default:
@@ -385,19 +385,19 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_assert(ret == 0);
 
         switch (sess->gtp_rat_type) {
-        case OGS_GTP_RAT_TYPE_UTRAN:
+        case OGS_GTP2_RAT_TYPE_UTRAN:
             val.i32 = OGS_DIAM_RAT_TYPE_UTRAN;
             break;
-        case OGS_GTP_RAT_TYPE_GERAN:
+        case OGS_GTP2_RAT_TYPE_GERAN:
             val.i32 = OGS_DIAM_RAT_TYPE_GERAN;
             break;
-        case OGS_GTP_RAT_TYPE_HSPA_EVOLUTION:
+        case OGS_GTP2_RAT_TYPE_HSPA_EVOLUTION:
             val.i32 = OGS_DIAM_RAT_TYPE_HSPA_EVOLUTION;
             break;
-        case OGS_GTP_RAT_TYPE_EUTRAN:
+        case OGS_GTP2_RAT_TYPE_EUTRAN:
             val.i32 = OGS_DIAM_RAT_TYPE_EUTRAN;
             break;
-        case OGS_GTP_RAT_TYPE_WLAN:
+        case OGS_GTP2_RAT_TYPE_WLAN:
             val.i32 = OGS_DIAM_RAT_TYPE_WLAN;
             break;
         default:
@@ -489,12 +489,12 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
 
         /* Set 3GPP-User-Location-Info */
         if (sess->gtp.user_location_information.presence) {
-            ogs_gtp_uli_t uli;
+            ogs_gtp2_uli_t uli;
             int16_t uli_len;
 
-            uint8_t uli_buf[OGS_GTP_MAX_ULI_LEN];
+            uint8_t uli_buf[OGS_GTP2_MAX_ULI_LEN];
 
-            uli_len = ogs_gtp_parse_uli(
+            uli_len = ogs_gtp2_parse_uli(
                     &uli, &sess->gtp.user_location_information);
             ogs_assert(sess->gtp.user_location_information.len == uli_len);
 

--- a/src/smf/gy-handler.c
+++ b/src/smf/gy-handler.c
@@ -32,14 +32,14 @@ static uint8_t gtp_cause_from_diameter(
     if (dia_err) {
         switch (*dia_err) {
         case OGS_DIAM_UNKNOWN_SESSION_ID:
-            return OGS_GTP_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION;
+            return OGS_GTP2_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION;
         }
     }
 
     ogs_error("Unexpected Diameter Result Code %d/%d, defaulting to severe "
               "network failure",
               dia_err ? *dia_err : -1, dia_exp_err ? *dia_exp_err : -1);
-    return OGS_GTP_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
+    return OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
 }
 
 static void urr_enable_total_volume_threshold(smf_sess_t *sess, ogs_pfcp_urr_t *urr,
@@ -118,8 +118,8 @@ void smf_gy_handle_cca_initial_request(
             ogs_gtp1_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE, cause_value);
         else
-            ogs_gtp_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
 

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -526,12 +526,12 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
 
     /* 3GPP-User-Location-Info */
     if (sess->gtp.user_location_information.presence) {
-        ogs_gtp_uli_t uli;
+        ogs_gtp2_uli_t uli;
         int16_t uli_len;
 
-        uint8_t uli_buf[OGS_GTP_MAX_ULI_LEN];
+        uint8_t uli_buf[OGS_GTP2_MAX_ULI_LEN];
 
-        uli_len = ogs_gtp_parse_uli(
+        uli_len = ogs_gtp2_parse_uli(
                 &uli, &sess->gtp.user_location_information);
         ogs_assert(sess->gtp.user_location_information.len == uli_len);
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -70,43 +70,43 @@ uint8_t gtp_cause_from_pfcp(uint8_t pfcp_cause, uint8_t gtp_version)
         case 2:
             switch (pfcp_cause) {
             case OGS_PFCP_CAUSE_REQUEST_ACCEPTED:
-                return OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+                return OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
             case OGS_PFCP_CAUSE_REQUEST_REJECTED:
-                return OGS_GTP_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED;
+                return OGS_GTP2_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED;
             case OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND:
-                return OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+                return OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
             case OGS_PFCP_CAUSE_MANDATORY_IE_MISSING:
-                return OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                return OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             case OGS_PFCP_CAUSE_CONDITIONAL_IE_MISSING:
-                return OGS_GTP_CAUSE_CONDITIONAL_IE_MISSING;
+                return OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
             case OGS_PFCP_CAUSE_INVALID_LENGTH:
-                return OGS_GTP_CAUSE_INVALID_LENGTH;
+                return OGS_GTP2_CAUSE_INVALID_LENGTH;
             case OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT:
-                return OGS_GTP_CAUSE_MANDATORY_IE_INCORRECT;
+                return OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
             case OGS_PFCP_CAUSE_INVALID_FORWARDING_POLICY:
             case OGS_PFCP_CAUSE_INVALID_F_TEID_ALLOCATION_OPTION:
-                return OGS_GTP_CAUSE_INVALID_MESSAGE_FORMAT;
+                return OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT;
             case OGS_PFCP_CAUSE_NO_ESTABLISHED_PFCP_ASSOCIATION:
-                return OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+                return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
             case OGS_PFCP_CAUSE_RULE_CREATION_MODIFICATION_FAILURE:
-                return OGS_GTP_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
+                return OGS_GTP2_CAUSE_SEMANTIC_ERROR_IN_THE_TFT_OPERATION;
             case OGS_PFCP_CAUSE_PFCP_ENTITY_IN_CONGESTION:
-                return OGS_GTP_CAUSE_GTP_C_ENTITY_CONGESTION;
+                return OGS_GTP2_CAUSE_GTP_C_ENTITY_CONGESTION;
             case OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE:
-                return OGS_GTP_CAUSE_NO_RESOURCES_AVAILABLE;
+                return OGS_GTP2_CAUSE_NO_RESOURCES_AVAILABLE;
             case OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED:
-                return OGS_GTP_CAUSE_SERVICE_NOT_SUPPORTED;
+                return OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED;
             case OGS_PFCP_CAUSE_SYSTEM_FAILURE:
-                return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+                return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
             case OGS_PFCP_CAUSE_ALL_DYNAMIC_ADDRESS_ARE_OCCUPIED:
-                return OGS_GTP_CAUSE_ALL_DYNAMIC_ADDRESSES_ARE_OCCUPIED;
+                return OGS_GTP2_CAUSE_ALL_DYNAMIC_ADDRESSES_ARE_OCCUPIED;
             default:
-                return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+                return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
             }
             break;
     }
 
-    return OGS_GTP_CAUSE_SYSTEM_FAILURE;
+    return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
 }
 
 static int sbi_status_from_pfcp(uint8_t pfcp_cause)
@@ -749,29 +749,29 @@ void smf_epc_n4_handle_session_establishment_response(
         cause_value = OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
         resp_type = OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE;
     } else {
-        cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
-        resp_type = OGS_GTP_CREATE_SESSION_RESPONSE_TYPE;
+        cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
+        resp_type = OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE;
     }
 
     if (!sess) {
         ogs_warn("No Context");
         cause_value = (gtp_xact->gtp_version == 1) ?
                         OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND :
-                        OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+                        OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (rsp->up_f_seid.presence == 0) {
         ogs_error("No UP F-SEID");
         cause_value = (gtp_xact->gtp_version == 1) ?
                         OGS_GTP1_CAUSE_MANDATORY_IE_MISSING :
-                        OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                        OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (rsp->created_pdr[0].presence == 0) {
         ogs_error("No Created PDR");
         cause_value = (gtp_xact->gtp_version == 1) ?
                         OGS_GTP1_CAUSE_MANDATORY_IE_MISSING :
-                        OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                        OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (rsp->cause.presence) {
@@ -783,11 +783,11 @@ void smf_epc_n4_handle_session_establishment_response(
         ogs_error("No Cause");
         cause_value = (gtp_xact->gtp_version == 1) ?
                         OGS_GTP1_CAUSE_MANDATORY_IE_MISSING :
-                        OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                        OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if ((gtp_xact->gtp_version == 1 && cause_value == OGS_GTP1_CAUSE_REQUEST_ACCEPTED) ||
-        (gtp_xact->gtp_version == 2 && cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED)) {
+        (gtp_xact->gtp_version == 2 && cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED)) {
         int i;
 
         uint8_t pfcp_cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
@@ -842,7 +842,7 @@ void smf_epc_n4_handle_session_establishment_response(
 
 
     if ((gtp_xact->gtp_version == 1 && cause_value != OGS_GTP1_CAUSE_REQUEST_ACCEPTED) ||
-        (gtp_xact->gtp_version == 2 && cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED)) {
+        (gtp_xact->gtp_version == 2 && cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED)) {
         ogs_gtp_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
                 resp_type, cause_value);
         return;
@@ -857,7 +857,7 @@ void smf_epc_n4_handle_session_establishment_response(
         ogs_gtp_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
                 resp_type,
                 (gtp_xact->gtp_version == 1) ?
-                OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND : OGS_GTP_CAUSE_GRE_KEY_NOT_FOUND);
+                OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND : OGS_GTP2_CAUSE_GRE_KEY_NOT_FOUND);
         return;
     }
 
@@ -875,7 +875,7 @@ void smf_epc_n4_handle_session_establishment_response(
         break;
     }
 
-    if (sess->gtp_rat_type == OGS_GTP_RAT_TYPE_WLAN) {
+    if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_WLAN) {
         /*
          * TS23.214
          * 6.3.1.7 Procedures with modification of bearer
@@ -892,14 +892,14 @@ void smf_epc_n4_handle_session_establishment_response(
         ogs_assert(smf_ue);
 
         eutran_sess = smf_sess_find_by_apn(
-            smf_ue, sess->session.name, OGS_GTP_RAT_TYPE_EUTRAN);
+            smf_ue, sess->session.name, OGS_GTP2_RAT_TYPE_EUTRAN);
         if (eutran_sess) {
             ogs_assert(OGS_OK ==
                 smf_epc_pfcp_send_session_modification_request(
                     eutran_sess, NULL,
                     OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                     OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                    OGS_GTP_CAUSE_RAT_CHANGED_FROM_3GPP_TO_NON_3GPP));
+                    OGS_GTP2_CAUSE_RAT_CHANGED_FROM_3GPP_TO_NON_3GPP));
         }
     }
 
@@ -915,7 +915,7 @@ void smf_epc_n4_handle_session_modification_response(
     smf_bearer_t *bearer = NULL;
     ogs_gtp_xact_t *gtp_xact = NULL;
     uint8_t gtp_pti = OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED;
-    uint8_t gtp_cause = OGS_GTP_CAUSE_UNDEFINED_VALUE;
+    uint8_t gtp_cause = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
     uint64_t flags = 0;
 
     uint8_t pfcp_cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
@@ -1037,15 +1037,15 @@ void smf_epc_n4_handle_session_modification_response(
          * 2. SMF sends Delete Bearer Request(DEDICATED BEARER) to SGW/MME
          * 3. MME sends Delete Bearer Response(DEDICATED BEARER) to SGW/SMF
          */
-            ogs_gtp_header_t h;
+            ogs_gtp2_header_t h;
             ogs_pkbuf_t *pkbuf = NULL;
             int rv;
 
             ogs_assert(bearer);
 
-            memset(&h, 0, sizeof(ogs_gtp_header_t));
+            memset(&h, 0, sizeof(ogs_gtp2_header_t));
             h.teid = sess->sgw_s5c_teid;
-            h.type = OGS_GTP_DELETE_BEARER_REQUEST_TYPE;
+            h.type = OGS_GTP2_DELETE_BEARER_REQUEST_TYPE;
 
             pkbuf = smf_s5c_build_delete_bearer_request(
                     h.type, bearer, gtp_pti, gtp_cause);
@@ -1150,15 +1150,15 @@ void smf_epc_n4_handle_session_deletion_response(
         resp_type = OGS_GTP1_DELETE_PDP_CONTEXT_RESPONSE_TYPE;
         cause_value = OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
     } else {
-        resp_type = OGS_GTP_DELETE_SESSION_RESPONSE_TYPE;
-        cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+        resp_type = OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE;
+        cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
     }
 
     if (!sess) {
         ogs_warn("No Context");
         cause_value = (gtp_version == 1) ?
                         OGS_GTP1_CAUSE_NON_EXISTENT :
-                        OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+                        OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (rsp->cause.presence) {
@@ -1170,12 +1170,12 @@ void smf_epc_n4_handle_session_deletion_response(
         ogs_error("No Cause");
         cause_value = (gtp_xact->gtp_version == 1) ?
                         OGS_GTP1_CAUSE_MANDATORY_IE_MISSING :
-                        OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                        OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (gtp_xact &&
         ((gtp_version == 1 && cause_value != OGS_GTP1_CAUSE_REQUEST_ACCEPTED) ||
-         (gtp_version == 2 && cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED))) {
+         (gtp_version == 2 && cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED))) {
         ogs_gtp_send_error_message(gtp_xact, sess->sgw_s5c_teid, resp_type,
                 cause_value);
         return;
@@ -1265,7 +1265,7 @@ void smf_n4_handle_session_report_request(
 
     ogs_debug("Session Report Request");
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
@@ -1274,10 +1274,10 @@ void smf_n4_handle_session_report_request(
 
     if (pfcp_req->report_type.presence == 0) {
         ogs_error("No Report Type");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_pfcp_send_error_message(pfcp_xact, 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 cause_value, 0);
@@ -1316,7 +1316,7 @@ void smf_n4_handle_session_report_request(
                                 "Paging Policy Indication Value");
                         ogs_pfcp_send_error_message(pfcp_xact, 0,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
-                                OGS_GTP_CAUSE_SERVICE_NOT_SUPPORTED, 0);
+                                OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED, 0);
                         return;
                     }
 

--- a/src/smf/s5c-build.c
+++ b/src/smf/s5c-build.c
@@ -28,15 +28,15 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     int rv;
     smf_bearer_t *bearer = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_session_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_session_response_t *rsp = NULL;
 
-    ogs_gtp_cause_t cause;
-    ogs_gtp_cause_t bearer_cause;
-    ogs_gtp_f_teid_t smf_s5c_teid, pgw_s5u_teid;
-    ogs_gtp_ambr_t ambr;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_cause_t bearer_cause;
+    ogs_gtp2_f_teid_t smf_s5c_teid, pgw_s5u_teid;
+    ogs_gtp2_ambr_t ambr;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
     int len;
     uint8_t pco_buf[OGS_MAX_PCO_LEN];
     int16_t pco_len;
@@ -53,7 +53,7 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
             bearer->sgw_s5u_teid, bearer->pgw_s5u_teid);
 
     rsp = &gtp_message.create_session_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Set Cause */
     memset(&cause, 0, sizeof(cause));
@@ -61,25 +61,25 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     rsp->cause.len = sizeof(cause);
     rsp->cause.data = &cause;
 
-    cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
     if (sess->ue_session_type != sess->session.session_type)
-        cause.value = OGS_GTP_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE;
+        cause.value = OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE;
 
     /* Control Plane(UL) : SMF-S5C */
-    memset(&smf_s5c_teid, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&smf_s5c_teid, 0, sizeof(ogs_gtp2_f_teid_t));
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
-        smf_s5c_teid.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_C;
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
+        smf_s5c_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_C;
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
-        smf_s5c_teid.interface_type = OGS_GTP_F_TEID_S2B_PGW_GTP_C;
+    case OGS_GTP2_RAT_TYPE_WLAN:
+        smf_s5c_teid.interface_type = OGS_GTP2_F_TEID_S2B_PGW_GTP_C;
         break;
     default:
         ogs_error("Unknown RAT Type [%d]", sess->gtp_rat_type);
         ogs_assert_if_reached();
     }
     smf_s5c_teid.teid = htobe32(sess->smf_n4_teid);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             ogs_gtp_self()->gtpc_addr, ogs_gtp_self()->gtpc_addr6,
             &smf_s5c_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
@@ -104,11 +104,11 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
 
     /* APN Restriction */
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
         rsp->apn_restriction.presence = 1;
-        rsp->apn_restriction.u8 = OGS_GTP_APN_NO_RESTRICTION;
+        rsp->apn_restriction.u8 = OGS_GTP2_APN_NO_RESTRICTION;
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
+    case OGS_GTP2_RAT_TYPE_WLAN:
         break;
     default:
         ogs_error("Unknown RAT Type [%d]", sess->gtp_rat_type);
@@ -118,7 +118,7 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     /* APN-AMBR
      * if PCRF changes APN-AMBR, this should be included. */
     if (sess->gtp.create_session_response_apn_ambr == true) {
-        memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+        memset(&ambr, 0, sizeof(ogs_gtp2_ambr_t));
         ambr.uplink = htobe32(sess->session.ambr.uplink / 1000);
         ambr.downlink = htobe32(sess->session.ambr.downlink / 1000);
         rsp->aggregate_maximum_bit_rate.presence = 1;
@@ -147,7 +147,7 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     rsp->bearer_contexts_created.cause.presence = 1;
     rsp->bearer_contexts_created.cause.len = sizeof(bearer_cause);
     rsp->bearer_contexts_created.cause.data = &bearer_cause;
-    bearer_cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    bearer_cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     /* Bearer QoS
      * if PCRF changes Bearer QoS, this should be included. */
@@ -161,8 +161,8 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
             sess->session.qos.arp.pre_emption_vulnerability;
 
         rsp->bearer_contexts_created.bearer_level_qos.presence = 1;
-        ogs_gtp_build_bearer_qos(&rsp->bearer_contexts_created.bearer_level_qos,
-                &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+        ogs_gtp2_build_bearer_qos(&rsp->bearer_contexts_created.bearer_level_qos,
+                &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
     }
 
     /* Bearer Charging ID */
@@ -170,22 +170,22 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     rsp->bearer_contexts_created.charging_id.u32 = sess->charging.id;
 
     /* Data Plane(UL) : SMF-S5U */
-    memset(&pgw_s5u_teid, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&pgw_s5u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
     pgw_s5u_teid.teid = htobe32(bearer->pgw_s5u_teid);
     ogs_assert(bearer->pgw_s5u_addr || bearer->pgw_s5u_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
         bearer->pgw_s5u_addr, bearer->pgw_s5u_addr6, &pgw_s5u_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
 
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
-        pgw_s5u_teid.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_U;
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
+        pgw_s5u_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_U;
         rsp->bearer_contexts_created.s5_s8_u_sgw_f_teid.presence = 1;
         rsp->bearer_contexts_created.s5_s8_u_sgw_f_teid.data = &pgw_s5u_teid;
         rsp->bearer_contexts_created.s5_s8_u_sgw_f_teid.len = len;
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
-        pgw_s5u_teid.interface_type = OGS_GTP_F_TEID_S2B_U_PGW_GTP_U;
+    case OGS_GTP2_RAT_TYPE_WLAN:
+        pgw_s5u_teid.interface_type = OGS_GTP2_F_TEID_S2B_U_PGW_GTP_U;
         rsp->bearer_contexts_created.s12_rnc_f_teid.presence = 1;
         rsp->bearer_contexts_created.s12_rnc_f_teid.data = &pgw_s5u_teid;
         rsp->bearer_contexts_created.s12_rnc_f_teid.len = len;
@@ -196,25 +196,25 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *smf_s5c_build_delete_session_response(
         uint8_t type, smf_sess_t *sess)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_session_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_session_response_t *rsp = NULL;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
     uint8_t pco_buf[OGS_MAX_PCO_LEN];
     int16_t pco_len;
     
     /* prepare cause */
     memset(&cause, 0, sizeof(cause));
-    cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rsp = &gtp_message.delete_session_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     /* Cause */
     rsp->cause.presence = 1;
@@ -238,26 +238,26 @@ ogs_pkbuf_t *smf_s5c_build_delete_session_response(
 
     /* build */
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *smf_s5c_build_modify_bearer_response(
         uint8_t type, smf_sess_t *sess,
-        ogs_gtp_modify_bearer_request_t *req)
+        ogs_gtp2_modify_bearer_request_t *req)
 {
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_modify_bearer_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_modify_bearer_response_t *rsp = NULL;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
 
     ogs_assert(sess);
     ogs_assert(req);
 
     rsp = &gtp_message.modify_bearer_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     memset(&cause, 0, sizeof(cause));
-    cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rsp->cause.presence = 1;
     rsp->cause.data = &cause;
@@ -279,24 +279,24 @@ ogs_pkbuf_t *smf_s5c_build_modify_bearer_response(
 
     /* build */
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
-        uint8_t type, smf_bearer_t *bearer, ogs_gtp_tft_t *tft)
+        uint8_t type, smf_bearer_t *bearer, ogs_gtp2_tft_t *tft)
 {
     int rv;
     smf_sess_t *sess = NULL;
     smf_bearer_t *linked_bearer = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_bearer_request_t *req = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_bearer_request_t *req = NULL;
 
-    ogs_gtp_f_teid_t pgw_s5u_teid;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
+    ogs_gtp2_f_teid_t pgw_s5u_teid;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
     int len;
-    char tft_buf[OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE];
+    char tft_buf[OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE];
 
     ogs_assert(bearer);
     sess = bearer->sess;
@@ -309,7 +309,7 @@ ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
     req = &gtp_message.create_bearer_request;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
  
     /* Linked EBI */
     req->linked_eps_bearer_id.presence = 1;
@@ -321,11 +321,11 @@ ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
     req->bearer_contexts.eps_bearer_id.u8 = bearer->ebi;
 
     /* Data Plane(UL) : PGW-S5U */
-    memset(&pgw_s5u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    pgw_s5u_teid.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_U;
+    memset(&pgw_s5u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    pgw_s5u_teid.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_U;
     pgw_s5u_teid.teid = htobe32(bearer->pgw_s5u_teid);
     ogs_assert(bearer->pgw_s5u_addr || bearer->pgw_s5u_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
         bearer->pgw_s5u_addr, bearer->pgw_s5u_addr6, &pgw_s5u_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
     req->bearer_contexts.s4_u_sgsn_f_teid.presence = 1;
@@ -346,33 +346,33 @@ ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
     bearer_qos.ul_gbr = bearer->qos.gbr.uplink;
 
     req->bearer_contexts.bearer_level_qos.presence = 1;
-    ogs_gtp_build_bearer_qos(&req->bearer_contexts.bearer_level_qos,
-            &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+    ogs_gtp2_build_bearer_qos(&req->bearer_contexts.bearer_level_qos,
+            &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
 
     /* Bearer TFT */
     if (tft && tft->num_of_packet_filter) {
         req->bearer_contexts.tft.presence = 1;
-        ogs_gtp_build_tft(&req->bearer_contexts.tft,
-                tft, tft_buf, OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE);
+        ogs_gtp2_build_tft(&req->bearer_contexts.tft,
+                tft, tft_buf, OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE);
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
         uint8_t type, smf_bearer_t *bearer, uint8_t pti,
-        ogs_gtp_tft_t *tft, bool qos_presence)
+        ogs_gtp2_tft_t *tft, bool qos_presence)
 {
     smf_sess_t *sess = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_update_bearer_request_t *req = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_update_bearer_request_t *req = NULL;
 
-    ogs_gtp_ambr_t ambr;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
-    char tft_buf[OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE];
+    ogs_gtp2_ambr_t ambr;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
+    char tft_buf[OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE];
 
     ogs_assert(bearer);
     sess = bearer->sess;
@@ -382,7 +382,7 @@ ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
     req = &gtp_message.update_bearer_request;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
  
     /* Bearer EBI */
     req->bearer_contexts.presence = 1;
@@ -397,7 +397,7 @@ ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
          * but it shall be encoded as shown in Figure 8.7-1 as
          * Unsigned32 binary integer values in kbps (1000 bits per second).
          */
-        memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+        memset(&ambr, 0, sizeof(ogs_gtp2_ambr_t));
         ambr.uplink = htobe32(sess->session.ambr.uplink / 1000);
         ambr.downlink = htobe32(sess->session.ambr.downlink / 1000);
         req->aggregate_maximum_bit_rate.presence = 1;
@@ -426,19 +426,19 @@ ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
         bearer_qos.ul_gbr = bearer->qos.gbr.uplink;
 
         req->bearer_contexts.bearer_level_qos.presence = 1;
-        ogs_gtp_build_bearer_qos(&req->bearer_contexts.bearer_level_qos,
-                &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+        ogs_gtp2_build_bearer_qos(&req->bearer_contexts.bearer_level_qos,
+                &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
     }
 
     /* Bearer TFT */
     if (tft && tft->num_of_packet_filter) {
         req->bearer_contexts.tft.presence = 1;
-        ogs_gtp_build_tft(&req->bearer_contexts.tft,
-                tft, tft_buf, OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE);
+        ogs_gtp2_build_tft(&req->bearer_contexts.tft,
+                tft, tft_buf, OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE);
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
@@ -447,10 +447,10 @@ ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
     smf_sess_t *sess = NULL;
     smf_bearer_t *linked_bearer = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_bearer_request_t *req = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_bearer_request_t *req = NULL;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
 
     ogs_assert(bearer);
     sess = bearer->sess;
@@ -462,7 +462,7 @@ ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
     req = &gtp_message.delete_bearer_request;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
  
     if (bearer->ebi == linked_bearer->ebi) {
        /*
@@ -500,7 +500,7 @@ ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
         req->procedure_transaction_id.u8 = pti;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_UNDEFINED_VALUE) {
+    if (cause_value != OGS_GTP2_CAUSE_UNDEFINED_VALUE) {
         memset(&cause, 0, sizeof(cause));
         cause.value = cause_value;
         req->cause.presence = 1;
@@ -509,5 +509,5 @@ ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
     }
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }

--- a/src/smf/s5c-build.h
+++ b/src/smf/s5c-build.h
@@ -33,13 +33,13 @@ ogs_pkbuf_t *smf_s5c_build_delete_session_response(
 
 ogs_pkbuf_t *smf_s5c_build_modify_bearer_response(
         uint8_t type, smf_sess_t *sess,
-        ogs_gtp_modify_bearer_request_t *req);
+        ogs_gtp2_modify_bearer_request_t *req);
 
 ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
-        uint8_t type, smf_bearer_t *bearer, ogs_gtp_tft_t *tft);
+        uint8_t type, smf_bearer_t *bearer, ogs_gtp2_tft_t *tft);
 ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
         uint8_t type, smf_bearer_t *bearer, uint8_t pti,
-        ogs_gtp_tft_t *tft, bool qos_presence);
+        ogs_gtp2_tft_t *tft, bool qos_presence);
 ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
         uint8_t type, smf_bearer_t *bearer, uint8_t pti, uint8_t cause_value);
 #ifdef __cplusplus

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -28,7 +28,7 @@
 #include "ipfw/ipfw2.h"
 
 void smf_s5c_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_request_t *req)
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req)
 {
     ogs_assert(xact);
     ogs_assert(req);
@@ -36,18 +36,18 @@ void smf_s5c_handle_echo_request(
     ogs_debug("[PGW] Receiving Echo Request");
     /* FIXME : Before implementing recovery counter correctly,
      *         I'll re-use the recovery value in request message */
-    ogs_gtp_send_echo_response(xact, req->recovery.u8, 0);
+    ogs_gtp2_send_echo_response(xact, req->recovery.u8, 0);
 }
 
 void smf_s5c_handle_echo_response(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_response_t *req)
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *req)
 {
     /* Not Implemented */
 }
 
 void smf_s5c_handle_create_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_create_session_request_t *req)
+        ogs_gtp2_create_session_request_t *req)
 {
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
@@ -55,15 +55,15 @@ void smf_s5c_handle_create_session_request(
     int rv;
     uint8_t cause_value = 0;
 
-    ogs_gtp_uli_t uli;
+    ogs_gtp2_uli_t uli;
 
     smf_ue_t *smf_ue = NULL;
 
-    ogs_gtp_f_teid_t *sgw_s5c_teid, *sgw_s5u_teid;
+    ogs_gtp2_f_teid_t *sgw_s5c_teid, *sgw_s5u_teid;
     ogs_paa_t *paa = NULL;
     smf_bearer_t *bearer = NULL;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    ogs_gtp_ambr_t *ambr = NULL;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    ogs_gtp2_ambr_t *ambr = NULL;
     uint16_t decoded = 0;
 
     ogs_assert(xact);
@@ -71,86 +71,86 @@ void smf_s5c_handle_create_session_request(
 
     ogs_debug("Create Session Request");
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (req->imsi.presence == 0) {
         ogs_error("No IMSI");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->sender_f_teid_for_control_plane.presence == 0) {
         ogs_error("No TEID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->bearer_contexts_to_be_created.presence == 0) {
         ogs_error("No Bearer");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->bearer_contexts_to_be_created.eps_bearer_id.presence == 0) {
         ogs_error("No EPS Bearer ID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->bearer_contexts_to_be_created.bearer_level_qos.presence == 0) {
         ogs_error("No EPS Bearer QoS");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->pdn_address_allocation.presence == 0) {
         ogs_error("No PAA");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->serving_network.presence == 0) {
         ogs_error("No Serving Network");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->serving_network.data == NULL) {
         ogs_error("No Data in Serving Network");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->serving_network.len != OGS_PLMN_ID_LEN) {
         ogs_error("Invalid Len[%d] in Serving Network",
                 req->serving_network.len);
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (!sess) {
         ogs_error("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
         if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
             ogs_error("No Gx Diameter Peer");
-            cause_value = OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+            cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
         }
         switch (sess->gtp_rat_type) {
-        case OGS_GTP_RAT_TYPE_EUTRAN:
+        case OGS_GTP2_RAT_TYPE_EUTRAN:
             if (req->bearer_contexts_to_be_created.
                     s5_s8_u_sgw_f_teid.presence == 0) {
                 ogs_error("No S5/S8 SGW GTP-U TEID");
-                cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             }
             if (req->user_location_information.presence == 0) {
                 ogs_error("No UE Location Information");
-                cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             }
             break;
-        case OGS_GTP_RAT_TYPE_WLAN:
+        case OGS_GTP2_RAT_TYPE_WLAN:
             if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
                 ogs_error("No S6b Diameter Peer");
-                cause_value = OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+                cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
             }
             if (req->bearer_contexts_to_be_created.
                     s2b_u_epdg_f_teid_5.presence == 0) {
                 ogs_error("No S2b ePDG GTP-U TEID");
-                cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             }
             break;
         default:
             ogs_error("Unknown RAT Type [%d]", req->rat_type.u8);
-            cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
         }
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -158,23 +158,23 @@ void smf_s5c_handle_create_session_request(
     smf_ue = sess->smf_ue;
     ogs_assert(smf_ue);
 
-    if (sess->gtp_rat_type == OGS_GTP_RAT_TYPE_EUTRAN) {
+    if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_EUTRAN) {
         /* User Location Inforation is mandatory only for E-UTRAN */
         ogs_assert(req->user_location_information.presence);
-        ogs_gtp_parse_uli(&uli, &req->user_location_information);
+        ogs_gtp2_parse_uli(&uli, &req->user_location_information);
         memcpy(&sess->e_tai, &uli.tai, sizeof(sess->e_tai));
         memcpy(&sess->e_cgi, &uli.e_cgi, sizeof(sess->e_cgi));
 
-    } else if (sess->gtp_rat_type == OGS_GTP_RAT_TYPE_WLAN) {
+    } else if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_WLAN) {
         /* Even after handover to WLAN,
          * there must be at least one EUTRAN session */
         smf_sess_t *eutran_sess = smf_sess_find_by_apn(
-                smf_ue, sess->session.name, OGS_GTP_RAT_TYPE_EUTRAN);
+                smf_ue, sess->session.name, OGS_GTP2_RAT_TYPE_EUTRAN);
         if (eutran_sess) {
             /* Need to check handover is possible */
             int eutran_session_count = 0;
             ogs_list_for_each(&smf_ue->sess_list, eutran_sess) {
-                if (eutran_sess->gtp_rat_type != OGS_GTP_RAT_TYPE_EUTRAN)
+                if (eutran_sess->gtp_rat_type != OGS_GTP2_RAT_TYPE_EUTRAN)
                     continue;
                 if (strcmp(eutran_sess->session.name, sess->session.name) == 0)
                     continue;
@@ -184,9 +184,9 @@ void smf_s5c_handle_create_session_request(
 
             if (eutran_session_count < 1) {
                 ogs_error("Cannot handover to WLAN");
-                ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                    OGS_GTP_CREATE_SESSION_RESPONSE_TYPE,
-                    OGS_GTP_CAUSE_MULTIPLE_ACCESSES_TO_A_PDN_CONNECTION_NOT_ALLOWED);
+                ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                    OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                    OGS_GTP2_CAUSE_MULTIPLE_ACCESSES_TO_A_PDN_CONNECTION_NOT_ALLOWED);
                 return;
             }
         }
@@ -201,9 +201,9 @@ void smf_s5c_handle_create_session_request(
     /* Check if selected PGW is associated with SMF */
     ogs_assert(sess->pfcp_node);
     if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_CREATE_SESSION_RESPONSE_TYPE,
-                OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING);
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING);
         return;
     }
 
@@ -216,7 +216,7 @@ void smf_s5c_handle_create_session_request(
 
     /* Initially Set Session Type from UE */
     sess->session.session_type = sess->ue_session_type;
-    rv = ogs_gtp_paa_to_ip(paa, &sess->session.ue_ip);
+    rv = ogs_gtp2_paa_to_ip(paa, &sess->session.ue_ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_assert(OGS_PFCP_CAUSE_REQUEST_ACCEPTED == smf_sess_set_ue_ip(sess));
@@ -241,28 +241,28 @@ void smf_s5c_handle_create_session_request(
     sgw_s5c_teid = req->sender_f_teid_for_control_plane.data;
     ogs_assert(sgw_s5c_teid);
     sess->sgw_s5c_teid = be32toh(sgw_s5c_teid->teid);
-    rv = ogs_gtp_f_teid_to_ip(sgw_s5c_teid, &sess->sgw_s5c_ip);
+    rv = ogs_gtp2_f_teid_to_ip(sgw_s5c_teid, &sess->sgw_s5c_ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
         sgw_s5u_teid = req->bearer_contexts_to_be_created.
             s5_s8_u_sgw_f_teid.data;
         ogs_assert(sgw_s5u_teid);
         bearer->sgw_s5u_teid = be32toh(sgw_s5u_teid->teid);
-        rv = ogs_gtp_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
+        rv = ogs_gtp2_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
         ogs_assert(rv == OGS_OK);
 
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
+    case OGS_GTP2_RAT_TYPE_WLAN:
         sgw_s5u_teid = req->bearer_contexts_to_be_created.
             s2b_u_epdg_f_teid_5.data;
         ogs_assert(sgw_s5u_teid);
         bearer->sgw_s5u_teid = be32toh(sgw_s5u_teid->teid);
-        rv = ogs_gtp_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
+        rv = ogs_gtp2_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
         ogs_assert(rv == OGS_OK);
         break;
     default:
@@ -274,7 +274,7 @@ void smf_s5c_handle_create_session_request(
             bearer->sgw_s5u_teid, bearer->pgw_s5u_teid);
 
     /* Set Bearer QoS */
-    decoded = ogs_gtp_parse_bearer_qos(&bearer_qos,
+    decoded = ogs_gtp2_parse_bearer_qos(&bearer_qos,
         &req->bearer_contexts_to_be_created.bearer_level_qos);
     ogs_assert(req->bearer_contexts_to_be_created.bearer_level_qos.len ==
             decoded);
@@ -317,11 +317,11 @@ void smf_s5c_handle_create_session_request(
     }
 
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
         smf_gx_send_ccr(sess, xact,
             OGS_DIAM_GX_CC_REQUEST_TYPE_INITIAL_REQUEST);
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
+    case OGS_GTP2_RAT_TYPE_WLAN:
         smf_s6b_send_aar(sess, xact);
         break;
     default:
@@ -332,7 +332,7 @@ void smf_s5c_handle_create_session_request(
 
 void smf_s5c_handle_delete_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_delete_session_request_t *req)
+        ogs_gtp2_delete_session_request_t *req)
 {
     uint8_t cause_value = 0;
 
@@ -341,28 +341,28 @@ void smf_s5c_handle_delete_session_request(
     ogs_assert(xact);
     ogs_assert(req);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
         if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
             ogs_error("No Gx Diameter Peer");
-            cause_value = OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+            cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
         }
 
-        if (sess->gtp_rat_type == OGS_GTP_RAT_TYPE_WLAN) {
+        if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_WLAN) {
             if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
                 ogs_error("No S6b Diameter Peer");
-                cause_value = OGS_GTP_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+                cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
             }
         }
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_DELETE_SESSION_RESPONSE_TYPE, cause_value);
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -370,11 +370,11 @@ void smf_s5c_handle_delete_session_request(
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
         smf_gx_send_ccr(sess, xact,
             OGS_DIAM_GX_CC_REQUEST_TYPE_TERMINATION_REQUEST);
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
+    case OGS_GTP2_RAT_TYPE_WLAN:
         smf_s6b_send_str(sess, xact,
             OGS_DIAM_TERMINATION_CAUSE_DIAMETER_LOGOUT);
         break;
@@ -386,13 +386,13 @@ void smf_s5c_handle_delete_session_request(
 
 void smf_s5c_handle_modify_bearer_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_modify_bearer_request_t *req)
+        ogs_gtp2_modify_bearer_request_t *req)
 {
     int rv;
     uint8_t cause_value = 0;
-    ogs_gtp_indication_t *indication = NULL;
+    ogs_gtp2_indication_t *indication = NULL;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     smf_ue_t *smf_ue = NULL;
@@ -403,16 +403,16 @@ void smf_s5c_handle_modify_bearer_request(
     ogs_assert(xact);
     ogs_assert(req);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (!sess) {
         ogs_warn("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -427,8 +427,8 @@ void smf_s5c_handle_modify_bearer_request(
      * to what is done in smf_gn_handle_update_pdp_context_request()
      */
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_MODIFY_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE;
     h.teid = sess->sgw_s5c_teid;
 
     pkbuf = smf_s5c_build_modify_bearer_response(h.type, sess, req);
@@ -448,7 +448,7 @@ void smf_s5c_handle_modify_bearer_request(
     if (indication && indication->handover_indication) {
         ogs_assert(sess->session.name);
         wlan_sess = smf_sess_find_by_apn(
-                smf_ue, sess->session.name, OGS_GTP_RAT_TYPE_WLAN);
+                smf_ue, sess->session.name, OGS_GTP2_RAT_TYPE_WLAN);
         ogs_expect_or_return(wlan_sess);
         ogs_expect_or_return(ogs_list_first(&wlan_sess->bearer_list));
 
@@ -457,17 +457,17 @@ void smf_s5c_handle_modify_bearer_request(
                 wlan_sess, NULL,
                 OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                OGS_GTP_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP));
+                OGS_GTP2_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP));
     }
 }
 
 void smf_s5c_handle_create_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_create_bearer_response_t *rsp)
+        ogs_gtp2_create_bearer_response_t *rsp)
 {
     int rv;
     uint8_t cause_value;
-    ogs_gtp_f_teid_t *sgw_s5u_teid, *pgw_s5u_teid;
+    ogs_gtp2_f_teid_t *sgw_s5u_teid, *pgw_s5u_teid;
     smf_bearer_t *bearer = NULL;
     ogs_pfcp_far_t *dl_far = NULL;
 
@@ -479,18 +479,18 @@ void smf_s5c_handle_create_bearer_response(
 
     ogs_debug("Create Bearer Response");
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect(rv == OGS_OK);
 
     if (rsp->bearer_contexts.presence == 0) {
         ogs_error("No Bearer");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (rsp->bearer_contexts.eps_bearer_id.presence == 0) {
         ogs_error("No EPS Bearer ID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (rsp->bearer_contexts.s5_s8_u_pgw_f_teid.presence &&
@@ -511,11 +511,11 @@ void smf_s5c_handle_create_bearer_response(
 
     if (!pgw_s5u_teid) {
         ogs_error("No PGW TEID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (!sgw_s5u_teid) {
         ogs_error("No SGW TEID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (!sess) {
@@ -524,15 +524,15 @@ void smf_s5c_handle_create_bearer_response(
         sess = bearer->sess;
         ogs_assert(sess);
 
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (rsp->cause.presence) {
-        ogs_gtp_cause_t *cause = rsp->cause.data;
+        ogs_gtp2_cause_t *cause = rsp->cause.data;
         ogs_assert(cause);
 
         cause_value = cause->value;
-        if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+        if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
             if (rsp->bearer_contexts.cause.presence) {
                 cause = rsp->bearer_contexts.cause.data;
                 ogs_assert(cause);
@@ -540,22 +540,22 @@ void smf_s5c_handle_create_bearer_response(
                 cause_value = cause->value;
             } else {
                 ogs_error("No Cause");
-                cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             }
         } else {
             ogs_warn("GTP Failed [CAUSE:%d]", cause_value);
         }
     } else {
         ogs_error("No Cause");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_assert(OGS_OK ==
             smf_epc_pfcp_send_bearer_modification_request(
                 bearer, NULL, OGS_PFCP_MODIFY_REMOVE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                OGS_GTP_CAUSE_UNDEFINED_VALUE));
+                OGS_GTP2_CAUSE_UNDEFINED_VALUE));
         return;
     }
 
@@ -570,7 +570,7 @@ void smf_s5c_handle_create_bearer_response(
     /* Data Plane(DL) : SGW-S5U */
     ogs_assert(sgw_s5u_teid);
     bearer->sgw_s5u_teid = be32toh(sgw_s5u_teid->teid);
-    rv = ogs_gtp_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
+    rv = ogs_gtp2_f_teid_to_ip(sgw_s5u_teid, &bearer->sgw_s5u_ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_debug("Create Bearer Response : SGW[0x%x] --> SMF[0x%x]",
@@ -593,12 +593,12 @@ void smf_s5c_handle_create_bearer_response(
         smf_epc_pfcp_send_bearer_modification_request(
             bearer, NULL, OGS_PFCP_MODIFY_ACTIVATE,
             OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-            OGS_GTP_CAUSE_UNDEFINED_VALUE));
+            OGS_GTP2_CAUSE_UNDEFINED_VALUE));
 }
 
 void smf_s5c_handle_update_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_update_bearer_response_t *rsp)
+        ogs_gtp2_update_bearer_response_t *rsp)
 {
     int rv;
     uint8_t cause_value;
@@ -616,18 +616,18 @@ void smf_s5c_handle_update_bearer_response(
 
     ogs_debug("Update Bearer Response");
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect(rv == OGS_OK);
 
     if (rsp->bearer_contexts.presence == 0) {
         ogs_error("No Bearer");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (rsp->bearer_contexts.eps_bearer_id.presence == 0) {
         ogs_error("No EPS Bearer ID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (!sess) {
@@ -636,15 +636,15 @@ void smf_s5c_handle_update_bearer_response(
         sess = bearer->sess;
         ogs_assert(sess);
 
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (rsp->cause.presence) {
-        ogs_gtp_cause_t *cause = rsp->cause.data;
+        ogs_gtp2_cause_t *cause = rsp->cause.data;
         ogs_assert(cause);
 
         cause_value = cause->value;
-        if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+        if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
             if (rsp->bearer_contexts.cause.presence) {
                 cause = rsp->bearer_contexts.cause.data;
                 ogs_assert(cause);
@@ -652,20 +652,20 @@ void smf_s5c_handle_update_bearer_response(
                 cause_value = cause->value;
             } else {
                 ogs_error("No Cause");
-                cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
             }
         } else {
             ogs_warn("GTP Failed [CAUSE:%d]", cause_value);
         }
     } else {
         ogs_error("No Cause");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         return;
     }
 
@@ -687,12 +687,12 @@ void smf_s5c_handle_update_bearer_response(
             smf_epc_pfcp_send_bearer_modification_request(
                 bearer, NULL, pfcp_flags,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                OGS_GTP_CAUSE_UNDEFINED_VALUE));
+                OGS_GTP2_CAUSE_UNDEFINED_VALUE));
 }
 
 void smf_s5c_handle_delete_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_delete_bearer_response_t *rsp)
+        ogs_gtp2_delete_bearer_response_t *rsp)
 {
     int rv;
     uint8_t cause_value;
@@ -703,7 +703,7 @@ void smf_s5c_handle_delete_bearer_response(
 
     ogs_debug("Delete Bearer Response");
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     bearer = xact->data;
     ogs_assert(bearer);
@@ -717,7 +717,7 @@ void smf_s5c_handle_delete_bearer_response(
         sess = bearer->sess;
         ogs_assert(sess);
 
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
     if (rsp->linked_eps_bearer_id.presence) {
@@ -731,17 +731,17 @@ void smf_s5c_handle_delete_bearer_response(
          * 2. ePDG sends Delete Bearer Response(DEFAULT BEARER) to SMF.
          */
         if (rsp->cause.presence) {
-            ogs_gtp_cause_t *cause = rsp->cause.data;
+            ogs_gtp2_cause_t *cause = rsp->cause.data;
             ogs_assert(cause);
 
             cause_value = cause->value;
-            if (cause->value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+            if (cause->value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
             } else {
                 ogs_error("GTP Failed [CAUSE:%d]", cause_value);
             }
         } else {
             ogs_error("No Cause");
-            cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
         }
 
         ogs_assert(OGS_OK ==
@@ -761,19 +761,19 @@ void smf_s5c_handle_delete_bearer_response(
          */
         if (rsp->bearer_contexts.presence == 0) {
             ogs_error("No Bearer");
-            cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
         }
         if (rsp->bearer_contexts.eps_bearer_id.presence == 0) {
             ogs_error("No EPS Bearer ID");
-            cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
         }
 
         if (rsp->cause.presence) {
-            ogs_gtp_cause_t *cause = rsp->cause.data;
+            ogs_gtp2_cause_t *cause = rsp->cause.data;
             ogs_assert(cause);
 
             cause_value = cause->value;
-            if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+            if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                 if (rsp->bearer_contexts.cause.presence) {
                     cause = rsp->bearer_contexts.cause.data;
                     ogs_assert(cause);
@@ -781,14 +781,14 @@ void smf_s5c_handle_delete_bearer_response(
                     cause_value = cause->value;
                 } else {
                     ogs_error("No Cause");
-                    cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+                    cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
                 }
             } else {
                 ogs_warn("GTP Failed [CAUSE:%d]", cause_value);
             }
         } else {
             ogs_error("No Cause");
-            cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
         }
 
         ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
@@ -801,11 +801,11 @@ void smf_s5c_handle_delete_bearer_response(
             smf_epc_pfcp_send_bearer_modification_request(
                 bearer, NULL, OGS_PFCP_MODIFY_REMOVE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                OGS_GTP_CAUSE_UNDEFINED_VALUE));
+                OGS_GTP2_CAUSE_UNDEFINED_VALUE));
     }
 }
 
-static int reconfigure_packet_filter(smf_pf_t *pf, ogs_gtp_tft_t *tft, int i)
+static int reconfigure_packet_filter(smf_pf_t *pf, ogs_gtp2_tft_t *tft, int i)
 {
     int j;
 
@@ -899,20 +899,20 @@ static int reconfigure_packet_filter(smf_pf_t *pf, ogs_gtp_tft_t *tft, int i)
 
 void smf_s5c_handle_bearer_resource_command(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_bearer_resource_command_t *cmd)
+        ogs_gtp2_bearer_resource_command_t *cmd)
 {
     int rv;
     uint8_t cause_value = 0;
     int i;
 
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
     smf_bearer_t *bearer = NULL;
     smf_pf_t *pf = NULL;
 
     int16_t decoded;
-    ogs_gtp_tft_t tft;
+    ogs_gtp2_tft_t tft;
 
     int tft_update = 0;
     int qos_update = 0;
@@ -926,28 +926,28 @@ void smf_s5c_handle_bearer_resource_command(
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (cmd->procedure_transaction_id.presence == 0) {
         ogs_error("No PTI");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (cmd->traffic_aggregate_description.presence == 0) {
         ogs_error("No Traffic aggregate description(TAD)");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (cmd->linked_eps_bearer_id.presence == 0) {
         ogs_error("No Linked EPS Bearer ID");
-        cause_value = OGS_GTP_CAUSE_MANDATORY_IE_MISSING;
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
     if (!sess) {
         ogs_warn("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
-    if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+    if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         uint8_t ebi = cmd->linked_eps_bearer_id.u8;
 
         if (cmd->eps_bearer_id.presence)
@@ -961,36 +961,36 @@ void smf_s5c_handle_bearer_resource_command(
 
     if (!bearer) {
         ogs_error("No Context");
-        cause_value = OGS_GTP_CAUSE_CONTEXT_NOT_FOUND;
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
-    if (cause_value != OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
 
     ogs_assert(bearer);
 
-    decoded = ogs_gtp_parse_tft(&tft, &cmd->traffic_aggregate_description);
+    decoded = ogs_gtp2_parse_tft(&tft, &cmd->traffic_aggregate_description);
     ogs_assert(cmd->traffic_aggregate_description.len == decoded);
 
-    if (tft.code == OGS_GTP_TFT_CODE_NO_TFT_OPERATION) {
+    if (tft.code == OGS_GTP2_TFT_CODE_NO_TFT_OPERATION) {
         /* No operation */
-    } else if (tft.code == OGS_GTP_TFT_CODE_DELETE_EXISTING_TFT) {
+    } else if (tft.code == OGS_GTP2_TFT_CODE_DELETE_EXISTING_TFT) {
         smf_pf_remove_all(bearer);
         tft_delete = 1;
     } else if (tft.code ==
-            OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING) {
+            OGS_GTP2_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING) {
         for (i = 0; i < tft.num_of_packet_filter &&
                     i < OGS_MAX_NUM_OF_FLOW_IN_GTP; i++) {
             pf = smf_pf_find_by_id(bearer, tft.pf[i].identifier+1);
             if (pf) {
                 if (reconfigure_packet_filter(pf, &tft, i) < 0) {
-                    ogs_gtp_send_error_message(
+                    ogs_gtp2_send_error_message(
                         xact, sess ? sess->sgw_s5c_teid : 0,
-                        OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
-                        OGS_GTP_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
+                        OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
+                        OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
                     return;
                 }
 /*
@@ -1043,9 +1043,9 @@ void smf_s5c_handle_bearer_resource_command(
             }
         }
     } else if (tft.code ==
-                OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT ||
-                tft.code == OGS_GTP_TFT_CODE_CREATE_NEW_TFT) {
-        if (tft.code == OGS_GTP_TFT_CODE_CREATE_NEW_TFT)
+                OGS_GTP2_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT ||
+                tft.code == OGS_GTP2_TFT_CODE_CREATE_NEW_TFT) {
+        if (tft.code == OGS_GTP2_TFT_CODE_CREATE_NEW_TFT)
             smf_pf_remove_all(bearer);
 
         for (i = 0; i < tft.num_of_packet_filter &&
@@ -1056,10 +1056,10 @@ void smf_s5c_handle_bearer_resource_command(
             ogs_assert(pf);
 
             if (reconfigure_packet_filter(pf, &tft, i) < 0) {
-                ogs_gtp_send_error_message(
+                ogs_gtp2_send_error_message(
                     xact, sess ? sess->sgw_s5c_teid : 0,
-                    OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
-                    OGS_GTP_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
+                    OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
+                    OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
                 return;
             }
 /*
@@ -1112,7 +1112,7 @@ void smf_s5c_handle_bearer_resource_command(
             tft_update = 1;
         }
     } else if (tft.code ==
-            OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING) {
+            OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING) {
         for (i = 0; i < tft.num_of_packet_filter &&
                     i <= OGS_MAX_NUM_OF_FLOW_IN_GTP; i++) {
             pf = smf_pf_find_by_id(bearer, tft.pf[i].identifier+1);
@@ -1127,9 +1127,9 @@ void smf_s5c_handle_bearer_resource_command(
     }
 
     if (cmd->flow_quality_of_service.presence) {
-        ogs_gtp_flow_qos_t flow_qos;
+        ogs_gtp2_flow_qos_t flow_qos;
 
-        decoded = ogs_gtp_parse_flow_qos(
+        decoded = ogs_gtp2_parse_flow_qos(
                 &flow_qos, &cmd->flow_quality_of_service);
         ogs_assert(cmd->flow_quality_of_service.len == decoded);
 
@@ -1143,9 +1143,9 @@ void smf_s5c_handle_bearer_resource_command(
 
     if (tft_update == 0 && tft_delete == 0 && qos_update == 0) {
         /* No modification */
-        ogs_gtp_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
-                OGS_GTP_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
-                OGS_GTP_CAUSE_SERVICE_NOT_SUPPORTED);
+        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+                OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
+                OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED);
         return;
     }
 
@@ -1164,12 +1164,12 @@ void smf_s5c_handle_bearer_resource_command(
                 bearer, xact,
                 OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                 cmd->procedure_transaction_id.u8,
-                OGS_GTP_CAUSE_UNDEFINED_VALUE));
+                OGS_GTP2_CAUSE_UNDEFINED_VALUE));
 
     } else {
-        memset(&h, 0, sizeof(ogs_gtp_header_t));
+        memset(&h, 0, sizeof(ogs_gtp2_header_t));
         h.teid = sess->sgw_s5c_teid;
-        h.type = OGS_GTP_UPDATE_BEARER_REQUEST_TYPE;
+        h.type = OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE;
 
         pkbuf = smf_s5c_build_update_bearer_request(
                 h.type, bearer, cmd->procedure_transaction_id.u8,

--- a/src/smf/s5c-handler.h
+++ b/src/smf/s5c-handler.h
@@ -27,31 +27,31 @@ extern "C" {
 #endif
 
 void smf_s5c_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_request_t *req);
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req);
 void smf_s5c_handle_echo_response(
-        ogs_gtp_xact_t *xact, ogs_gtp_echo_response_t *req);
+        ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *req);
 
 void smf_s5c_handle_create_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_create_session_request_t *req);
+        ogs_gtp2_create_session_request_t *req);
 void smf_s5c_handle_delete_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_delete_session_request_t *req);
+        ogs_gtp2_delete_session_request_t *req);
 void smf_s5c_handle_modify_bearer_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_modify_bearer_request_t *req);
+        ogs_gtp2_modify_bearer_request_t *req);
 void smf_s5c_handle_create_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_create_bearer_response_t *req);
+        ogs_gtp2_create_bearer_response_t *req);
 void smf_s5c_handle_update_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_update_bearer_response_t *req);
+        ogs_gtp2_update_bearer_response_t *req);
 void smf_s5c_handle_delete_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_delete_bearer_response_t *req);
+        ogs_gtp2_delete_bearer_response_t *req);
 void smf_s5c_handle_bearer_resource_command(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp_bearer_resource_command_t *cmd);
+        ogs_gtp2_bearer_resource_command_t *cmd);
 
 #ifdef __cplusplus
 }

--- a/src/smf/s6b-path.c
+++ b/src/smf/s6b-path.c
@@ -194,10 +194,10 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
     ogs_assert(ret == 0);
 
     switch (sess->gtp_rat_type) {
-    case OGS_GTP_RAT_TYPE_EUTRAN:
+    case OGS_GTP2_RAT_TYPE_EUTRAN:
         val.i32 = OGS_DIAM_RAT_TYPE_EUTRAN;
         break;
-    case OGS_GTP_RAT_TYPE_WLAN:
+    case OGS_GTP2_RAT_TYPE_WLAN:
         val.i32 = OGS_DIAM_RAT_TYPE_WLAN;
         break;
     default:

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -57,7 +57,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
     ogs_gtp_node_t *gnode = NULL;
     ogs_gtp_xact_t *gtp_xact = NULL;
-    ogs_gtp_message_t gtp_message;
+    ogs_gtp2_message_t gtp_message;
     ogs_gtp1_message_t gtp1_message;
 
     ogs_diam_gx_message_t *gx_message = NULL;
@@ -95,8 +95,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
 
-        if (ogs_gtp_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
-            ogs_error("ogs_gtp_parse_msg() failed");
+        if (ogs_gtp2_parse_msg(&gtp_message, recvbuf) != OGS_OK) {
+            ogs_error("ogs_gtp2_parse_msg() failed");
             ogs_pkbuf_free(recvbuf);
             break;
         }
@@ -120,13 +120,13 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         }
 
         switch(gtp_message.h.type) {
-        case OGS_GTP_ECHO_REQUEST_TYPE:
+        case OGS_GTP2_ECHO_REQUEST_TYPE:
             smf_s5c_handle_echo_request(gtp_xact, &gtp_message.echo_request);
             break;
-        case OGS_GTP_ECHO_RESPONSE_TYPE:
+        case OGS_GTP2_ECHO_RESPONSE_TYPE:
             smf_s5c_handle_echo_response(gtp_xact, &gtp_message.echo_response);
             break;
-        case OGS_GTP_CREATE_SESSION_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
             if (gtp_message.h.teid == 0) {
                 ogs_expect(!sess);
                 sess = smf_sess_add_by_gtp_message(&gtp_message);
@@ -136,27 +136,27 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             smf_s5c_handle_create_session_request(
                 sess, gtp_xact, &gtp_message.create_session_request);
             break;
-        case OGS_GTP_DELETE_SESSION_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
             smf_s5c_handle_delete_session_request(
                 sess, gtp_xact, &gtp_message.delete_session_request);
             break;
-        case OGS_GTP_MODIFY_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
             smf_s5c_handle_modify_bearer_request(
                 sess, gtp_xact, &gtp_message.modify_bearer_request);
             break;
-        case OGS_GTP_CREATE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE:
             smf_s5c_handle_create_bearer_response(
                 sess, gtp_xact, &gtp_message.create_bearer_response);
             break;
-        case OGS_GTP_UPDATE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
             smf_s5c_handle_update_bearer_response(
                 sess, gtp_xact, &gtp_message.update_bearer_response);
             break;
-        case OGS_GTP_DELETE_BEARER_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
             smf_s5c_handle_delete_bearer_response(
                 sess, gtp_xact, &gtp_message.delete_bearer_response);
             break;
-        case OGS_GTP_BEARER_RESOURCE_COMMAND_TYPE:
+        case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
             smf_s5c_handle_bearer_resource_command(
                 sess, gtp_xact, &gtp_message.bearer_resource_command);
             break;
@@ -173,7 +173,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         ogs_assert(recvbuf);
 
         if (ogs_gtp1_parse_msg(&gtp1_message, recvbuf) != OGS_OK) {
-            ogs_error("ogs_gtp_parse_msg() failed");
+            ogs_error("ogs_gtp2_parse_msg() failed");
             ogs_pkbuf_free(recvbuf);
             break;
         }

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -219,7 +219,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t from;
 
-    ogs_gtp_header_t *gtp_h = NULL;
+    ogs_gtp2_header_t *gtp_h = NULL;
     ogs_pfcp_user_plane_report_t report;
 
     uint32_t teid;
@@ -244,8 +244,8 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->len);
 
-    gtp_h = (ogs_gtp_header_t *)pkbuf->data;
-    if (gtp_h->version != OGS_GTP_VERSION_1) {
+    gtp_h = (ogs_gtp2_header_t *)pkbuf->data;
+    if (gtp_h->version != OGS_GTP2_VERSION_1) {
         ogs_error("[DROP] Invalid GTPU version [%d]", gtp_h->version);
         ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
         goto cleanup;
@@ -255,7 +255,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
         ogs_pkbuf_t *echo_rsp;
 
         ogs_debug("[RECV] Echo Request from [%s]", OGS_ADDR(&from, buf));
-        echo_rsp = ogs_gtp_handle_echo_req(pkbuf);
+        echo_rsp = ogs_gtp2_handle_echo_req(pkbuf);
         ogs_expect(echo_rsp);
         if (echo_rsp) {
             ssize_t sent;
@@ -288,13 +288,13 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
          * Note 4 : For a GTP-PDU with several Extension Headers, the PDU
          *          Session Container should be the first Extension Header
          */
-        ogs_gtp_extension_header_t *extension_header =
-            (ogs_gtp_extension_header_t *)(pkbuf->data + OGS_GTPV1U_HEADER_LEN);
+        ogs_gtp2_extension_header_t *extension_header =
+            (ogs_gtp2_extension_header_t *)(pkbuf->data + OGS_GTPV1U_HEADER_LEN);
         ogs_assert(extension_header);
         if (extension_header->type ==
-                OGS_GTP_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER) {
+                OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER) {
             if (extension_header->pdu_type ==
-                OGS_GTP_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
+                OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
                     ogs_debug("   QFI [0x%x]",
                             extension_header->qos_flow_identifier);
                     qfi = extension_header->qos_flow_identifier;

--- a/tests/310014/epc-test.c
+++ b/tests/310014/epc-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "INTERNET", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "INTERNET", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/attach/auth-test.c
+++ b/tests/attach/auth-test.c
@@ -67,7 +67,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/attach/emm-status-test.c
+++ b/tests/attach/emm-status-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/attach/guti-test.c
+++ b/tests/attach/guti-test.c
@@ -67,7 +67,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -494,7 +494,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -913,7 +913,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -1249,7 +1249,7 @@ static void test4_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/attach/idle-test.c
+++ b/tests/attach/idle-test.c
@@ -67,7 +67,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -401,7 +401,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -691,7 +691,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/attach/issues-test.c
+++ b/tests/attach/issues-test.c
@@ -69,7 +69,7 @@ static void issues_1431_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -210,7 +210,7 @@ static void issues_1431_func(abts_case *tc, void *data)
     ogs_msleep(100);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 2;
 
@@ -240,7 +240,7 @@ static void issues_1431_func(abts_case *tc, void *data)
     ogs_msleep(100);
 
     /* Send Attach Request - Integrity */
-    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 3;
 

--- a/tests/attach/reset-test.c
+++ b/tests/attach/reset-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -347,7 +347,7 @@ static void test2_func(abts_case *tc, void *data)
         test_ue[i]->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
         sess = test_sess_add_by_apn(
-                test_ue[i], "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+                test_ue[i], "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
         ogs_assert(sess);
 
         /********** Insert Subscriber in Database */
@@ -358,7 +358,7 @@ static void test2_func(abts_case *tc, void *data)
 
     for (i = 0; i < NUM_OF_TEST_UE; i++) {
         sess = test_sess_find_by_apn(
-                test_ue[i], "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+                test_ue[i], "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
         ogs_assert(sess);
 
         /* Send Attach Request */
@@ -574,7 +574,7 @@ static void test3_func(abts_case *tc, void *data)
         test_ue[i]->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
         sess = test_sess_add_by_apn(
-                test_ue[i], "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+                test_ue[i], "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
         ogs_assert(sess);
 
         /********** Insert Subscriber in Database */
@@ -585,7 +585,7 @@ static void test3_func(abts_case *tc, void *data)
 
     for (i = 0; i < NUM_OF_TEST_UE; i++) {
         sess = test_sess_find_by_apn(
-                test_ue[i], "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+                test_ue[i], "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
         ogs_assert(sess);
 
         /* Send Attach Request */

--- a/tests/attach/ue-context-test.c
+++ b/tests/attach/ue-context-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -232,7 +232,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -517,7 +517,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -1175,7 +1175,7 @@ test_bearer_t *test_bearer_find_by_ue_ebi(test_ue_t *test_ue, uint8_t ebi)
     ogs_assert(test_ue);
 
     ogs_list_for_each(&test_ue->sess_list, sess) {
-        if (sess->gtp_rat_type != OGS_GTP_RAT_TYPE_EUTRAN)
+        if (sess->gtp_rat_type != OGS_GTP2_RAT_TYPE_EUTRAN)
             continue;
 
         bearer = test_bearer_find_by_sess_ebi(sess, ebi);

--- a/tests/common/esm-build.c
+++ b/tests/common/esm-build.c
@@ -422,7 +422,7 @@ ogs_pkbuf_t *testesm_build_bearer_resource_modification_request(
         &req->traffic_flow_aggregate;
     ogs_nas_eps_quality_of_service_t *qos = &req->required_traffic_flow_qos;
 
-    ogs_gtp_tft_t tft;
+    ogs_gtp2_tft_t tft;
     ogs_tlv_octet_t octet;
     ogs_ipsubnet_t ipsubnet;
 
@@ -451,7 +451,7 @@ ogs_pkbuf_t *testesm_build_bearer_resource_modification_request(
 
     memset(&tft, 0, sizeof tft);
     tft.code = tft_code;
-    if (tft.code == OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING) {
+    if (tft.code == OGS_GTP2_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING) {
         tft.num_of_packet_filter = 1;
         tft.pf[0].direction = 1;
         tft.pf[0].identifier = 0;
@@ -465,7 +465,7 @@ ogs_pkbuf_t *testesm_build_bearer_resource_modification_request(
         tft.pf[0].content.component[0].ipv4.mask = ipsubnet.mask[0];
         tft.pf[0].content.num_of_component = 1;
     } else if (tft.code ==
-            OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT) {
+            OGS_GTP2_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT) {
         tft.num_of_packet_filter = 1;
         tft.pf[0].direction = 2;
         tft.pf[0].identifier = 4;
@@ -491,7 +491,7 @@ ogs_pkbuf_t *testesm_build_bearer_resource_modification_request(
 #endif
         tft.pf[0].content.num_of_component = 1;
 
-    } else if (tft.code == OGS_GTP_TFT_CODE_CREATE_NEW_TFT) {
+    } else if (tft.code == OGS_GTP2_TFT_CODE_CREATE_NEW_TFT) {
         tft.num_of_packet_filter = 4;
 
         tft.pf[0].direction = 1;
@@ -590,15 +590,15 @@ ogs_pkbuf_t *testesm_build_bearer_resource_modification_request(
         tft.pf[3].content.component[3].port.low = 20361;
         tft.pf[3].content.num_of_component = 4;
     } else if (tft.code ==
-            OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING) {
+            OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING) {
         tft.num_of_packet_filter = 4;
         tft.pf[0].identifier = 0;
         tft.pf[1].identifier = 1;
         tft.pf[2].identifier = 2;
         tft.pf[3].identifier = 3;
     }
-    tad->length = ogs_gtp_build_tft(&octet,
-            &tft, tad->buffer, OGS_GTP_MAX_TRAFFIC_FLOW_TEMPLATE);
+    tad->length = ogs_gtp2_build_tft(&octet,
+            &tft, tad->buffer, OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE);
 
     if (qci) {
         req->presencemask |=

--- a/tests/common/esm-handler.c
+++ b/tests/common/esm-handler.c
@@ -41,7 +41,7 @@ void testesm_handle_activate_default_eps_bearer_context_request(
         &activate_default_eps_bearer_context_request->access_point_name;
 
     sess = test_sess_find_by_apn(
-            test_ue, access_point_name->apn, OGS_GTP_RAT_TYPE_EUTRAN);
+            test_ue, access_point_name->apn, OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     bearer = test_bearer_find_by_sess_ebi(
             sess, message->esm.h.eps_bearer_identity);

--- a/tests/common/gtpu.c
+++ b/tests/common/gtpu.c
@@ -108,7 +108,7 @@ void testgtpu_recv(test_ue_t *test_ue, ogs_pkbuf_t *pkbuf)
     test_sess_t *sess = NULL;
     test_bearer_t *bearer = NULL;
 
-    ogs_gtp_header_t *gtp_h = NULL;
+    ogs_gtp2_header_t *gtp_h = NULL;
     struct ip6_hdr *ip6_h =  NULL;
     struct nd_router_advert *advert_h = NULL;
     struct nd_opt_prefix_info *prefix = NULL;
@@ -119,10 +119,10 @@ void testgtpu_recv(test_ue_t *test_ue, ogs_pkbuf_t *pkbuf)
     ogs_assert(test_ue);
     ogs_assert(pkbuf);
 
-    gtp_h = (ogs_gtp_header_t *)pkbuf->data;
+    gtp_h = (ogs_gtp2_header_t *)pkbuf->data;
     ogs_assert(gtp_h);
 
-    ogs_assert(gtp_h->version == OGS_GTP_VERSION_1);
+    ogs_assert(gtp_h->version == OGS_GTP1_VERSION_1);
     ogs_assert(gtp_h->type == OGS_GTPU_MSGTYPE_GPDU);
 
     teid = be32toh(gtp_h->teid);
@@ -172,7 +172,7 @@ found:
 
 int test_gtpu_send(
         ogs_socknode_t *node, test_bearer_t *bearer,
-        ogs_gtp_header_t *gtp_hdesc, ogs_gtp_extension_header_t *ext_hdesc,
+        ogs_gtp2_header_t *gtp_hdesc, ogs_gtp2_extension_header_t *ext_hdesc,
         ogs_pkbuf_t *pkbuf)
 {
     ogs_gtp_node_t gnode;
@@ -214,9 +214,9 @@ int test_gtpu_send(
     }
 
     ext_hdesc->pdu_type =
-        OGS_GTP_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION;
+        OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION;
 
-    return ogs_gtp_send_user_plane(&gnode, gtp_hdesc, ext_hdesc, pkbuf);
+    return ogs_gtp2_send_user_plane(&gnode, gtp_hdesc, ext_hdesc, pkbuf);
 }
 
 int test_gtpu_send_ping(
@@ -225,8 +225,8 @@ int test_gtpu_send_ping(
     int rv;
     test_sess_t *sess = NULL;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_ipsubnet_t dst_ipsub;
@@ -338,8 +338,8 @@ int test_gtpu_send_slacc_rs(ogs_socknode_t *node, test_bearer_t *bearer)
 {
     test_sess_t *sess = NULL;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_pkbuf_t *pkbuf = NULL;
     struct ip6_hdr *ip6_h = NULL;
@@ -406,8 +406,8 @@ int test_gtpu_send_error_indication(
     test_sess_t *sess = NULL;
     uint32_t teid = 0;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_pkbuf_t *pkbuf = NULL;
 
@@ -428,7 +428,7 @@ int test_gtpu_send_error_indication(
         ogs_assert_if_reached();
     }
 
-    pkbuf = ogs_gtp_build_error_indication(teid, node->addr);
+    pkbuf = ogs_gtp2_build_error_indication(teid, node->addr);
     ogs_assert(pkbuf);
 
     memset(&gtp_hdesc, 0, sizeof(gtp_hdesc));
@@ -436,7 +436,7 @@ int test_gtpu_send_error_indication(
 
     gtp_hdesc.type = OGS_GTPU_MSGTYPE_ERR_IND;
     gtp_hdesc.flags = OGS_GTPU_FLAGS_S|OGS_GTPU_FLAGS_E;
-    ext_hdesc.type = OGS_GTP_EXTENSION_HEADER_TYPE_UDP_PORT;
+    ext_hdesc.type = OGS_GTP2_EXTENSION_HEADER_TYPE_UDP_PORT;
 
     return test_gtpu_send(node, bearer, &gtp_hdesc, &ext_hdesc, pkbuf);
 }
@@ -446,8 +446,8 @@ int test_gtpu_send_indirect_data_forwarding(
 {
     test_sess_t *sess = NULL;
 
-    ogs_gtp_header_t gtp_hdesc;
-    ogs_gtp_extension_header_t ext_hdesc;
+    ogs_gtp2_header_t gtp_hdesc;
+    ogs_gtp2_extension_header_t ext_hdesc;
 
     ogs_assert(bearer);
     sess = bearer->sess;

--- a/tests/common/gtpu.h
+++ b/tests/common/gtpu.h
@@ -35,7 +35,7 @@ void testgtpu_recv(test_ue_t *test_ue, ogs_pkbuf_t *pkbuf);
 
 int test_gtpu_send(
         ogs_socknode_t *node, test_bearer_t *bearer,
-        ogs_gtp_header_t *gtp_hdesc, ogs_gtp_extension_header_t *ext_hdesc,
+        ogs_gtp2_header_t *gtp_hdesc, ogs_gtp2_extension_header_t *ext_hdesc,
         ogs_pkbuf_t *pkbuf);
 int test_gtpu_send_ping(
         ogs_socknode_t *node, test_bearer_t *bearer, const char *dst_ip);

--- a/tests/common/ngap-build.c
+++ b/tests/common/ngap-build.c
@@ -2303,7 +2303,7 @@ static ogs_pkbuf_t *testngap_build_pdu_session_resource_setup_response_trasfer(
     int rv;
     test_bearer_t *qos_flow = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -2332,11 +2332,11 @@ static ogs_pkbuf_t *testngap_build_pdu_session_resource_setup_response_trasfer(
     uPTransportLayerInformation->choice.gTPTunnel = gTPTunnel;
 
     ogs_assert(sess->gnb_n3_addr || sess->gnb_n3_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             sess->gnb_n3_addr, sess->gnb_n3_addr6, &f_teid, &len);
     ogs_assert(rv == OGS_OK);
 
-    rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+    rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_asn_ip_to_BIT_STRING(&ip, &gTPTunnel->transportLayerAddress);
@@ -2422,7 +2422,7 @@ static ogs_pkbuf_t *testngap_build_path_switch_request_trasfer(
 
     test_bearer_t *qos_flow = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -2446,11 +2446,11 @@ static ogs_pkbuf_t *testngap_build_path_switch_request_trasfer(
     dL_NGU_UP_TNLInformation->choice.gTPTunnel = gTPTunnel;
 
     ogs_assert(sess->gnb_n3_addr || sess->gnb_n3_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             sess->gnb_n3_addr, sess->gnb_n3_addr6, &f_teid, &len);
     ogs_assert(rv == OGS_OK);
 
-    rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+    rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_asn_ip_to_BIT_STRING(&ip, &gTPTunnel->transportLayerAddress);
@@ -2476,7 +2476,7 @@ static ogs_pkbuf_t *testngap_build_handover_required_transfer(
 
     test_bearer_t *qos_flow = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -2507,7 +2507,7 @@ static ogs_pkbuf_t *testngap_build_handover_request_ack_transfer(
     int rv;
     test_bearer_t *qos_flow = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -2532,11 +2532,11 @@ static ogs_pkbuf_t *testngap_build_handover_request_ack_transfer(
     ogs_assert(gTPTunnel);
 
     ogs_assert(sess->gnb_n3_addr || sess->gnb_n3_addr6);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             sess->gnb_n3_addr, sess->gnb_n3_addr6, &f_teid, &len);
     ogs_assert(rv == OGS_OK);
 
-    rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+    rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_asn_ip_to_BIT_STRING(&ip, &gTPTunnel->transportLayerAddress);

--- a/tests/common/s1ap-build.c
+++ b/tests/common/s1ap-build.c
@@ -472,7 +472,7 @@ ogs_pkbuf_t *test_s1ap_build_initial_context_setup_response(test_ue_t *test_ue)
     test_sess_t *sess = NULL;
     test_bearer_t *bearer = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -553,11 +553,11 @@ ogs_pkbuf_t *test_s1ap_build_initial_context_setup_response(test_ue_t *test_ue)
 
         e_rab->e_RAB_ID = bearer->ebi;
 
-        rv = ogs_gtp_sockaddr_to_f_teid(
+        rv = ogs_gtp2_sockaddr_to_f_teid(
                 bearer->enb_s1u_addr, bearer->enb_s1u_addr6, &f_teid, &len);
         ogs_assert(rv == OGS_OK);
 
-        rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+        rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
         ogs_assert(rv == OGS_OK);
 
         rv = ogs_asn_ip_to_BIT_STRING(&ip, &e_rab->transportLayerAddress);
@@ -827,7 +827,7 @@ ogs_pkbuf_t *test_s1ap_build_e_rab_setup_response(test_bearer_t *bearer)
     S1AP_E_RABSetupItemBearerSUResIEs_t *item = NULL;
     S1AP_E_RABSetupItemBearerSURes_t *e_rab = NULL;
 
-    ogs_gtp_f_teid_t f_teid;
+    ogs_gtp2_f_teid_t f_teid;
     ogs_ip_t ip;
     int len;
 
@@ -893,11 +893,11 @@ ogs_pkbuf_t *test_s1ap_build_e_rab_setup_response(test_bearer_t *bearer)
 
     e_rab->e_RAB_ID = bearer->ebi;
 
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             bearer->enb_s1u_addr, bearer->enb_s1u_addr6, &f_teid, &len);
     ogs_assert(rv == OGS_OK);
 
-    rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+    rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
     ogs_assert(rv == OGS_OK);
 
     rv = ogs_asn_ip_to_BIT_STRING(&ip, &e_rab->transportLayerAddress);
@@ -1229,7 +1229,7 @@ ogs_pkbuf_t *test_s1ap_build_e_rab_modification_indication(test_ue_t *test_ue)
             S1AP_E_RABToBeModifiedItemBearerModIndIEs_t *item = NULL;
             S1AP_E_RABToBeModifiedItemBearerModInd_t *e_rab = NULL;
 
-            ogs_gtp_f_teid_t f_teid;
+            ogs_gtp2_f_teid_t f_teid;
             ogs_ip_t ip;
             int len;
 
@@ -1245,11 +1245,11 @@ ogs_pkbuf_t *test_s1ap_build_e_rab_modification_indication(test_ue_t *test_ue)
 
             e_rab->e_RAB_ID = bearer->ebi;
 
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     bearer->enb_s1u_addr, bearer->enb_s1u_addr6, &f_teid, &len);
             ogs_assert(rv == OGS_OK);
 
-            rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+            rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
             ogs_assert(rv == OGS_OK);
 
             rv = ogs_asn_ip_to_BIT_STRING(&ip, &e_rab->transportLayerAddress);
@@ -1357,7 +1357,7 @@ ogs_pkbuf_t *test_s1ap_build_path_switch_request(test_ue_t *test_ue)
             S1AP_E_RABToBeSwitchedDLItemIEs_t *item = NULL;
             S1AP_E_RABToBeSwitchedDLItem_t *e_rab = NULL;
 
-            ogs_gtp_f_teid_t f_teid;
+            ogs_gtp2_f_teid_t f_teid;
             ogs_ip_t ip;
             int len;
 
@@ -1372,11 +1372,11 @@ ogs_pkbuf_t *test_s1ap_build_path_switch_request(test_ue_t *test_ue)
 
             e_rab->e_RAB_ID = bearer->ebi;
 
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     bearer->enb_s1u_addr, bearer->enb_s1u_addr6, &f_teid, &len);
             ogs_assert(rv == OGS_OK);
 
-            rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+            rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
             ogs_assert(rv == OGS_OK);
 
             rv = ogs_asn_ip_to_BIT_STRING(&ip, &e_rab->transportLayerAddress);
@@ -1635,7 +1635,7 @@ ogs_pkbuf_t *test_s1ap_build_handover_request_ack(test_ue_t *test_ue)
             S1AP_E_RABAdmittedItemIEs_t *item = NULL;
             S1AP_E_RABAdmittedItem_t *e_rab = NULL;
 
-            ogs_gtp_f_teid_t f_teid;
+            ogs_gtp2_f_teid_t f_teid;
             ogs_ip_t ip;
             int len;
 
@@ -1651,11 +1651,11 @@ ogs_pkbuf_t *test_s1ap_build_handover_request_ack(test_ue_t *test_ue)
 
             e_rab->e_RAB_ID = bearer->ebi;
 
-            rv = ogs_gtp_sockaddr_to_f_teid(
+            rv = ogs_gtp2_sockaddr_to_f_teid(
                     bearer->enb_s1u_addr, bearer->enb_s1u_addr6, &f_teid, &len);
             ogs_assert(rv == OGS_OK);
 
-            rv = ogs_gtp_f_teid_to_ip(&f_teid, &ip);
+            rv = ogs_gtp2_f_teid_to_ip(&f_teid, &ip);
             ogs_assert(rv == OGS_OK);
 
             rv = ogs_asn_ip_to_BIT_STRING(&ip, &e_rab->transportLayerAddress);

--- a/tests/csfb/crash-test.c
+++ b/tests/csfb/crash-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mo-active-test.c
+++ b/tests/csfb/mo-active-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mo-idle-test.c
+++ b/tests/csfb/mo-idle-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -355,7 +355,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -555,7 +555,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -841,7 +841,7 @@ static void test4_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mo-sms-test.c
+++ b/tests/csfb/mo-sms-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mt-active-test.c
+++ b/tests/csfb/mt-active-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mt-idle-test.c
+++ b/tests/csfb/mt-idle-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/csfb/mt-sms-test.c
+++ b/tests/csfb/mt-sms-test.c
@@ -66,7 +66,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/handover/epc-s1-test.c
+++ b/tests/handover/epc-s1-test.c
@@ -67,7 +67,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* Two eNB connects to MME */
@@ -637,7 +637,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* Two eNB connects to MME */
@@ -964,7 +964,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* Two eNB connects to MME */

--- a/tests/handover/epc-x2-test.c
+++ b/tests/handover/epc-x2-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* Two eNB connects to MME */

--- a/tests/non3gpp/epdg-test.c
+++ b/tests/non3gpp/epdg-test.c
@@ -115,7 +115,7 @@ static void test1_func(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
 
     /* Setup WLAN Session */
-    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     OGS_SETUP_GTP_NODE(sess, ogs_list_first(&test_self()->gtpc_list));
@@ -261,7 +261,7 @@ static void test2_func(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
 
     /* Setup WLAN Session */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     OGS_SETUP_GTP_NODE(sess, ogs_list_first(&test_self()->gtpc_list));
@@ -412,7 +412,7 @@ static void test3_func(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
 
     /* Setup WLAN Session */
-    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     OGS_SETUP_GTP_NODE(sess, ogs_list_first(&test_self()->gtpc_list));
@@ -438,7 +438,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Setup EUTRAN Session */
-    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* Send Attach Request */
@@ -556,7 +556,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Receive S2b Delete Session Response */
-    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     recvbuf = test_epdg_read(epdg_c);
@@ -564,7 +564,7 @@ static void test3_func(abts_case *tc, void *data)
     test_s2b_recv(sess, recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -606,7 +606,7 @@ static void test3_func(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
 
     /* Setup WLAN Session */
-    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     OGS_SETUP_GTP_NODE(sess, ogs_list_first(&test_self()->gtpc_list));
@@ -641,7 +641,7 @@ static void test3_func(abts_case *tc, void *data)
             test_ue->s1ap_procedure_code);
 
     /* Send E-RABReleaseResponse */
-    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     bearer = test_bearer_find_by_sess_ebi(sess, 5);
@@ -665,7 +665,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_msleep(300);
 
     /* Setup EUTRAN Session */
-    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     sess->pdn_connectivity_param.apn = 1;
@@ -715,7 +715,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Receive S2b Delete Session Response */
-    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP_RAT_TYPE_WLAN);
+    sess = test_sess_find_by_apn(test_ue, "wlan", OGS_GTP2_RAT_TYPE_WLAN);
     ogs_assert(sess);
 
     recvbuf = test_epdg_read(epdg_c);

--- a/tests/non3gpp/gtp-path.c
+++ b/tests/non3gpp/gtp-path.c
@@ -79,15 +79,15 @@ ogs_pkbuf_t *test_epdg_read(ogs_socknode_t *node)
 void test_s2b_recv(test_sess_t *sess, ogs_pkbuf_t *pkbuf)
 {
     int rv;
-    ogs_gtp_message_t gtp_message;
+    ogs_gtp2_message_t gtp_message;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(sess);
     ogs_assert(sess->gnode);
     ogs_assert(pkbuf);
 
-    if (ogs_gtp_parse_msg(&gtp_message, pkbuf) != OGS_OK) {
-        ogs_error("ogs_gtp_parse_msg() failed");
+    if (ogs_gtp2_parse_msg(&gtp_message, pkbuf) != OGS_OK) {
+        ogs_error("ogs_gtp2_parse_msg() failed");
         ogs_pkbuf_free(pkbuf);
         return;
     }
@@ -100,19 +100,19 @@ void test_s2b_recv(test_sess_t *sess, ogs_pkbuf_t *pkbuf)
     }
 
     switch (gtp_message.h.type) {
-        case OGS_GTP_CREATE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
             test_s2b_handle_create_session_response(
                 xact, sess, &gtp_message.create_session_response);
             break;
-        case OGS_GTP_DELETE_SESSION_RESPONSE_TYPE:
+        case OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE:
             test_s2b_handle_delete_session_response(
                 xact, sess, &gtp_message.delete_session_response);
             break;
-        case OGS_GTP_CREATE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
             test_s2b_handle_create_bearer_request(
                 xact, sess, &gtp_message.create_bearer_request);
             break;
-        case OGS_GTP_DELETE_BEARER_REQUEST_TYPE:
+        case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
             test_s2b_handle_delete_bearer_request(
                 xact, sess, &gtp_message.delete_bearer_request);
             break;
@@ -127,14 +127,14 @@ void test_s2b_recv(test_sess_t *sess, ogs_pkbuf_t *pkbuf)
 int test_s2b_send_create_session_request(test_sess_t *sess, bool handover_ind)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(sess);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_CREATE_SESSION_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_create_session_request(h.type, sess, handover_ind);
@@ -152,14 +152,14 @@ int test_s2b_send_create_session_request(test_sess_t *sess, bool handover_ind)
 int test_s2b_send_delete_session_request(test_sess_t *sess)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_gtp_xact_t *xact = NULL;
 
     ogs_assert(sess);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DELETE_SESSION_REQUEST_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_delete_session_request(h.type, sess);
@@ -178,7 +178,7 @@ int test_s2b_send_create_bearer_response(
         test_bearer_t *bearer, ogs_gtp_xact_t *xact)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     test_sess_t *sess = NULL;
 
@@ -187,8 +187,8 @@ int test_s2b_send_create_bearer_response(
     sess = bearer->sess;
     ogs_assert(sess);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_CREATE_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_create_bearer_response(h.type, bearer);
@@ -207,7 +207,7 @@ int test_s2b_send_delete_bearer_response(
         test_bearer_t *bearer, ogs_gtp_xact_t *xact)
 {
     int rv;
-    ogs_gtp_header_t h;
+    ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
     test_sess_t *sess = NULL;
 
@@ -216,8 +216,8 @@ int test_s2b_send_delete_bearer_response(
     sess = bearer->sess;
     ogs_assert(sess);
 
-    memset(&h, 0, sizeof(ogs_gtp_header_t));
-    h.type = OGS_GTP_DELETE_BEARER_RESPONSE_TYPE;
+    memset(&h, 0, sizeof(ogs_gtp2_header_t));
+    h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_delete_bearer_response(h.type, bearer);

--- a/tests/non3gpp/s2b-build.c
+++ b/tests/non3gpp/s2b-build.c
@@ -26,24 +26,24 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     ogs_session_t *session = NULL;
     test_ue_t *test_ue = NULL;
     test_bearer_t *bearer = NULL;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_session_request_t *req = &gtp_message.create_session_request;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_session_request_t *req = &gtp_message.create_session_request;
 
     uint8_t msisdn_buf[OGS_MAX_MSISDN_LEN];
     int msisdn_len;
 
-    ogs_gtp_uli_t uli;
-    char uli_buf[OGS_GTP_MAX_ULI_LEN];
-    ogs_gtp_f_teid_t test_s2b_c_teid, test_s2b_u_teid;
+    ogs_gtp2_uli_t uli;
+    char uli_buf[OGS_GTP2_MAX_ULI_LEN];
+    ogs_gtp2_f_teid_t test_s2b_c_teid, test_s2b_u_teid;
     int len;
     ogs_paa_t paa;
 
-    ogs_gtp_ambr_t ambr;
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
+    ogs_gtp2_ambr_t ambr;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
     char apn[OGS_MAX_APN_LEN+1];
 
-    ogs_gtp_indication_t indication;
+    ogs_gtp2_indication_t indication;
 
     ogs_assert(sess);
     test_ue = sess->test_ue;
@@ -55,14 +55,14 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     ogs_assert(bearer);
 
     ogs_debug("Create Session Request");
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     if (handover_ind == true) {
-	    memset(&indication, 0, sizeof(ogs_gtp_indication_t));
+	    memset(&indication, 0, sizeof(ogs_gtp2_indication_t));
 	    indication.handover_indication = 1;
 	    req->indication_flags.presence = 1;
 	    req->indication_flags.data = &indication;
-	    req->indication_flags.len = sizeof(ogs_gtp_indication_t);
+	    req->indication_flags.len = sizeof(ogs_gtp2_indication_t);
     }
 
     ogs_assert(test_ue->imsi_len);
@@ -76,7 +76,7 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     req->msisdn.data = msisdn_buf;
     req->msisdn.len = msisdn_len;
 
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_nas_from_plmn_id(&uli.tai.nas_plmn_id, &test_ue->e_tai.plmn_id);
@@ -84,21 +84,21 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     ogs_nas_from_plmn_id(&uli.e_cgi.nas_plmn_id, &test_ue->e_cgi.plmn_id);
     uli.e_cgi.cell_id = test_ue->e_cgi.cell_id;
     req->user_location_information.presence = 1;
-    ogs_gtp_build_uli(&req->user_location_information, &uli, 
-            uli_buf, OGS_GTP_MAX_ULI_LEN);
+    ogs_gtp2_build_uli(&req->user_location_information, &uli, 
+            uli_buf, OGS_GTP2_MAX_ULI_LEN);
 
     req->serving_network.presence = 1;
     req->serving_network.data = &uli.tai.nas_plmn_id;
     req->serving_network.len = sizeof(uli.tai.nas_plmn_id);
 
     req->rat_type.presence = 1;
-    req->rat_type.u8 = OGS_GTP_RAT_TYPE_WLAN;
+    req->rat_type.u8 = OGS_GTP2_RAT_TYPE_WLAN;
 
-    memset(&test_s2b_c_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    test_s2b_c_teid.interface_type = OGS_GTP_F_TEID_S2B_EPDG_GTP_C;
+    memset(&test_s2b_c_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    test_s2b_c_teid.interface_type = OGS_GTP2_F_TEID_S2B_EPDG_GTP_C;
     test_s2b_c_teid.teid = htobe32(sess->epdg_s2b_c_teid);
     ogs_assert(sess->gnode->sock);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             &sess->gnode->sock->local_addr, NULL, &test_s2b_c_teid, &len);
     ogs_assert(rv == OGS_OK);
     req->sender_f_teid_for_control_plane.presence = 1;
@@ -112,7 +112,7 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
 
     req->selection_mode.presence = 1;
     req->selection_mode.u8 = 
-        OGS_GTP_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN;
+        OGS_GTP2_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN;
 
     memset(&paa, 0, sizeof(paa));
     paa.session_type = OGS_PDU_SESSION_TYPE_IPV4V6;
@@ -121,7 +121,7 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     req->pdn_address_allocation.data = &paa;
     req->pdn_address_allocation.len = OGS_PAA_IPV4V6_LEN;
 
-    memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+    memset(&ambr, 0, sizeof(ogs_gtp2_ambr_t));
     ambr.uplink = htobe32(50000);
     ambr.downlink = htobe32(150000);
     req->aggregate_maximum_bit_rate.presence = 1;
@@ -132,11 +132,11 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     req->bearer_contexts_to_be_created.eps_bearer_id.presence = 1;
     req->bearer_contexts_to_be_created.eps_bearer_id.u8 = bearer->ebi;
 
-    memset(&test_s2b_u_teid, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&test_s2b_u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
     test_s2b_u_teid.teid = htobe32(bearer->enb_s1u_teid);
-    test_s2b_u_teid.interface_type = OGS_GTP_F_TEID_S2B_U_EPDG_GTP_U;
+    test_s2b_u_teid.interface_type = OGS_GTP2_F_TEID_S2B_U_EPDG_GTP_U;
     ogs_assert(sess->gnode->sock);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             &sess->gnode->sock->local_addr, NULL, &test_s2b_u_teid, &len);
 
     req->bearer_contexts_to_be_created.s2b_u_epdg_f_teid_5.presence = 1;
@@ -150,9 +150,9 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     bearer_qos.pre_emption_capability = 0;
     bearer_qos.pre_emption_vulnerability = 0;
     req->bearer_contexts_to_be_created.bearer_level_qos.presence = 1;
-    ogs_gtp_build_bearer_qos(
+    ogs_gtp2_build_bearer_qos(
             &req->bearer_contexts_to_be_created.bearer_level_qos,
-            &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+            &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
 
     req->recovery.presence = 1;
     req->recovery.u8 = 66;
@@ -163,7 +163,7 @@ ogs_pkbuf_t *test_s2b_build_create_session_request(
     req->additional_protocol_configuration_options.len = 4;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *test_s2b_build_delete_session_request(
@@ -172,21 +172,21 @@ ogs_pkbuf_t *test_s2b_build_delete_session_request(
     int rv;
     test_bearer_t *bearer = NULL;
 
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_session_request_t *req = &gtp_message.delete_session_request;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_session_request_t *req = &gtp_message.delete_session_request;
 
     ogs_assert(sess);
     bearer = ogs_list_first(&sess->bearer_list);
     ogs_assert(bearer);
 
     ogs_debug("Delete Session Request");
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     req->linked_eps_bearer_id.presence = 1;
     req->linked_eps_bearer_id.u8 = bearer->ebi;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *test_s2b_build_create_bearer_response(
@@ -194,13 +194,13 @@ ogs_pkbuf_t *test_s2b_build_create_bearer_response(
 {
     int rv;
     ogs_session_t *session = NULL;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_create_bearer_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_create_bearer_response_t *rsp = NULL;
 
     test_sess_t *sess = NULL;
 
-    ogs_gtp_cause_t cause;
-    ogs_gtp_f_teid_t epdg_s2b_u_teid, smf_s2b_u_teid;
+    ogs_gtp2_cause_t cause;
+    ogs_gtp2_f_teid_t epdg_s2b_u_teid, smf_s2b_u_teid;
     int len;
 
     ogs_assert(bearer);
@@ -209,10 +209,10 @@ ogs_pkbuf_t *test_s2b_build_create_bearer_response(
 
     ogs_debug("Create Bearer Response");
     rsp = &gtp_message.create_bearer_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     memset(&cause, 0, sizeof(cause));
-    cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rsp->cause.presence = 1;
     rsp->cause.data = &cause;
@@ -224,11 +224,11 @@ ogs_pkbuf_t *test_s2b_build_create_bearer_response(
     rsp->bearer_contexts.eps_bearer_id.u8 = bearer->ebi;
 
     /* Data Plane(DL) : ePDG-S2B-U */
-    memset(&epdg_s2b_u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    epdg_s2b_u_teid.interface_type = OGS_GTP_F_TEID_S2B_U_EPDG_GTP_U;
+    memset(&epdg_s2b_u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    epdg_s2b_u_teid.interface_type = OGS_GTP2_F_TEID_S2B_U_EPDG_GTP_U;
     epdg_s2b_u_teid.teid = htobe32(bearer->enb_s1u_teid);
     ogs_assert(sess->gnode->sock);
-    rv = ogs_gtp_sockaddr_to_f_teid(
+    rv = ogs_gtp2_sockaddr_to_f_teid(
             &sess->gnode->sock->local_addr, NULL, &epdg_s2b_u_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
     rsp->bearer_contexts.s2b_u_epdg_f_teid_8.presence = 1;
@@ -236,14 +236,14 @@ ogs_pkbuf_t *test_s2b_build_create_bearer_response(
     rsp->bearer_contexts.s2b_u_epdg_f_teid_8.len = len;
 
     /* Data Plane(UL) : SMF-S2B-U */
-    memset(&smf_s2b_u_teid, 0, sizeof(ogs_gtp_f_teid_t));
-    smf_s2b_u_teid.interface_type = OGS_GTP_F_TEID_S2B_U_PGW_GTP_U;
+    memset(&smf_s2b_u_teid, 0, sizeof(ogs_gtp2_f_teid_t));
+    smf_s2b_u_teid.interface_type = OGS_GTP2_F_TEID_S2B_U_PGW_GTP_U;
     smf_s2b_u_teid.teid = htobe32(bearer->sgw_s1u_teid);
-    rv = ogs_gtp_ip_to_f_teid(&bearer->sgw_s1u_ip, &smf_s2b_u_teid, &len);
+    rv = ogs_gtp2_ip_to_f_teid(&bearer->sgw_s1u_ip, &smf_s2b_u_teid, &len);
     ogs_expect_or_return_val(rv == OGS_OK, NULL);
     rsp->bearer_contexts.s2b_u_pgw_f_teid.presence = 1;
     rsp->bearer_contexts.s2b_u_pgw_f_teid.data = &smf_s2b_u_teid;
-    rsp->bearer_contexts.s2b_u_pgw_f_teid.len = OGS_GTP_F_TEID_IPV4_LEN;
+    rsp->bearer_contexts.s2b_u_pgw_f_teid.len = OGS_GTP2_F_TEID_IPV4_LEN;
 
     /* Bearer Context : Cause */
     rsp->bearer_contexts.cause.presence = 1;
@@ -251,7 +251,7 @@ ogs_pkbuf_t *test_s2b_build_create_bearer_response(
     rsp->bearer_contexts.cause.data = &cause;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }
 
 ogs_pkbuf_t *test_s2b_build_delete_bearer_response(
@@ -259,19 +259,19 @@ ogs_pkbuf_t *test_s2b_build_delete_bearer_response(
 {
     int rv;
     ogs_session_t *session = NULL;
-    ogs_gtp_message_t gtp_message;
-    ogs_gtp_delete_bearer_response_t *rsp = NULL;
+    ogs_gtp2_message_t gtp_message;
+    ogs_gtp2_delete_bearer_response_t *rsp = NULL;
 
-    ogs_gtp_cause_t cause;
+    ogs_gtp2_cause_t cause;
 
     ogs_assert(bearer);
 
     ogs_debug("Delete Bearer Response");
     rsp = &gtp_message.delete_bearer_response;
-    memset(&gtp_message, 0, sizeof(ogs_gtp_message_t));
+    memset(&gtp_message, 0, sizeof(ogs_gtp2_message_t));
 
     memset(&cause, 0, sizeof(cause));
-    cause.value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause.value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rsp->cause.presence = 1;
     rsp->cause.data = &cause;
@@ -281,5 +281,5 @@ ogs_pkbuf_t *test_s2b_build_delete_bearer_response(
     rsp->linked_eps_bearer_id.u8 = bearer->ebi;
 
     gtp_message.h.type = type;
-    return ogs_gtp_build_msg(&gtp_message);
+    return ogs_gtp2_build_msg(&gtp_message);
 }

--- a/tests/non3gpp/s2b-handler.c
+++ b/tests/non3gpp/s2b-handler.c
@@ -22,14 +22,14 @@
 
 void test_s2b_handle_create_session_response(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_create_session_response_t *rsp)
+        ogs_gtp2_create_session_response_t *rsp)
 {
     int rv;
     uint8_t cause_value;
 
     test_bearer_t *bearer = NULL;
-    ogs_gtp_f_teid_t *smf_s2b_c_teid = NULL;
-    ogs_gtp_f_teid_t *smf_s2b_u_teid = NULL;
+    ogs_gtp2_f_teid_t *smf_s2b_c_teid = NULL;
+    ogs_gtp2_f_teid_t *smf_s2b_u_teid = NULL;
     ogs_paa_t paa;
 
     ogs_assert(xact);
@@ -40,11 +40,11 @@ void test_s2b_handle_create_session_response(
     ogs_expect(rv == OGS_OK);
 
     if (rsp->cause.presence) {
-        ogs_gtp_cause_t *cause = rsp->cause.data;
+        ogs_gtp2_cause_t *cause = rsp->cause.data;
         ogs_assert(cause);
 
         cause_value = cause->value;
-        if (cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED) {
+        if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         } else {
             ogs_error("GTP Failed [CAUSE:%d]", cause_value);
             return;
@@ -92,7 +92,7 @@ void test_s2b_handle_create_session_response(
 
     bearer->sgw_s1u_teid = be32toh(smf_s2b_u_teid->teid);
     ogs_assert(OGS_OK ==
-            ogs_gtp_f_teid_to_ip(smf_s2b_u_teid, &bearer->sgw_s1u_ip));
+            ogs_gtp2_f_teid_to_ip(smf_s2b_u_teid, &bearer->sgw_s1u_ip));
 
     memcpy(&paa,
             rsp->pdn_address_allocation.data, rsp->pdn_address_allocation.len);
@@ -122,7 +122,7 @@ void test_s2b_handle_create_session_response(
 
 void test_s2b_handle_delete_session_response(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_delete_session_response_t *rsp)
+        ogs_gtp2_delete_session_response_t *rsp)
 {
     int rv;
     uint8_t cause_value;
@@ -131,17 +131,17 @@ void test_s2b_handle_delete_session_response(
     ogs_assert(sess);
     ogs_assert(rsp);
 
-    cause_value = OGS_GTP_CAUSE_REQUEST_ACCEPTED;
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect(rv == OGS_OK);
 
     if (rsp->cause.presence) {
-        ogs_gtp_cause_t *cause = rsp->cause.data;
+        ogs_gtp2_cause_t *cause = rsp->cause.data;
         ogs_assert(cause);
 
         cause_value = cause->value;
-        ogs_assert(cause_value == OGS_GTP_CAUSE_REQUEST_ACCEPTED);
+        ogs_assert(cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED);
     }
 
     test_sess_remove(sess);
@@ -149,12 +149,12 @@ void test_s2b_handle_delete_session_response(
 
 void test_s2b_handle_create_bearer_request(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_create_bearer_request_t *req)
+        ogs_gtp2_create_bearer_request_t *req)
 {
     int rv;
     test_bearer_t *linked_bearer = NULL;
     test_bearer_t *bearer = NULL;
-    ogs_gtp_f_teid_t *smf_s2b_u_teid = NULL;
+    ogs_gtp2_f_teid_t *smf_s2b_u_teid = NULL;
 
     ogs_assert(xact);
     ogs_assert(sess);
@@ -198,7 +198,7 @@ void test_s2b_handle_create_bearer_request(
     smf_s2b_u_teid = req->bearer_contexts.s4_u_sgsn_f_teid.data;
     ogs_assert(smf_s2b_u_teid);
     bearer->sgw_s1u_teid = be32toh(smf_s2b_u_teid->teid);
-    rv = ogs_gtp_f_teid_to_ip(smf_s2b_u_teid, &bearer->sgw_s1u_ip);
+    rv = ogs_gtp2_f_teid_to_ip(smf_s2b_u_teid, &bearer->sgw_s1u_ip);
     ogs_assert(rv == OGS_OK);
 
     ogs_assert(OGS_OK == test_s2b_send_create_bearer_response(bearer, xact));
@@ -206,10 +206,10 @@ void test_s2b_handle_create_bearer_request(
 
 void test_s2b_handle_delete_bearer_request(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_delete_bearer_request_t *req)
+        ogs_gtp2_delete_bearer_request_t *req)
 {
     test_bearer_t *bearer = NULL;
-    ogs_gtp_cause_t *cause = NULL;
+    ogs_gtp2_cause_t *cause = NULL;
 
     ogs_assert(xact);
     ogs_assert(sess);
@@ -220,7 +220,7 @@ void test_s2b_handle_delete_bearer_request(
     ogs_assert(cause);
 
     ogs_assert(cause->value ==
-            OGS_GTP_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP);
+            OGS_GTP2_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP);
 
     ogs_assert(req->linked_eps_bearer_id.presence);
     bearer = test_bearer_find_by_sess_ebi(sess, req->linked_eps_bearer_id.u8);

--- a/tests/non3gpp/s2b-handler.h
+++ b/tests/non3gpp/s2b-handler.h
@@ -28,17 +28,17 @@ extern "C" {
 
 void test_s2b_handle_create_session_response(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_create_session_response_t *rsp);
+        ogs_gtp2_create_session_response_t *rsp);
 void test_s2b_handle_delete_session_response(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_delete_session_response_t *rsp);
+        ogs_gtp2_delete_session_response_t *rsp);
 
 void test_s2b_handle_create_bearer_request(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_create_bearer_request_t *req);
+        ogs_gtp2_create_bearer_request_t *req);
 void test_s2b_handle_delete_bearer_request(
         ogs_gtp_xact_t *xact, test_sess_t *sess,
-        ogs_gtp_delete_bearer_request_t *req);
+        ogs_gtp2_delete_bearer_request_t *req);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/gtp-message-test.c
+++ b/tests/unit/gtp-message-test.c
@@ -24,7 +24,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
 {
     int rv;
     /* Create Session Request */
-    const char *_payload = 
+    const char *_payload =
         "0100080055153011 340010f44c000600 9471527600414b00 0800536120009178"
         "840056000d001855 f501102255f50100 019d015300030055 f501520001000657"
         "0009008a80000084 0a32360a57000901 87000000000a3236 254700220005766f"
@@ -36,25 +36,25 @@ static void gtp_message_test1(abts_case *tc, void *data)
     char *_value = NULL;
     char hexbuf[OGS_MAX_SDU_LEN];
 
-    ogs_gtp_create_session_request_t req;
-    ogs_gtp_uli_t uli;
-    char ulibuf[OGS_GTP_MAX_ULI_LEN];
+    ogs_gtp2_create_session_request_t req;
+    ogs_gtp2_uli_t uli;
+    char ulibuf[OGS_GTP2_MAX_ULI_LEN];
     ogs_plmn_id_t serving_network;
     char apnbuf[34];
-    ogs_gtp_f_teid_t s11, s5;
+    ogs_gtp2_f_teid_t s11, s5;
     ogs_paa_t paa;
-    ogs_gtp_ambr_t ambr;
+    ogs_gtp2_ambr_t ambr;
     ogs_pco_t pco;
     unsigned char pcobuf[OGS_MAX_PCO_LEN];
-    ogs_gtp_bearer_qos_t bearer_qos;
-    char bearer_qos_buf[GTP_BEARER_QOS_LEN];
-    ogs_gtp_ue_timezone_t ue_timezone;
+    ogs_gtp2_bearer_qos_t bearer_qos;
+    char bearer_qos_buf[GTP2_BEARER_QOS_LEN];
+    ogs_gtp2_ue_timezone_t ue_timezone;
     int size = 0;
 
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t sa;
 
-    memset(&req, 0, sizeof(ogs_gtp_create_session_request_t));
+    memset(&req, 0, sizeof(ogs_gtp2_create_session_request_t));
 
     req.imsi.presence = 1;
     req.imsi.data = (uint8_t *)"\x55\x15\x30\x11\x34\x00\x10\xf4";
@@ -68,7 +68,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
     req.me_identity.data = (uint8_t *)"\x53\x61\x20\x00\x91\x78\x84\x00";
     req.me_identity.len = 8;
 
-    memset(&uli, 0, sizeof(ogs_gtp_uli_t));
+    memset(&uli, 0, sizeof(ogs_gtp2_uli_t));
     uli.flags.e_cgi = 1;
     uli.flags.tai = 1;
     ogs_plmn_id_build(&uli.tai.nas_plmn_id, 555, 10, 2);
@@ -76,8 +76,8 @@ static void gtp_message_test1(abts_case *tc, void *data)
     ogs_plmn_id_build(&uli.e_cgi.nas_plmn_id, 555, 10, 2);
     uli.e_cgi.cell_id = 105729;
     req.user_location_information.presence = 1;
-    size = ogs_gtp_build_uli(&req.user_location_information, &uli, 
-            ulibuf, OGS_GTP_MAX_ULI_LEN);
+    size = ogs_gtp2_build_uli(&req.user_location_information, &uli,
+            ulibuf, OGS_GTP2_MAX_ULI_LEN);
     ABTS_INT_EQUAL(tc, 13, req.user_location_information.len);
 
     req.serving_network.presence = 1;
@@ -85,27 +85,27 @@ static void gtp_message_test1(abts_case *tc, void *data)
     req.serving_network.len = sizeof(serving_network);
 
     req.rat_type.presence = 1;
-    req.rat_type.u8 = OGS_GTP_RAT_TYPE_EUTRAN;
+    req.rat_type.u8 = OGS_GTP2_RAT_TYPE_EUTRAN;
 
-    memset(&s11, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&s11, 0, sizeof(ogs_gtp2_f_teid_t));
     s11.ipv4 = 1;
-    s11.interface_type = OGS_GTP_F_TEID_S11_MME_GTP_C;
+    s11.interface_type = OGS_GTP2_F_TEID_S11_MME_GTP_C;
     s11.teid = htonl(0x80000084);
     ogs_inet_pton(AF_INET, "10.50.54.10", &sa);
     s11.addr = sa.sin.sin_addr.s_addr;
     req.sender_f_teid_for_control_plane.presence = 1;
     req.sender_f_teid_for_control_plane.data = &s11;
-    req.sender_f_teid_for_control_plane.len = OGS_GTP_F_TEID_IPV4_LEN;
+    req.sender_f_teid_for_control_plane.len = OGS_GTP2_F_TEID_IPV4_LEN;
 
-    memset(&s5, 0, sizeof(ogs_gtp_f_teid_t));
+    memset(&s5, 0, sizeof(ogs_gtp2_f_teid_t));
     s5.ipv4 = 1;
-    s5.interface_type = OGS_GTP_F_TEID_S5_S8_PGW_GTP_C;
+    s5.interface_type = OGS_GTP2_F_TEID_S5_S8_PGW_GTP_C;
     ogs_inet_pton(AF_INET, "10.50.54.37", &sa);
     s5.addr = sa.sin.sin_addr.s_addr;
     req.pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
     req.pgw_s5_s8_address_for_control_plane_or_pmip.data = &s5;
     req.pgw_s5_s8_address_for_control_plane_or_pmip.len =
-        OGS_GTP_F_TEID_IPV4_LEN;
+        OGS_GTP2_F_TEID_IPV4_LEN;
 
     _value = (char*)"05766f6c7465036e 6732046d6e657406 6d6e63303130066d 6363353535046770 7273";
     req.access_point_name.presence = 1;
@@ -113,8 +113,8 @@ static void gtp_message_test1(abts_case *tc, void *data)
     req.access_point_name.len = sizeof(apnbuf);
 
     req.selection_mode.presence = 1;
-    req.selection_mode.u8 = 
-        OGS_GTP_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN | 0xfc;
+    req.selection_mode.u8 =
+        OGS_GTP2_SELECTION_MODE_MS_OR_NETWORK_PROVIDED_APN | 0xfc;
 
     req.pdn_type.presence = 1;
     req.pdn_type.u8 = OGS_PDU_SESSION_TYPE_IPV4;
@@ -126,9 +126,9 @@ static void gtp_message_test1(abts_case *tc, void *data)
     req.pdn_address_allocation.len = OGS_PAA_IPV4_LEN;
 
     req.maximum_apn_restriction.presence = 1;
-    req.maximum_apn_restriction.u8 = OGS_GTP_APN_NO_RESTRICTION;
+    req.maximum_apn_restriction.u8 = OGS_GTP2_APN_NO_RESTRICTION;
 
-    memset(&ambr, 0, sizeof(ogs_gtp_ambr_t));
+    memset(&ambr, 0, sizeof(ogs_gtp2_ambr_t));
     ambr.uplink = htonl(1000);
     ambr.downlink = htonl(2000);
     req.aggregate_maximum_bit_rate.presence = 1;
@@ -137,7 +137,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
 
     memset(&pco, 0, sizeof(ogs_pco_t));
     pco.ext = 1;
-    pco.configuration_protocol = 
+    pco.configuration_protocol =
         OGS_PCO_PPP_FOR_USE_WITH_IP_PDP_TYPE_OR_IP_PDN_TYPE;
     pco.num_of_id = 3;
     pco.ids[0].id = OGS_PCO_ID_INTERNET_PROTOCOL_CONTROL_PROTOCOL;
@@ -150,7 +150,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
 
     req.protocol_configuration_options.presence = 1;
     req.protocol_configuration_options.data = &pcobuf;
-    req.protocol_configuration_options.len = 
+    req.protocol_configuration_options.len =
         ogs_pco_build(pcobuf, OGS_MAX_PCO_LEN, &pco);
 
     req.bearer_contexts_to_be_created.presence = 1;
@@ -163,14 +163,14 @@ static void gtp_message_test1(abts_case *tc, void *data)
     bearer_qos.pre_emption_capability = 1;
     bearer_qos.qci = 5;
     req.bearer_contexts_to_be_created.bearer_level_qos.presence = 1;
-    size = ogs_gtp_build_bearer_qos(
+    size = ogs_gtp2_build_bearer_qos(
             &req.bearer_contexts_to_be_created.bearer_level_qos,
-            &bearer_qos, bearer_qos_buf, GTP_BEARER_QOS_LEN);
+            &bearer_qos, bearer_qos_buf, GTP2_BEARER_QOS_LEN);
 
     memset(&ue_timezone, 0, sizeof(ue_timezone));
     ue_timezone.timezone = 0x40;
-    ue_timezone.daylight_saving_time = 
-        OGS_GTP_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
+    ue_timezone.daylight_saving_time =
+        OGS_GTP2_UE_TIME_ZONE_NO_ADJUSTMENT_FOR_DAYLIGHT_SAVING_TIME;
     req.ue_time_zone.presence = 1;
     req.ue_time_zone.data = &ue_timezone;
     req.ue_time_zone.len = sizeof(ue_timezone);
@@ -179,15 +179,15 @@ static void gtp_message_test1(abts_case *tc, void *data)
     req.charging_characteristics.data = (uint8_t *)"\x54\x00";
     req.charging_characteristics.len = 2;
 
-    pkbuf = ogs_tlv_build_msg(&ogs_gtp_tlv_desc_create_session_request,
+    pkbuf = ogs_tlv_build_msg(&ogs_gtp2_tlv_desc_create_session_request,
             &req, OGS_TLV_MODE_T1_L2_I1);
     ABTS_PTR_NOTNULL(tc, pkbuf);
 
-    ABTS_TRUE(tc, memcmp(pkbuf->data, 
+    ABTS_TRUE(tc, memcmp(pkbuf->data,
         OGS_HEX(_payload, strlen(_payload), hexbuf), pkbuf->len) == 0);
 
     memset(&req, 0, sizeof(req));
-    rv = ogs_tlv_parse_msg(&req, &ogs_gtp_tlv_desc_create_session_request,
+    rv = ogs_tlv_parse_msg(&req, &ogs_gtp2_tlv_desc_create_session_request,
             pkbuf, OGS_TLV_MODE_T1_L2_I1);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
 
@@ -196,13 +196,13 @@ static void gtp_message_test1(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, 1, req.imsi.presence);
     ABTS_INT_EQUAL(tc, 8, req.imsi.len);
     _value = (char*)"55153011 340010f4";
-    ABTS_TRUE(tc, memcmp(OGS_HEX(_value, strlen(_value), hexbuf), 
+    ABTS_TRUE(tc, memcmp(OGS_HEX(_value, strlen(_value), hexbuf),
                 req.imsi.data, req.imsi.len) == 0);
 
     ABTS_INT_EQUAL(tc, 1, req.msisdn.presence);
     ABTS_INT_EQUAL(tc, 6, req.msisdn.len);
     _value = (char*)"94715276 0041";
-    ABTS_TRUE(tc, memcmp(OGS_HEX(_value, strlen(_value), hexbuf), 
+    ABTS_TRUE(tc, memcmp(OGS_HEX(_value, strlen(_value), hexbuf),
                 req.msisdn.data, req.msisdn.len) == 0);
 
     ABTS_INT_EQUAL(tc, 1, req.me_identity.presence);
@@ -212,7 +212,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
         req.me_identity.data, req.me_identity.len) == 0);
 
     ABTS_INT_EQUAL(tc, 1, req.user_location_information.presence);
-    size = ogs_gtp_parse_uli(&uli, &req.user_location_information);
+    size = ogs_gtp2_parse_uli(&uli, &req.user_location_information);
     ABTS_INT_EQUAL(tc, 13, size);
     ABTS_INT_EQUAL(tc, 0, uli.flags.lai);
     ABTS_INT_EQUAL(tc, 1, uli.flags.e_cgi);
@@ -244,25 +244,25 @@ static void gtp_message_test1(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, 1, pco.ext);
     ABTS_INT_EQUAL(tc, 0, pco.configuration_protocol);
     ABTS_INT_EQUAL(tc, 3, pco.num_of_id);
-    ABTS_INT_EQUAL(tc, 
-        OGS_PCO_ID_INTERNET_PROTOCOL_CONTROL_PROTOCOL, 
+    ABTS_INT_EQUAL(tc,
+        OGS_PCO_ID_INTERNET_PROTOCOL_CONTROL_PROTOCOL,
         pco.ids[0].id);
-    ABTS_INT_EQUAL(tc, 16, pco.ids[0].len); 
+    ABTS_INT_EQUAL(tc, 16, pco.ids[0].len);
     ABTS_TRUE(tc, memcmp(
         "\x01\x00\x00\x10\x81\x06\x00\x00\x00\x00\x83\x06\x00\x00\x00\x00",
         pco.ids[0].data, pco.ids[0].len) == 0);
-    ABTS_INT_EQUAL(tc, 
-        OGS_PCO_ID_DNS_SERVER_IPV4_ADDRESS_REQUEST, 
+    ABTS_INT_EQUAL(tc,
+        OGS_PCO_ID_DNS_SERVER_IPV4_ADDRESS_REQUEST,
         pco.ids[1].id);
-    ABTS_INT_EQUAL(tc, 0, pco.ids[1].len); 
-    ABTS_INT_EQUAL(tc, 
-        OGS_PCO_ID_IP_ADDRESS_ALLOCATION_VIA_NAS_SIGNALLING, 
+    ABTS_INT_EQUAL(tc, 0, pco.ids[1].len);
+    ABTS_INT_EQUAL(tc,
+        OGS_PCO_ID_IP_ADDRESS_ALLOCATION_VIA_NAS_SIGNALLING,
         pco.ids[2].id);
-    ABTS_INT_EQUAL(tc, 0, pco.ids[2].len); 
+    ABTS_INT_EQUAL(tc, 0, pco.ids[2].len);
     ABTS_INT_EQUAL(tc, 1, req.bearer_contexts_to_be_created.presence);
     ABTS_INT_EQUAL(tc, 1, req.
                 bearer_contexts_to_be_created.eps_bearer_id.presence);
-    ABTS_INT_EQUAL(tc, 0x05, 
+    ABTS_INT_EQUAL(tc, 0x05,
             req.bearer_contexts_to_be_created.eps_bearer_id.u8);
     ABTS_INT_EQUAL(tc, 0, req.
                 bearer_contexts_to_be_created.tft.presence);
@@ -276,7 +276,7 @@ static void gtp_message_test1(abts_case *tc, void *data)
                 bearer_contexts_to_be_created.bearer_level_qos.presence);
     ABTS_INT_EQUAL(tc, 22,
             req.bearer_contexts_to_be_created.bearer_level_qos.len);
-    size = ogs_gtp_parse_bearer_qos(&bearer_qos, 
+    size = ogs_gtp2_parse_bearer_qos(&bearer_qos,
             &req.bearer_contexts_to_be_created.bearer_level_qos);
     ABTS_INT_EQUAL(tc, 22, size);
     ABTS_INT_EQUAL(tc, 1, bearer_qos.pre_emption_vulnerability);

--- a/tests/volte/bearer-test.c
+++ b/tests/volte/bearer-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */

--- a/tests/volte/cx-test.c
+++ b/tests/volte/cx-test.c
@@ -75,7 +75,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 #endif
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -218,7 +218,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 

--- a/tests/volte/rx-test.c
+++ b/tests/volte/rx-test.c
@@ -70,7 +70,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -213,7 +213,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -348,7 +348,7 @@ static void test1_func(abts_case *tc, void *data)
     /* Send Bearer resource modification request */
     sess->pti = 7;
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_NO_TFT_OPERATION, 0, 0);
+            bearer, OGS_GTP2_TFT_CODE_NO_TFT_OPERATION, 0, 0);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
     ABTS_PTR_NOTNULL(tc, sendbuf);
@@ -363,7 +363,7 @@ static void test1_func(abts_case *tc, void *data)
     /* Send Bearer resource modification request */
     sess->pti = 8;
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT, 1, 0);
+            bearer, OGS_GTP2_TFT_CODE_ADD_PACKET_FILTERS_TO_EXISTING_TFT, 1, 0);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
     ABTS_PTR_NOTNULL(tc, sendbuf);
@@ -396,7 +396,7 @@ static void test1_func(abts_case *tc, void *data)
     /* Send Bearer resource modification request */
     sess->pti = 9;
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING, 0, 0);
+            bearer, OGS_GTP2_TFT_CODE_REPLACE_PACKET_FILTERS_IN_EXISTING, 0, 0);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
     ABTS_PTR_NOTNULL(tc, sendbuf);
@@ -429,7 +429,7 @@ static void test1_func(abts_case *tc, void *data)
     /* Send Bearer resource modification request */
     sess->pti = 10;
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -585,7 +585,7 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -719,7 +719,7 @@ static void test2_func(abts_case *tc, void *data)
     tests1ap_recv(test_ue, recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -936,7 +936,7 @@ static void test3_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -1079,7 +1079,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 37;
 
@@ -1164,7 +1164,7 @@ static void test3_func(abts_case *tc, void *data)
             test_ue->s1ap_procedure_code);
 
     /* Send PDN connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 39;
 
@@ -1286,7 +1286,7 @@ static void test4_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -1429,7 +1429,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 7;
 
@@ -1474,7 +1474,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_msleep(100);
 
     /* Send PDN disconnectivity request */
-    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     sess->pti = 8;
     esmbuf = testesm_build_pdn_disconnect_request(sess);
     ABTS_PTR_NOTNULL(tc, esmbuf);
@@ -1512,7 +1512,7 @@ static void test4_func(abts_case *tc, void *data)
     test_sess_remove(sess);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 9;
 
@@ -1557,7 +1557,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_msleep(100);
 
     /* Send AA-Request */
-    sess = test_sess_find_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     test_rx_send_aar_audio(&rx_sid, sess,
             OGS_DIAM_RX_SUBSCRIPTION_ID_TYPE_END_USER_IMSI, 1, 1);
@@ -1640,15 +1640,15 @@ static void test4_func(abts_case *tc, void *data)
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
 
     /* Test Session Remove */
-    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     test_sess_remove(sess);
-    sess = test_sess_find_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_find_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     test_sess_remove(sess);
 
     /* Send Attach Request */
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     memset(&sess->pdn_connectivity_param,
@@ -1815,7 +1815,7 @@ static void test5_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -1958,7 +1958,7 @@ static void test5_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 7;
 
@@ -2321,7 +2321,7 @@ static void test6_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -2464,7 +2464,7 @@ static void test6_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -2746,7 +2746,7 @@ static void test7_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -2889,7 +2889,7 @@ static void test7_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 

--- a/tests/volte/session-test.c
+++ b/tests/volte/session-test.c
@@ -64,7 +64,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -198,7 +198,7 @@ static void test1_func(abts_case *tc, void *data)
     tests1ap_recv(test_ue, recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -314,7 +314,7 @@ static void test1_func(abts_case *tc, void *data)
     test_sess_remove(sess);
 
     /* Send INVALID PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims2", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims2", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 9;
 

--- a/tests/volte/video-test.c
+++ b/tests/volte/video-test.c
@@ -68,7 +68,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
     test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
 
-    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
 
     /* eNB connects to MME */
@@ -211,7 +211,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     /* Send PDN Connectivity Request */
-    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP_RAT_TYPE_EUTRAN);
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
     ogs_assert(sess);
     sess->pti = 5;
 
@@ -346,7 +346,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 7);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -508,7 +508,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 9);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -670,7 +670,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 11);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -832,7 +832,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 13);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -994,7 +994,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 15);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
@@ -1156,7 +1156,7 @@ static void test1_func(abts_case *tc, void *data)
     bearer = test_bearer_find_by_ue_ebi(test_ue, 8);
     ogs_assert(bearer);
     esmbuf = testesm_build_bearer_resource_modification_request(
-            bearer, OGS_GTP_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
+            bearer, OGS_GTP2_TFT_CODE_DELETE_PACKET_FILTERS_FROM_EXISTING, 0,
             ESM_CAUSE_REGULAR_DEACTIVATION);
     ABTS_PTR_NOTNULL(tc, esmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);


### PR DESCRIPTION
In the past only GTPv2C was supported, and had the "gtp" generic prefix.
Later on, GTPv1C support was added, and "gtp1" prefix was used.
Let's move GTPv2C specific bits to have "gtp2" prefix too, and leave
"gtp" prefix for generic stuff among different GTP versions.