### PR TITLE
[AMF] Add support for SUCI protection schemes A and B

### DIFF
--- a/lib/nas/5gs/conv.c
+++ b/lib/nas/5gs/conv.c
@@ -70,7 +70,9 @@ char *ogs_nas_5gs_suci_from_mobile_identity(
     ogs_expect_or_return_val(mobile_identity_suci->h.supi_format ==
             OGS_NAS_5GS_SUPI_FORMAT_IMSI, NULL);
     ogs_expect_or_return_val(mobile_identity_suci->protection_scheme_id ==
-            OGS_NAS_5GS_NULL_SCHEME, NULL);
+            OGS_NAS_5GS_NULL_SCHEME || mobile_identity_suci->protection_scheme_id ==
+            OGS_NAS_5GS_ECIES_SCHEME_PROFILE_A || mobile_identity_suci->protection_scheme_id ==
+            OGS_NAS_5GS_ECIES_SCHEME_PROFILE_B, NULL);
 
     suci = ogs_msprintf("suci-%d-", mobile_identity_suci->h.supi_format);
     ogs_expect_or_return_val(suci, NULL);
@@ -107,8 +109,14 @@ char *ogs_nas_5gs_suci_from_mobile_identity(
     ogs_expect_or_return_val(scheme_output_len > 0, NULL);
     ogs_expect_or_return_val(
             scheme_output_len <= OGS_NAS_MAX_SCHEME_OUTPUT_LEN, NULL);
-    ogs_buffer_to_bcd(mobile_identity_suci->scheme_output,
+
+    if (mobile_identity_suci->protection_scheme_id != OGS_NAS_5GS_NULL_SCHEME) {
+        ogs_hex_to_ascii(mobile_identity_suci->scheme_output, 
+            scheme_output_len, tmp, sizeof(tmp));
+    } else {
+        ogs_buffer_to_bcd(mobile_identity_suci->scheme_output,
             scheme_output_len, tmp);
+    }
 
     suci = ogs_mstrcatf(suci, "%s-%d-%d-%s",
             routing_indicator,

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1353,7 +1353,6 @@ amf_ue_t *amf_ue_find_by_message(ogs_nas_5gs_message_t *message)
     ogs_nas_5gs_service_request_t *service_request = NULL;
     ogs_nas_5gs_mobile_identity_t *mobile_identity = NULL;
     ogs_nas_5gs_mobile_identity_header_t *mobile_identity_header = NULL;
-    ogs_nas_5gs_mobile_identity_suci_t *mobile_identity_suci = NULL;
     ogs_nas_5gs_mobile_identity_guti_t *mobile_identity_guti = NULL;
     ogs_nas_5gs_mobile_identity_s_tmsi_t *mobile_identity_s_tmsi = NULL;
     ogs_nas_5gs_guti_t nas_guti;
@@ -1380,14 +1379,8 @@ amf_ue_t *amf_ue_find_by_message(ogs_nas_5gs_message_t *message)
 
         switch (mobile_identity_header->type) {
         case OGS_NAS_5GS_MOBILE_IDENTITY_SUCI:
-            mobile_identity_suci =
-                (ogs_nas_5gs_mobile_identity_suci_t *)mobile_identity->buffer;
-            if (mobile_identity_suci->protection_scheme_id !=
-                    OGS_NAS_5GS_NULL_SCHEME) {
-                ogs_error("Not implemented ProtectionSchemeID(%d) in SUCI",
-                    mobile_identity_suci->protection_scheme_id);
-                return NULL;
-            }
+            /*mobile_identity_suci =
+                (ogs_nas_5gs_mobile_identity_suci_t *)mobile_identity->buffer;*/
 
             suci = ogs_nas_5gs_suci_from_mobile_identity(mobile_identity);
             ogs_assert(suci);

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -42,7 +42,6 @@ int gmm_handle_registration_request(amf_ue_t *amf_ue,
     ogs_nas_5gs_registration_type_t *registration_type = NULL;
     ogs_nas_5gs_mobile_identity_t *mobile_identity = NULL;
     ogs_nas_5gs_mobile_identity_header_t *mobile_identity_header = NULL;
-    ogs_nas_5gs_mobile_identity_suci_t *mobile_identity_suci = NULL;
     ogs_nas_5gs_mobile_identity_guti_t *mobile_identity_guti = NULL;
     ogs_nas_ue_security_capability_t *ue_security_capability = NULL;
     ogs_nas_5gs_guti_t nas_guti;
@@ -141,18 +140,8 @@ int gmm_handle_registration_request(amf_ue_t *amf_ue,
 
     switch (mobile_identity_header->type) {
     case OGS_NAS_5GS_MOBILE_IDENTITY_SUCI:
-        mobile_identity_suci =
-            (ogs_nas_5gs_mobile_identity_suci_t *)mobile_identity->buffer;
-        if (mobile_identity_suci->protection_scheme_id !=
-                OGS_NAS_5GS_NULL_SCHEME) {
-            ogs_error("Not implemented ProtectionSchemeID(%d) in SUCI",
-                mobile_identity_suci->protection_scheme_id);
-            ogs_assert(OGS_OK ==
-                nas_5gs_send_registration_reject(amf_ue,
-                    OGS_5GMM_CAUSE_MESSAGE_TYPE_NON_EXISTENT_OR_NOT_IMPLEMENTED)
-            );
-            return OGS_ERROR;
-        }
+        /*mobile_identity_suci =
+            (ogs_nas_5gs_mobile_identity_suci_t *)mobile_identity->buffer;*/
         amf_ue_set_suci(amf_ue, mobile_identity);
         ogs_info("[%s]    SUCI", amf_ue->suci);
         break;


### PR DESCRIPTION
For null protection scheme the SUCI needs to be BCD encoded. Whereas for
protection scheme profiles A and B the SUCI needs to be converted from
hexadecimal to ASCII.

This still needs the support for protection schemes A and B in UDM to
work.