### PR TITLE
[SMF] pfcp-sm: Fix ogs_fsm_dispatch() on NULL sess

### DIFF
--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -225,7 +225,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                     ogs_gtp2_send_error_message(gtp_xact, 0,
                             OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                             OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
-                return;
+                break;
             }
             ogs_fsm_dispatch(&sess->sm, e);
             break;
@@ -248,6 +248,21 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
         case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
             if (!message->h.seid_presence)
                 ogs_error("No SEID");
+            if (!sess) {
+                ogs_gtp_xact_t *gtp_xact = xact->assoc_xact;
+                if (!gtp_xact)
+                        break;
+                if (gtp_xact->gtp_version == 1)
+                    ogs_gtp1_send_error_message(gtp_xact, 0,
+                            OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE,
+                            OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND);
+                else
+                    ogs_gtp2_send_error_message(gtp_xact, 0,
+                            OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                            OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
+                break;
+            }
+
             ogs_fsm_dispatch(&sess->sm, e);
             break;
 


### PR DESCRIPTION
It was spotted that if DeleteSessionReq sent by SMF is answered by UPF
with cause="Session context not found", then it contains SEID=0 (this is
correct as per specs). Hence, since SEID=0 session is not looked up, so
sess=NULL.