### PR TITLE
[AMF] Add missing fields to request to SMF when activating PDU session

### DIFF
--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -388,6 +388,9 @@ void amf_sbi_send_activating_session(amf_sess_t *sess, int state)
 
     memset(&param, 0, sizeof(param));
     param.upCnxState = OpenAPI_up_cnx_state_ACTIVATING;
+    param.cause = OpenAPI_cause_PDU_SESSION_RESUMED;
+    param.ue_location = true;
+    param.ue_timezone = true;
 
     amf_sess_sbi_discover_and_send(OpenAPI_nf_type_SMF, NULL,
             amf_nsmf_pdusession_build_update_sm_context, sess, state, &param);


### PR DESCRIPTION
TS 129 502: 5.2.2.3.16 Connection Resume in CM-IDLE with Suspend procedure

The NF Service Consumer shall request the SMF to resume the user plane
connection of the PDU session by sending a POST request, as specified in
clause 5.2.2.3.1, with the following information:
- the upCnxState attribute set to ACTIVATING;
- user location and user location timestamp;
- cause attribute set to "PDU_SESSION_RESUMED";
- N2 SM information received from the 5G-AN, ...
...