### PR TITLE
[config,metrics] Move metrics configuration section under respective …

### DIFF
--- a/configs/310014.yaml.in
+++ b/configs/310014.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 310
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -111,6 +117,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 310

--- a/configs/csfb.yaml.in
+++ b/configs/csfb.yaml.in
@@ -67,6 +67,9 @@ mme:
               mcc: 724
               mnc: 21
             lac: 51544
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       - plmn_id:
           mcc: 999
@@ -113,6 +116,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -143,6 +149,9 @@ amf:
     sbi:
       - addr: 127.0.0.5
         port: 7777
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     ngap:
       - addr: 127.0.0.5
     guami:

--- a/configs/non3gpp.yaml.in
+++ b/configs/non3gpp.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -113,6 +119,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -178,6 +178,13 @@ logger:
 #          sinit_max_attempts : 4
 #          sinit_max_init_timeo : 8000
 #
+#  <Metrics Server>
+#
+#  o Metrics Server(http://<any address>:9090)
+#    metrics:
+#      addr: 0.0.0.0
+#      port: 9090
+#
 #  <GUAMI>
 #
 #  o Multiple GUAMI
@@ -263,6 +270,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999
@@ -391,17 +401,3 @@ usrsctp:
 #    handover:
 #        duration: 500
 time:
-
-#
-# metrics:
-#
-#  <Metrics Server>
-#
-#  o Metrics Server(http://<any address>:9090)
-#    metrics:
-#      addr: 0.0.0.0
-#      port: 9090
-#
-metrics:
-    addr: 127.0.0.5
-    port: 9090

--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -175,6 +175,12 @@ logger:
 #              mnc: 02
 #            lac: 43693
 #
+#  <Metrics Server>
+#
+#  o Metrics Server(http://<any address>:9090)
+#    metrics:
+#      addr: 0.0.0.0
+#      port: 9090
 #
 #  <GUMMEI>
 #
@@ -248,6 +254,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+      addr: 127.0.0.2
+      port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -421,17 +430,3 @@ usrsctp:
 #    handover:
 #        duration: 500
 time:
-
-#
-# metrics:
-#
-#  <Metrics Server>
-#
-#  o Metrics Server(http://<any address>:9090)
-#    metrics:
-#      addr: 0.0.0.0
-#      port: 9090
-#
-metrics:
-    addr: 127.0.0.2
-    port: 9090

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -16,7 +16,7 @@
 #
 #  o Set OGS_LOG_TRACE to all domain level
 #    level: trace
-#    domain: core,pfcp,fd,pfcp,gtp,smf,event,tlv,mem,sock
+#    domain: core,fd,pfcp,gtp,smf,event,tlv,mem,sock
 #
 logger:
     file: @localstatedir@/log/open5gs/smf.log
@@ -178,6 +178,13 @@ logger:
 #      addr: 127.0.0.4
 #      option:
 #        so_bindtodevice: vrf-blue
+#
+#  <Metrics Server>
+#
+#  o Metrics Server(http://<any address>:9090)
+#    metrics:
+#      addr: 0.0.0.0
+#      port: 9090
 #
 #  <Subnet for UE Pool>
 #
@@ -423,6 +430,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -599,17 +609,3 @@ max:
 #    handover:
 #        duration: 500
 time:
-
-#
-# metrics:
-#
-#  <Metrics Server>
-#
-#  o Metrics Server(http://<any address>:9090)
-#    metrics:
-#      addr: 0.0.0.0
-#      port: 9090
-#
-metrics:
-    addr: 127.0.0.4
-    port: 9090

--- a/configs/sample.yaml.in
+++ b/configs/sample.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -136,6 +142,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/configs/slice.yaml.in
+++ b/configs/slice.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -111,6 +117,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/configs/srslte.yaml.in
+++ b/configs/srslte.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.1.100
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -111,6 +117,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/configs/volte.yaml.in
+++ b/configs/volte.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -114,6 +120,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/configs/vonr.yaml.in
+++ b/configs/vonr.yaml.in
@@ -43,6 +43,9 @@ mme:
       - addr: 127.0.0.2
     gtpc:
       - addr: 127.0.0.2
+    metrics:
+        addr: 127.0.0.2
+        port: 9090
     gummei:
       plmn_id:
         mcc: 999
@@ -79,6 +82,9 @@ smf:
     gtpu:
       - addr: 127.0.0.4
       - addr: ::1
+    metrics:
+        addr: 127.0.0.4
+        port: 9090
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
@@ -114,6 +120,9 @@ amf:
         port: 7777
     ngap:
       - addr: 127.0.0.5
+    metrics:
+        addr: 127.0.0.5
+        port: 9090
     guami:
       - plmn_id:
           mcc: 999

--- a/lib/metrics/context.h
+++ b/lib/metrics/context.h
@@ -39,7 +39,7 @@ void ogs_metrics_context_open(ogs_metrics_context_t *ctx);
 void ogs_metrics_context_close(ogs_metrics_context_t *ctx);
 void ogs_metrics_context_final(void);
 ogs_metrics_context_t *ogs_metrics_self(void);
-int ogs_metrics_context_parse_config(void);
+int ogs_metrics_context_parse_config(const char *local);
 
 typedef struct ogs_metrics_spec_s ogs_metrics_spec_t;
 ogs_metrics_spec_t *ogs_metrics_spec_new(

--- a/lib/metrics/prometheus/context.c
+++ b/lib/metrics/prometheus/context.c
@@ -104,7 +104,7 @@ ogs_metrics_context_t *ogs_metrics_self(void)
     return &self;
 }
 
-int ogs_metrics_context_parse_config(void)
+int ogs_metrics_context_parse_config(const char *local)
 {
     int family = AF_UNSPEC;
     const char *hostname = NULL;
@@ -121,17 +121,26 @@ int ogs_metrics_context_parse_config(void)
     while (ogs_yaml_iter_next(&root_iter)) {
         const char *root_key = ogs_yaml_iter_key(&root_iter);
         ogs_assert(root_key);
-        if (!strcmp(root_key, "metrics")) {
+        if (local && !strcmp(root_key, local)) {
             ogs_yaml_iter_t local_iter;
             ogs_yaml_iter_recurse(&root_iter, &local_iter);
             while (ogs_yaml_iter_next(&local_iter)) {
                 const char *local_key = ogs_yaml_iter_key(&local_iter);
-                if (!strcmp(local_key, "addr")) {
-                    if ((v = ogs_yaml_iter_value(&local_iter)))
-                        hostname = v;
-                } else if (!strcmp(local_key, "port")) {
-                    if ((v = ogs_yaml_iter_value(&local_iter)))
-                        port = atoi(v);
+                ogs_assert(local_key);
+                if (!strcmp(local_key, "metrics")) {
+                    ogs_yaml_iter_t metrics_iter;
+                    ogs_yaml_iter_recurse(&local_iter, &metrics_iter);
+                    while (ogs_yaml_iter_next(&metrics_iter)) {
+                        const char *metrics_key = ogs_yaml_iter_key(&metrics_iter);
+                        ogs_assert(metrics_key);
+                        if (!strcmp(metrics_key, "addr")) {
+                            if ((v = ogs_yaml_iter_value(&metrics_iter)))
+                                hostname = v;
+                        } else if (!strcmp(metrics_key, "port")) {
+                            if ((v = ogs_yaml_iter_value(&metrics_iter)))
+                                port = atoi(v);
+                        }
+                    }
                 }
             }
         }

--- a/lib/metrics/void/context.c
+++ b/lib/metrics/void/context.c
@@ -50,7 +50,7 @@ ogs_metrics_context_t *ogs_metrics_self(void)
     return &self;
 }
 
-int ogs_metrics_context_parse_config(void)
+int ogs_metrics_context_parse_config(const char *local)
 {
     return OGS_OK;
 }

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -825,6 +825,8 @@ int amf_context_parse_config(void)
                     /* handle config in sbi library */
                 } else if (!strcmp(amf_key, "discovery")) {
                     /* handle config in sbi library */
+                } else if (!strcmp(amf_key, "metrics")) {
+                    /* handle config in metrics library */
                 } else
                     ogs_warn("unknown key `%s`", amf_key);
             }

--- a/src/amf/init.c
+++ b/src/amf/init.c
@@ -37,7 +37,7 @@ int amf_initialize()
     rv = ogs_sbi_context_parse_config("amf", "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
-    rv = ogs_metrics_context_parse_config();
+    rv = ogs_metrics_context_parse_config("amf");
     if (rv != OGS_OK) return rv;
 
     rv = amf_context_parse_config();

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1277,6 +1277,8 @@ int mme_context_parse_config()
                             YAML_SEQUENCE_NODE);
                 } else if (!strcmp(mme_key, "mme_name")) {
                     self.mme_name = ogs_yaml_iter_value(&mme_iter);
+                } else if (!strcmp(mme_key, "metrics")) {
+                    /* handle config in metrics library */
                 } else
                     ogs_warn("unknown key `%s`", mme_key);
             }

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -49,7 +49,7 @@ int mme_initialize()
     rv = ogs_gtp_context_parse_config("mme", "sgwc");
     if (rv != OGS_OK) return rv;
 
-    rv = ogs_metrics_context_parse_config();
+    rv = ogs_metrics_context_parse_config("mme");
     if (rv != OGS_OK) return rv;
 
     rv = mme_context_parse_config();

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -835,6 +835,8 @@ int smf_context_parse_config(void)
                     /* handle config in sbi library */
                 } else if (!strcmp(smf_key, "discovery")) {
                     /* handle config in sbi library */
+                } else if (!strcmp(smf_key, "metrics")) {
+                    /* handle config in metrics library */
                 } else
                     ogs_warn("unknown key `%s`", smf_key);
             }

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -55,7 +55,7 @@ int smf_initialize()
     rv = ogs_sbi_context_parse_config("smf", "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
-    rv = ogs_metrics_context_parse_config();
+    rv = ogs_metrics_context_parse_config("smf");
     if (rv != OGS_OK) return rv;
 
     rv = smf_context_parse_config();


### PR DESCRIPTION
…NF section

Without this change, using metrics with core setup configurations (configs/vonr.yaml for example) would not be possible. Having one metrics section for whole config file causes every NF to start metrics server on same port causing an abort.