### PR TITLE
[DBI] Disable Change Streams with mongo Version

### DIFF
--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -352,8 +352,12 @@ int ogs_app_context_parse_config(void)
                         ogs_yaml_iter_bool(&parameter_iter);
                 } else if (!strcmp(parameter_key,
                             "use_mongodb_change_stream")) {
+#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
                     self.use_mongodb_change_stream = 
                         ogs_yaml_iter_bool(&parameter_iter);
+#else
+                    self.use_mongodb_change_stream = false;
+#endif
                 } else
                     ogs_warn("unknown key `%s`", parameter_key);
             }

--- a/lib/dbi/ogs-mongoc.c
+++ b/lib/dbi/ogs-mongoc.c
@@ -182,15 +182,18 @@ void ogs_dbi_final()
         mongoc_collection_destroy(self.collection.subscriber);
     }
 
+#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
     if (self.stream) {
         mongoc_change_stream_destroy(self.stream);
     }
+#endif
 
     ogs_mongoc_final();
 }
 
 int ogs_dbi_collection_watch_init(void)
 {
+#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
     bson_t empty = BSON_INITIALIZER;    
     const bson_t *err_doc;
     bson_error_t error;
@@ -213,10 +216,14 @@ int ogs_dbi_collection_watch_init(void)
     }
 
     return OGS_OK;
+# else
+    return OGS_ERROR;
+#endif
 }
 
 int ogs_dbi_poll_change_stream(void)
 {
+#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
     int rv;
     
     const bson_t *document;
@@ -240,4 +247,7 @@ int ogs_dbi_poll_change_stream(void)
     }
 
     return OGS_OK;
+# else
+    return OGS_ERROR;
+#endif
 }

--- a/lib/dbi/ogs-mongoc.h
+++ b/lib/dbi/ogs-mongoc.h
@@ -37,7 +37,9 @@ typedef struct ogs_mongoc_s {
     void *client;
     void *database;
 
+#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
     mongoc_change_stream_t *stream;
+#endif
 
     char *masked_db_uri;
 

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -1201,8 +1201,13 @@ int hss_handle_change_event(const bson_t *document)
 
     char *imsi_bcd;
 
+#if BSON_MAJOR_VERSION >= 1 && BSON_MINOR_VERSION >= 7
     char *as_json = bson_as_relaxed_extended_json(document, NULL);
-    ogs_debug("Got document: %s\n", as_json);
+    ogs_debug("Received change stream document: %s\n", as_json);
+    bson_free (as_json);
+# else
+    ogs_debug("Received change stream document.");
+#endif
     if (!bson_iter_init_find(&iter, document, "fullDocument")) {
         ogs_error("No 'imsi' field in this document.");
         return OGS_ERROR;
@@ -1275,8 +1280,6 @@ int hss_handle_change_event(const bson_t *document)
     } else {
         ogs_debug("No 'updateDescription' field in this document");
     }
-
-    bson_free (as_json);
 
     if (send_clr_flag) {
         ogs_info("[%s] Cancel Location Requested", imsi_bcd);


### PR DESCRIPTION
In response to this:

> Hi Folks, what version of the mongo-c-driver are you assuming? I'm asking because this appears to break compilation on my side. I'm building open5gs on AmazonLinux2, which comes with version 1.3.6 of the mongo-c-driver. See
> 
> ## In file included from ../lib/dbi/ogs-dbi.h:28:0,
> 592 | from ../lib/dbi/session.c:20: 
> 593 | ../lib/dbi/ogs-mongoc.h:40:5: error: unknown type name 'mongoc_change_stream_t' 
> 594 | mongoc_change_stream_t *stream; 
> 595 | ^~~~~~~~~~~~~~~~~~~~~~

_Originally posted by @rmerz in https://github.com/open5gs/open5gs/issues/1758#issuecomment-1275785067_
      

Support for change stream is only available in mongoc >=1.9.0
- Disabled related functions in dbi.

Support for bson to json used in debug statement only in libbson >=1.7.0
- Simple debug message displayed when using lower versions.