### PR TITLE
fix MME crash after sctp disconnect

### DIFF
--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -461,7 +461,9 @@ void mme_gtp_send_release_all_ue_in_enb(mme_enb_t *enb, int action)
         if (mme_ue) {
             ogs_assert(OGS_OK ==
                 mme_gtp_send_release_access_bearers_request(mme_ue, action));
-
+            if (action == OGS_GTP_RELEASE_S1_CONTEXT_REMOVE_BY_LO_CONNREFUSED) {
+                enb_ue_remove(enb_ue);
+            }
         } else {
             ogs_warn("mme_gtp_send_release_all_ue_in_enb()");
             ogs_warn("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d] Action[%d]",


### PR DESCRIPTION
This is a tentative fix to an obscure crash we have started noticing in production. I would love some help/feedback as to the best way to solve this problem, because I am not sure if this is the best place to put this fix, or if the fix needs something else as well.

The crash happens when one or more users is connected to an eNB, and then the eNB and user-plane-server (SGWU and UPF) go offline at the same time. More explanation: when the eNB goes offline, after 90 seconds of unanswered HEARTBEAT messages, the SCTP handler tears down the connection. This codepath results in the MME sending a Release Access Bearers Request to the SGWC. The SGWC then sends a PFCP Session Modification Request to the SGWU. If the SGWU is offline, it (obviously) does not respond. The SGWC re-sends the Session Modification Request two more times, then times-out silently and does not do anything else. Meanwhile, the MME re-sends the Release Access Bearers Request to the SGWC two more times, before timing-out. When the timeout hits, the MME sends a Delete Session Request to the SGWC. SGWC forwards it to the SMF, which sends a PFCP Session Deletion Request to the UPF, which (obviously) does not respond. After two more re-transmits, timeout at the SMF, nothing happens. After two more retransmits of Delete Session Request, timeout happens at the MME, and then it crashes trying to send a S1AP release to the UE.

Even More Discussion:
From a software perspective, this is a corner-case where the code has already released/cleaned-up the SCTP socket, but retains a pointer/reference to the enb_ue. Specifically, the crash is driven by the logic at mme-gtp-path.c:135 where after it doesn't get a response to Delete Session Request, it decides to tear down the S1AP connection by calling s1ap_send_ue_context_release_command (which panics at s1ap-path.c:57 since the SCTP socket is invalid).

In "normal" operation, where the eNB goes offline but everything else stays online, it looks like this reference is cleaned-up and removed when the MME receives a Release Access Bearers Response, specifically at mme-s11-handler.c:859.

Proposed Solution:
I struggled for a while over where to put this fix. We could add some special error-handling in the timeout() function to silently handle this case, or we could also just always tear down the enb_ue state in mme_gtp_send_release_access_bearers_request() before we send the request, instead of when we get the response. I added the code here, only when OGS_GTP_RELEASE_S1_CONTEXT_REMOVE_BY_LO_CONNREFUSED, so that this only happens when SCTP is torn-down, not in any other context. This is because I think the other code-paths are correct, and also because it's not entirely clear to me if we need to do more cleanup, or if that creates issues. Would love your help here.

As a side note, I think this problem-case also highlights some small bugs in PFCP, in that if the SGWU/UPF disappear, then the SGWC/SMF should still respond to the RAB Request. I will look into those next week, but either way I think the MME needs to be fixed. No matter what other services crash, the MME should be able to revert itself into a correct and stable state.

Please let me know what you think, or if you want to see logs/PCAP. Took me a while to understand exactly what was happening and how to recreate but now I have nice clean traces for everything.