### PR TITLE
[SMF] Fix abort on app exit when no Diameter configuration

### DIFF
--- a/src/smf/fd-path.c
+++ b/src/smf/fd-path.c
@@ -54,6 +54,13 @@ int smf_fd_init(void)
 
 void smf_fd_final(void)
 {
+    if (smf_self()->diam_conf_path == NULL &&
+        (smf_self()->diam_config->cnf_diamid == NULL ||
+        smf_self()->diam_config->cnf_diamrlm == NULL ||
+        smf_self()->diam_config->cnf_addr == NULL)) {
+        return;
+    }
+
     smf_gx_final();
     smf_s6b_final();
 


### PR DESCRIPTION
In case that SMF was configured to run without Diameter, it would crash
on application exit due to uninitialized variables/pointers.

ERROR  pid:unnamed in fd_sess_handler_destroy@sessions.c:324: ERROR: Invalid parameter '(handler && ( ((*handler) != ((void *)0)) && ( ((struct session_handler *)(*handler))->eyec == 0x53554AD1) ))', 22
[smf] FATAL: smf_gx_final: Assertion `ret == 0' failed. (../src/smf/gx-path.c:1353)