### PR TITLE
[AMF] Handle APN/DNN names as case-insensitive

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1014,7 +1014,7 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                                         OGS_MAX_NUM_OF_SESS);
                                     break;
                                 }
-                                if (!strcmp(dnn->value,
+                                if (!ogs_strcasecmp(dnn->value,
                                             amf_ue->slice[i].session[k].name)) {
 
                                     selected_slice = amf_ue->slice + i;


### PR DESCRIPTION
In case that APN name sent from UE does not case-match with the one configured in the database, AMF would reject the registration with the message:

[gmm] WARNING: [imsi-xxx] DNN Not Supported OR Not Subscribed in the Slice (../src/amf/gmm-handler.c:1051)


Also somewhat relevant issue: https://github.com/open5gs/open5gs/issues/617