### PR TITLE
[AMF] Do not send Deregistration Event to UDM when UE deregisters

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -450,39 +450,6 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             END
             break;
 
-        CASE(OGS_SBI_SERVICE_NAME_NUDM_UECM)
-            SWITCH(sbi_message->h.resource.component[1])
-            CASE(OGS_SBI_RESOURCE_NAME_REGISTRATIONS)
-                SWITCH(sbi_message->h.resource.component[2])
-                CASE(OGS_SBI_RESOURCE_NAME_AMF_3GPP_ACCESS)
-                    SWITCH(sbi_message->h.method)
-                    CASE(OGS_SBI_HTTP_METHOD_PATCH)
-
-                        ogs_assert(true ==
-                            amf_ue_sbi_discover_and_send(
-                                OpenAPI_nf_type_PCF, amf_ue,
-                                NULL, amf_npcf_am_policy_control_build_delete));
-
-                        break;
-
-                    DEFAULT
-                        ogs_error("Unknown method [%s]", sbi_message->h.method);
-                        ogs_assert_if_reached();
-                    END
-                    break;
-                DEFAULT
-                    ogs_error("Invalid resource name [%s]",
-                            sbi_message->h.resource.component[2]);
-                    ogs_assert_if_reached();
-                END
-                break;
-
-            DEFAULT
-                ogs_error("Invalid resource name [%s]",
-                        sbi_message->h.resource.component[1]);
-                ogs_assert_if_reached();
-            END
-            break;
         DEFAULT
             ogs_error("Invalid service name [%s]", sbi_message->h.service.name);
             ogs_assert_if_reached();

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -886,8 +886,8 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
 
                     ogs_assert(true ==
                         amf_ue_sbi_discover_and_send(
-                            OpenAPI_nf_type_UDM, amf_ue,
-                            NULL, amf_nudm_uecm_build_registration_delete));
+                            OpenAPI_nf_type_PCF, amf_ue,
+                            NULL, amf_npcf_am_policy_control_build_delete));
 
                 } else if (OGS_FSM_CHECK(&amf_ue->sm, gmm_state_registered)) {
                     /*


### PR DESCRIPTION
According to TS 23.502, 4.2.2.2.2, AMF sends Registration event to UDM
in the following cases:
- If the AMF has changed since the last Registration procedure, or
- if the UE provides a SUPI which doesn't refer to a valid context in
the AMF,
- or if the UE registers to the same AMF it has already registered
to a non- 3GPP access (i.e. the UE is registered over a non-3GPP access
and initiates this Registration procedure to add a 3GPP access).

In case that UE re-registers to the network with a GUTI, it bypasses
authentication check to the AUSF. In this case, AMF does not send
Registration event to UDM.
Consequently, when UE deregisters again, AMF would send a Deregistration
Event to a UDM, which does not have a context for it.

3GPP standard does not say when AMF sends Deregistration Event to UDM,
only that it is optional.

These (De-)Registration events are for (de-)registering AMF to the UDM
for serving the UE. And not for (de-)registering UE itself for purpose
of tracking when UE is registered on the network.

This partially reverts commit 7be7029ac40b2eecbf70564d5306f85dafa2b848