### PR TITLE
Added show commands in the dbctl

### DIFF
--- a/misc/db/open5gs-dbctl
+++ b/misc/db/open5gs-dbctl
@@ -22,7 +22,9 @@ display_help() {
     echo "   update_apn {imsi apn slice_num}: adds an APN to the slice number slice_num of an existent UE"
     echo "   update_slice {imsi apn sst sd}: adds an slice to an existent UE"
     echo "   showall: shows the list of subscriber in the db"
-    echo "   show specific: shows {imsi key opc apn ip} information of subscriber"
+    echo "   showpretty: shows the list of subscriber in the db in a pretty json tree format"
+    echo "   showfiltered: shows {imsi key opc apn ip} information of subscriber"
+
 
 }
 
@@ -675,81 +677,18 @@ if [ "$1" = "update_slice" ]; then
     echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl update_slice imsi apn sst sd\""
     exit 1
 fi
-if [ "$1" = "show" ]; then
-    if [ "$#" -eq 1 ]; then
-        IMSI=$2 
-        KI=$3
-        OPC=$4
-
-        mongo --eval "db.subscribers.find()" $DB_URI
+if [ "$1" = "showall" ]; then
+   mongo --eval "db.subscribers.find()" $DB_URI
         exit $?
-    fi
-
-    if [ "$#" -eq 2 ]; then
-        IMSI=$2 
-        IP=$3
-        KI=$4
-        OPC=$5
-
-        mongo --eval "db.subscribers.update( { \"imsi\" : \"$IMSI\" }, 
-            { \$setOnInsert: 
-                { 
-                    \"imsi\" : \"$IMSI\", 
-                    \"subscribed_rau_tau_timer\" : NumberInt(12), 
-                    \"network_access_mode\" : NumberInt(0), 
-                    \"subscriber_status\" : NumberInt(0), 
-                    \"access_restriction_data\" : NumberInt(32), 
-                    \"slice\" : 
-                    [{ 
-                        \"sst\" : NumberInt(1), 
-                        \"default_indicator\" : true, 
-                        \"_id\" : new ObjectId(), 
-                        \"session\" : 
-                        [{ 
-                            \"name\" : \"internet\", 
-                            \"type\" : NumberInt(3), 
-                            \"_id\" : new ObjectId(), 
-                            \"pcc_rule\" : [],
-                            \"ue\" : 
-                            {
-                                \"addr\" : \"$IP\",
-                            },
-                            \"ambr\" : 
-                            { 
-                                \"uplink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
-                                \"downlink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
-                            }, 
-                            \"qos\" : 
-                            { 
-                                \"index\" : NumberInt(9), 
-                                \"arp\" : 
-                                { 
-                                    \"priority_level\" : NumberInt(8), 
-                                    \"pre_emption_capability\" : NumberInt(1), 
-                                    \"pre_emption_vulnerability\" : NumberInt(1), 
-                                }, 
-                            }, 
-                        }], 
-                    }], 
-                    \"ambr\" : 
-                    { 
-                        \"uplink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3),}, 
-                        \"downlink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
-                    },  
-                    \"security\" : 
-                    { 
-                        \"k\" : \"$KI\", 
-                        \"amf\" : \"8000\", 
-                        \"op\" : null, 
-                        \"opc\" : \"$OPC\" 
-                    }, 
-                    \"__v\" : 0
-                },  
-            },
-            upsert=true);" $DB_URI
+fi
+if [ "$1" = "showpretty" ]; then
+   mongo --eval "db.subscribers.find().pretty()" $DB_URI
         exit $?
-    fi
-
+fi
+if [ "$1" = "showfiltered" ]; then
+   mongo --eval "db.subscribers.find({},{'_id':0,'imsi':1,'security.k':1, 'security.opc':1,'slice.session.name':1,'slice.session.ue.addr':1})" $DB_URI
+        exit $?
+fi
     echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl add imsi key opc\""
     exit 1
 fi

--- a/misc/db/open5gs-dbctl
+++ b/misc/db/open5gs-dbctl
@@ -21,6 +21,8 @@ display_help() {
     echo "   add_ue_with_slice {imsi key opc apn sst sd}: adds a user to the database with a specific apn, sst and sd"
     echo "   update_apn {imsi apn slice_num}: adds an APN to the slice number slice_num of an existent UE"
     echo "   update_slice {imsi apn sst sd}: adds an slice to an existent UE"
+    echo "   showall: shows the list of subscriber in the db"
+    echo "   show specific: shows {imsi key opc apn ip} information of subscriber"
 
 }
 
@@ -671,6 +673,84 @@ if [ "$1" = "update_slice" ]; then
     fi
 
     echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl update_slice imsi apn sst sd\""
+    exit 1
+fi
+if [ "$1" = "show" ]; then
+    if [ "$#" -eq 1 ]; then
+        IMSI=$2 
+        KI=$3
+        OPC=$4
+
+        mongo --eval "db.subscribers.find()" $DB_URI
+        exit $?
+    fi
+
+    if [ "$#" -eq 2 ]; then
+        IMSI=$2 
+        IP=$3
+        KI=$4
+        OPC=$5
+
+        mongo --eval "db.subscribers.update( { \"imsi\" : \"$IMSI\" }, 
+            { \$setOnInsert: 
+                { 
+                    \"imsi\" : \"$IMSI\", 
+                    \"subscribed_rau_tau_timer\" : NumberInt(12), 
+                    \"network_access_mode\" : NumberInt(0), 
+                    \"subscriber_status\" : NumberInt(0), 
+                    \"access_restriction_data\" : NumberInt(32), 
+                    \"slice\" : 
+                    [{ 
+                        \"sst\" : NumberInt(1), 
+                        \"default_indicator\" : true, 
+                        \"_id\" : new ObjectId(), 
+                        \"session\" : 
+                        [{ 
+                            \"name\" : \"internet\", 
+                            \"type\" : NumberInt(3), 
+                            \"_id\" : new ObjectId(), 
+                            \"pcc_rule\" : [],
+                            \"ue\" : 
+                            {
+                                \"addr\" : \"$IP\",
+                            },
+                            \"ambr\" : 
+                            { 
+                                \"uplink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
+                                \"downlink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
+                            }, 
+                            \"qos\" : 
+                            { 
+                                \"index\" : NumberInt(9), 
+                                \"arp\" : 
+                                { 
+                                    \"priority_level\" : NumberInt(8), 
+                                    \"pre_emption_capability\" : NumberInt(1), 
+                                    \"pre_emption_vulnerability\" : NumberInt(1), 
+                                }, 
+                            }, 
+                        }], 
+                    }], 
+                    \"ambr\" : 
+                    { 
+                        \"uplink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3),}, 
+                        \"downlink\" : { \"value\": NumberInt(1), \"unit\" : NumberInt(3) }, 
+                    },  
+                    \"security\" : 
+                    { 
+                        \"k\" : \"$KI\", 
+                        \"amf\" : \"8000\", 
+                        \"op\" : null, 
+                        \"opc\" : \"$OPC\" 
+                    }, 
+                    \"__v\" : 0
+                },  
+            },
+            upsert=true);" $DB_URI
+        exit $?
+    fi
+
+    echo "open5gs-dbctl: incorrect number of args, format is \"open5gs-dbctl add imsi key opc\""
     exit 1
 fi
 


### PR DESCRIPTION
Added the following show commands for the command line user interface of Mongo to be able to see the list of users in database

showall: shows the list of subscribers in the db"
showpretty: shows the list of subscribers in the db in a pretty json tree format"
showfiltered: shows {imsi key opc apn ip} information of subscriber"
