### PR TITLE
[metrics] Change order when to finalize metrics contexts

### DIFF
--- a/src/amf/init.c
+++ b/src/amf/init.c
@@ -102,10 +102,11 @@ void amf_terminate(void)
 
     ngap_close();
     amf_sbi_close();
-    amf_metrics_close();
 
     amf_context_final();
     ogs_sbi_context_final();
+
+    amf_metrics_close();
     ogs_metrics_context_final();
 }
 

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -124,8 +124,6 @@ void smf_terminate(void)
     smf_gtp_close();
     smf_pfcp_close();
     smf_sbi_close();
-    smf_metrics_close();
-
     smf_fd_final();
 
     smf_context_final();
@@ -133,6 +131,8 @@ void smf_terminate(void)
     ogs_pfcp_context_final();
     ogs_sbi_context_final();
     ogs_gtp_context_final();
+
+    smf_metrics_close();
     ogs_metrics_context_final();
 
     ogs_pfcp_xact_final();


### PR DESCRIPTION
Without this change, the NF would abort on application exit due to UE contexts being deallocated and metric values trying to decrement, but the metrics were already deallocated.