### PR TITLE
Update mme-sm.c for Typo

### DIFF
--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -191,7 +191,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         else
             enb->max_num_of_ostreams = max_num_of_ostreams;
 
-        ogs_info("eNB-N2[%s] max_num_of_ostreams : %d",
+        ogs_info("eNB-S1[%s] max_num_of_ostreams : %d",
             OGS_ADDR(enb->sctp.addr, buf), enb->max_num_of_ostreams);
 
         break;


### PR DESCRIPTION
Still in an MME, so, should refer to the eNB interface as S1.