### PR TITLE
[pfcp] idempotent session establishment request/response

### DIFF
--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -73,7 +73,7 @@ enum PFCP_STATES {
     PFCP_WAIT_ESTABLISHMENT,
     PFCP_ESTABLISHED,
     PFCP_WAIT_DELETION,
-    PFCP_DELETED
+    PFCP_ERROR,
 };
 
 #define SGWC_SESS(pfcp_sess) ogs_container_of(pfcp_sess, sgwc_sess_t, pfcp)

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -68,13 +68,22 @@ typedef struct sgwc_ue_s {
     ogs_gtp_node_t  *gnode;
 } sgwc_ue_t;
 
+enum PFCP_STATES {
+    PFCP_ENTRY,
+    PFCP_WAIT_ESTABLISHMENT,
+    PFCP_ESTABLISHED,
+    PFCP_WAIT_DELETION,
+    PFCP_DELETED
+};
+
 #define SGWC_SESS(pfcp_sess) ogs_container_of(pfcp_sess, sgwc_sess_t, pfcp)
 typedef struct sgwc_sess_s {
     ogs_lnode_t     lnode;          /* A node of list_t */
     uint32_t        index;          /**< An index of this node */
 
     ogs_pfcp_sess_t pfcp;           /* PFCP session context */
-
+    int pfcp_state;                 /* PFCP state machine */
+    
     uint32_t        sgw_s5c_teid;   /* SGW-S5C-TEID is derived from INDEX */
     uint32_t        pgw_s5c_teid;   /* PGW-S5C-TEID is received from PGW */
 

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -259,7 +259,9 @@ int sgwc_pfcp_send_session_establishment_request(
     ogs_expect_or_return_val(rv == OGS_OK, OGS_ERROR);
 
     rv = ogs_pfcp_xact_commit(xact);
-    ogs_expect(rv == OGS_OK);
+    ogs_expect_or_return_val(rv == OGS_OK, OGS_ERROR);
+
+    sess->pfcp_state = PFCP_WAIT_ESTABLISHMENT;
 
     return rv;
 }
@@ -364,7 +366,9 @@ int sgwc_pfcp_send_session_deletion_request(
     ogs_expect_or_return_val(rv == OGS_OK, OGS_ERROR);
 
     rv = ogs_pfcp_xact_commit(xact);
-    ogs_expect(rv == OGS_OK);
+    ogs_expect_or_return_val(rv == OGS_OK, OGS_ERROR);
+
+    sess->pfcp_state = PFCP_WAIT_DELETION;
 
     return rv;
 }

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -250,7 +250,7 @@ int sgwc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->sgwu_sxa_seid;
+    h.seid = 0;
 
     sxabuf = sgwc_sxa_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(sxabuf, OGS_ERROR);

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -250,7 +250,7 @@ int sgwc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = sgwc_sxa_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(sxabuf, OGS_ERROR);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -739,6 +739,9 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
     smf_sess_t *sess = NULL;
     ogs_pkbuf_t *pkbuf = NULL;
 
+    ogs_pfcp_xact_t *pfcp_xact = NULL;
+    ogs_pfcp_message_t *pfcp_message = NULL;
+
     ogs_nas_5gs_message_t *nas_message = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
@@ -1131,6 +1134,30 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
         default:
             ogs_error("Unknown message[%d]", e->ngap.type);
+        }
+        break;
+
+    case SMF_EVT_N4_MESSAGE:
+        pfcp_xact = e->pfcp_xact;
+        ogs_assert(pfcp_xact);
+        pfcp_message = e->pfcp_message;
+        ogs_assert(pfcp_message);
+
+        switch (pfcp_message->h.type) {
+        case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
+            ogs_warn("Received PFCP Session Establishment Response for already established session");
+
+            if (pfcp_xact->epc) {
+                smf_epc_n4_handle_session_establishment_response(
+                        sess, pfcp_xact, &pfcp_message->pfcp_session_establishment_response);
+            } else {
+                ogs_error("5GC PFCP re-establish session not yet written");
+            }
+            break;
+
+        default:
+            ogs_error("cannot handle PFCP message type[%d]",
+                    pfcp_message->h.type);
         }
         break;
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -684,7 +684,6 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     uint8_t cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 
     smf_bearer_t *bearer = NULL;
-    ogs_gtp_xact_t *gtp_xact = NULL;
 
     ogs_pfcp_f_seid_t *up_f_seid = NULL;
 
@@ -693,9 +692,6 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     ogs_assert(rsp);
 
     ogs_debug("Session Establishment Response [epc]");
-
-    gtp_xact = xact->assoc_xact;
-    ogs_assert(gtp_xact);
 
     ogs_pfcp_xact_commit(xact);
 

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -370,7 +370,7 @@ int smf_5gc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);
@@ -490,7 +490,7 @@ int smf_epc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -370,7 +370,7 @@ int smf_5gc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->upf_n4_seid;
+    h.seid = 0;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);
@@ -490,7 +490,7 @@ int smf_epc_pfcp_send_session_establishment_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE;
-    h.seid = sess->upf_n4_seid;
+    h.seid = 0;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess);
     ogs_expect_or_return_val(n4buf, OGS_ERROR);


### PR DESCRIPTION
I wanted to make the PFCP Session Establishment Request/Response pairing totally idempotent, since it's already very very close, and idempotentcy helps a lot when messages get e.g. dropped. This PR embodies two simple changes:

- SGWU/UPF: It looks like the UPS code (sgwu and upf) is already 100% idempotent. If it receives a session establishment message for a session it already has, it updates as needed, sends a response, and all's well.
- SMF: smf_epc_n4_handle_session_establishment_response is already idempotent, so we simply need to add code in smf_gsm_state_operational that calls it on the occasion that we receive another Session Establishment Response message even when we're already in state established. The reason we need to read the response is in case the SEID has changed (likely). This codepath won't send a GTP response since according to GTP we're still in an established state and all's well. Because of this, we need to remove the gtp_xact assertion in smf_epc_n4_handle_session_establishment_response but that's fine because it's actually never used in the codepath anyways.
- SGWC: Since the SGWC doesn't really have a state-machine I added some code to keep track of the current PFCP state. If we receive another Session Establishment Response in state established, we need to handle it separately using sgwc_sxa_handle_session_reestablishment. This is primarily so we don't crash on the GTP asserts (since that isn't yet separated out), but also because we need to make sure the SEID is correct.