### PR TITLE
[SMF] copy UE ip address to uplink PDR rules.

### DIFF
--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -486,6 +486,10 @@ bool smf_npcf_smpolicycontrol_handle_create(
 
     ogs_assert(OGS_OK ==
         ogs_pfcp_paa_to_ue_ip_addr(&sess->session.paa,
+            &ul_pdr->ue_ip_addr, &ul_pdr->ue_ip_addr_len));
+
+    ogs_assert(OGS_OK ==
+        ogs_pfcp_paa_to_ue_ip_addr(&sess->session.paa,
             &dl_pdr->ue_ip_addr, &dl_pdr->ue_ip_addr_len));
     dl_pdr->ue_ip_addr.sd = OGS_PFCP_UE_IP_DST;
 


### PR DESCRIPTION
This helps UPF to add ACL based on UE src ip

Signed-off-by: Networkmama <networkmama12@gmail.com>