### PR TITLE
[AMF] Increase size of TMSI pool

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -60,7 +60,7 @@ void amf_context_init(void)
     ogs_pool_init(&amf_ue_pool, ogs_app()->max.ue);
     ogs_pool_init(&ran_ue_pool, ogs_app()->max.ue);
     ogs_pool_init(&amf_sess_pool, ogs_app()->pool.sess);
-    ogs_pool_init(&self.m_tmsi, ogs_app()->max.ue);
+    ogs_pool_init(&self.m_tmsi, ogs_app()->max.ue*2);
 
     ogs_list_init(&self.gnb_list);
     ogs_list_init(&self.amf_ue_list);
@@ -2120,7 +2120,7 @@ int amf_m_tmsi_pool_generate()
     int index = 0;
 
     ogs_trace("M-TMSI Pool try to generate...");
-    for (i = 0; index < ogs_app()->max.ue; i++) {
+    for (i = 0; index < ogs_app()->max.ue*2; i++) {
         amf_m_tmsi_t *m_tmsi = NULL;
         int conflict = 0;
 


### PR DESCRIPTION
Each UE context has 'current' and 'next' TMSI values. AMF first allocates the 'next' value, before confirming it and releasing the 'previous'. This means that we potentially need pool size of 2x the amount of maximum configured UE.

Without this change, AMF would crash in case that there are 'x' configured maximum amount of UE, and there are already 'x' registered UE.

[gmm] INFO: Registration request (../src/amf/gmm-sm.c:135)
[gmm] INFO: [suci-0-001-01-1234-0-1-1000000000]    SUCI (../src/amf/gmm-handler.c:149)
[gmm] DEBUG:     OLD TSC[UE:0,AMF:0] KSI[UE:7,AMF:0] (../src/amf/gmm-handler.c:179)
[gmm] DEBUG:     NEW TSC[UE:0,AMF:0] KSI[UE:7,AMF:0] (../src/amf/gmm-handler.c:186)
[amf] FATAL: amf_m_tmsi_alloc: Assertion `m_tmsi' failed. (../src/amf/context.c:2160)
[core] FATAL: backtrace() returned 13 addresses (../lib/core/ogs-abort.c:37)