### PR TITLE
add send_asr option to PFCP configuration

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -402,6 +402,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         int i, num = 0;
                         const char *hostname[OGS_MAX_NUM_OF_HOSTNAME];
                         uint16_t port = self.pfcp_port;
+                        bool send_asr = 1;
                         uint16_t tac[OGS_MAX_NUM_OF_TAI] = {0,};
                         uint8_t num_of_tac = 0;
                         const char *dnn[OGS_MAX_NUM_OF_DNN];
@@ -468,6 +469,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                             } else if (!strcmp(pfcp_key, "port")) {
                                 const char *v = ogs_yaml_iter_value(&pfcp_iter);
                                 if (v) port = atoi(v);
+                            } else if (!strcmp(pfcp_key, "send_asr")) {
+                                bool send_asr = ogs_yaml_iter_bool(&pfcp_iter);
                             } else if (!strcmp(pfcp_key, "tac")) {
                                 ogs_yaml_iter_t tac_iter;
                                 ogs_yaml_iter_recurse(&pfcp_iter, &tac_iter);
@@ -599,6 +602,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         node = ogs_pfcp_node_new(addr);
                         ogs_assert(node);
                         ogs_list_add(&self.pfcp_peer_list, node);
+
+                        node->send_asr = send_asr;
 
                         node->num_of_tac = num_of_tac;
                         if (num_of_tac != 0)

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -470,7 +470,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                 const char *v = ogs_yaml_iter_value(&pfcp_iter);
                                 if (v) port = atoi(v);
                             } else if (!strcmp(pfcp_key, "send_asr")) {
-                                bool send_asr = ogs_yaml_iter_bool(&pfcp_iter);
+                                send_asr = ogs_yaml_iter_bool(&pfcp_iter);
                             } else if (!strcmp(pfcp_key, "tac")) {
                                 ogs_yaml_iter_t tac_iter;
                                 ogs_yaml_iter_recurse(&pfcp_iter, &tac_iter);

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -94,6 +94,8 @@ typedef struct ogs_pfcp_node_s {
     ogs_timer_t     *t_association; /* timer to retry to associate peer node */
     ogs_timer_t     *t_no_heartbeat; /* heartbeat timer to check aliveness */
 
+    bool            send_asr; /* send association setup request or just listen? */
+
     uint16_t        tac[OGS_MAX_NUM_OF_TAI];
     uint8_t         num_of_tac;
     const char*     dnn[OGS_MAX_DNN_LEN+1];

--- a/lib/pfcp/path.h
+++ b/lib/pfcp/path.h
@@ -49,7 +49,7 @@ extern "C" {
         ogs_assert(ogs_pfcp_self()->pfcp_addr || ogs_pfcp_self()->pfcp_addr6); \
         \
         ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, pfcp_node) \
-            pfcp_node_fsm_init(pfcp_node, true); \
+            pfcp_node_fsm_init(pfcp_node, pfcp_node->send_asr); \
         \
     } while(0)
 


### PR DESCRIPTION
This is a small change to enable manual configuration of a PFCP node, to either send (or not send) Association Setup Requests. I do not think it is critical but is definitely nice to have.

The default PFCP behavior is if a node is configured to know a remote node's IP address, it will send an Association Setup Request to this address, and keep sending this request until the node is connected. If a node is not configured with any remote IP addresses, it will (obviously) not send any requests. In both cases, the node will also listen for incoming requests.

The default behavior creates a problem for our network, and we were thinking other teams might have the same problem. We run a single SGWC and SMF connected to multiple SGWUs and UPFs that may or may not be online (basically we have one Control-Plane-Server and many User-Plane-Servers). Our architecture selects a SGWU/UPF combo for a traffic flow based on various identifiers (APN, IMSI, TAC, etc), so to do this the SGWC/SMF need to be aware of all possible SGWU/UPF addresses at boot time, even if many of them are offline. This then clogs up our logs with the SGWC/SMF sending lots of unanswered ASRs and throwing error messages when they do not get responses.

By building this option, default behavior is unchanged, but by adding the option "send asr: false" to a PFCP remote node configuration, the SGWC/SMF will stay silent until it is contacted by the SGWU/UPF first.