### PR TITLE
Build webui from local source

### DIFF
--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -2,15 +2,7 @@ FROM node:19
 
 MAINTAINER Sukchan Lee <acetcom@gmail.com>
 
-ARG PACKAGE=open5gs
-ARG VERSION=2.5.5
-
-RUN set -e; \
-    cd /usr/src; \
-    rm -rf ./$PACKAGE; \
-    curl -SLO "https://github.com/open5gs/$PACKAGE/archive/v$VERSION.tar.gz"; \
-    tar -xvf v$VERSION.tar.gz; \
-    mv ./$PACKAGE-$VERSION/ ./$PACKAGE;
+COPY webui /usr/src/open5gs/webui
 
 WORKDIR /usr/src/open5gs/webui
 RUN npm clean-install && \


### PR DESCRIPTION
Use local copy of source code to build webui,
instead of downloading the code from Github.