### PR TITLE
[SMF] Handle upCnxState=ACTIVATING by later replying with 200 instead of 204

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -270,6 +270,8 @@ typedef struct smf_sess_s {
      * of [POST] /npcf-smpolocycontrol/v1/policies */
     char *policy_association_id;
 
+    OpenAPI_up_cnx_state_e up_cnx_state;
+
     /* PLMN ID & NID */
     ogs_plmn_id_t   plmn_id;
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -400,7 +400,14 @@ void smf_5gc_n4_handle_session_modification_response(
 
         } else {
             sess->paging.ue_requested_pdu_session_establishment_done = true;
-            ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
+
+            if (sess->up_cnx_state == OpenAPI_up_cnx_state_ACTIVATING) {
+                sess->up_cnx_state = OpenAPI_up_cnx_state_ACTIVATED;
+                smf_sbi_send_sm_context_updated_data_up_cnx_state(
+                        sess, stream, OpenAPI_up_cnx_state_ACTIVATED);
+            } else {
+                ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
+            }
         }
 
     } else if (flags & OGS_PFCP_MODIFY_DEACTIVATE) {

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -432,6 +432,7 @@ bool smf_nsmf_handle_update_sm_context(
 
             memset(&SmContextUpdatedData, 0, sizeof(SmContextUpdatedData));
             SmContextUpdatedData.up_cnx_state = OpenAPI_up_cnx_state_ACTIVATING;
+            sess->up_cnx_state = OpenAPI_up_cnx_state_ACTIVATING;
             SmContextUpdatedData.n2_sm_info_type =
                 OpenAPI_n2_sm_info_type_PDU_RES_SETUP_REQ;
             SmContextUpdatedData.n2_sm_info = &n2SmInfo;


### PR DESCRIPTION
According to TS 29.502 5.2.2.3.2.2. step 4 we should reply with a 200 response
including the upCnxState attribute.