### PR TITLE
[SMF] Inegrate session setup cycle into sess->sm

### DIFF
--- a/src/smf/event.h
+++ b/src/smf/event.h
@@ -21,6 +21,7 @@
 #define SMF_EVENT_H
 
 #include "ogs-core.h"
+#include "ogs-gtp.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,6 +81,11 @@ typedef struct smf_event_s {
     ogs_pfcp_node_t *pfcp_node;
     ogs_pfcp_xact_t *pfcp_xact;
     ogs_pfcp_message_t *pfcp_message;
+
+    union {
+        ogs_gtp1_message_t *gtp1_message;
+        ogs_gtp2_message_t *gtp2_message;
+    };
 
     union {
         ogs_diam_gx_message_t *gx_message;

--- a/src/smf/gn-handler.h
+++ b/src/smf/gn-handler.h
@@ -32,7 +32,7 @@ void smf_gn_handle_echo_request(
 void smf_gn_handle_echo_response(
         ogs_gtp_xact_t *xact, ogs_gtp1_echo_response_t *req);
 
-void smf_gn_handle_create_pdp_context_request(
+uint8_t smf_gn_handle_create_pdp_context_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_gtp1_create_pdp_context_request_t *req);
 void smf_gn_handle_delete_pdp_context_request(

--- a/src/smf/gx-handler.h
+++ b/src/smf/gx-handler.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-void smf_gx_handle_cca_initial_request(
+uint32_t smf_gx_handle_cca_initial_request(
         smf_sess_t *sess, ogs_diam_gx_message_t *gx_message,
         ogs_gtp_xact_t *gtp_xact);
 void smf_gx_handle_cca_termination_request(

--- a/src/smf/gy-handler.h
+++ b/src/smf/gy-handler.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-void smf_gy_handle_cca_initial_request(
+uint32_t smf_gy_handle_cca_initial_request(
         smf_sess_t *sess, ogs_diam_gy_message_t *gy_message,
         ogs_gtp_xact_t *gtp_xact);
 void smf_gy_handle_cca_update_request(

--- a/src/smf/n4-handler.h
+++ b/src/smf/n4-handler.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-void smf_5gc_n4_handle_session_establishment_response(
+uint8_t smf_5gc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_pfcp_session_establishment_response_t *rsp);
 void smf_5gc_n4_handle_session_modification_response(
@@ -36,7 +36,7 @@ void smf_5gc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_pfcp_session_deletion_response_t *rsp);
 
-void smf_epc_n4_handle_session_establishment_response(
+uint8_t smf_epc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_pfcp_session_establishment_response_t *rsp);
 void smf_epc_n4_handle_session_modification_response(

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -187,6 +187,8 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
 
         if (message->h.seid_presence && message->h.seid != 0)
             sess = smf_sess_find_by_seid(message->h.seid);
+        if (sess)
+            e->sess = sess;
 
         switch (message->h.type) {
         case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:
@@ -210,17 +212,22 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                     &message->pfcp_association_setup_response);
             break;
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
-            if (!message->h.seid_presence) {
+            if (!message->h.seid_presence)
                 ogs_error("No SEID");
-                break;
+            if (!sess) {
+                ogs_gtp_xact_t *gtp_xact = xact->assoc_xact;
+                ogs_assert(gtp_xact);
+                if (gtp_xact->gtp_version == 1)
+                    ogs_gtp1_send_error_message(gtp_xact, 0,
+                            OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE,
+                            OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND);
+                else
+                    ogs_gtp2_send_error_message(gtp_xact, 0,
+                            OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                            OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
+                return;
             }
-
-            if (xact->epc)
-                smf_epc_n4_handle_session_establishment_response(
-                    sess, xact, &message->pfcp_session_establishment_response);
-            else
-                smf_5gc_n4_handle_session_establishment_response(
-                    sess, xact, &message->pfcp_session_establishment_response);
+            ogs_fsm_dispatch(&sess->sm, e);
             break;
 
         case OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE:

--- a/src/smf/s5c-handler.h
+++ b/src/smf/s5c-handler.h
@@ -31,7 +31,7 @@ void smf_s5c_handle_echo_request(
 void smf_s5c_handle_echo_response(
         ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *req);
 
-void smf_s5c_handle_create_session_request(
+uint8_t smf_s5c_handle_create_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_gtp2_create_session_request_t *req);
 void smf_s5c_handle_delete_session_request(

--- a/src/smf/smf-sm.h
+++ b/src/smf/smf-sm.h
@@ -48,6 +48,8 @@ void smf_gsm_state_session_will_release(ogs_fsm_t *s, smf_event_t *e);
 void smf_gsm_state_exception(ogs_fsm_t *s, smf_event_t *e);
 
 void smf_pfcp_state_initial(ogs_fsm_t *s, smf_event_t *e);
+void smf_gsm_state_initial_wait_auth(ogs_fsm_t *s, smf_event_t *e);
+void smf_gsm_state_initial_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e);
 void smf_pfcp_state_final(ogs_fsm_t *s, smf_event_t *e);
 void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e);
 void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e);


### PR DESCRIPTION
It allows for much better control on the lifecycle of the session, and
already shows some missing tear down paths in case of errors.
It also clarifies the existence of "sess" pointer in several paths.

The code also becomes clearer overall, since all the transitions and
logic to send next messages are put together.

Tear down of the session will be integrated into gsm-sm in a follow-up
patch.

The 5gc session setup is only partially moved to gsm-sm, and left as an
exercise for users wishin to improve 5gc support.