### PR TITLE
[MME] Attach Reject does not properly clear UE

### DIFF
--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -221,6 +221,8 @@ int esm_handle_information_response(mme_sess_t *sess,
             nas_eps_send_pdn_connectivity_reject(
                 sess, OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN,
                 OGS_GTP_CREATE_IN_ATTACH_REQUEST));
+
+        mme_ue_fsm_init(mme_ue);
         return OGS_ERROR;
     }
 

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -221,8 +221,6 @@ int esm_handle_information_response(mme_sess_t *sess,
             nas_eps_send_pdn_connectivity_reject(
                 sess, OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN,
                 OGS_GTP_CREATE_IN_ATTACH_REQUEST));
-
-        mme_ue_fsm_init(mme_ue);
         return OGS_ERROR;
     }
 

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -347,6 +347,7 @@ int nas_eps_send_pdn_connectivity_reject(
                     S1AP_Cause_PR_nas, S1AP_CauseNas_unspecified,
                     S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0));
         }
+        mme_ue_fsm_init(mme_ue);
     } else {
         esmbuf = esm_build_pdn_connectivity_reject(
                     sess, esm_cause, create_action);

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -339,7 +339,7 @@ int nas_eps_send_pdn_connectivity_reject(
         rv = nas_eps_send_attach_reject(mme_ue,
             OGS_NAS_EMM_CAUSE_EPS_SERVICES_AND_NON_EPS_SERVICES_NOT_ALLOWED, esm_cause);
         ogs_expect(rv == OGS_OK);
-        
+
         enb_ue = enb_ue_cycle(mme_ue->enb_ue);
         if (enb_ue) {
             ogs_assert(OGS_OK ==
@@ -347,8 +347,6 @@ int nas_eps_send_pdn_connectivity_reject(
                     S1AP_Cause_PR_nas, S1AP_CauseNas_unspecified,
                     S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0));
         }
-
-        OGS_FSM_TRAN(&mme_ue->sm, &emm_state_de_registered);
     } else {
         esmbuf = esm_build_pdn_connectivity_reject(
                     sess, esm_cause, create_action);

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -327,6 +327,7 @@ int nas_eps_send_pdn_connectivity_reject(
     int rv;
     mme_ue_t *mme_ue;
     ogs_pkbuf_t *esmbuf = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(sess);
     mme_ue = sess->mme_ue;
@@ -338,6 +339,16 @@ int nas_eps_send_pdn_connectivity_reject(
         rv = nas_eps_send_attach_reject(mme_ue,
             OGS_NAS_EMM_CAUSE_EPS_SERVICES_AND_NON_EPS_SERVICES_NOT_ALLOWED, esm_cause);
         ogs_expect(rv == OGS_OK);
+        
+        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        if (enb_ue) {
+            ogs_assert(OGS_OK ==
+                s1ap_send_ue_context_release_command(enb_ue,
+                    S1AP_Cause_PR_nas, S1AP_CauseNas_unspecified,
+                    S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0));
+        }
+
+        OGS_FSM_TRAN(&mme_ue->sm, &emm_state_de_registered);
     } else {
         esmbuf = esm_build_pdn_connectivity_reject(
                     sess, esm_cause, create_action);


### PR DESCRIPTION
When PDN requested at attach is missing from subscription resulting in Attach Reject and PDN connectivity reject (Missing or unknown APN), the device is unable to perform the next attach.  The UE context release is not immediate after the reject, and none of the UE state is cleaned up.

This change will immediately send the UE Context release after the rejection, and perform cleanup.