### PR TITLE
[SMF] Gy: Send Multiple-Services-Indicator AVP only during Initial CCR

### DIFF
--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -834,13 +834,15 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     ogs_assert(ret == 0);
 
     /* Multiple-Services-Indicator */
-    ret = fd_msg_avp_new(ogs_diam_gy_multiple_services_ind, 0, &avp);
-    ogs_assert(ret == 0);
-    val.i32 = OGS_DIAM_GY_MULTIPLE_SERVICES_NOT_SUPPORTED;
-    ret = fd_msg_avp_setvalue(avp, &val);
-    ogs_assert(ret == 0);
-    ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
-    ogs_assert(ret == 0);
+    if (cc_request_type == OGS_DIAM_GY_CC_REQUEST_TYPE_INITIAL_REQUEST) {
+        ret = fd_msg_avp_new(ogs_diam_gy_multiple_services_ind, 0, &avp);
+        ogs_assert(ret == 0);
+        val.i32 = OGS_DIAM_GY_MULTIPLE_SERVICES_NOT_SUPPORTED;
+        ret = fd_msg_avp_setvalue(avp, &val);
+        ogs_assert(ret == 0);
+        ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
+        ogs_assert(ret == 0);
+    }
 
     /* TS 32.299 7.1.9 Multiple-Services-Credit-Control AVP */
     fill_multiple_services_credit_control_ccr(sess, cc_request_type, req);


### PR DESCRIPTION
Gy (3GPP TS 32.299 ) refers to AVP in DCCA (RFC4006).

RFC4006 5.1.2:
"[...] by including the Multiple-Services-Indicator AVP in the first
interrogation."

Nokia's infocenter documentation also states it's sent during Initial CCR
only: "(CCR-I only)".