### PR TITLE
silently handle OGS_GTP2_CAUSE_UE_ALREADY_RE_ATTACHED

### DIFF
--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -1171,7 +1171,8 @@ void sgwc_s11_handle_downlink_data_notification_ack(
         ogs_assert(cause);
 
         cause_value = cause->value;
-        if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED)
+        if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED && 
+            cause_value != OGS_GTP2_CAUSE_UE_ALREADY_RE_ATTACHED)
             ogs_warn("GTP Failed [CAUSE:%d] - PFCP_CAUSE[%d]",
                     cause_value, pfcp_cause_from_gtp(cause_value));
     } else {


### PR DESCRIPTION
OGS_GTP2_CAUSE_UE_ALREADY_RE_ATTACHED is an okay situation and does not indicate an error. The only time it is seen is when the system gracefully handles a race condition when sgwc sends downlink-data-notification asking mme to wake up a ue, but the mme has already just woken up that ue. As such, the sgwc should just proceed as normal, and should not log a "GTP Failed" message.