### PR TITLE
Fix minor typos

### DIFF
--- a/lib/app/ogs-init.c
+++ b/lib/app/ogs-init.c
@@ -32,9 +32,6 @@ int ogs_app_initialize(
         char *log_file;
         char *log_level;
         char *domain_mask;
-
-        bool enable_debug;
-        bool enable_trace;
     } optarg;
 
     ogs_core_initialize();

--- a/src/amf/nf-sm.c
+++ b/src/amf/nf-sm.c
@@ -195,7 +195,7 @@ void amf_nf_state_registered(ogs_fsm_t *s, amf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/ausf/nf-sm.c
+++ b/src/ausf/nf-sm.c
@@ -195,7 +195,7 @@ void ausf_nf_state_registered(ogs_fsm_t *s, ausf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/bsf/nf-sm.c
+++ b/src/bsf/nf-sm.c
@@ -196,7 +196,7 @@ void bsf_nf_state_registered(ogs_fsm_t *s, bsf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/nrf/nf-sm.c
+++ b/src/nrf/nf-sm.c
@@ -189,7 +189,7 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("[%s] NF registred [Heartbeat:%ds]",
+        ogs_info("[%s] NF registered [Heartbeat:%ds]",
                 nf_instance->id, nf_instance->time.heartbeat_interval);
         if (nf_instance->time.heartbeat_interval) {
             ogs_timer_start(nf_instance->t_no_heartbeat,

--- a/src/nssf/nf-sm.c
+++ b/src/nssf/nf-sm.c
@@ -195,7 +195,7 @@ void nssf_nf_state_registered(ogs_fsm_t *s, nssf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/pcf/nf-sm.c
+++ b/src/pcf/nf-sm.c
@@ -195,7 +195,7 @@ void pcf_nf_state_registered(ogs_fsm_t *s, pcf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/smf/nf-sm.c
+++ b/src/smf/nf-sm.c
@@ -196,7 +196,7 @@ void smf_nf_state_registered(ogs_fsm_t *s, smf_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/udm/nf-sm.c
+++ b/src/udm/nf-sm.c
@@ -195,7 +195,7 @@ void udm_nf_state_registered(ogs_fsm_t *s, udm_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/src/udr/nf-sm.c
+++ b/src/udr/nf-sm.c
@@ -195,7 +195,7 @@ void udr_nf_state_registered(ogs_fsm_t *s, udr_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;

--- a/tests/af/nf-sm.c
+++ b/tests/af/nf-sm.c
@@ -196,7 +196,7 @@ void af_nf_state_registered(ogs_fsm_t *s, af_event_t *e)
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
         if (NF_INSTANCE_IS_SELF(nf_instance->id)) {
-            ogs_info("[%s] NF registred [Heartbeat:%ds]",
+            ogs_info("[%s] NF registered [Heartbeat:%ds]",
                     nf_instance->id, nf_instance->time.heartbeat_interval);
 
             client = nf_instance->client;


### PR DESCRIPTION
- fix minor typo in the log output (`registred` -> `registered`)
- remove unused struct member