### PR TITLE
Build WebUI from local source

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       - ../docs/assets/webui/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
 
   webui:
-    build: webui
+    build:
+      context: ../
+      dockerfile: docker/webui/Dockerfile
     image: ${USER}/open5gs-webui
     container_name: open5gs-webui
     depends_on:

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -2,15 +2,7 @@ FROM node:19
 
 MAINTAINER Sukchan Lee <acetcom@gmail.com>
 
-ARG PACKAGE=open5gs
-ARG VERSION=2.5.5
-
-RUN set -e; \
-    cd /usr/src; \
-    rm -rf ./$PACKAGE; \
-    curl -SLO "https://github.com/open5gs/$PACKAGE/archive/v$VERSION.tar.gz"; \
-    tar -xvf v$VERSION.tar.gz; \
-    mv ./$PACKAGE-$VERSION/ ./$PACKAGE;
+COPY webui /usr/src/open5gs/webui
 
 WORKDIR /usr/src/open5gs/webui
 RUN npm clean-install && \


### PR DESCRIPTION
Use local copy of source code to build WebUI,
instead of downloading the code from Github.