### PR TITLE
Fix attach reject when ULA subscription data does not contain MSISDN

### DIFF
--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -148,14 +148,18 @@ uint8_t smf_gn_handle_create_pdp_context_request(
     /* Set MSISDN: */
     /* TS 29.060 sec 7.7.33, TS 29.002 ISDN-AddressString
      * 1 byte offset: Get rid of address and numbering plan indicator  */
-    if (req->msisdn.len == 0 || (req->msisdn.len - 1) > sizeof(smf_ue->msisdn))  {
-        ogs_error("MSISDN wrong size %u > %zu", (req->msisdn.len - 1), sizeof(smf_ue->msisdn));
+    if (req->msisdn.len == 0 ||
+        (req->msisdn.len - 1) > sizeof(smf_ue->msisdn))  {
+        ogs_error("MSISDN wrong size %u > %zu",
+            (req->msisdn.len - 1), sizeof(smf_ue->msisdn));
         return OGS_GTP1_CAUSE_MANDATORY_IE_INCORRECT;
     }
     smf_ue->msisdn_len = req->msisdn.len - 1;
     if (smf_ue->msisdn_len > 0) {
-        memcpy(smf_ue->msisdn, (uint8_t*)req->msisdn.data + 1, smf_ue->msisdn_len);
-        ogs_buffer_to_bcd(smf_ue->msisdn, smf_ue->msisdn_len, smf_ue->msisdn_bcd);
+        memcpy(smf_ue->msisdn,
+            (uint8_t*)req->msisdn.data + 1, smf_ue->msisdn_len);
+        ogs_buffer_to_bcd(
+            smf_ue->msisdn, smf_ue->msisdn_len, smf_ue->msisdn_bcd);
     }
 
     /* Set Bearer QoS */

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -482,28 +482,30 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     ogs_assert(ret == 0);
 
     /* Subscription-Id (MSISDN) */
-    ret = fd_msg_avp_new(ogs_diam_subscription_id, 0, &avp);
-    ogs_assert(ret == 0);
+    if (smf_ue->msisdn_len > 0) {
+        ret = fd_msg_avp_new(ogs_diam_subscription_id, 0, &avp);
+        ogs_assert(ret == 0);
 
-    ret = fd_msg_avp_new(ogs_diam_subscription_id_type, 0, &avpch1);
-    ogs_assert(ret == 0);
-    val.i32 = OGS_DIAM_SUBSCRIPTION_ID_TYPE_END_USER_E164;
-    ret = fd_msg_avp_setvalue (avpch1, &val);
-    ogs_assert(ret == 0);
-    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
-    ogs_assert(ret == 0);
+        ret = fd_msg_avp_new(ogs_diam_subscription_id_type, 0, &avpch1);
+        ogs_assert(ret == 0);
+        val.i32 = OGS_DIAM_SUBSCRIPTION_ID_TYPE_END_USER_E164;
+        ret = fd_msg_avp_setvalue (avpch1, &val);
+        ogs_assert(ret == 0);
+        ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+        ogs_assert(ret == 0);
 
-    ret = fd_msg_avp_new(ogs_diam_subscription_id_data, 0, &avpch1);
-    ogs_assert(ret == 0);
-    val.os.data = (uint8_t *)smf_ue->msisdn_bcd;
-    val.os.len = strlen(smf_ue->msisdn_bcd);
-    ret = fd_msg_avp_setvalue (avpch1, &val);
-    ogs_assert(ret == 0);
-    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
-    ogs_assert(ret == 0);
+        ret = fd_msg_avp_new(ogs_diam_subscription_id_data, 0, &avpch1);
+        ogs_assert(ret == 0);
+        val.os.data = (uint8_t *)smf_ue->msisdn_bcd;
+        val.os.len = strlen(smf_ue->msisdn_bcd);
+        ret = fd_msg_avp_setvalue (avpch1, &val);
+        ogs_assert(ret == 0);
+        ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+        ogs_assert(ret == 0);
 
-    ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
-    ogs_assert(ret == 0);
+        ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
+        ogs_assert(ret == 0);
+    }
 
     /* Termination-Cause */
     if (cc_request_type == OGS_DIAM_GY_CC_REQUEST_TYPE_TERMINATION_REQUEST) {

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -78,10 +78,6 @@ uint8_t smf_s5c_handle_create_session_request(
         ogs_error("No IMSI");
         cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
     }
-    if (req->msisdn.presence == 0) {
-        ogs_error("No MSISDN");
-        cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
-    }
     if (req->sender_f_teid_for_control_plane.presence == 0) {
         ogs_error("No TEID");
         cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
@@ -156,14 +152,18 @@ uint8_t smf_s5c_handle_create_session_request(
 
     /* Set MSISDN: */
     /* TS 29.274 sec 8.11, TS 29.002 ISDN-AddressString  */
-    if (req->msisdn.len > sizeof(smf_ue->msisdn))  {
-        ogs_error("MSISDN wrong size %u > %zu", req->msisdn.len, sizeof(smf_ue->msisdn));
-        return OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
-    }
-    smf_ue->msisdn_len = req->msisdn.len;
-    if (smf_ue->msisdn_len > 0) {
-        memcpy(smf_ue->msisdn, req->msisdn.data, smf_ue->msisdn_len);
-        ogs_buffer_to_bcd(smf_ue->msisdn, smf_ue->msisdn_len, smf_ue->msisdn_bcd);
+    if (req->msisdn.presence == 1) {
+        if (req->msisdn.len > sizeof(smf_ue->msisdn))  {
+            ogs_error("MSISDN wrong size %u > %zu",
+                req->msisdn.len, sizeof(smf_ue->msisdn));
+            return OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
+        }
+        smf_ue->msisdn_len = req->msisdn.len;
+        if (smf_ue->msisdn_len > 0) {
+            memcpy(smf_ue->msisdn, req->msisdn.data, smf_ue->msisdn_len);
+            ogs_buffer_to_bcd(
+                smf_ue->msisdn, smf_ue->msisdn_len, smf_ue->msisdn_bcd);
+        }
     }
 
     if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_EUTRAN) {


### PR DESCRIPTION
Issue:
When the ULA - Subscription Data does not contain MSISDN, the Create Session Request
from MME to SGW does not contain MSISDN IE resulting in SMF throwing following log

```
smf        | 05/09 15:20:53.683: [smf] ERROR: No MSISDN (../src/smf/s5c-handler.c:82)
sgwc       | 05/09 15:20:53.683: [sgwc] ERROR: No Context in TEID (../src/sgwc/s5c-handler.c:104)
mme        | 05/09 15:20:53.683: [mme] ERROR: No Context in TEID (../src/mme/mme-s11-handler.c:122)
```

As per 3GPP TS 29.274 version 16.5.0, table 7.2.1-1: MSISDN IE shall only be included
in Create Session Request if its provided in subscription data from the HSS. This commit
fixes this by removing the mandatory MSISDN IE check in SMF.