### PR TITLE
[metrics] Fix double-free on application exit

### DIFF
--- a/lib/metrics/prometheus/context.c
+++ b/lib/metrics/prometheus/context.c
@@ -427,7 +427,7 @@ void ogs_metrics_inst_free(ogs_metrics_inst_t *inst)
 {
     unsigned int i;
 
-    ogs_list_remove(&inst->spec->inst_list, inst);
+    ogs_list_remove(&inst->spec->inst_list, &inst->entry);
 
     for (i = 0; i < inst->num_labels; i++)
         ogs_free(inst->label_values[i]);


### PR DESCRIPTION
Adding metric instance to the list used "&inst->entry", while trying to
remove it from the list used pointer "inst". This has caused that the
instance was freed, but the pointer still remained in the list.

On application exit, each application cleanups it's own metrics, while
metrics library does the same. This has caused double-free crash.