### PR TITLE
[pfcp] add addr and port to pfcp assoc/de-assoc log messages

### DIFF
--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -169,12 +169,16 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated");
+        ogs_info("PFCP associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated");
+        ogs_info("PFCP de-associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case SGWC_EVT_SXA_MESSAGE:
@@ -206,12 +210,16 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                     &message->pfcp_heartbeat_response));
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated");
+            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated");
+            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -165,12 +165,16 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated");
+        ogs_info("PFCP associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated");
+        ogs_info("PFCP de-associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case SGWU_EVT_SXA_MESSAGE:
@@ -194,12 +198,16 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
                     &message->pfcp_heartbeat_response));
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated");
+            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_up_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated");
+            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_up_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -171,12 +171,16 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated");
+        ogs_info("PFCP associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated");
+        ogs_info("PFCP de-associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case SMF_EVT_N4_MESSAGE:
@@ -210,12 +214,16 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                     &message->pfcp_heartbeat_response));
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated");
+            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated");
+            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -170,12 +170,16 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated");
+        ogs_info("PFCP associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated");
+        ogs_info("PFCP de-associated [%s]:%d",
+            OGS_ADDR(&node->addr, buf),
+            OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case UPF_EVT_N4_MESSAGE:
@@ -199,12 +203,16 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
                     &message->pfcp_heartbeat_response));
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated");
+            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_up_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated");
+            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
+                OGS_ADDR(&node->addr, buf),
+                OGS_PORT(&node->addr));
             ogs_pfcp_up_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;


### PR DESCRIPTION
Adding slightly more verbose logging when PFCP associates/de-associates. This is very useful in contexts where you have more than one sgwu or upf.