### PR TITLE
[CORE] Compare port in ogs_sockaddr_is_equal()

### DIFF
--- a/lib/core/ogs-sockaddr.c
+++ b/lib/core/ogs-sockaddr.c
@@ -416,17 +416,23 @@ bool ogs_sockaddr_is_equal(void *p, void *q)
     if (a->ogs_sa_family != b->ogs_sa_family)
         return false;
 
-    if (a->ogs_sa_family == AF_INET && memcmp(
-        &a->sin.sin_addr, &b->sin.sin_addr, sizeof(struct in_addr)) == 0)
+    switch (a->ogs_sa_family) {
+    case AF_INET:
+        if (a->sin.sin_port != b->sin.sin_port)
+            return false;
+        if (memcmp(&a->sin.sin_addr, &b->sin.sin_addr, sizeof(struct in_addr)) != 0)
+            return false;
         return true;
-    else if (a->ogs_sa_family == AF_INET6 && memcmp(
-        &a->sin6.sin6_addr, &b->sin6.sin6_addr, sizeof(struct in6_addr)) == 0)
+    case AF_INET6:
+        if (a->sin6.sin6_port != b->sin6.sin6_port)
+            return false;
+        if (memcmp(&a->sin6.sin6_addr, &b->sin6.sin6_addr, sizeof(struct in6_addr)) != 0)
+            return false;
         return true;
-    else {
-        return false;
+    default:
+        ogs_error("Unexpected address faimily %u", a->ogs_sa_family);
+        ogs_abort();
     }
-
-    return false;
 }
 
 static int parse_network(ogs_ipsubnet_t *ipsub, const char *network)

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -169,8 +169,7 @@ ogs_sbi_client_t *ogs_sbi_client_find(ogs_sockaddr_t *addr)
     ogs_assert(addr);
 
     ogs_list_for_each(&ogs_sbi_self()->client_list, client) {
-        if (ogs_sockaddr_is_equal(client->node.addr, addr) == true &&
-            OGS_PORT(client->node.addr) == OGS_PORT(addr))
+        if (ogs_sockaddr_is_equal(client->node.addr, addr) == true)
             break;
     }
 


### PR DESCRIPTION
A sockaddr of type AF_INET and AF_INET6 has fields: addr and port.
Only port was checked so far, meaning sockaddresses with same IP address
but different port would be seen as equal, which is wrong.

As a result, ogs_gtp_node_find_by_addr() would be unable to identify GTP
peers having same IP address but different remote port.

Related: https://github.com/open5gs/open5gs/issues/1607