### PR TITLE
Handle Deregistration Notify in AMF

### DIFF
--- a/lib/nas/5gs/decoder.c
+++ b/lib/nas/5gs/decoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-01-22 09:24:09.045630 by acetcom
+ * Created on: 2022-07-11 07:09:47.173881 by ubuntu
  * from 24501-g41.docx
  ******************************************************************************/
 
@@ -979,7 +979,7 @@ int ogs_nas_5gs_decode_deregistration_request_from_ue(ogs_nas_5gs_message_t *mes
     int decoded = 0;
     int size = 0;
 
-    ogs_trace("[NAS] Decode DEREGISTRATION_REQUEST\n");
+    ogs_trace("[NAS] Decode DEREGISTRATION_REQUEST_FROM_UE\n");
 
     size = ogs_nas_5gs_decode_de_registration_type(&deregistration_request_from_ue->de_registration_type, pkbuf);
     if (size < 0) {
@@ -1006,7 +1006,7 @@ int ogs_nas_5gs_decode_deregistration_request_to_ue(ogs_nas_5gs_message_t *messa
     int decoded = 0;
     int size = 0;
 
-    ogs_trace("[NAS] Decode DEREGISTRATION_REQUEST\n");
+    ogs_trace("[NAS] Decode DEREGISTRATION_REQUEST_TO_UE\n");
 
     size = ogs_nas_5gs_decode_de_registration_type(&deregistration_request_to_ue->de_registration_type, pkbuf);
     if (size < 0) {
@@ -1028,34 +1028,34 @@ int ogs_nas_5gs_decode_deregistration_request_to_ue(ogs_nas_5gs_message_t *messa
         decoded += size;
 
         switch(type) {
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_TYPE:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_TYPE:
             size = ogs_nas_5gs_decode_5gmm_cause(&deregistration_request_to_ue->gmm_cause, pkbuf);
             if (size < 0) {
                ogs_error("ogs_nas_5gs_decode_5gmm_cause() failed");
                return size;
             }
 
-            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_PRESENT;
+            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_PRESENT;
             decoded += size;
             break;
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_TYPE:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_TYPE:
             size = ogs_nas_5gs_decode_gprs_timer_2(&deregistration_request_to_ue->t3346_value, pkbuf);
             if (size < 0) {
                ogs_error("ogs_nas_5gs_decode_gprs_timer_2() failed");
                return size;
             }
 
-            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_PRESENT;
+            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_PRESENT;
             decoded += size;
             break;
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_TYPE:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_TYPE:
             size = ogs_nas_5gs_decode_rejected_nssai(&deregistration_request_to_ue->rejected_nssai, pkbuf);
             if (size < 0) {
                ogs_error("ogs_nas_5gs_decode_rejected_nssai() failed");
                return size;
             }
 
-            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_PRESENT;
+            deregistration_request_to_ue->presencemask |= OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_PRESENT;
             decoded += size;
             break;
         default:
@@ -3742,7 +3742,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
 
         decoded += size;
         break;
-    case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
         size = ogs_nas_5gs_decode_deregistration_request_from_ue(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_deregistration_request_from_ue() failed");
@@ -3751,7 +3751,18 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
 
         decoded += size;
         break;
-    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT:
+    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT_FROM_UE:
+        break;
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE:
+        size = ogs_nas_5gs_decode_deregistration_request_to_ue(message, pkbuf);
+        if (size < 0) {
+           ogs_error("ogs_nas_5gs_decode_deregistration_request_to_ue() failed");
+           return size;
+        }
+
+        decoded += size;
+        break;
+    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT_TO_UE:
         break;
     case OGS_NAS_5GS_SERVICE_REQUEST:
         size = ogs_nas_5gs_decode_service_request(message, pkbuf);

--- a/lib/nas/5gs/encoder.c
+++ b/lib/nas/5gs/encoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-01-22 09:24:09.053958 by acetcom
+ * Created on: 2022-07-11 07:09:47.188485 by ubuntu
  * from 24501-g41.docx
  ******************************************************************************/
 
@@ -851,7 +851,7 @@ int ogs_nas_5gs_encode_deregistration_request_from_ue(ogs_pkbuf_t *pkbuf, ogs_na
     int encoded = 0;
     int size = 0;
 
-    ogs_trace("[NAS] Encode DEREGISTRATION_REQUEST");
+    ogs_trace("[NAS] Encode DEREGISTRATION_REQUEST_FROM_UE");
 
     size = ogs_nas_5gs_encode_de_registration_type(pkbuf, &deregistration_request_from_ue->de_registration_type);
     ogs_assert(size >= 0);
@@ -870,14 +870,14 @@ int ogs_nas_5gs_encode_deregistration_request_to_ue(ogs_pkbuf_t *pkbuf, ogs_nas_
     int encoded = 0;
     int size = 0;
 
-    ogs_trace("[NAS] Encode DEREGISTRATION_REQUEST");
+    ogs_trace("[NAS] Encode DEREGISTRATION_REQUEST_TO_UE");
 
     size = ogs_nas_5gs_encode_de_registration_type(pkbuf, &deregistration_request_to_ue->de_registration_type);
     ogs_assert(size >= 0);
     encoded += size;
 
-    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_PRESENT) {
-        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_TYPE);
+    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_PRESENT) {
+        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_TYPE);
         ogs_assert(size >= 0);
         encoded += size;
 
@@ -886,8 +886,8 @@ int ogs_nas_5gs_encode_deregistration_request_to_ue(ogs_pkbuf_t *pkbuf, ogs_nas_
         encoded += size;
     }
 
-    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_PRESENT) {
-        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_TYPE);
+    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_PRESENT) {
+        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_TYPE);
         ogs_assert(size >= 0);
         encoded += size;
 
@@ -896,8 +896,8 @@ int ogs_nas_5gs_encode_deregistration_request_to_ue(ogs_pkbuf_t *pkbuf, ogs_nas_
         encoded += size;
     }
 
-    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_PRESENT) {
-        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_TYPE);
+    if (deregistration_request_to_ue->presencemask & OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_PRESENT) {
+        size = ogs_nas_5gs_encode_optional_type(pkbuf, OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_TYPE);
         ogs_assert(size >= 0);
         encoded += size;
 
@@ -2848,12 +2848,19 @@ ogs_pkbuf_t *ogs_nas_5gmm_encode(ogs_nas_5gs_message_t *message)
         ogs_assert(size >= 0);
         encoded += size;
         break;
-    case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
+        size = ogs_nas_5gs_encode_deregistration_request_from_ue(pkbuf, message);
+        ogs_assert(size >= 0);
+        encoded += size;
+        break;
+    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT_FROM_UE:
+        break;
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE:
         size = ogs_nas_5gs_encode_deregistration_request_to_ue(pkbuf, message);
         ogs_assert(size >= 0);
         encoded += size;
         break;
-    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT:
+    case OGS_NAS_5GS_DEREGISTRATION_ACCEPT_TO_UE:
         break;
     case OGS_NAS_5GS_SERVICE_REQUEST:
         size = ogs_nas_5gs_encode_service_request(pkbuf, message);

--- a/lib/nas/5gs/ies.c
+++ b/lib/nas/5gs/ies.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-01-22 09:24:09.032504 by acetcom
+ * Created on: 2022-07-11 07:09:47.151738 by ubuntu
  * from 24501-g41.docx
  ******************************************************************************/
 

--- a/lib/nas/5gs/ies.h
+++ b/lib/nas/5gs/ies.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-01-22 09:24:09.029942 by acetcom
+ * Created on: 2022-07-11 07:09:47.146947 by ubuntu
  * from 24501-g41.docx
  ******************************************************************************/
 

--- a/lib/nas/5gs/message.h
+++ b/lib/nas/5gs/message.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2022-01-22 09:24:09.040249 by acetcom
+ * Created on: 2022-07-11 07:09:47.165005 by ubuntu
  * from 24501-g41.docx
  ******************************************************************************/
 
@@ -72,8 +72,10 @@ typedef struct ogs_nas_5gs_security_header_s {
 #define OGS_NAS_5GS_REGISTRATION_ACCEPT 66
 #define OGS_NAS_5GS_REGISTRATION_COMPLETE 67
 #define OGS_NAS_5GS_REGISTRATION_REJECT 68
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST 69
-#define OGS_NAS_5GS_DEREGISTRATION_ACCEPT 70
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE 69
+#define OGS_NAS_5GS_DEREGISTRATION_ACCEPT_FROM_UE 70
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE 71
+#define OGS_NAS_5GS_DEREGISTRATION_ACCEPT_TO_UE 72
 #define OGS_NAS_5GS_SERVICE_REQUEST 76
 #define OGS_NAS_5GS_SERVICE_REJECT 77
 #define OGS_NAS_5GS_SERVICE_ACCEPT 78
@@ -396,12 +398,12 @@ typedef struct ogs_nas_5gs_deregistration_request_from_ue_s {
 /*******************************************************
  * DEREGISTRATION REQUEST TO UE
  ******************************************************/
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_PRESENT ((uint64_t)1<<0)
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_PRESENT ((uint64_t)1<<1)
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_PRESENT ((uint64_t)1<<2)
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_5GMM_CAUSE_TYPE 0x58
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_T3346_VALUE_TYPE 0x5F
-#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_REJECTED_NSSAI_TYPE 0x6D
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_PRESENT ((uint64_t)1<<0)
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_PRESENT ((uint64_t)1<<1)
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_PRESENT ((uint64_t)1<<2)
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_TYPE 0x58
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_T3346_VALUE_TYPE 0x5F
+#define OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_REJECTED_NSSAI_TYPE 0x6D
 
 typedef struct ogs_nas_5gs_deregistration_request_to_ue_s {
     /* Mandatory fields */

--- a/lib/nas/5gs/support/nas-message.py
+++ b/lib/nas/5gs/support/nas-message.py
@@ -106,7 +106,7 @@ def usage():
     print("-h        Print this help and return")
 
 def v_upper(v):
-    return re.sub('_TO_UE', '', re.sub('_FROM_UE', '', re.sub('\'', '_', re.sub('/', '_', re.sub('-', '_', re.sub(' ', '_', v)))).upper()))
+    return re.sub('\'', '_', re.sub('/', '_', re.sub('-', '_', re.sub(' ', '_', v)))).upper()
 
 def v_lower(v):
     return re.sub('\'', '_', re.sub('/', '_', re.sub('-', '_', re.sub(' ', '_', v)))).lower()
@@ -550,8 +550,7 @@ typedef struct ogs_nas_5gs_security_header_s {
 """)
 
 for (k, v) in sorted_msg_list:
-    if k.find("TO UE") == -1:
-        f.write("#define OGS_NAS_5GS_" + v_upper(k) + " " + v.split('.')[0] + "\n")
+    f.write("#define OGS_NAS_5GS_" + v_upper(k) + " " + v.split('.')[0] + "\n")
 f.write("\n")
 
 for (k, v) in sorted_msg_list:
@@ -749,7 +748,7 @@ f.write("""int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *
 for (k, v) in sorted_msg_list:
     if "ies" not in msg_list[k]:
         continue;
-    if float(msg_list[k]["type"]) < 192 and k.find("TO UE") == -1:
+    if float(msg_list[k]["type"]) < 192:
         f.write("    case OGS_NAS_5GS_%s:\n" % v_upper(k))
         if len(msg_list[k]["ies"]) != 0:
             f.write("        size = ogs_nas_5gs_decode_%s(message, pkbuf);\n" % v_lower(k))
@@ -903,7 +902,7 @@ f.write("""ogs_pkbuf_t *ogs_nas_5gmm_encode(ogs_nas_5gs_message_t *message)
 for (k, v) in sorted_msg_list:
     if "ies" not in msg_list[k]:
         continue;
-    if float(msg_list[k]["type"]) < 192 and k.find("FROM UE") == -1:
+    if float(msg_list[k]["type"]) < 192:
         f.write("    case OGS_NAS_5GS_%s:\n" % v_upper(k))
         if len(msg_list[k]["ies"]) != 0:
             f.write("        size = ogs_nas_5gs_encode_%s(pkbuf, message);\n" % v_lower(k))

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -173,6 +173,8 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_sm_policy_notification_free(message->SmPolicyNotification);
     if (message->TerminationNotification)
         OpenAPI_termination_notification_free(message->TerminationNotification);
+    if (message->DeregistrationData)
+        OpenAPI_deregistration_data_free(message->DeregistrationData);
 
     for (i = 0; i < message->num_of_part; i++) {
         if (message->part[i].pkbuf)
@@ -887,6 +889,10 @@ static char *build_json(ogs_sbi_message_t *message)
     } else if (message->TerminationNotification) {
         item = OpenAPI_termination_notification_convertToJSON(
                 message->TerminationNotification);
+        ogs_assert(item);
+    } else if (message->DeregistrationData) {
+        item = OpenAPI_deregistration_data_convertToJSON(
+                message->DeregistrationData);
         ogs_assert(item);
     }
 
@@ -1721,6 +1727,15 @@ static int parse_json(ogs_sbi_message_t *message,
                 message->SmContextStatusNotification =
                     OpenAPI_sm_context_status_notification_parseFromJSON(item);
                 if (!message->SmContextStatusNotification) {
+                    rv = OGS_ERROR;
+                    ogs_error("JSON parse error");
+                }
+                break;
+
+            CASE(OGS_SBI_RESOURCE_NAME_DEREG_NOTIFY)
+                message->DeregistrationData =
+                    OpenAPI_deregistration_data_parseFromJSON(item);
+                if (!message->DeregistrationData) {
                     rv = OGS_ERROR;
                     ogs_error("JSON parse error");
                 }

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -408,6 +408,7 @@ typedef struct ogs_sbi_message_s {
         *AppSessionContextUpdateDataPatch;
     OpenAPI_sm_policy_notification_t *SmPolicyNotification;
     OpenAPI_termination_notification_t *TerminationNotification;
+    OpenAPI_deregistration_data_t *DeregistrationData;
 
     ogs_sbi_links_t *links;
 

--- a/lib/sbi/ogs-sbi.h
+++ b/lib/sbi/ogs-sbi.h
@@ -73,6 +73,7 @@
 #include "model/policy_update.h"
 #include "model/sm_policy_notification.h"
 #include "model/termination_notification.h"
+#include "model/deregistration_data.h"
 
 #include "custom/links.h"
 #include "custom/ue_authentication_ctx.h"

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -209,11 +209,10 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                         stream, &sbi_message);
                 break;
 
-            /* TODO */
-#if 0
             CASE(OGS_SBI_RESOURCE_NAME_DEREG_NOTIFY)
+                amf_namf_callback_handle_dereg_notify(stream, &sbi_message);
                 break;
-#endif
+
             CASE(OGS_SBI_RESOURCE_NAME_AM_POLICY_NOTIFY)
                 ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
                 break;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1475,7 +1475,7 @@ amf_ue_t *amf_ue_find_by_message(ogs_nas_5gs_message_t *message)
                     mobile_identity_header->type);
         }
         break;
-    case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
         deregistration_request = &message->gmm.deregistration_request_from_ue;
         ogs_assert(deregistration_request);
         mobile_identity = &deregistration_request->mobile_identity;

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -408,6 +408,9 @@ struct amf_ue_s {
         long cause;
     } handover;
 
+    /* Network Initiated De-Registration */
+    bool network_initiated_de_reg;
+
     ogs_list_t      sess_list;
 };
 

--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -271,7 +271,7 @@ ogs_pkbuf_t *gmm_build_de_registration_accept(amf_ue_t *amf_ue)
 
     message.gmm.h.extended_protocol_discriminator =
         OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GMM;
-    message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_ACCEPT;
+    message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_ACCEPT_FROM_UE;
 
     return nas_5gs_security_encode(amf_ue, &message);
 }

--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -276,6 +276,35 @@ ogs_pkbuf_t *gmm_build_de_registration_accept(amf_ue_t *amf_ue)
     return nas_5gs_security_encode(amf_ue, &message);
 }
 
+ogs_pkbuf_t *gmm_build_de_registration_request(amf_ue_t *amf_ue)
+{
+    ogs_nas_5gs_message_t message;
+    ogs_nas_5gs_deregistration_request_to_ue_t *dereg_req =
+        &message.gmm.deregistration_request_to_ue;
+
+    ogs_assert(amf_ue);
+
+    memset(&message, 0, sizeof(message));
+    message.h.security_header_type =
+        OGS_NAS_SECURITY_HEADER_INTEGRITY_PROTECTED_AND_CIPHERED;
+    message.h.extended_protocol_discriminator =
+        OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GMM;
+
+    message.gmm.h.extended_protocol_discriminator =
+        OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GMM;
+    message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE;
+
+    dereg_req->de_registration_type.switch_off = 1;
+    dereg_req->de_registration_type.re_registration_required = 0;
+    dereg_req->de_registration_type.access_type = OGS_ACCESS_TYPE_3GPP;
+
+    dereg_req->presencemask |=
+        OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE_5GMM_CAUSE_PRESENT;
+    dereg_req->gmm_cause = OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED;
+
+    return nas_5gs_security_encode(amf_ue, &message);
+}
+
 ogs_pkbuf_t *gmm_build_identity_request(amf_ue_t *amf_ue)
 {
     ogs_nas_5gs_message_t message;

--- a/src/amf/gmm-build.h
+++ b/src/amf/gmm-build.h
@@ -34,6 +34,7 @@ ogs_pkbuf_t *gmm_build_service_reject(
         amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 
 ogs_pkbuf_t *gmm_build_de_registration_accept(amf_ue_t *amf_ue);
+ogs_pkbuf_t *gmm_build_de_registration_request(amf_ue_t *amf_ue);
 
 ogs_pkbuf_t *gmm_build_identity_request(amf_ue_t *amf_ue);
 ogs_pkbuf_t *gmm_build_security_mode_command(amf_ue_t *amf_ue);

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -679,7 +679,7 @@ int gmm_handle_deregistration_request(amf_ue_t *amf_ue,
     /* Set 5GS De-registration Type */
     memcpy(&amf_ue->nas.de_registration,
             de_registration_type, sizeof(ogs_nas_de_registration_type_t));
-    amf_ue->nas.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST;
+    amf_ue->nas.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE;
 
     amf_ue->nas.ue.tsc = de_registration_type->tsc;
     amf_ue->nas.ue.ksi = de_registration_type->ksi;

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -278,7 +278,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             OGS_FSM_TRAN(s, &gmm_state_exception);
             break;
 
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
             ogs_info("[%s] Deregistration request", amf_ue->supi);
 
             gmm_handle_deregistration_request(
@@ -625,7 +625,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             OGS_FSM_TRAN(s, &gmm_state_exception);
             break;
 
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
             ogs_warn("[%s] Deregistration request", amf_ue->supi);
 
             gmm_handle_deregistration_request(
@@ -870,7 +870,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
             OGS_FSM_TRAN(s, &gmm_state_exception);
             break;
 
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
             ogs_warn("[%s] Deregistration request", amf_ue->supi);
 
             gmm_handle_deregistration_request(
@@ -1193,7 +1193,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             OGS_FSM_TRAN(s, &gmm_state_exception);
             break;
 
-        case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+        case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
             ogs_warn("[%s] Deregistration request", amf_ue->supi);
 
             gmm_handle_deregistration_request(

--- a/src/amf/namf-handler.h
+++ b/src/amf/namf-handler.h
@@ -30,6 +30,8 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 int amf_namf_callback_handle_sm_context_status(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_callback_handle_dereg_notify(
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -276,6 +276,38 @@ int nas_5gs_send_de_registration_accept(amf_ue_t *amf_ue)
     return rv;
 }
 
+int nas_5gs_send_de_registration_request(amf_ue_t *amf_ue)
+{
+    int rv;
+
+    ran_ue_t *ran_ue = NULL;
+    ogs_pkbuf_t *gmmbuf = NULL;
+
+    ogs_assert(amf_ue);
+    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ogs_expect_or_return_val(ran_ue, OGS_ERROR);
+
+    ogs_debug("[%s] De-registration request", amf_ue->supi);
+
+    if (amf_ue->t3522.pkbuf) {
+        gmmbuf = amf_ue->t3522.pkbuf;
+        ogs_expect_or_return_val(gmmbuf, OGS_ERROR);
+    } else {
+        gmmbuf = gmm_build_de_registration_request(amf_ue);
+        ogs_expect_or_return_val(gmmbuf, OGS_ERROR);
+    }
+
+    amf_ue->t3522.pkbuf = ogs_pkbuf_copy(gmmbuf);
+    ogs_expect_or_return_val(amf_ue->t3522.pkbuf, OGS_ERROR);
+    ogs_timer_start(amf_ue->t3522.timer,
+            amf_timer_cfg(AMF_TIMER_T3522)->duration);
+
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    ogs_expect_or_return_val(rv == OGS_OK, OGS_ERROR);
+
+    return rv;
+}
+
 int nas_5gs_send_identity_request(amf_ue_t *amf_ue)
 {
     int rv;

--- a/src/amf/nas-path.h
+++ b/src/amf/nas-path.h
@@ -41,6 +41,7 @@ int nas_5gs_send_service_reject(
         amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 
 int nas_5gs_send_de_registration_accept(amf_ue_t *amf_ue);
+int nas_5gs_send_de_registration_request(amf_ue_t *amf_ue);
 
 int nas_5gs_send_identity_request(amf_ue_t *amf_ue);
 

--- a/tests/common/gmm-build.c
+++ b/tests/common/gmm-build.c
@@ -408,7 +408,7 @@ ogs_pkbuf_t *testgmm_build_de_registration_request(
     }
     message.gmm.h.extended_protocol_discriminator =
             OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GMM;
-    message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST;
+    message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE;
 
     de_registration_type->ksi = test_ue->nas.ksi;
     de_registration_type->switch_off = switch_off;

--- a/tests/common/nas-encoder.c
+++ b/tests/common/nas-encoder.c
@@ -44,7 +44,7 @@ ogs_pkbuf_t *test_nas_5gmm_encode(ogs_nas_5gs_message_t *message)
     encoded += size;
 
     switch(message->gmm.h.message_type) {
-    case OGS_NAS_5GS_DEREGISTRATION_REQUEST:
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
         size = ogs_nas_5gs_encode_deregistration_request_from_ue(
                 pkbuf, message);
         ogs_assert(size >= 0);

--- a/tests/common/nas-security.c
+++ b/tests/common/nas-security.c
@@ -75,7 +75,7 @@ ogs_pkbuf_t *test_nas_5gs_security_encode(
         message->h.extended_protocol_discriminator;
     h.sequence_number = (test_ue->ul_count & 0xff);
 
-    if (message->gmm.h.message_type == OGS_NAS_5GS_DEREGISTRATION_REQUEST)
+    if (message->gmm.h.message_type == OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE)
         new = test_nas_5gs_plain_encode(message);
     else
         new = ogs_nas_5gs_plain_encode(message);


### PR DESCRIPTION
Handle Network initiated deregistration of UE.
When UDM sends a Deregistration Notify message to AMF, AMF should send Deregistration Request to UE and delete all resources used by UE.

It was tested using the following branch - a workaround for UDM, to send network-initated deregistration of UE after 10 seconds of UE registering on to the network
https://github.com/open5gs/open5gs/compare/main...bmeglicit:open5gs:gh_udm_war_dereg_notify

![image](https://user-images.githubusercontent.com/103102696/178217289-35dc30cd-4bfb-47dd-9d62-62bd24b1e4d5.png)
[amf_dereg_notify.pcapng.zip](https://github.com/open5gs/open5gs/files/9081945/amf_dereg_notify.pcapng.zip)


