### PR TITLE
[SMF] Send PDU Session Establish Accept to serving AMF

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1341,6 +1341,26 @@ void ogs_sbi_select_nf(
     }
 }
 
+void ogs_sbi_select_nf_by_instanceid(
+        ogs_sbi_object_t *sbi_object, OpenAPI_nf_type_e nf_type, void *state,
+        char *nf_instance_id)
+{
+    ogs_sbi_nf_instance_t *nf_instance = NULL;
+
+    ogs_assert(sbi_object);
+    ogs_assert(nf_type);
+    ogs_assert(state);
+
+    ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance) {
+        if (OGS_FSM_CHECK(&nf_instance->sm, state) &&
+            (nf_instance->nf_type == nf_type) &&
+            (!(strcmp(nf_instance->id, nf_instance_id)))) {
+            OGS_SBI_SETUP_NF(sbi_object, nf_type, nf_instance);
+            break;
+        }
+    }
+}
+
 bool ogs_sbi_client_associate(ogs_sbi_nf_instance_t *nf_instance)
 {
     ogs_sbi_client_t *client = NULL;

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -339,6 +339,9 @@ OpenAPI_uri_scheme_e ogs_sbi_default_uri_scheme(void);
 
 void ogs_sbi_select_nf(
         ogs_sbi_object_t *sbi_object, OpenAPI_nf_type_e nf_type, void *state);
+void ogs_sbi_select_nf_by_instanceid(
+    ogs_sbi_object_t *sbi_object, OpenAPI_nf_type_e nf_type, void *state,
+    char *nf_instance_id);
 
 void ogs_sbi_object_free(ogs_sbi_object_t *sbi_object);
 

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -480,6 +480,26 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_unsubscribe(
     return request;
 }
 
+ogs_sbi_request_t *ogs_nnrf_nfm_build_profile_retrieve(char *nf_instance_id)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    ogs_assert(nf_instance_id);
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_GET;
+    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NNRF_NFM;
+    message.h.api.version = (char *)OGS_SBI_API_V1;
+    message.h.resource.component[0] =
+        (char *)OGS_SBI_RESOURCE_NAME_NF_INSTANCES;
+    message.h.resource.component[1] = nf_instance_id;
+
+    request = ogs_sbi_build_request(&message);
+
+    return request;
+}
+
 ogs_sbi_request_t *ogs_nnrf_disc_build_discover(
         OpenAPI_nf_type_e target_nf_type, OpenAPI_nf_type_e requester_nf_type)
 {

--- a/lib/sbi/nnrf-build.h
+++ b/lib/sbi/nnrf-build.h
@@ -34,6 +34,7 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_subscribe(
         ogs_sbi_subscription_t *subscription);
 ogs_sbi_request_t *ogs_nnrf_nfm_build_status_unsubscribe(
         ogs_sbi_subscription_t *subscription);
+ogs_sbi_request_t *ogs_nnrf_nfm_build_profile_retrieve(char *nf_instance_id);
 
 ogs_sbi_request_t *ogs_nnrf_disc_build_discover(
         OpenAPI_nf_type_e target_nf_type, OpenAPI_nf_type_e requester_nf_type);

--- a/lib/sbi/path.h
+++ b/lib/sbi/path.h
@@ -30,11 +30,16 @@ bool ogs_sbi_send(ogs_sbi_nf_instance_t *nf_instance,
         ogs_sbi_client_cb_f client_cb, ogs_sbi_xact_t *xact);
 bool ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact,
         ogs_fsm_handler_t nf_state_registered, ogs_sbi_client_cb_f client_cb);
+bool ogs_sbi_discover_by_nf_instanceid_and_send(ogs_sbi_xact_t *xact,
+        ogs_fsm_handler_t nf_state_registered, ogs_sbi_client_cb_f client_cb,
+        char *nf_instance_id);
 
 bool ogs_nnrf_nfm_send_nf_register(
         ogs_sbi_nf_instance_t *nf_instance, ogs_sbi_request_t *(*build)(void));
 bool ogs_nnrf_nfm_send_nf_update(ogs_sbi_nf_instance_t *nf_instance);
 bool ogs_nnrf_nfm_send_nf_de_register(ogs_sbi_nf_instance_t *nf_instance);
+bool ogs_nnrf_nfm_send_nf_profile_retrieve(ogs_sbi_nf_instance_t *nf_instance,
+        char *nf_instance_id, void *data);
 
 bool ogs_nnrf_nfm_send_nf_status_subscribe(ogs_sbi_client_t *client,
         OpenAPI_nf_type_e req_nf_type, char *req_nf_instance_id,

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1658,6 +1658,8 @@ void smf_sess_remove(smf_sess_t *sess)
 
     if (sess->pcf_id)
         ogs_free(sess->pcf_id);
+    if (sess->serving_nf_id)
+        ogs_free(sess->serving_nf_id);
 
     /* Free SBI object memory */
     ogs_sbi_object_free(&sess->sbi);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -300,6 +300,9 @@ typedef struct smf_sess_s {
     /* PCF ID */
     char            *pcf_id;
 
+    /* Serving NF (AMF) Id */
+    char            *serving_nf_id;
+
     /* Integrity protection maximum data rate */
     struct {
         uint8_t mbr_dl;

--- a/src/smf/nnrf-handler.h
+++ b/src/smf/nnrf-handler.h
@@ -36,6 +36,8 @@ bool smf_nnrf_handle_nf_status_notify(
 
 void smf_nnrf_handle_nf_discover(
         ogs_sbi_xact_t *xact, ogs_sbi_message_t *recvmsg);
+void smf_nnrf_handle_nf_profile_retrieve(
+        ogs_sbi_xact_t *xact, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -197,6 +197,12 @@ bool smf_nsmf_handle_create_sm_context(
         ogs_assert(sess->pcf_id);
     }
 
+    if (SmContextCreateData->serving_nf_id) {
+        if (sess->serving_nf_id) ogs_free(sess->serving_nf_id);
+        sess->serving_nf_id = ogs_strdup(SmContextCreateData->serving_nf_id);
+        ogs_assert(sess->serving_nf_id);
+    }
+
     /*
      * NOTE : The pkbuf created in the SBI message will be removed
      *        from ogs_sbi_message_free().

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -200,8 +200,13 @@ void smf_namf_comm_send_n1_n2_message_transfer(
 
     xact->state = param->state;
 
-    ogs_sbi_discover_and_send(xact,
-            (ogs_fsm_handler_t)smf_nf_state_registered, client_cb);
+    if (ogs_sbi_discover_by_nf_instanceid_and_send(xact,
+            (ogs_fsm_handler_t)smf_nf_state_registered, client_cb,
+            sess->serving_nf_id) != true)
+    {
+        ogs_error("smf_namf_comm_send_n1_n2_message_transfer() failed");
+        ogs_sbi_xact_remove(xact);
+    }
 }
 
 void smf_sbi_send_sm_context_create_error(

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -658,12 +658,27 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
             SWITCH(sbi_message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
-                nf_instance = e->sbi.data;
-                ogs_assert(nf_instance);
-                ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
-                e->sbi.message = &sbi_message;
-                ogs_fsm_dispatch(&nf_instance->sm, e);
+                SWITCH(sbi_message.h.method)
+                CASE(OGS_SBI_HTTP_METHOD_GET)
+                    sbi_xact = e->sbi.data;
+                    ogs_assert(sbi_xact);
+
+                    if (sbi_message.res_status == OGS_SBI_HTTP_STATUS_OK)
+                        smf_nnrf_handle_nf_profile_retrieve(
+                            sbi_xact, &sbi_message);
+                    else
+                        ogs_error("HTTP response error [%d]",
+                                sbi_message.res_status);
+                    break;
+                DEFAULT
+                    nf_instance = e->sbi.data;
+                    ogs_assert(nf_instance);
+                    ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
+
+                    e->sbi.message = &sbi_message;
+                    ogs_fsm_dispatch(&nf_instance->sm, e);
+                END
                 break;
 
             CASE(OGS_SBI_RESOURCE_NAME_SUBSCRIPTIONS)


### PR DESCRIPTION
[SBI] Add function to request NF Instance from NRF by providing it's Instance Id


[SMF] Send PDU Session Establish Accept to serving AMF

In case there are multiple AMF registered to NRF, SMF would pick only
the first AMF from the list.
In the case of sending PDU Session Establishment Accept from SMF to
AMF, this would mean a high chance of failure since the AMF might
be different than the original requester, and would not know about a
particular UE.

Modify SMF to use ServingNfId field from original request
SmContextCreateData from AMF to determine to which AMF should it send
PDU Session Establishment Accept message.