### PR TITLE
gracefully handle ogs_pfcp_sendto socket errors

### DIFF
--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -563,8 +563,6 @@ int ogs_pfcp_xact_commit(ogs_pfcp_xact_t *xact)
 
     if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
         ogs_error("ogs_pfcp_sendto() failed");
-        ogs_pfcp_xact_delete(xact);
-        return OGS_ERROR;
     }
 
     return OGS_OK;

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -607,7 +607,7 @@ static void response_timeout(void *data)
 
         if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
             ogs_error("ogs_pfcp_sendto() failed");
-            goto out;
+            // goto out;
         }
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -607,7 +607,6 @@ static void response_timeout(void *data)
 
         if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
             ogs_error("ogs_pfcp_sendto() failed");
-            // goto out;
         }
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "
@@ -626,7 +625,6 @@ static void response_timeout(void *data)
 
     return;
 
-out:
     ogs_pfcp_xact_delete(xact);
 }
 


### PR DESCRIPTION
ogs_pfcp_sendto can encounter a socket error for many short-lived and recoverable reasons, e.g. a network config changes, a link goes down, a VPN is offline, or a firewall rule comes into effect.

As-written, the code will crash the entire program if a socket error happens on ogs_pfcp_xact_commit. If a socket error happens during response_timeout, the code will keep running, but will essentially "deadlock" the program since it doesn't set another timer when it errors out.

Removing these error pathways solves these problems by punting error-recovery to the existing PFCP mechanisms. With this PR, the code simply logs an error ("ogs_pfcp_sendto() failed") and proceeds with regular error detection/recovery. e.g. it will re-send a session message N times before giving up, or in the case of heartbeat messages, detect a timeout and de-associate.