### PR TITLE
swap CP and UP SEIDs in ogs_info log messages

### DIFF
--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -154,7 +154,7 @@ sgwu_sess_t *sgwu_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
     ogs_hash_set(self.seid_hash, &sess->sgwc_sxa_f_seid.seid,
             sizeof(sess->sgwc_sxa_f_seid.seid), sess);
 
-    ogs_info("UE F-SEID[CP:0x%lx UP:0x%lx]",
+    ogs_info("UE F-SEID[UP:0x%lx CP:0x%lx]",
         (long)sess->sgwu_sxa_seid, (long)sess->sgwc_sxa_f_seid.seid);
 
     ogs_list_add(&self.sess_list, sess);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -394,7 +394,7 @@ uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
                 pdr->dnn ? pdr->dnn : "");
     }
 
-    ogs_info("UE F-SEID[CP:0x%lx UP:0x%lx] "
+    ogs_info("UE F-SEID[UP:0x%lx CP:0x%lx] "
              "APN[%s] PDN-Type[%d] IPv4[%s] IPv6[%s]",
         (long)sess->upf_n4_seid, (long)sess->smf_n4_f_seid.seid,
         pdr->dnn, session_type,


### PR DESCRIPTION
To my understanding, the CP SEID is generated by the control plane functions {sgwc, smf} and the UP SEID is generated by the user plane functions {sgwu, upf}. The ogs_info log messages currently have this backwards.