### PR TITLE
[tests] Fix running unit tests inside docker environment

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -15,4 +15,4 @@ services:
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
     hostname: open5gs-test
-    command: /bin/bash -c "/root/setup.sh; cd open5gs/build && meson test -v"
+    command: /bin/bash -c "/root/setup.sh; cd /open5gs/build && meson test -v"


### PR DESCRIPTION
The issue was introduced with the commit, which builds Open5GS from
local sources instead of downloading them each time from Github.

Fixes: d2cbcf711 ("[build] Use local sources to build applications (#1583)")