### PR TITLE
Per https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2, http/2 headers must be lower case.

### DIFF
--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -235,8 +235,8 @@ extern "C" {
 
 #define OGS_SBI_SCHEME                              ":scheme"
 #define OGS_SBI_AUTHORITY                           ":authority"
-#define OGS_SBI_ACCEPT                              "Accept"
-#define OGS_SBI_ACCEPT_ENCODING                     "Accept-Encoding"
+#define OGS_SBI_ACCEPT                              "accept"
+#define OGS_SBI_ACCEPT_ENCODING                     "accept-encoding"
 #define OGS_SBI_USER_AGENT                          "user-agent"
 #define OGS_SBI_CONTENT_TYPE                        "Content-Type"
 #define OGS_SBI_LOCATION                            "Location"

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -237,7 +237,7 @@ extern "C" {
 #define OGS_SBI_AUTHORITY                           ":authority"
 #define OGS_SBI_ACCEPT                              "Accept"
 #define OGS_SBI_ACCEPT_ENCODING                     "Accept-Encoding"
-#define OGS_SBI_USER_AGENT                          "User-Agent"
+#define OGS_SBI_USER_AGENT                          "user-agent"
 #define OGS_SBI_CONTENT_TYPE                        "Content-Type"
 #define OGS_SBI_LOCATION                            "Location"
 #define OGS_SBI_EXPECT                              "Expect"


### PR DESCRIPTION
Currently, User-Agent vs. user-agent causes issues with third party http/2 clients making SBI calls.
