### PR TITLE
[SBI] Fix invalid read beyond allocated memory

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -471,7 +471,7 @@ static void check_multi_info(ogs_sbi_client_t *client)
 
                 if (conn->memory) {
                     response->http.content =
-                        ogs_memdup(conn->memory, conn->size);
+                        ogs_memdup(conn->memory, conn->size + 1);
                     ogs_assert(response->http.content);
                     response->http.content_length = conn->size;
                     ogs_assert(response->http.content_length);


### PR DESCRIPTION
Valgrind memcheck tool reports an error, of invalid read beyond the
allocated memory.

Function "write_cb()" already allocates (realloc) +1 byte and
null-terminates the data. But the length "conn->size" does not contain
this extra null-terminated byte.
When a copy of the received data is made in "check_multi_info()", it
does not include the null character, resulting in potentially a
non-null terminated string.
Later on when parsing the data, "strlen()" will read beyond the
allocated memory to search for the null character, resulting in an
invalid read.

==1994== Invalid read of size 1
==1994==    at 0x484ED24: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1994==    by 0x4D3F401: cJSON_ParseWithOpts (cJSON.c:1109)
==1994==    by 0x4D3F65C: cJSON_Parse (cJSON.c:1197)
==1994==    by 0x4C927DE: parse_json (message.c:913)
==1994==    by 0x4C972D8: parse_content (message.c:1790)
==1994==    by 0x4C90096: ogs_sbi_parse_response (message.c:589)
==1994==    by 0x136431: amf_state_operational (amf-sm.c:248)
...
==1994==  Address 0x668371d is 0 bytes after a block of size 253 alloc'd
==1994==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1994==    by 0x5107D7F: ??? (in /usr/lib/x86_64-linux-gnu/libtalloc.so.2.3.3)
==1994==    by 0x510814B: _talloc_memdup (in /usr/lib/x86_64-linux-gnu/libtalloc.so.2.3.3)
==1994==    by 0x4871568: ogs_talloc_memdup (ogs-strings.c:184)
==1994==    by 0x4CA7755: check_multi_info (client.c:475)
...