### PR TITLE
[metrics] Fix log output for metrics

### DIFF
--- a/src/amf/init.c
+++ b/src/amf/init.c
@@ -49,12 +49,12 @@ int amf_initialize()
     rv = amf_m_tmsi_pool_generate();
     if (rv != OGS_OK) return rv;
 
-    rv = amf_metrics_open();
-    if (rv != 0) return OGS_ERROR;
-
     rv = ogs_log_config_domain(
             ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
+
+    rv = amf_metrics_open();
+    if (rv != 0) return OGS_ERROR;
 
     rv = amf_sbi_open();
     if (rv != OGS_OK) return rv;

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -55,15 +55,15 @@ int mme_initialize()
     rv = mme_context_parse_config();
     if (rv != OGS_OK) return rv;
 
-    rv = mme_metrics_open();
-    if (rv != 0) return OGS_ERROR;
-
     rv = ogs_log_config_domain(
             ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = mme_m_tmsi_pool_generate();
     if (rv != OGS_OK) return rv;
+
+    rv = mme_metrics_open();
+    if (rv != 0) return OGS_ERROR;
 
     rv = mme_fd_init();
     if (rv != OGS_OK) return OGS_ERROR;


### PR DESCRIPTION
Even if the configured log level for the application was set to "error", the first "info" message of the metrics library was output to the log. Reorder the initialization of the metrics library.