### PR TITLE
[MME] Add MME Initiated Detach Functions

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -543,12 +543,29 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e)
 
             CLEAR_MME_UE_TIMER(mme_ue->t3422);
 
-            rv = s1ap_send_ue_context_release_command(enb_ue,
-                    S1AP_Cause_PR_nas, S1AP_CauseNas_detach,
-                    S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0);
-            ogs_expect(rv == OGS_OK);
+            switch (mme_ue->detach_type) {
+            case MME_DETACH_TYPE_MME_EXPLICIT:
+                rv = s1ap_send_ue_context_release_command(enb_ue,
+                        S1AP_Cause_PR_nas, S1AP_CauseNas_detach,
+                        S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0);
+                ogs_expect(rv == OGS_OK);
+                OGS_FSM_TRAN(s, &emm_state_de_registered);
+                break;
 
-            OGS_FSM_TRAN(s, &emm_state_de_registered);
+            case MME_DETACH_TYPE_HSS_EXPLICIT:
+                rv = s1ap_send_ue_context_release_command(enb_ue,
+                        S1AP_Cause_PR_nas, S1AP_CauseNas_detach,
+                        S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0);
+                ogs_expect(rv == OGS_OK);
+                OGS_FSM_TRAN(s, &emm_state_de_registered);
+                break;
+
+            default:
+                ogs_error("[%s] Invalid Detach Type for Detach Accept",
+                        mme_ue->imsi_bcd);
+                break;
+            }
+
             break;
 
         case OGS_NAS_EPS_UPLINK_NAS_TRANSPORT:

--- a/src/mme/mme-path.h
+++ b/src/mme/mme-path.h
@@ -32,6 +32,9 @@ void mme_send_release_access_bearer_or_ue_context_release(enb_ue_t *enb_ue);
 
 void mme_send_after_paging(mme_ue_t *mme_ue, bool failed);
 
+void mme_detach_explicit(mme_ue_t *mme_ue, uint8_t reattach_required);
+void mme_detach_implicit(mme_ue_t *mme_ue);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Hi @acetcom,

Here with the follow up for this.

I have added two functions, one for each of the MME Initiated Detach scenarios.  Both have been tested with temporary internal code to trigger the functions.  I will be using the MME Explicit shortly as part of introducting Delete-Subscriber-Data.  The MME Implicit can be used in the future if we make use of something like the periodic_tau timer, followed by Purge-UE-Request to HSS.

As you had brought up about the conditional case where !SESSION_CONTEXT_IS_AVAILABLE(mme_ue) on MME Explicit Detach, I have decided to implement this on all the Network Detach cases.  If I was already checking for SESSION_CONTEXT, I best handle the negative case.  However, I feel this is rare, as we do not allow Attach without an active PDN context in open5gs.  But, it will be good to catch these abnormal cases.  In my testing, I wasn't able to trigger this branch of code.

The detach accept handling in emm-sm has been altered to account for MME Detach will retain the UE Context, however, the HSS Detach shall remove the UE Context.

