### PR TITLE
Change handling of SessionManagementSubscriptionData as an array

### DIFF
--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -385,8 +385,7 @@ typedef struct ogs_sbi_message_s {
     OpenAPI_sm_context_update_error_t *SmContextUpdateError;
     OpenAPI_sm_context_release_data_t *SmContextReleaseData;
     OpenAPI_sm_context_released_data_t *SmContextReleasedData;
-    OpenAPI_session_management_subscription_data_t *
-            SessionManagementSubscriptionData;
+    OpenAPI_list_t *SessionManagementSubscriptionDataList;
     OpenAPI_n1_n2_message_transfer_req_data_t *N1N2MessageTransferReqData;
     OpenAPI_n1_n2_message_transfer_rsp_data_t *N1N2MessageTransferRspData;
     OpenAPI_n1_n2_msg_txfr_failure_notification_t

--- a/src/smf/nudm-handler.c
+++ b/src/smf/nudm-handler.c
@@ -56,8 +56,23 @@ bool smf_nudm_sdm_handle_get(smf_sess_t *sess, ogs_sbi_stream_t *stream,
 
     ogs_assert(recvmsg);
 
-    SessionManagementSubscriptionData =
-        recvmsg->SessionManagementSubscriptionData;
+
+    if ((!recvmsg->SessionManagementSubscriptionDataList) ||
+        (recvmsg->SessionManagementSubscriptionDataList->count == 0))
+    {
+        strerror = ogs_msprintf("[%s:%d] No SessionManagementSubscriptionDataList",
+                smf_ue->supi, sess->psi);
+        goto cleanup;
+    }
+
+    OpenAPI_list_for_each(recvmsg->SessionManagementSubscriptionDataList, node)
+    {
+        SessionManagementSubscriptionData = node->data;
+
+        /* currently supported to parse only first element of the array */
+        break;
+    }
+    
     if (!SessionManagementSubscriptionData) {
         strerror = ogs_msprintf("[%s:%d] No SessionManagementSubscriptionData",
                 smf_ue->supi, sess->psi);

--- a/src/udr/nudr-handler.c
+++ b/src/udr/nudr-handler.c
@@ -793,8 +793,12 @@ bool udr_nudr_dr_handle_subscription_provisioned(
                 dnnConfigurationList;
 
         memset(&sendmsg, 0, sizeof(sendmsg));
-        sendmsg.SessionManagementSubscriptionData =
-            &SessionManagementSubscriptionData;
+        
+        sendmsg.SessionManagementSubscriptionDataList = OpenAPI_list_create();
+        ogs_assert(sendmsg.SessionManagementSubscriptionDataList);
+
+        OpenAPI_list_add(sendmsg.SessionManagementSubscriptionDataList,
+            &SessionManagementSubscriptionData);
 
         response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_OK);
         ogs_assert(response);


### PR DESCRIPTION
According to the following standards the response to the endpoint
/nudm-sdm/${supi}/sm-data should be an array of
SessionManagementSubscriptionData objects, instead of only one object.

TS 29.503 version 16.6.0
TS 29.505 version 16.4.0

UDR now responds to the request with only item in the array.
UDM copies all items as is.
SMF uses only the first item in the array, even if there are more
present.