### PR TITLE
d/open5gs-upf.postinst: don't restart service in chroot

### DIFF
--- a/debian/open5gs-upf.postinst
+++ b/debian/open5gs-upf.postinst
@@ -27,7 +27,9 @@ case "$1" in
 	if test "x`systemctl is-enabled systemd-networkd`" = xdisabled; then
 		systemctl enable systemd-networkd
 	fi
-	deb-systemd-invoke restart systemd-networkd
+	if test -d "/run/systemd"; then
+		deb-systemd-invoke restart systemd-networkd
+	fi
 	if test -f /etc/sysctl.d/30-open5gs.conf && grep "ogstun" /proc/net/dev > /dev/null; then
 		echo "net.ipv6.conf.ogstun.disable_ipv6=0" > /etc/sysctl.d/30-open5gs.conf
 		sysctl -p /etc/sysctl.d/30-open5gs.conf


### PR DESCRIPTION
Don't attempt to restart systemd-networkd if systemd is not running
(e.g. installing open5gs inside a chroot).

Fix for:
```
  System has not been booted with systemd as init system (PID 1). Can't operate.
  Failed to connect to bus: Host is down
  dpkg: error processing package open5gs-upf:amd64 (--configure):
   installed open5gs-upf:amd64 package post-installation script subprocess returned error exit status 1
```