### PR TITLE
Gx: add support for 3GPP-Charging-Identifier

### DIFF
--- a/lib/diameter/gx/message.c
+++ b/lib/diameter/gx/message.c
@@ -56,6 +56,7 @@ struct dict_object *ogs_diam_gx_3gpp_user_location_info = NULL;
 struct dict_object *ogs_diam_gx_called_station_id = NULL;
 struct dict_object *ogs_diam_gx_default_eps_bearer_qos = NULL;
 struct dict_object *ogs_diam_gx_3gpp_ms_timezone = NULL;
+struct dict_object *ogs_diam_gx_3gpp_charging_characteristics = NULL;
 struct dict_object *ogs_diam_gx_event_trigger = NULL;
 struct dict_object *ogs_diam_gx_bearer_control_mode = NULL;
 struct dict_object *ogs_diam_gx_charging_rule_install = NULL;
@@ -133,6 +134,7 @@ int ogs_diam_gx_init(void)
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Event-Trigger", &ogs_diam_gx_event_trigger);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Bearer-Control-Mode", &ogs_diam_gx_bearer_control_mode);
 
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "3GPP-Charging-Characteristics", &ogs_diam_gx_3gpp_charging_characteristics);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Charging-Rule-Install", &ogs_diam_gx_charging_rule_install);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Charging-Rule-Remove", &ogs_diam_gx_charging_rule_remove);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Charging-Rule-Definition", &ogs_diam_gx_charging_rule_definition);

--- a/lib/diameter/gx/message.h
+++ b/lib/diameter/gx/message.h
@@ -86,6 +86,7 @@ extern struct dict_object *ogs_diam_gx_3gpp_user_location_info;
 extern struct dict_object *ogs_diam_gx_called_station_id;
 extern struct dict_object *ogs_diam_gx_default_eps_bearer_qos;
 extern struct dict_object *ogs_diam_gx_3gpp_ms_timezone;
+extern struct dict_object *ogs_diam_gx_3gpp_charging_characteristics;
 extern struct dict_object *ogs_diam_gx_event_trigger;
 extern struct dict_object *ogs_diam_gx_bearer_control_mode;
 extern struct dict_object *ogs_diam_gx_charging_rule_install;

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -538,6 +538,25 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
         }
     }
 
+    /* 3GPP-Charging-Characteristics, 3GPP TS 29.061 16.4.7.2 13 */
+    if (sess->gtp.charging_characteristics.presence &&
+		    sess->gtp.charging_characteristics.len > 0) {
+	    uint8_t oct1, oct2;
+	    char digits[5];
+	    ret = fd_msg_avp_new(ogs_diam_gx_3gpp_charging_characteristics, 0, &avp);
+	    ogs_assert(ret == 0);
+	    oct1 = ((uint8_t*)sess->gtp.charging_characteristics.data)[0];
+	    oct2 = (sess->gtp.charging_characteristics.len > 1) ?
+		    ((uint8_t*)sess->gtp.charging_characteristics.data)[1] : 0;
+	    snprintf(digits, sizeof(digits), "%02x%02x", oct1, oct2);
+	    val.os.data = (uint8_t*)&digits[0];
+	    val.os.len = 4;
+	    ret = fd_msg_avp_setvalue(avp, &val);
+	    ogs_assert(ret == 0);
+	    ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
+	    ogs_assert(ret == 0);
+    }
+
     /* Set Called-Station-Id */
     ret = fd_msg_avp_new(ogs_diam_gx_called_station_id, 0, &avp);
     ogs_assert(ret == 0);


### PR DESCRIPTION
The 3GPP-Charging-Characteristics is an operator specific AVP
(optional). The 3GPP-Charging-Characteristics can be filled by the HSS
and forwarded by the MME, SGWc towards the SMF.

In preparation to allow the PCRF to work without any database.