### PR TITLE
[docker] Fixate MongoDB version to version 5

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mongodb:
-    image: mongo
+    image: mongo:5
     container_name: open5gs-mongodb
     ports:
       - "27017:27017"


### PR DESCRIPTION
Recently the MongoDB was updated to version 6. New version dropped support for some commands that WebUI is using. When unsupported command is sent to MongoDB, WebUI crashes.

In case that MongoDB 6 upgrades the existing database contents, it is not possible to downgrade again to MongoDB 5 version.

https://www.mongodb.com/docs/v6.0/release-notes/6.0-compatibility/#legacy-opcodes-removed