### PR TITLE
[MME] Introduce support for handling Charging Characteristics from HSS

### DIFF
--- a/lib/core/ogs-3gpp-types.h
+++ b/lib/core/ogs-3gpp-types.h
@@ -56,6 +56,8 @@ extern "C" {
 #define OGS_PLMN_ID_LEN                 3
 #define OGS_MAX_PLMN_ID_BCD_LEN         6
 
+#define OGS_CHRGCHARS_LEN               2
+
 #define OGS_BCD_TO_BUFFER_LEN(x)        (((x)+1)/2)
 #define OGS_MAX_IMSI_BCD_LEN            15
 #define OGS_MAX_IMSI_LEN                \
@@ -452,6 +454,9 @@ typedef struct ogs_session_s {
 
     uint32_t context_identifier; /* EPC */
     bool default_dnn_indicator; /* 5GC */
+
+    uint8_t charging_characteristics[OGS_CHRGCHARS_LEN];
+    bool charging_characteristics_presence;
 
 #define OGS_PDU_SESSION_TYPE_IPV4                   1
 #define OGS_PDU_SESSION_TYPE_IPV6                   2

--- a/lib/diameter/s6a/message.c
+++ b/lib/diameter/s6a/message.c
@@ -57,6 +57,7 @@ struct dict_object *ogs_diam_s6a_apn_configuration = NULL;
 struct dict_object *ogs_diam_s6a_max_bandwidth_ul = NULL;
 struct dict_object *ogs_diam_s6a_max_bandwidth_dl = NULL;
 struct dict_object *ogs_diam_s6a_pdn_type = NULL;
+struct dict_object *ogs_diam_s6a_3gpp_charging_characteristics = NULL;
 struct dict_object *ogs_diam_s6a_served_party_ip_address = NULL;
 struct dict_object *ogs_diam_s6a_eps_subscribed_qos_profile = NULL;
 struct dict_object *ogs_diam_s6a_qos_class_identifier = NULL;
@@ -125,6 +126,7 @@ int ogs_diam_s6a_init(void)
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "All-APN-Configurations-Included-Indicator", &ogs_diam_s6a_all_apn_configuration_included_indicator);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "APN-Configuration", &ogs_diam_s6a_apn_configuration);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "PDN-Type", &ogs_diam_s6a_pdn_type);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "3GPP-Charging-Characteristics", &ogs_diam_s6a_3gpp_charging_characteristics);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Served-Party-IP-Address", &ogs_diam_s6a_served_party_ip_address);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Subscription-Data", &ogs_diam_s6a_subscription_data);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Subscriber-Status", &ogs_diam_s6a_subscriber_status);

--- a/lib/diameter/s6a/message.h
+++ b/lib/diameter/s6a/message.h
@@ -103,6 +103,7 @@ extern struct dict_object *ogs_diam_s6a_apn_configuration;
 extern struct dict_object *ogs_diam_s6a_max_bandwidth_ul;
 extern struct dict_object *ogs_diam_s6a_max_bandwidth_dl;
 extern struct dict_object *ogs_diam_s6a_pdn_type;
+extern struct dict_object *ogs_diam_s6a_3gpp_charging_characteristics;
 extern struct dict_object *ogs_diam_s6a_served_party_ip_address;
 extern struct dict_object *ogs_diam_s6a_eps_subscribed_qos_profile;
 extern struct dict_object *ogs_diam_s6a_qos_class_identifier;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -422,6 +422,8 @@ struct mme_ue_s {
     /* HSS Info */
     ogs_bitrate_t   ambr; /* UE-AMBR */
     uint32_t        network_access_mode; /* Permitted EPS Attach Type */
+    uint8_t         charging_characteristics[OGS_CHRGCHARS_LEN]; /* Subscription Level Charging Characteristics */
+    bool            charging_characteristics_presence;
 
     uint32_t        context_identifier; /* default APN */
 

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -1023,8 +1023,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
                             OGS_HEX(hdr->avp_value->os.data, (int)hdr->avp_value->os.len, buf), OGS_CHRGCHARS_LEN);
                         session->charging_characteristics_presence = true;
                     } else {
-                        memcpy(session->charging_characteristics, mme_ue->charging_characteristics, OGS_CHRGCHARS_LEN);
-                        session->charging_characteristics_presence = mme_ue->charging_characteristics_presence;
+                        memcpy(session->charging_characteristics, (uint8_t *)"\x00\x00", OGS_CHRGCHARS_LEN);
+                        session->charging_characteristics_presence = false;
                     }
 
                     /* AVP: 'Served-Party-IP-Address'(848)

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -330,9 +330,11 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     req->ue_time_zone.data = &ue_timezone;
     req->ue_time_zone.len = sizeof(ue_timezone);
 
-    req->charging_characteristics.presence = 1;
-    req->charging_characteristics.data = (uint8_t *)"\x54\x00";
-    req->charging_characteristics.len = 2;
+    if (session->charging_characteristics_presence == true) {
+        req->charging_characteristics.presence = 1;
+        req->charging_characteristics.data = session->charging_characteristics;
+        req->charging_characteristics.len = 2;
+    }
 
     gtp_message.h.type = type;
     return ogs_gtp2_build_msg(&gtp_message);

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -333,7 +333,11 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     if (session->charging_characteristics_presence == true) {
         req->charging_characteristics.presence = 1;
         req->charging_characteristics.data = session->charging_characteristics;
-        req->charging_characteristics.len = 2;
+        req->charging_characteristics.len = OGS_CHRGCHARS_LEN;
+    } else if (mme_ue->charging_characteristics_presence == true) {
+        req->charging_characteristics.presence = 1;
+        req->charging_characteristics.data = mme_ue->charging_characteristics;
+        req->charging_characteristics.len = OGS_CHRGCHARS_LEN;
     }
 
     gtp_message.h.type = type;

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -91,6 +91,11 @@ void mme_s6a_handle_ula(mme_ue_t *mme_ue,
 
         memcpy(&mme_ue->session[i].smf_ip, &slice_data->session[i].smf_ip,
                 sizeof(mme_ue->session[i].smf_ip));
+
+        memcpy(&mme_ue->session[i].charging_characteristics, &slice_data->session[i].charging_characteristics,
+                sizeof(mme_ue->session[i].charging_characteristics));
+        mme_ue->session[i].charging_characteristics_presence =
+            slice_data->session[i].charging_characteristics_presence;
     }
 
     mme_ue->num_of_session = i;


### PR DESCRIPTION
When using commercial HSS which includes the CC in the profile, the expected result was not found in the S11 Create Session Request.  Similarly, when the HSS did not include the CC, it was still being included.  MME currently uses a default charging_characteristics value.  I am recommending this change to make use of the charging characteristics value at both the subscription and PDN level.  If there is no charging characteristic specifically sent for the PDN, the subscription level cc is used.  If neither are included, then no charging characteristic is sent in S11, following TS32.251 A.4.