### PR TITLE
Metrics library PoC

### DIFF
--- a/lib/metrics/context.h
+++ b/lib/metrics/context.h
@@ -65,6 +65,31 @@ static inline void ogs_metrics_inst_dec(ogs_metrics_inst_t *inst)
     ogs_metrics_inst_add(inst, -1);
 }
 
+
+typedef struct ogs_metrics_inst2_s ogs_metrics_inst2_t;
+ogs_metrics_inst2_t *ogs_metrics_inst2_new(
+        ogs_metrics_context_t *ctx, ogs_metrics_metric_type_t type,
+        const char *name, const char *description,
+        int initial_val, unsigned int num_labels, const char **labels);
+void ogs_metrics_inst2_free(ogs_metrics_inst2_t *inst);
+
+void ogs_metrics_inst2_set(ogs_metrics_inst2_t *inst,
+    int val, int label_num, const char **label_values);
+void ogs_metrics_inst2_reset(ogs_metrics_inst2_t *inst,
+    int label_num, const char **label_values);
+void ogs_metrics_inst2_add(ogs_metrics_inst2_t *inst,
+    int val, int label_num, const char **label_values);
+
+static inline void ogs_metrics_inst2_inc(ogs_metrics_inst2_t *inst,
+    int label_num, const char **label_values)
+{
+    ogs_metrics_inst2_add(inst, 1, label_num, label_values);
+}
+static inline void ogs_metrics_inst2_dec(ogs_metrics_inst2_t *inst,
+    int label_num, const char **label_values)
+{
+    ogs_metrics_inst2_add(inst, -1, label_num, label_values);
+}
 #ifdef __cplusplus
 }
 #endif

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -876,6 +876,8 @@ amf_gnb_t *amf_gnb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
 
     ogs_list_add(&self.gnb_list, gnb);
     amf_metrics_inst_global_inc(AMF_METR_GLOB_GAUGE_GNB);
+    amf_metrics_inst2_global_inc(AMF_METR_GLOB_GAUGE_GNB, 1, (const char *[]) { "AMFName1" });
+/*    amf_metrics_inst2_global_inc(AMF_METR_GLOB_GAUGE_GNB, 0, NULL);*/
 
     ogs_info("[Added] Number of gNBs is now %d",
             ogs_list_count(&self.gnb_list));

--- a/src/amf/metrics.c
+++ b/src/amf/metrics.c
@@ -22,6 +22,25 @@ static int amf_metrics_init_inst(ogs_metrics_inst_t **inst, ogs_metrics_spec_t *
     return OGS_OK;
 }
 
+int amf_metrics_init_inst2(ogs_metrics_context_t *ctx,
+    ogs_metrics_inst2_t **inst,
+    amf_metrics_spec_def_t *specs, unsigned int len);
+
+int amf_metrics_init_inst2(ogs_metrics_context_t *ctx,
+    ogs_metrics_inst2_t **inst,
+    amf_metrics_spec_def_t *specs, unsigned int len)
+{
+    unsigned int i;
+
+    for (i = 0; i < len; i++) {
+        inst[i] = ogs_metrics_inst2_new(ctx, specs[i].type,
+            specs[i].name, specs[i].description, specs[i].initial_val,
+            specs[i].num_labels, specs[i].labels);
+    }
+
+    return OGS_OK;
+}
+
 static int amf_metrics_free_inst(ogs_metrics_inst_t **inst,
         unsigned int len)
 {
@@ -65,8 +84,44 @@ amf_metrics_spec_def_t amf_metrics_spec_def_global[_AMF_METR_GLOB_MAX] = {
     .description = "gNodeBs",
 },
 };
+
+const char *labels_nf_name[] = {
+    "nf_name"
+};
+
+ogs_metrics_inst2_t *amf_metrics_inst_global2[_AMF_METR_GLOB_MAX];
+amf_metrics_spec_def_t amf_metrics_spec_def_global2[_AMF_METR_GLOB_MAX] = {
+/* Global Gauges: */
+[AMF_METR_GLOB_GAUGE_RAN_UE] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "bm_ran_ue",
+    .description = "RAN UEs",
+    .num_labels = OGS_ARRAY_SIZE(labels_nf_name),
+    .labels = labels_nf_name,
+},
+[AMF_METR_GLOB_GAUGE_AMF_SESS] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "bm_amf_session",
+    .description = "AMF Sessions",
+    .num_labels = OGS_ARRAY_SIZE(labels_nf_name),
+    .labels = labels_nf_name,
+},
+[AMF_METR_GLOB_GAUGE_GNB] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "bm_gnb",
+    .description = "gNodeBs",
+    .num_labels = OGS_ARRAY_SIZE(labels_nf_name),
+    .labels = labels_nf_name,
+},
+};
+
 static int amf_metrics_init_inst_global(void)
 {
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+
+    amf_metrics_init_inst2(ctx, amf_metrics_inst_global2,
+        amf_metrics_spec_def_global2, _AMF_METR_GLOB_MAX);
+
     return amf_metrics_init_inst(amf_metrics_inst_global, amf_metrics_spec_global,
                 _AMF_METR_GLOB_MAX, 0, NULL);
 }

--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -14,6 +14,7 @@ typedef enum amf_metric_type_global_s {
     _AMF_METR_GLOB_MAX,
 } amf_metric_type_global_t;
 extern ogs_metrics_inst_t *amf_metrics_inst_global[_AMF_METR_GLOB_MAX];
+extern ogs_metrics_inst2_t *amf_metrics_inst_global2[_AMF_METR_GLOB_MAX];
 
 static inline void amf_metrics_inst_global_set(amf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(amf_metrics_inst_global[t], val); }
@@ -23,6 +24,16 @@ static inline void amf_metrics_inst_global_inc(amf_metric_type_global_t t)
 { ogs_metrics_inst_inc(amf_metrics_inst_global[t]); }
 static inline void amf_metrics_inst_global_dec(amf_metric_type_global_t t)
 { ogs_metrics_inst_dec(amf_metrics_inst_global[t]); }
+
+
+static inline void amf_metrics_inst2_global_set(amf_metric_type_global_t t, int val, int label_num, const char **label_values)
+{ ogs_metrics_inst2_set(amf_metrics_inst_global2[t], val, label_num, label_values); }
+static inline void amf_metrics_inst2_global_add(amf_metric_type_global_t t, int val, int label_num, const char **label_values)
+{ ogs_metrics_inst2_add(amf_metrics_inst_global2[t], val, label_num, label_values); }
+static inline void amf_metrics_inst2_global_inc(amf_metric_type_global_t t, int label_num, const char **label_values)
+{ ogs_metrics_inst2_inc(amf_metrics_inst_global2[t], label_num, label_values); }
+static inline void amf_metrics_inst2_global_dec(amf_metric_type_global_t t, int label_num, const char **label_values)
+{ ogs_metrics_inst2_dec(amf_metrics_inst_global2[t], label_num, label_values); }
 
 int amf_metrics_open(void);
 int amf_metrics_close(void);

--- a/src/smf/metrics.h
+++ b/src/smf/metrics.h
@@ -61,6 +61,35 @@ static inline void smf_metrics_inst_gtp_node_dec(
     ogs_metrics_inst_t **inst, smf_metric_type_gtp_node_t t)
 { ogs_metrics_inst_dec(inst[t]); }
 
+
+extern ogs_metrics_inst2_t *test_metrics2[_SMF_METR_GTP_NODE_MAX];
+
+static inline void smf_metrics_inst2_gtp_node_set(
+        smf_metric_type_gtp_node_t t, int val,
+        int label_num, const char **label_values)
+{ ogs_metrics_inst2_set( test_metrics2[t], val, label_num, label_values); }
+
+static inline void smf_metrics_inst2_gtp_node_add(
+        smf_metric_type_gtp_node_t t, int val,
+        int label_num, const char **label_values)
+{ ogs_metrics_inst2_add(test_metrics2[t], val, label_num, label_values); }
+
+static inline void smf_metrics_inst2_gtp_node_inc(
+    smf_metric_type_gtp_node_t t,
+    int label_num, const char **label_values)
+{ ogs_metrics_inst2_inc(test_metrics2[t], label_num, label_values); }
+
+static inline void smf_metrics_inst2_gtp_node_dec(
+    smf_metric_type_gtp_node_t t,
+    int label_num, const char **label_values)
+{ ogs_metrics_inst2_dec(test_metrics2[t], label_num, label_values); }
+
+static inline void smf_metrics_inst2_gtp_node_reset(
+    smf_metric_type_gtp_node_t t,
+    int label_num, const char **label_values)
+{ ogs_metrics_inst2_reset(test_metrics2[t], label_num, label_values); }
+
+
 int smf_metrics_open(void);
 int smf_metrics_close(void);
 


### PR DESCRIPTION
I propose the following change to the metrics library. It is just a PoC, so it needs a lot more work, but wanted to get some input before commiting to it.


Current metrics library (wrapper around libprometheus-client-c) is in my opinion overly complicated and uses too much memory.
I know that the merge request for original code was left open for review, but did not see the following issues at that time.

- for each and every metric, the code duplicates `name` and `description` strings, even though they are used only at initalization time.
- if metric uses labels, it duplicates those label keys and values as well
- metrics with labels (as found in SMF) are instantiated for every label value


This PoC changes the behaviour to the following:
- have only the type `ogs_metrics_inst_t`, without `ogs_metrics_spec_t`
- for metrics without labels, it does not change much. Instantiate a metric, and use that to increment/decrement values
- for metrics with labels, provide label values directly at runtime, in case they might not be known at initialization time. Instantiate a metric, provide label keys at initialization time, and provide label values at runtime when incrementing/decrementing values.
.
- I think that my proposal could live side by side with the original code if needed
- With some clever macros, we could have the same function names for with labels or without (for example `amf_metrics_inst2_global_inc(AMF_METR_GLOB_GAUGE_GNB, 1, (const char *[]) { "AMFName1" });`
`amf_metrics_inst2_global_inc(AMF_METR_GLOB_GAUGE_GNB);`
- Potential downside of this approach is mistakes at development stage - number of label values provided at metric increment/decrement must match the number of label values at initialization
- Order of label values must match between value changing and initialization - but this same flaw is already with original code
- Can be more easily used to count HTTP response codes - count number of (un-)successful HTTP requests and log the HTTP response codes. With original approach we would have to instantiate metrics for each and every HTTP code we want to measure. With new approach we could just provide the HTTP code as a label value directly.