### PR TITLE
[build] Use local sources to build applications

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/*.md
+**/docker-compose*.yml
+**/docker-compose*.yaml
+**/Dockerfile*
+.git
+.dockerignore
+.cache
+.gitignore
+.github
+build

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -5,15 +5,8 @@ FROM ${username}/${dist}-${tag}-open5gs-base
 
 MAINTAINER Sukchan Lee <acetcom@gmail.com>
 
-WORKDIR /root
-COPY setup.sh /root
+WORKDIR /open5gs
+COPY docker/build/setup.sh /root
+COPY ./ /open5gs
 
-ARG USER=open5gs
-ARG REPO=open5gs
-ARG BRANCH=main
-RUN git clone https://github.com/$USER/$REPO
-ADD https://api.github.com/repos/$USER/$REPO/git/refs/heads/$BRANCH /root/open5gs-ver.json
-
-RUN cd $REPO && \
-    git fetch && git checkout -f -B $BRANCH origin/$BRANCH && \
-    meson build && ninja -C build install
+RUN meson build && ninja -C build install

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,8 @@ services:
 
   build:
     build:
-      context: ./build
+      context: ../
+      dockerfile: docker/build/Dockerfile
       args:
         dist: ${DIST-ubuntu}
         tag: ${TAG-latest}


### PR DESCRIPTION
"build" Docker image previously downloaded latest version of Open5GS
from github, and built the project from that.
Use local source files for building instead.