### PR TITLE
Add TLS support

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -372,6 +372,9 @@ static connection_t *connection_add(
         request->h.uri = uri;
     }
 
+    curl_easy_setopt(conn->easy, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(conn->easy, CURLOPT_SSL_VERIFYHOST, 0);
+
     /* HTTP Method */
     if (strcmp(request->h.method, OGS_SBI_HTTP_METHOD_PUT) == 0 ||
         strcmp(request->h.method, OGS_SBI_HTTP_METHOD_PATCH) == 0 ||

--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -56,6 +56,7 @@ typedef int (*ogs_sbi_client_cb_f)(
 
 typedef struct ogs_sbi_client_s {
     ogs_socknode_t  node;
+    OpenAPI_uri_scheme_e scheme;
 
     struct {
         const char  *key;

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1473,6 +1473,7 @@ static void nf_service_associate_client(ogs_sbi_nf_service_t *nf_service)
             client = ogs_sbi_client_find(addr);
             if (!client) {
                 client = ogs_sbi_client_add(addr);
+                client->scheme = nf_service->scheme;
                 ogs_assert(client);
             }
         }

--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -103,6 +103,8 @@ char *ogs_sbi_client_uri(ogs_sbi_client_t *client, ogs_sbi_header_t *h)
 
     if (client->tls.key && client->tls.pem)
         https = true;
+    else if (client->scheme == OpenAPI_uri_scheme_https)
+        https = true;
 
     return ogs_uridup(https, client->node.addr, h);
 }

--- a/lib/sbi/meson.build
+++ b/lib/sbi/meson.build
@@ -52,6 +52,8 @@ libsbi_inc = include_directories('.')
 sbi_cc_flags = ['-DOGS_SBI_COMPILATION']
 
 libgnutls_dep = cc.find_library('gnutls', required : true)
+libssl_dep = cc.find_library('ssl', required : true)
+libcrypto_dep = cc.find_library('crypto', required : true)
 libnghttp2_dep = dependency('libnghttp2', version: '>=1.18.1')
 libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.40')
 libcurl_dep = dependency('libcurl', version: '>=7.52.1')
@@ -65,6 +67,8 @@ libsbi = library('ogssbi',
                     libapp_dep,
                     libsbi_openapi_dep,
                     libgnutls_dep,
+                    libssl_dep,
+                    libcrypto_dep,
                     libnghttp2_dep,
                     libmicrohttpd_dep,
                     libcurl_dep],
@@ -78,6 +82,8 @@ libsbi_dep = declare_dependency(
                     libapp_dep,
                     libsbi_openapi_dep,
                     libgnutls_dep,
+                    libssl_dep,
+                    libcrypto_dep,
                     libnghttp2_dep,
                     libmicrohttpd_dep,
                     libcurl_dep])

--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -598,8 +598,8 @@ static void session_remove(ogs_sbi_session_t *sbi_sess)
     stream_remove_all(sbi_sess);
     nghttp2_session_del(sbi_sess->session);
 
-    ogs_assert(sbi_sess->poll.read);
-    ogs_pollset_remove(sbi_sess->poll.read);
+    if (sbi_sess->poll.read)
+        ogs_pollset_remove(sbi_sess->poll.read);
 
     if (sbi_sess->poll.write)
         ogs_pollset_remove(sbi_sess->poll.write);
@@ -661,13 +661,12 @@ static void accept_handler(short when, ogs_socket_t fd, void *data)
     ogs_assert(sbi_sess);
 
     if (sbi_sess->ssl) {
-        int err ;
+        int err;
         SSL_set_fd(sbi_sess->ssl, new->fd);
         SSL_set_accept_state(sbi_sess->ssl);
         err = SSL_accept(sbi_sess->ssl);
         if (err <= 0) {
             ogs_error("SSL_accept failed: %s", ERR_error_string(ERR_get_error(), NULL));
-            ogs_sock_destroy(new);
             session_remove(sbi_sess);
             return;
         }

--- a/lib/sbi/server.h
+++ b/lib/sbi/server.h
@@ -28,6 +28,9 @@
 extern "C" {
 #endif
 
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
 typedef struct ogs_sbi_stream_s ogs_sbi_stream_t;
 
 typedef struct ogs_sbi_server_s {
@@ -38,6 +41,8 @@ typedef struct ogs_sbi_server_s {
         const char  *key;
         const char  *pem;
     } tls;
+
+    SSL_CTX *ssl_ctx;
 
     int (*cb)(ogs_sbi_request_t *request, void *data);
     ogs_list_t      session_list;


### PR DESCRIPTION
This TLS support is currently implemented only on NF HTTP2 server side to get encrypted traffic between NFs.
It is still not implemented that client checks server certificate and that server checks client certificate. That's left for the next phase.

https://github.com/open5gs/open5gs/issues/754

https://github.com/open5gs/open5gs/discussions/1102