### PR TITLE
Fix PCO IE sent in response over S5c and Gn irrespective of its presence in request

### DIFF
--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -314,6 +314,18 @@ uint8_t smf_gn_handle_delete_pdp_context_request(
         return OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE;
     }
 
+    /* PCO */
+    if (req->protocol_configuration_options.presence) {
+        OGS_TLV_STORE_DATA(&sess->gtp.ue_pco,
+                &req->protocol_configuration_options);
+    } else {
+        /*
+         * Clear contents to reflect whether PCO IE was included or not as part
+         * of Delete PDP context request
+         */
+        OGS_TLV_CLEAR_DATA(&sess->gtp.ue_pco);
+    }
+
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
     return OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
@@ -460,6 +472,12 @@ void smf_gn_handle_update_pdp_context_request(
     if (req->protocol_configuration_options.presence) {
         OGS_TLV_STORE_DATA(&sess->gtp.ue_pco,
                 &req->protocol_configuration_options);
+    } else {
+        /*
+         * Clear contents to reflect whether PCO IE was included or not as part
+         * of Update PDP context request
+         */
+        OGS_TLV_CLEAR_DATA(&sess->gtp.ue_pco);
     }
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -410,6 +410,23 @@ uint8_t smf_s5c_handle_delete_session_request(
         }
     }
 
+    /* PCO
+     * 3GPP TS 29.274 version 10.5.0, Table 7.2.9.1-1
+     * If the UE includes the PCO IE, then the MME/SGSN shall copy
+     * the content of this IE transparently from the PCO IE included by the UE.
+     * If SGW receives the PCO IE, SGW shall forward it to PGW.
+     */
+    if (req->protocol_configuration_options.presence) {
+        OGS_TLV_STORE_DATA(&sess->gtp.ue_pco,
+                &req->protocol_configuration_options);
+    } else {
+        /* 
+         * Clear contents to reflect whether PCO IE was included or not as part
+         * of session deletion procedure
+         */
+        OGS_TLV_CLEAR_DATA(&sess->gtp.ue_pco);
+    }
+
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 


### PR DESCRIPTION
S5c: As per 3GPP TS 29.274 version 10.5.0, section 7.2.9 and 7.2.10,
Only if PCO IE is included in Delete Session Request then it
must be present in Delete Session Response.

And

Gn: As per 3GPP TS 29.060 version 15.3.0, section 7.3.3, 7.3.4, 7.3.5 and 7.3.6
Only if PCO IE is included in Update/Delete PDP Context Request then it
must be present in Update/Delete PDP Context Response.

In order to reflect on whether the request contained PCO IE or not
the SMF context containing the GTP request needs to be updated
i.e. update if present else clear the contents