### PR TITLE
[UPF] Avoid crash if no default subnet configured

### DIFF
--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -119,8 +119,9 @@ void upf_n4_handle_session_establishment_request(
         /* Setup UE IP address */
         if (pdr->ue_ip_addr_len) {
             if (req->pdn_type.presence == 1) {
-                ogs_assert(OGS_PFCP_CAUSE_REQUEST_ACCEPTED ==
-                        upf_sess_set_ue_ip(sess, req->pdn_type.u8, pdr));
+                cause_value = upf_sess_set_ue_ip(sess, req->pdn_type.u8, pdr);
+                if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
+                    goto cleanup;
             } else {
                 ogs_error("No PDN Type");
             }


### PR DESCRIPTION
In that case, ogs_pfcp_ue_ip_alloc() will fail with  the error message
"CHECK CONFIGURATION: Cannot find subnet [...]" and the assert will make
upf crash.
That's not desirable, let's keep it running and simply reject the
request. The error log is big enoguh to find out.