### PR TITLE
[AMF] Reject registration requests when pool for UE contexts is empty

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -800,7 +800,15 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             amf_ue = amf_ue_find_by_message(&nas_message);
             if (!amf_ue) {
                 amf_ue = amf_ue_add(ran_ue);
-                ogs_assert(amf_ue);
+                if (amf_ue == NULL) {
+                    ogs_expect(OGS_OK ==
+                        ngap_send_ran_ue_context_release_command(ran_ue,
+                            NGAP_Cause_PR_misc,
+                            NGAP_CauseMisc_control_processing_overload,
+                            NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0));
+                    ogs_pkbuf_free(pkbuf);
+                    return;
+                }
             } else {
                 /* Here, if the AMF_UE Context is found,
                  * the integrity check is not performed

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1063,7 +1063,11 @@ ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint32_t ran_ue_ngap_id)
     ogs_assert(gnb);
 
     ogs_pool_alloc(&ran_ue_pool, &ran_ue);
-    ogs_assert(ran_ue);
+    if (ran_ue == NULL) {
+        ogs_error("Could not allocate ran_ue context from pool");
+        return NULL;
+    }
+
     memset(ran_ue, 0, sizeof *ran_ue);
 
     ran_ue->t_ng_holding = ogs_timer_add(
@@ -1257,7 +1261,11 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
     ogs_assert(gnb);
 
     ogs_pool_alloc(&amf_ue_pool, &amf_ue);
-    ogs_assert(amf_ue);
+    if (amf_ue == NULL) {
+        ogs_error("Could not allocate amf_ue context from pool");
+        return NULL;
+    }
+
     memset(amf_ue, 0, sizeof *amf_ue);
 
     /* Add All Timers */

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -398,7 +398,13 @@ void ngap_handle_initial_ue_message(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     ran_ue = ran_ue_find_by_ran_ue_ngap_id(gnb, *RAN_UE_NGAP_ID);
     if (!ran_ue) {
         ran_ue = ran_ue_add(gnb, *RAN_UE_NGAP_ID);
-        ogs_assert(ran_ue);
+        if (ran_ue == NULL) {
+            ogs_assert(OGS_OK ==
+                ngap_send_error_indication(gnb, NULL, NULL,
+                    NGAP_Cause_PR_misc,
+                    NGAP_CauseMisc_control_processing_overload));
+            return;
+        }
 
         /* Find AMF_UE if 5G-S_TMSI included */
         if (FiveG_S_TMSI) {
@@ -2771,7 +2777,12 @@ void ngap_handle_handover_required(
 
     /* Target UE */
     target_ue = ran_ue_add(target_gnb, INVALID_UE_NGAP_ID);
-    ogs_assert(target_ue);
+    if (target_ue == NULL) {
+        ogs_assert(OGS_OK ==
+            ngap_send_error_indication2(amf_ue, NGAP_Cause_PR_misc,
+                NGAP_CauseMisc_control_processing_overload));
+        return;
+    }
 
     /* Source UE - Target UE associated */
     source_ue_associate_target_ue(source_ue, target_ue);


### PR DESCRIPTION
AMF does not crash anymore when a new UE registration request arrives, and there is no available space left in UE context pool. Now it just rejects the request with an error.