### PR TITLE
[SMF] Store MSISDN from GTPC and pass it in Gy CCR

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -109,6 +109,11 @@ typedef struct smf_ue_s {
     int imsi_len;
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
 
+    /* MSISDN */
+    uint8_t msisdn[OGS_MAX_MSISDN_LEN];
+    int msisdn_len;
+    char msisdn_bcd[OGS_MAX_MSISDN_BCD_LEN+1];
+
     ogs_list_t sess_list;
 } smf_ue_t;
 

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -457,7 +457,7 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
     ogs_assert(ret == 0);
 
-    /* Subscription-Id */
+    /* Subscription-Id (IMSI) */
     ret = fd_msg_avp_new(ogs_diam_subscription_id, 0, &avp);
     ogs_assert(ret == 0);
 
@@ -473,6 +473,30 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     ogs_assert(ret == 0);
     val.os.data = (uint8_t *)smf_ue->imsi_bcd;
     val.os.len = strlen(smf_ue->imsi_bcd);
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
+    ogs_assert(ret == 0);
+
+    /* Subscription-Id (MSISDN) */
+    ret = fd_msg_avp_new(ogs_diam_subscription_id, 0, &avp);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_subscription_id_type, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.i32 = OGS_DIAM_SUBSCRIPTION_ID_TYPE_END_USER_E164;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_subscription_id_data, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.os.data = (uint8_t *)smf_ue->msisdn_bcd;
+    val.os.len = strlen(smf_ue->msisdn_bcd);
     ret = fd_msg_avp_setvalue (avpch1, &val);
     ogs_assert(ret == 0);
     ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -1291,6 +1291,10 @@ bson_t *test_db_new_simple(test_ue_t *test_ue)
 
     doc = BCON_NEW(
             "imsi", BCON_UTF8(test_ue->imsi),
+            "msisdn", "[",
+                BCON_UTF8(TEST_MSISDN),
+                BCON_UTF8(TEST_ADDITIONAL_MSISDN),
+            "]",
             "ambr", "{",
                 "downlink", "{",
                     "value", BCON_INT32(1),
@@ -1351,6 +1355,10 @@ bson_t *test_db_new_qos_flow(test_ue_t *test_ue)
 
     doc = BCON_NEW(
             "imsi", BCON_UTF8(test_ue->imsi),
+            "msisdn", "[",
+                BCON_UTF8(TEST_MSISDN),
+                BCON_UTF8(TEST_ADDITIONAL_MSISDN),
+            "]",
             "ambr", "{",
                 "downlink", "{",
                     "value", BCON_INT32(1),
@@ -1451,6 +1459,10 @@ bson_t *test_db_new_session(test_ue_t *test_ue)
 
     doc = BCON_NEW(
             "imsi", BCON_UTF8(test_ue->imsi),
+            "msisdn", "[",
+                BCON_UTF8(TEST_MSISDN),
+                BCON_UTF8(TEST_ADDITIONAL_MSISDN),
+            "]",
             "ambr", "{",
                 "downlink", "{",
                     "value", BCON_INT32(1),
@@ -1725,6 +1737,10 @@ bson_t *test_db_new_slice_with_same_dnn(test_ue_t *test_ue)
 
     doc = BCON_NEW(
             "imsi", BCON_UTF8(test_ue->imsi),
+            "msisdn", "[",
+                BCON_UTF8(TEST_MSISDN),
+                BCON_UTF8(TEST_ADDITIONAL_MSISDN),
+            "]",
             "ambr", "{",
                 "downlink", "{",
                     "value", BCON_INT32(1),
@@ -2098,6 +2114,10 @@ bson_t *test_db_new_slice_with_different_dnn(test_ue_t *test_ue)
 
     doc = BCON_NEW(
             "imsi", BCON_UTF8(test_ue->imsi),
+            "msisdn", "[",
+                BCON_UTF8(TEST_MSISDN),
+                BCON_UTF8(TEST_ADDITIONAL_MSISDN),
+            "]",
             "ambr", "{",
                 "downlink", "{",
                     "value", BCON_INT32(1),


### PR DESCRIPTION
The encoding in GTPv1C is different than in GTPv2C. The former has an
extra byte prepended specifying the nature of address and numbering plan
indicator. Diameter doesn't require that information so we simply strip
it of.
In any case TS 29.060 (GTPv1C) sec 7.7.33 states:
"""
The MSISDN shall be in international format and the "nature of address indicator" shall indicate
"international number".
"""
So we are fine stripping and copying over.