### PR TITLE
[AMF,UDM] Add support to subscribe to SDM changes

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -179,6 +179,10 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_termination_notification_free(message->TerminationNotification);
     if (message->DeregistrationData)
         OpenAPI_deregistration_data_free(message->DeregistrationData);
+    if (message->SDMSubscription)
+        OpenAPI_sdm_subscription_free(message->SDMSubscription);
+    if (message->ModificationNotification)
+        OpenAPI_modification_notification_free(message->ModificationNotification);
 
     /* HTTP Part */
     for (i = 0; i < message->num_of_part; i++) {
@@ -1022,6 +1026,15 @@ static char *build_json(ogs_sbi_message_t *message)
         item = OpenAPI_deregistration_data_convertToJSON(
                 message->DeregistrationData);
         ogs_assert(item);
+    } else if (message->SDMSubscription) {
+        item = OpenAPI_sdm_subscription_convertToJSON(
+                message->SDMSubscription);
+        ogs_assert(item);
+    }
+    else if (message->ModificationNotification) {
+        item = OpenAPI_modification_notification_convertToJSON(
+            message->ModificationNotification);
+        ogs_assert(item);
     }
 
     if (item) {
@@ -1323,6 +1336,15 @@ static int parse_json(ogs_sbi_message_t *message,
                         smsub_item = OpenAPI_session_management_subscription_data_parseFromJSON(smsubJSON);
                         OpenAPI_list_add(message->SessionManagementSubscriptionDataList, smsub_item);
                     }
+                }
+                break;
+
+            CASE(OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS)
+                message->SDMSubscription =
+                    OpenAPI_sdm_subscription_parseFromJSON(item);
+                if (!message->SDMSubscription) {
+                    rv = OGS_ERROR;
+                    ogs_error("JSON parse error");
                 }
                 break;
 
@@ -1864,6 +1886,15 @@ static int parse_json(ogs_sbi_message_t *message,
                 message->DeregistrationData =
                     OpenAPI_deregistration_data_parseFromJSON(item);
                 if (!message->DeregistrationData) {
+                    rv = OGS_ERROR;
+                    ogs_error("JSON parse error");
+                }
+                break;
+
+            CASE(OGS_SBI_RESOURCE_NAME_SDMSUBSCRIPTION_NOTIFY)
+                message->ModificationNotification =
+                    OpenAPI_modification_notification_parseFromJSON(item);
+                if (!message->ModificationNotification) {
                     rv = OGS_ERROR;
                     ogs_error("JSON parse error");
                 }

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -95,6 +95,7 @@ extern "C" {
 #define OGS_SBI_RESOURCE_NAME_UE_CONTEXT_IN_SMF_DATA "ue-context-in-smf-data"
 #define OGS_SBI_RESOURCE_NAME_SMF_SELECTION_SUBSCRIPTION_DATA \
                                             "smf-selection-subscription-data"
+#define OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS     "sdm-subscriptions"
 
 #define OGS_SBI_RESOURCE_NAME_SECURITY_INFORMATION  "security-information"
 #define OGS_SBI_RESOURCE_NAME_GENERATE_AUTH_DATA    "generate-auth-data"
@@ -126,6 +127,8 @@ extern "C" {
 #define OGS_SBI_RESOURCE_NAME_SM_CONTEXT_STATUS     "sm-context-status"
 #define OGS_SBI_RESOURCE_NAME_AM_POLICY_NOTIFY      "am-policy-notify"
 #define OGS_SBI_RESOURCE_NAME_DEREG_NOTIFY          "dereg-notify"
+#define OGS_SBI_RESOURCE_NAME_SDMSUBSCRIPTION_NOTIFY \
+                                            "sdmsubscription-notify"
 
 #define OGS_SBI_RESOURCE_NAME_POLICIES              "policies"
 #define OGS_SBI_RESOURCE_NAME_SM_POLICIES           "sm-policies"
@@ -452,6 +455,8 @@ typedef struct ogs_sbi_message_s {
     OpenAPI_sm_policy_notification_t *SmPolicyNotification;
     OpenAPI_termination_notification_t *TerminationNotification;
     OpenAPI_deregistration_data_t *DeregistrationData;
+    OpenAPI_sdm_subscription_t *SDMSubscription;
+    OpenAPI_modification_notification_t *ModificationNotification;
 
     ogs_sbi_links_t *links;
 

--- a/lib/sbi/ogs-sbi.h
+++ b/lib/sbi/ogs-sbi.h
@@ -75,6 +75,8 @@
 #include "model/sm_policy_notification.h"
 #include "model/termination_notification.h"
 #include "model/deregistration_data.h"
+#include "model/sdm_subscription.h"
+#include "model/modification_notification.h"
 
 #include "custom/links.h"
 #include "custom/ue_authentication_ctx.h"

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -213,6 +213,11 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 amf_namf_callback_handle_dereg_notify(stream, &sbi_message);
                 break;
 
+            CASE(OGS_SBI_RESOURCE_NAME_SDMSUBSCRIPTION_NOTIFY)
+                amf_namf_callback_handle_sdm_data_change_notify(
+                        stream, &sbi_message);
+                break;
+
             CASE(OGS_SBI_RESOURCE_NAME_AM_POLICY_NOTIFY)
                 ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
                 break;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1387,6 +1387,8 @@ void amf_ue_remove(amf_ue_t *amf_ue)
 
     if (amf_ue->policy_association_id)
         ogs_free(amf_ue->policy_association_id);
+    if (amf_ue->data_change_subscription_id)
+        ogs_free(amf_ue->data_change_subscription_id);
 
     if (amf_ue->confirmation_url_for_5g_aka)
         ogs_free(amf_ue->confirmation_url_for_5g_aka);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -393,6 +393,9 @@ struct amf_ue_s {
     /* Network Initiated De-Registration */
     bool network_initiated_de_reg;
 
+    /* SubscriptionId of Subscription to Data Change Notification to UDM */
+    char *data_change_subscription_id;
+
     ogs_list_t      sess_list;
 };
 

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -988,6 +988,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             SWITCH(sbi_message->h.resource.component[1])
             CASE(OGS_SBI_RESOURCE_NAME_REGISTRATIONS)
                 if (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED &&
+                    sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT &&
                     sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) {
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
@@ -1027,7 +1028,9 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             CASE(OGS_SBI_RESOURCE_NAME_AM_DATA)
             CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
             CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXT_IN_SMF_DATA)
-                if (sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) {
+            CASE(OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS)
+                if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
+                    (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED)) {
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
                     ogs_assert(OGS_OK ==

--- a/src/amf/namf-handler.h
+++ b/src/amf/namf-handler.h
@@ -32,6 +32,8 @@ int amf_namf_callback_handle_sm_context_status(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 int amf_namf_callback_handle_dereg_notify(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_callback_handle_sdm_data_change_notify(
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/amf/nudm-build.h
+++ b/src/amf/nudm-build.h
@@ -31,6 +31,8 @@ ogs_sbi_request_t *amf_nudm_uecm_build_registration(
 ogs_sbi_request_t *amf_nudm_uecm_build_registration_delete(
         amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nudm_sdm_build_get(amf_ue_t *amf_ue, void *data);
+ogs_sbi_request_t *amf_nudm_sdm_build_subscription(
+        amf_ue_t *amf_ue, void *data);
 
 #ifdef __cplusplus
 }

--- a/src/udm/context.c
+++ b/src/udm/context.c
@@ -188,6 +188,8 @@ void udm_ue_remove(udm_ue_t *udm_ue)
         ogs_free(udm_ue->amf_instance_id);
     if (udm_ue->dereg_callback_uri)
         ogs_free(udm_ue->dereg_callback_uri);
+    if (udm_ue->data_change_callback_uri)
+        ogs_free(udm_ue->data_change_callback_uri);
 
     ogs_pool_free(&udm_ue_pool, udm_ue);
 }

--- a/src/udm/context.h
+++ b/src/udm/context.h
@@ -58,6 +58,7 @@ struct udm_ue_s {
     char *amf_instance_id;
 
     char *dereg_callback_uri;
+    char *data_change_callback_uri;
 
     uint8_t k[OGS_KEY_LEN];
     uint8_t opc[OGS_KEY_LEN];

--- a/src/udm/nudm-handler.h
+++ b/src/udm/nudm-handler.h
@@ -38,6 +38,8 @@ bool udm_nudm_uecm_handle_registration_update(
 
 bool udm_nudm_sdm_handle_subscription_provisioned(
     udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+bool udm_nudm_sdm_handle_subscription_create(
+    udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -163,6 +163,23 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
                             "Invalid resource name", message->h.method));
                 END
                 break;
+
+            CASE(OGS_SBI_HTTP_METHOD_POST)
+                SWITCH(message->h.resource.component[1])
+                CASE(OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS)
+                    udm_nudm_sdm_handle_subscription_create(
+                            udm_ue, stream, message);
+                    break;
+
+                DEFAULT
+                    ogs_error("[%s] Invalid resource name [%s]",
+                            udm_ue->suci, message->h.resource.component[1]);
+                    ogs_assert(true ==
+                        ogs_sbi_server_send_error(stream,
+                            OGS_SBI_HTTP_STATUS_BAD_REQUEST, message,
+                            "Invalid resource name", message->h.method));
+                END
+                break;
             DEFAULT
                 ogs_error("[%s] Invalid HTTP method [%s]",
                         udm_ue->supi, message->h.method);


### PR DESCRIPTION
AMF subscribes to UDM for each registered UE.

At the moment, UDM does not send callback to AMF when any of the UE's properties in the database changes.
At the moment, AMF does properly parse the ModificationNotification, but does not do anything useful.