### PR TITLE
[core] prevent timer overflow on 32bit systems

### DIFF
--- a/lib/core/ogs-time.c
+++ b/lib/core/ogs-time.c
@@ -242,7 +242,7 @@ ogs_time_t ogs_get_monotonic_time(void)
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return ((ts.tv_sec * 1000000UL) + (ts.tv_nsec / 1000UL));
+    return (((int64_t) ts.tv_sec * 1000000UL) + (ts.tv_nsec / 1000UL));
 #elif defined(__APPLE__)
     static mach_timebase_info_data_t info = {0};
     static double ratio = 0.0;


### PR DESCRIPTION
On 32bit systems, the timer will lock-up after running for approximately 70 minutes due to a buffer overflow. Specifically, the value (ts.tv_sec * 1000000UL) is read as a 32bit val and overflows itself.

The code as-written (multiplying 32bit and 64bit vals together) downgrades "1000000UL" and the result to 32bits (potentially creating a buffer overflow) and then casts the result to 64bit. To get correct behavior we need to cast ts.tv_sec to 64bits before we multiply.