### PR TITLE
[MME] Set TAI list of InitialContextSetupRequest in S1AP/NAS-EPS for …

### DIFF
--- a/lib/nas/eps/types.c
+++ b/lib/nas/eps/types.c
@@ -91,3 +91,33 @@ int ogs_nas_tai_list_build(ogs_nas_tracking_area_identity_list_t *target,
 
     return OGS_OK;
 }
+
+int ogs_nas_tai_list_build_for_oai(ogs_nas_tracking_area_identity_list_t *target,
+        ogs_eps_tai_t *tai)
+{
+    int size = 0;
+
+    ogs_eps_tai2_list_t target2;
+    ogs_nas_plmn_id_t ogs_nas_plmn_id;
+
+    ogs_assert(target);
+    ogs_assert(tai);
+
+    memset(target, 0, sizeof(ogs_nas_tracking_area_identity_list_t));
+    memset(&target2, 0, sizeof(ogs_eps_tai2_list_t));
+
+    size = 1 + (3 + 2);
+
+    target2.type = OGS_TAI1_TYPE;
+    target2.num = 0;
+
+    memcpy(&target2.tai[0].plmn_id,
+           ogs_nas_from_plmn_id(&ogs_nas_plmn_id, &tai->plmn_id),
+           OGS_PLMN_ID_LEN);
+    target2.tai[0].tac = htobe16(tai->tac);
+
+    memcpy(target->buffer + target->length, &target2, size);
+    target->length += size;
+
+    return OGS_OK;
+}

--- a/lib/nas/eps/types.h
+++ b/lib/nas/eps/types.h
@@ -559,6 +559,9 @@ typedef struct ogs_nas_tracking_area_identity_list_s {
 int ogs_nas_tai_list_build(ogs_nas_tracking_area_identity_list_t *target,
         ogs_eps_tai0_list_t *source0, ogs_eps_tai2_list_t *source2);
 
+int ogs_nas_tai_list_build_for_oai(ogs_nas_tracking_area_identity_list_t *target,
+        ogs_eps_tai_t *tai);
+
 
 /* 9.9.3.35 UE radio capability information update needed
  * O TV 1 */

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -150,10 +150,16 @@ ogs_pkbuf_t *emm_build_attach_accept(
     ogs_debug("    SERVED_TAI_INDEX[%d]", served_tai_index);
     ogs_assert(served_tai_index >= 0 &&
             served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI);
-    ogs_assert(OGS_OK ==
-        ogs_nas_tai_list_build(&attach_accept->tai_list,
-            &mme_self()->served_tai[served_tai_index].list0,
-            &mme_self()->served_tai[served_tai_index].list2));
+    if (ogs_app()->parameter.use_openair == false) {
+        ogs_assert(OGS_OK ==
+            ogs_nas_tai_list_build(&attach_accept->tai_list,
+                &mme_self()->served_tai[served_tai_index].list0,
+                &mme_self()->served_tai[served_tai_index].list2));
+    } else {
+        ogs_assert(OGS_OK ==
+            ogs_nas_tai_list_build_for_oai(&attach_accept->tai_list,
+                &mme_ue->tai));
+    }
 
     attach_accept->esm_message_container.buffer = esmbuf->data;
     attach_accept->esm_message_container.length = esmbuf->len;


### PR DESCRIPTION
…UE/RAN of OAI.

When using OAI for UE/RAN (use_openair == true), set TAI list of InitialContextSetupRequest to TAI (PLMN x 1, TAC x 1). The TAI information at this time is used by copying the mme_ue->tai information as is. The reason is that OAI can parse the TAI list of InitialContextSetupRequest in S1AP/NAS-EPS only in this format, but fails to parse the TAI list in other formats, such as the following.

- (PLMN x 1, TAC x n)
- (PLMN x 1, TAC x 1) x n

In mme section of mme.yaml
```
mme:
    ...
    tai:
      plmn_id:
        mcc: 999
        mnc: 70
      tac: [1, 2]
```
or
```
mme:
    ...
    tai:
      - plmn_id:
          mcc: 999
          mnc: 70
        tac: 1
      - plmn_id:
          mcc: 999
          mnc: 70
        tac: 2
```
If configured as above, TAI list in InitialContextSetupRequest in S1AP/NAS-EPS will be sent to UE/RAN with values in such format, but OAI will fail to process this format data.

When trying functions of Open5GS CUPS-EPC, it is very convenient to use OAI's UE/RAN simulator and so I will pull request this.

The version of OAI used is v1.0.3 in the following.

https://github.com/s5uishida/open5gs_epc_oai_sample_config