### PR TITLE
Allow setting updating session rules in Npcf_SMPolicyControl service

### DIFF
--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -868,6 +868,40 @@ void ogs_sbi_free_pcc_rule(OpenAPI_pcc_rule_t *PccRule)
     ogs_free(PccRule);
 }
 
+void ogs_sbi_free_sess_rule(OpenAPI_session_rule_t *SessRule)
+{
+    ogs_assert(SessRule);
+    if (SessRule->auth_sess_ambr) {
+        if (SessRule->auth_sess_ambr->downlink)
+            ogs_free(SessRule->auth_sess_ambr->downlink);
+        if (SessRule->auth_sess_ambr->uplink)
+            ogs_free(SessRule->auth_sess_ambr->uplink);
+        ogs_free(SessRule->auth_sess_ambr);
+    }
+    if (SessRule->auth_def_qos) {
+        if (SessRule->auth_def_qos->arp)
+            ogs_free(SessRule->auth_def_qos->arp);
+        if (SessRule->auth_def_qos->maxbr_ul)
+            ogs_free(SessRule->auth_def_qos->maxbr_ul);
+        if (SessRule->auth_def_qos->maxbr_dl)
+            ogs_free(SessRule->auth_def_qos->maxbr_dl);
+        if (SessRule->auth_def_qos->gbr_ul)
+            ogs_free(SessRule->auth_def_qos->gbr_ul);
+        if (SessRule->auth_def_qos->gbr_dl)
+            ogs_free(SessRule->auth_def_qos->gbr_dl);
+        ogs_free(SessRule->auth_def_qos);
+    }
+    if (SessRule->sess_rule_id)
+        ogs_free(SessRule->sess_rule_id);
+    if (SessRule->ref_um_data)
+        ogs_free(SessRule->ref_um_data);
+    if (SessRule->ref_um_n3g_data)
+        ogs_free(SessRule->ref_um_n3g_data);
+    if (SessRule->ref_cond_data)
+        ogs_free(SessRule->ref_cond_data);
+    ogs_free(SessRule);
+}
+
 OpenAPI_qos_data_t *ogs_sbi_build_qos_data(ogs_pcc_rule_t *pcc_rule)
 {
     OpenAPI_qos_data_t *QosData = NULL;

--- a/lib/sbi/conv.h
+++ b/lib/sbi/conv.h
@@ -88,6 +88,8 @@ void ogs_sbi_free_pcc_rule(OpenAPI_pcc_rule_t *PccRule);
 OpenAPI_qos_data_t *ogs_sbi_build_qos_data(ogs_pcc_rule_t *pcc_rule);
 void ogs_sbi_free_qos_data(OpenAPI_qos_data_t *QosData);
 
+void ogs_sbi_free_sess_rule(OpenAPI_session_rule_t *SessRule);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -416,6 +416,10 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     OpenAPI_map_t *QosDecisionMap = NULL;
     OpenAPI_qos_data_t *QosData = NULL;
 
+    OpenAPI_list_t *SessRuleList = NULL;
+    OpenAPI_map_t *SessRuleMap = NULL;
+    OpenAPI_session_rule_t *SessRule = NULL;
+
     OpenAPI_lnode_t *node = NULL, *node2 = NULL, *node3 = NULL;
 
     ogs_assert(sess);
@@ -582,6 +586,9 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
 
     QosDecisionList = OpenAPI_list_create();
     ogs_assert(QosDecisionList);
+
+    SessRuleList = OpenAPI_list_create();
+    ogs_assert(SessRuleList);
 
     for (i = 0; i < ims_data.num_of_media_component; i++) {
         int flow_presence = 0;
@@ -751,6 +758,9 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     if (QosDecisionList->count)
         SmPolicyDecision.qos_decs = QosDecisionList;
 
+    if (SessRuleList->count)
+        SmPolicyDecision.sess_rules = SessRuleList;
+
     memset(&sendmsg, 0, sizeof(sendmsg));
 
     memset(&header, 0, sizeof(header));
@@ -769,7 +779,7 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
 
     ogs_free(sendmsg.http.location);
 
-    if (PccRuleList->count || QosDecisionList->count) {
+    if (PccRuleList->count || QosDecisionList->count || SessRuleList->count) {
         ogs_assert(true == pcf_sbi_send_smpolicycontrol_update_notify(
                                 sess, &SmPolicyDecision));
     }
@@ -795,6 +805,17 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
         }
     }
     OpenAPI_list_free(QosDecisionList);
+
+    OpenAPI_list_for_each(SessRuleList, node) {
+        SessRuleMap = node->data;
+        if (SessRuleMap) {
+            SessRule = SessRuleMap->value;
+            if (SessRule)
+                ogs_sbi_free_sess_rule(SessRule);
+            ogs_free(SessRuleMap);
+        }
+    }
+    OpenAPI_list_free(SessRuleList);
 
     ogs_ims_data_free(&ims_data);
     ogs_session_data_free(&session_data);
@@ -877,6 +898,10 @@ bool pcf_npcf_policyauthorization_handle_update(
     OpenAPI_list_t *QosDecisionList = NULL;
     OpenAPI_map_t *QosDecisionMap = NULL;
     OpenAPI_qos_data_t *QosData = NULL;
+
+    OpenAPI_list_t *SessRuleList = NULL;
+    OpenAPI_map_t *SessRuleMap = NULL;
+    OpenAPI_session_rule_t *SessRule = NULL;
 
     OpenAPI_lnode_t *node = NULL, *node2 = NULL, *node3 = NULL;
 
@@ -995,6 +1020,9 @@ bool pcf_npcf_policyauthorization_handle_update(
 
     QosDecisionList = OpenAPI_list_create();
     ogs_assert(QosDecisionList);
+
+    SessRuleList = OpenAPI_list_create();
+    ogs_assert(SessRuleList);
 
     for (i = 0; i < ims_data.num_of_media_component; i++) {
         int flow_presence = 0;
@@ -1163,6 +1191,9 @@ bool pcf_npcf_policyauthorization_handle_update(
     if (QosDecisionList->count)
         SmPolicyDecision.qos_decs = QosDecisionList;
 
+    if (SessRuleList->count)
+        SmPolicyDecision.sess_rules = SessRuleList;
+
     memset(&sendmsg, 0, sizeof(sendmsg));
 
     sendmsg.AppSessionContextUpdateDataPatch =
@@ -1172,7 +1203,7 @@ bool pcf_npcf_policyauthorization_handle_update(
     ogs_assert(response);
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 
-    if (PccRuleList->count || QosDecisionList->count) {
+    if (PccRuleList->count || QosDecisionList->count || SessRuleList->count) {
         ogs_assert(true == pcf_sbi_send_smpolicycontrol_update_notify(
                             sess, &SmPolicyDecision));
     }
@@ -1187,6 +1218,17 @@ bool pcf_npcf_policyauthorization_handle_update(
         }
     }
     OpenAPI_list_free(PccRuleList);
+
+    OpenAPI_list_for_each(SessRuleList, node) {
+        SessRuleMap = node->data;
+        if (SessRuleMap) {
+            SessRule = SessRuleMap->value;
+            if (SessRule)
+                ogs_sbi_free_sess_rule(SessRule);
+            ogs_free(SessRuleMap);
+        }
+    }
+    OpenAPI_list_free(SessRuleList);
 
     OpenAPI_list_for_each(QosDecisionList, node) {
         QosDecisionMap = node->data;
@@ -1222,6 +1264,17 @@ cleanup:
         }
     }
     OpenAPI_list_free(PccRuleList);
+
+    OpenAPI_list_for_each(SessRuleList, node) {
+        SessRuleMap = node->data;
+        if (SessRuleMap) {
+            SessRule = SessRuleMap->value;
+            if (SessRule)
+                ogs_sbi_free_sess_rule(SessRule);
+            ogs_free(SessRuleMap);
+        }
+    }
+    OpenAPI_list_free(SessRuleList);
 
     OpenAPI_list_for_each(QosDecisionList, node) {
         QosDecisionMap = node->data;

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -447,7 +447,7 @@ int smf_gtp2_send_create_bearer_request(smf_bearer_t *bearer)
     return rv;
 }
 
-void smf_qos_flow_binding(smf_sess_t *sess)
+void smf_qos_flow_binding(smf_sess_t *sess, bool default_rules_updated)
 {
     int rv;
     int i, j;
@@ -459,6 +459,17 @@ void smf_qos_flow_binding(smf_sess_t *sess)
     pfcp_flags = OGS_PFCP_MODIFY_NETWORK_REQUESTED;
 
     ogs_list_init(&sess->qos_flow_to_modify_list);
+
+    if (default_rules_updated) {
+        smf_bearer_t *qos_flow = smf_default_bearer_in_sess(sess);
+        ogs_assert(qos_flow);
+        ogs_assert(qos_flow->qer);
+        qos_flow->qer->mbr.uplink = sess->session.ambr.uplink;
+        qos_flow->qer->mbr.downlink = sess->session.ambr.downlink;
+        pfcp_flags |= OGS_PFCP_MODIFY_QOS_MODIFY;
+        ogs_list_add(&sess->qos_flow_to_modify_list,
+                                &qos_flow->to_modify_node);
+    }
 
     for (i = 0; i < sess->policy.num_of_pcc_rule; i++) {
         smf_bearer_t *qos_flow = NULL;

--- a/src/smf/binding.h
+++ b/src/smf/binding.h
@@ -29,7 +29,7 @@ extern "C" {
 void smf_bearer_binding(smf_sess_t *sess);
 int smf_gtp2_send_create_bearer_request(smf_bearer_t *bearer);
 
-void smf_qos_flow_binding(smf_sess_t *sess);
+void smf_qos_flow_binding(smf_sess_t *sess, bool default_rules_updated);
 
 #ifdef __cplusplus
 }

--- a/src/smf/namf-handler.c
+++ b/src/smf/namf-handler.c
@@ -37,7 +37,7 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
     switch (state) {
     case SMF_UE_REQUESTED_PDU_SESSION_ESTABLISHMENT:
         if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_OK) {
-            smf_qos_flow_binding(sess);
+            smf_qos_flow_binding(sess, false);
         } else {
             ogs_error("[%s:%d] HTTP response error [%d]",
                 smf_ue->supi, sess->psi, recvmsg->res_status);

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -268,6 +268,110 @@ static void update_authorized_pcc_rule_and_qos(
     }
 }
 
+static bool update_default_session_rules(
+        smf_sess_t *sess, OpenAPI_sm_policy_decision_t *SmPolicyDecision)
+{
+    OpenAPI_lnode_t *node = NULL;
+
+    ogs_assert(sess);
+    ogs_assert(SmPolicyDecision);
+
+    bool session_changed = false;
+    smf_bearer_t *qos_flow = smf_default_bearer_in_sess(sess);
+
+    if (SmPolicyDecision->sess_rules) {
+        OpenAPI_map_t *SessRuleMap = NULL;
+        OpenAPI_session_rule_t *SessionRule = NULL;
+
+        OpenAPI_ambr_t *AuthSessAmbr = NULL;
+        OpenAPI_authorized_default_qos_t *AuthDefQos = NULL;
+
+        OpenAPI_list_for_each(SmPolicyDecision->sess_rules, node) {
+            SessRuleMap = node->data;
+            if (!SessRuleMap) {
+                ogs_error("No SessRuleMap");
+                continue;
+            }
+
+            SessionRule = SessRuleMap->value;
+            if (!SessionRule) {
+                ogs_error("No SessionRule");
+                continue;
+            }
+
+            AuthSessAmbr = SessionRule->auth_sess_ambr;
+            if (AuthSessAmbr) {
+                if (AuthSessAmbr->uplink) {
+                    uint64_t uplink_ambr = ogs_sbi_bitrate_from_string(AuthSessAmbr->uplink);
+                    if (qos_flow && qos_flow->qos.mbr.uplink != uplink_ambr)
+                        session_changed = true;
+                    sess->session.ambr.uplink = uplink_ambr;
+                }
+                if (AuthSessAmbr->downlink) {
+                    uint64_t downlink_ambr = ogs_sbi_bitrate_from_string(AuthSessAmbr->uplink);
+                    if (qos_flow && qos_flow->qos.mbr.downlink != downlink_ambr)
+                        session_changed = true;
+                    sess->session.ambr.downlink = downlink_ambr;
+                }
+            }
+
+            AuthDefQos = SessionRule->auth_def_qos;
+            if (AuthDefQos) {
+                if (qos_flow && (qos_flow->qos.index != AuthDefQos->_5qi ||
+                    qos_flow->qos.arp.priority_level != AuthDefQos->priority_level))
+                    session_changed = true;
+                sess->session.qos.index = AuthDefQos->_5qi;
+                sess->session.qos.arp.priority_level =
+                    AuthDefQos->priority_level;
+
+                if (AuthDefQos->arp) {
+                    if (qos_flow && (qos_flow->qos.arp.priority_level !=
+                        AuthDefQos->arp->priority_level))
+                        session_changed = true;
+                    sess->session.qos.arp.priority_level = AuthDefQos->arp->priority_level;
+
+                    if (AuthDefQos->arp->preempt_cap ==
+                        OpenAPI_preemption_capability_NOT_PREEMPT) {
+                        if (qos_flow && (qos_flow->qos.arp.pre_emption_capability
+                        != OGS_5GC_PRE_EMPTION_DISABLED))
+                            session_changed = true;
+                        sess->session.qos.arp.pre_emption_capability =
+                            OGS_5GC_PRE_EMPTION_DISABLED;
+                    }
+                    else if (AuthDefQos->arp->preempt_cap ==
+                        OpenAPI_preemption_capability_MAY_PREEMPT) {
+                        if (qos_flow && (qos_flow->qos.arp.pre_emption_capability !=
+                            OGS_5GC_PRE_EMPTION_ENABLED))
+                            session_changed = true;
+                        sess->session.qos.arp.pre_emption_capability =
+                            OGS_5GC_PRE_EMPTION_ENABLED;
+                    }
+                    ogs_assert(sess->session.qos.arp.pre_emption_capability);
+
+                    if (AuthDefQos->arp->preempt_vuln ==
+                        OpenAPI_preemption_vulnerability_NOT_PREEMPTABLE) {
+                        if (qos_flow && (qos_flow->qos.arp.pre_emption_vulnerability !=
+                            OGS_5GC_PRE_EMPTION_DISABLED))
+                            session_changed = true;
+                        sess->session.qos.arp.pre_emption_vulnerability =
+                            OGS_5GC_PRE_EMPTION_DISABLED;
+                    }
+                    else if (AuthDefQos->arp->preempt_vuln ==
+                        OpenAPI_preemption_vulnerability_PREEMPTABLE) {
+                        if (qos_flow && (qos_flow->qos.arp.pre_emption_vulnerability !=
+                            OGS_5GC_PRE_EMPTION_ENABLED))
+                            session_changed = true;
+                        sess->session.qos.arp.pre_emption_vulnerability =
+                            OGS_5GC_PRE_EMPTION_ENABLED;
+                    }
+                    ogs_assert(sess->session.qos.arp.pre_emption_vulnerability);
+                }
+            }
+        }
+    }
+    return session_changed;
+}
+
 bool smf_npcf_smpolicycontrol_handle_create(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, int state,
         ogs_sbi_message_t *recvmsg)
@@ -366,71 +470,8 @@ bool smf_npcf_smpolicycontrol_handle_create(
         }
     }
 
-    /* Update authorized session-AMBR */
-    if (SmPolicyDecision->sess_rules) {
-        OpenAPI_map_t *SessRuleMap = NULL;
-        OpenAPI_session_rule_t *SessionRule = NULL;
-
-        OpenAPI_ambr_t *AuthSessAmbr = NULL;
-        OpenAPI_authorized_default_qos_t *AuthDefQos = NULL;
-
-        OpenAPI_list_for_each(SmPolicyDecision->sess_rules, node) {
-            SessRuleMap = node->data;
-            if (!SessRuleMap) {
-                ogs_error("No SessRuleMap");
-                continue;
-            }
-
-            SessionRule = SessRuleMap->value;
-            if (!SessionRule) {
-                ogs_error("No SessionRule");
-                continue;
-            }
-
-
-            AuthSessAmbr = SessionRule->auth_sess_ambr;
-            if (AuthSessAmbr && trigger_results[
-                OpenAPI_policy_control_request_trigger_SE_AMBR_CH] == true) {
-                if (AuthSessAmbr->uplink)
-                    sess->session.ambr.uplink =
-                        ogs_sbi_bitrate_from_string(AuthSessAmbr->uplink);
-                if (AuthSessAmbr->downlink)
-                    sess->session.ambr.downlink =
-                        ogs_sbi_bitrate_from_string(AuthSessAmbr->downlink);
-            }
-
-            AuthDefQos = SessionRule->auth_def_qos;
-            if (AuthDefQos && trigger_results[
-                OpenAPI_policy_control_request_trigger_DEF_QOS_CH] == true) {
-                sess->session.qos.index = AuthDefQos->_5qi;
-                sess->session.qos.arp.priority_level =
-                    AuthDefQos->priority_level;
-                if (AuthDefQos->arp) {
-                    sess->session.qos.arp.priority_level =
-                            AuthDefQos->arp->priority_level;
-                    if (AuthDefQos->arp->preempt_cap ==
-                        OpenAPI_preemption_capability_NOT_PREEMPT)
-                        sess->session.qos.arp.pre_emption_capability =
-                            OGS_5GC_PRE_EMPTION_DISABLED;
-                    else if (AuthDefQos->arp->preempt_cap ==
-                        OpenAPI_preemption_capability_MAY_PREEMPT)
-                        sess->session.qos.arp.pre_emption_capability =
-                            OGS_5GC_PRE_EMPTION_ENABLED;
-                    ogs_assert(sess->session.qos.arp.pre_emption_capability);
-
-                    if (AuthDefQos->arp->preempt_vuln ==
-                        OpenAPI_preemption_vulnerability_NOT_PREEMPTABLE)
-                        sess->session.qos.arp.pre_emption_vulnerability =
-                            OGS_5GC_PRE_EMPTION_DISABLED;
-                    else if (AuthDefQos->arp->preempt_vuln ==
-                        OpenAPI_preemption_vulnerability_PREEMPTABLE)
-                        sess->session.qos.arp.pre_emption_vulnerability =
-                            OGS_5GC_PRE_EMPTION_ENABLED;
-                    ogs_assert(sess->session.qos.arp.pre_emption_vulnerability);
-                }
-            }
-        }
-    }
+    /* Update default session rules */
+    update_default_session_rules(sess, SmPolicyDecision);
 
     /* Update authorized PCC rule & QoS */
     update_authorized_pcc_rule_and_qos(sess, SmPolicyDecision);
@@ -643,12 +684,15 @@ bool smf_npcf_smpolicycontrol_handle_update_notify(
         goto cleanup;
     }
 
+    /* Update default session rules */
+    bool default_rules_updated = update_default_session_rules(sess, SmPolicyDecision);
+
     /* Update authorized PCC rule & QoS */
     update_authorized_pcc_rule_and_qos(sess, SmPolicyDecision);
 
     ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
 
-    smf_qos_flow_binding(sess);
+    smf_qos_flow_binding(sess, default_rules_updated);
 
     return true;
 


### PR DESCRIPTION
TS29.512 (4.2.6 Provisioning and Enforcement of Policy Decisions) state session rules can be enforced using the `Npcf_SMPolicyControl_Create`,  the `Npcf_SMPolicyControl_Update` and the `Npcf_SMPolicyControl_UpdateNotify`. The later can be used by the PCF to notify/enforce a given policy into the SMF (and later to the UPF via PFCP).
Unfortunately, open5gs lacks the respective processing of `SessionRules` from `SmPolicyDecisions` and the implementation of those updates. 

This PR extends the existing implementation allowing to change the overall session aggregate maximum bitrate (AMBR) during runtime (in addition to the already existing PCC rules).

--------

Taking advantage of this requires that an actual NF (on the SBI) provides a call to one of those methods and, unfortunately none exist at the moment in open5gs. Regardless, and just for the sake of completion, a callback from the PCF to the SMF can be externally simulated using the request below (provided that you "hack" the NF validation on the SBI) and have that PDU session (1) already established. 

```
diff --git a/lib/sbi/message.c b/lib/sbi/message.c
index 90ae995fd..0ca85562b 100644
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -691,11 +691,11 @@ int ogs_sbi_parse_request(
         }
     }
 
-    if (!message->http.requester_nf_type) {
-        ogs_error("No User-Agent in HTTP2 Header");
-        ogs_sbi_message_free(message);
-        return OGS_ERROR;
-    }
+    //if (!message->http.requester_nf_type) {
+    //    ogs_error("No User-Agent in HTTP2 Header");
+    //    ogs_sbi_message_free(message);
+    //    return OGS_ERROR;
+    //}
 
     if (parse_content(message, &request->http) != OGS_OK) {
         ogs_error("parse_content() failed");

``` 

```
curl -v -X POST --http2-prior-knowledge -H "User-Agent: test/test" -H 'Content-Type: application/json' http://127.0.0.4:7777/nsmf-callback/v1/sm-policy-notify/1/update -d '{"smPolicyDecision": {"sessRules": {"1": { "sessRuleId": "1", "authSessAmbr":{"uplink": "60 Mbps", "downlink": "60 Mbps"} }}}}'
```

In the request above `http://127.0.0.4:7777/nsmf-callback/v1/sm-policy-notify/1` is the `notification_uri` registered in `SMPolicyControl`. Default session AMBR is set to 60Mbps for both uplink and downlink.

Cheers