### PR TITLE
meson: Depend explicitly on libmicrohttpd >=0.9.61

### DIFF
--- a/lib/metrics/meson.build
+++ b/lib/metrics/meson.build
@@ -31,7 +31,7 @@ if metrics_impl_optval == 'prometheus'
     # 0.50.0: {'CMake Module'}
     # 0.51.0: {'subproject'}
 
-    libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.40')
+    libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.61')
 
     cmake = import('cmake')
     prometheus_client_c_proj = cmake.subproject('prometheus-client-c')

--- a/lib/sbi/meson.build
+++ b/lib/sbi/meson.build
@@ -49,7 +49,7 @@ sbi_cc_flags = ['-DOGS_SBI_COMPILATION']
 
 libgnutls_dep = cc.find_library('gnutls', required : true)
 libnghttp2_dep = dependency('libnghttp2', version: '>=1.18.1')
-libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.40')
+libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.61')
 libcurl_dep = dependency('libcurl', version: '>=7.52.1')
 
 libsbi = library('ogssbi',


### PR DESCRIPTION
Recent commit re-enabling SBI HTTP/1.1 support
(10bdf39505cf525b95886c140b3c2e82e7427d29) started using libmicrohttpd's
API MHD_create_response_from_buffer_with_free_callback(), which is only
available starting from v0.9.61.
As a result, compilation in xUbuntu 18.04 started failing with errors
about the function not being found, since it ships with libmicrohttpd
v0.9.59.
Depending on 0.9.61 is fine since it's quite old (november 2018) and all
major current distros should for sure have an >= one. Let's simply bump
the version check so that it fails in an informative manner.