### PR TITLE
remove segfaults in {sgwc,smf}_sess_remove

### DIFF
--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -114,9 +114,18 @@ typedef unsigned int ogs_index_t;
     if (((pool)->size != (pool)->avail)) \
         ogs_error("%d in '%s[%d]' were not released.", \
                 (pool)->size - (pool)->avail, (pool)->name, (pool)->size); \
-    ogs_free((pool)->free); \
-    ogs_free((pool)->array); \
-    ogs_free((pool)->index); \
+    if ((pool)->free) {\
+    	ogs_free((pool)->free); \
+	(pool)->free = NULL; \
+    } \
+    if ((pool)->array) {\
+        ogs_free((pool)->array); \
+	(pool)->array = NULL; \
+    } \
+    if ((pool)->index) {\
+        ogs_free((pool)->index); \
+	(pool)->index = NULL; \
+    } \
 } while (0)
 
 #ifdef __cplusplus

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -402,13 +402,16 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
 
     sgwc_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);        
+    }
 
     ogs_pfcp_pool_final(&sess->pfcp);
 
-    ogs_assert(sess->session.name);
-    ogs_free(sess->session.name);
+    if (sess->session.name) {
+        ogs_free(sess->session.name);
+        sess->session.name = NULL;
+    }
 
     ogs_pool_free(&sgwc_sess_pool, sess);
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1644,8 +1644,10 @@ void smf_sess_remove(smf_sess_t *sess)
     if (sess->policy_association_id)
         ogs_free(sess->policy_association_id);
 
-    if (sess->session.name)
+    if (sess->session.name) {
         ogs_free(sess->session.name);
+	sess->session.name = NULL;
+    }
 
     if (sess->upf_n3_addr)
         ogs_freeaddrinfo(sess->upf_n3_addr);
@@ -1667,8 +1669,9 @@ void smf_sess_remove(smf_sess_t *sess)
 
     smf_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);
+    }
 
     smf_sess_delete_cp_up_data_forwarding(sess);
 


### PR DESCRIPTION
sgwc_sess_remove and smf_sess_remove both have some potential segfault conditions due to double-frees. Each function will definitely segfault if called twice on the same sess structure. This is unlikely, but can actually happen in certain codepaths (e.g. releasing an old/outdated session). With these fixes, each function is essentially idempotent and safe to call multiple times on a given session. In the unlikely event that the session was already removed, nothing bad occurs.