### PR TITLE
make PFCP Session-Establishment-Request idempotent

### DIFF
--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -249,7 +249,7 @@ int sgwc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->sgwu_sxa_seid;
+    h.seid = 0;
 
     sxabuf = sgwc_sxa_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(sxabuf, OGS_ERROR);

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -215,6 +215,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
 
             if (!e->gtp_message) {
                 ogs_warn("No GTP Message Context");
+                break;
             }
 
             sgwc_sxa_handle_session_establishment_response(

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -213,6 +213,10 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                 break;
             }
 
+            if (!e->gtp_message) {
+                ogs_warn("No GTP Message Context");
+            }
+
             sgwc_sxa_handle_session_establishment_response(
                 sess, xact, e->gtp_message,
                 &message->pfcp_session_establishment_response);

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -369,7 +369,7 @@ int smf_5gc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->upf_n4_seid;
+    h.seid = 0;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);
@@ -485,7 +485,7 @@ int smf_epc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->upf_n4_seid;
+    h.seid = 0;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);


### PR DESCRIPTION
These edits are pretty tiny, and in-line with 3GPP: When sending a PFCP Session-Establishment-Request, header SEID should always be zero. The GTP line-edit avoids a segfault on the off-chance that there's no linked GTP context for a session-establishment-response.

What's interesting to me about these small edits is that they actually make the PFCP Session-Establishment-Request operation completely idempotent. With these edits, the SGWC could call e.g. sgwc_pfcp_send_session_establishment_request(temp_sess, NULL, NULL) at anytime, and the operation would (1) create the session in the sgwu only if needed, and (2) return successfully no matter what.

The reason I care about this (and my other PRs) is because my "end goal" is to write logic to cover all cases where the UPS crashes or loses connectivity with the CPS. making session establishments and deletes safe and idempotent is a huge part of that. My "end vision" is one where whenever the PFCP nodes lose connectivity and re-associate, the control plane node (1) sends a Session-Set-Delete to wipe out all sessions, and then (2) sends a Session-Establishment-Request for each active session it knows about. Idempotentcy in these operations helps a lot, obviously.