### PR TITLE
[AMF] Replace assert() with expect() when sending NGAP and SBI messages

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -749,7 +749,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_fsm_dispatch(&gnb->sm, e);
         } else {
             ogs_error("Cannot decode NGAP message");
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 ngap_send_error_indication(
                     gnb, NULL, NULL, NGAP_Cause_PR_protocol, 
                     NGAP_CauseProtocol_abstract_syntax_error_falsely_constructed_message));

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -630,7 +630,7 @@ ogs_nas_5gmm_cause_t gmm_handle_service_update(amf_ue_t *amf_ue,
     }
 
     if (amf_sess_xact_count(amf_ue) == xact_count)
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_service_accept(amf_ue));
 
     return OGS_5GMM_CAUSE_REQUEST_ACCEPTED;
@@ -719,7 +719,7 @@ int gmm_handle_authentication_response(amf_ue_t *amf_ue,
     memcpy(amf_ue->xres_star, authentication_response_parameter->res,
             authentication_response_parameter->length);
 
-    ogs_assert(true ==
+    ogs_expect(true ==
         amf_ue_sbi_discover_and_send(
             OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
             amf_nausf_auth_build_authenticate_confirmation, amf_ue, NULL));
@@ -1083,13 +1083,13 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                 }
 
                 if (nf_instance) {
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_sess_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                             amf_nsmf_pdusession_build_create_sm_context,
                             sess, AMF_CREATE_SM_CONTEXT_NO_STATE, NULL));
                 } else {
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_sess_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NNSSF_NSSELECTION, NULL,
                             amf_nnssf_nsselection_build_get, sess, 0, NULL));
@@ -1101,7 +1101,7 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                 param.release = 1;
                 param.cause = OpenAPI_cause_REL_DUE_TO_DUPLICATE_SESSION_ID;
 
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_sess_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                         amf_nsmf_pdusession_build_update_sm_context,
@@ -1128,14 +1128,14 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                 param.ue_location = true;
                 param.ue_timezone = true;
 
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_sess_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                         amf_nsmf_pdusession_build_update_sm_context,
                         sess, AMF_UPDATE_SM_CONTEXT_N1_RELEASED, &param));
             } else {
 
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_sess_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                         amf_nsmf_pdusession_build_update_sm_context,

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -175,7 +175,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
                     }
 
                     if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
-                        ogs_assert(true ==
+                        ogs_expect(true ==
                             amf_ue_sbi_discover_and_send(
                                 OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
                                 NULL,
@@ -200,7 +200,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
                 amf_sbi_send_release_all_sessions(
                         amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
                 if (amf_sess_xact_count(amf_ue) == xact_count) {
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_ue_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                             amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -278,7 +278,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             amf_sbi_send_release_all_sessions(
                     amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
             if (amf_sess_xact_count(amf_ue) == xact_count) {
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                         amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -308,7 +308,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             /* De-associate NG with NAS/EMM */
             ran_ue_deassociate(amf_ue->ran_ue);
 
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 ngap_send_ran_ue_context_release_command(amf_ue->ran_ue,
                     NGAP_Cause_PR_misc, NGAP_CauseMisc_om_intervention,
                     NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0));
@@ -406,7 +406,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             } else {
                 amf_ue->t3513.retry_count++;
                 /* If t3513 is timeout, the saved pkbuf is used.  */
-                ogs_assert(OGS_OK == ngap_send_paging(amf_ue));
+                ogs_expect(OGS_OK == ngap_send_paging(amf_ue));
             }
             break;
 
@@ -479,7 +479,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
                 CASE(OGS_SBI_HTTP_METHOD_DELETE)
 
                     if (!amf_ue->network_initiated_de_reg)
-                        ogs_assert(OGS_OK ==
+                        ogs_expect(OGS_OK ==
                             nas_5gs_send_de_registration_accept(amf_ue));
 
                     PCF_AM_POLICY_CLEAR(amf_ue);
@@ -587,7 +587,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
 
             case OGS_5GMM_CAUSE_NGKSI_ALREADY_IN_USE:
                 ogs_warn("Authentication failure(ngKSI already in use)");
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                         amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -600,7 +600,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                             authentication_failure_parameter->length);
                     break;
                 }
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                         amf_nausf_auth_build_authenticate,
@@ -633,7 +633,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                 break;
             }
 
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_ue_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                     amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -705,7 +705,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                         ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->suci, sbi_message->res_status);
                     }
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_gmm_reject_from_sbi(
                             amf_ue, sbi_message->res_status));
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -719,7 +719,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                     if (rv != OGS_OK) {
                         ogs_error("[%s] Cannot handle SBI message",
                                 amf_ue->suci);
-                        ogs_assert(OGS_OK ==
+                        ogs_expect(OGS_OK ==
                             nas_5gs_send_authentication_reject(amf_ue));
                         OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
                     }
@@ -730,7 +730,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                     if (rv != OGS_OK) {
                         ogs_error("[%s] Cannot handle SBI message",
                                 amf_ue->suci);
-                        ogs_assert(OGS_OK ==
+                        ogs_expect(OGS_OK ==
                             nas_5gs_send_authentication_reject(amf_ue));
                         OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
                     } else {
@@ -844,7 +844,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
             ogs_kdf_nh_gnb(amf_ue->kamf, amf_ue->kgnb, amf_ue->nh);
             amf_ue->nhcc = 1;
 
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_ue_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NUDM_UECM, NULL,
                     amf_nudm_uecm_build_registration, amf_ue, NULL));
@@ -880,7 +880,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
                 break;
             }
 
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_ue_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                     amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -999,7 +999,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) {
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_gmm_reject(
                             amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED));
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -1008,7 +1008,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
 
                 SWITCH(sbi_message->h.method)
                 CASE(OGS_SBI_HTTP_METHOD_PUT)
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_ue_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
                             amf_nudm_sdm_build_get,
@@ -1040,7 +1040,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED)) {
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_gmm_reject(
                             amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED));
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -1051,7 +1051,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                 if (rv != OGS_OK) {
                     ogs_error("[%s] amf_nudm_sdm_handle_provisioned(%s) failed",
                             amf_ue->supi, sbi_message->h.resource.component[1]);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_gmm_reject(
                             amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED));
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -1083,7 +1083,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     ogs_assert(amf_ue->nas.message_type ==
                             OGS_NAS_5GS_REGISTRATION_REQUEST);
                     CLEAR_AMF_UE_TIMER(amf_ue->t3550);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                             nas_5gs_send_registration_accept(amf_ue));
 
                     /* In nsmf-handler.c
@@ -1211,7 +1211,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             amf_sbi_send_release_all_sessions(
                     amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
             if (amf_sess_xact_count(amf_ue) == xact_count) {
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                         amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -1311,7 +1311,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
                 amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
 
         if (ogs_list_count(&amf_ue->sess_list) == 0)
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 ngap_send_amf_ue_context_release_command(amf_ue,
                     NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release,
                     NGAP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0));
@@ -1375,7 +1375,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
                     }
 
                     if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
-                        ogs_assert(true ==
+                        ogs_expect(true ==
                             amf_ue_sbi_discover_and_send(
                                 OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
                                 NULL,
@@ -1400,7 +1400,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
                 amf_sbi_send_release_all_sessions(
                         amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
                 if (amf_sess_xact_count(amf_ue) == xact_count) {
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_ue_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                             amf_nausf_auth_build_authenticate, amf_ue, NULL));

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -279,10 +279,10 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
                 AMF_SESS_STORE_N2_TRANSFER(
                         sess, pdu_session_resource_setup_request, n2buf);
 
-                ogs_assert(OGS_OK == ngap_send_paging(amf_ue));
+                ogs_expect(OGS_OK == ngap_send_paging(amf_ue));
 
             } else if (CM_CONNECTED(amf_ue)) {
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     ngap_send_pdu_resource_setup_request(sess, n2buf));
 
             } else {
@@ -338,7 +338,7 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
                     OGS_NAS_5GS_PDU_SESSION_MODIFICATION_COMMAND,
                     n1buf, n2buf);
 
-            ogs_assert(OGS_OK == ngap_send_paging(amf_ue));
+            ogs_expect(OGS_OK == ngap_send_paging(amf_ue));
 
         } else if (CM_CONNECTED(amf_ue)) {
             gmmbuf = gmm_build_dl_nas_transport(sess,
@@ -571,23 +571,23 @@ int amf_namf_callback_handle_dereg_notify(
     {
         amf_ue->network_initiated_de_reg = true;
 
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_de_registration_request(amf_ue,
                 DeregistrationData->dereg_reason));
 
-            amf_sbi_send_release_all_sessions(
-                amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
+        amf_sbi_send_release_all_sessions(
+            amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
 
-            if ((ogs_list_count(&amf_ue->sess_list) == 0) &&
-                (PCF_AM_POLICY_ASSOCIATED(amf_ue)))
-            {
-                ogs_assert(true ==
-                    amf_ue_sbi_discover_and_send(
-                        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
-                        amf_npcf_am_policy_control_build_delete, amf_ue, NULL));
-            }
+        if ((ogs_list_count(&amf_ue->sess_list) == 0) &&
+            (PCF_AM_POLICY_ASSOCIATED(amf_ue)))
+        {
+            ogs_expect(true ==
+                amf_ue_sbi_discover_and_send(
+                    OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
+                    amf_npcf_am_policy_control_build_delete, amf_ue, NULL));
+        }
 
-            OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_de_registered);
+        OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_de_registered);
     }
     else if (CM_IDLE(amf_ue)) {
         /* TODO: need to page UE */

--- a/src/amf/nausf-handler.c
+++ b/src/amf/nausf-handler.c
@@ -111,7 +111,7 @@ int amf_nausf_auth_handle_authenticate(
 
     amf_ue->nas.ue.ksi = amf_ue->nas.amf.ksi;
 
-    ogs_assert(OGS_OK ==
+    ogs_expect(OGS_OK ==
         nas_5gs_send_authentication_request(amf_ue));
 
     return OGS_OK;

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -909,7 +909,7 @@ void ngap_handle_initial_context_setup_response(
         param.n2SmInfoType = OpenAPI_n2_sm_info_type_PDU_RES_SETUP_RSP;
         ogs_pkbuf_put_data(param.n2smbuf, transfer->buf, transfer->size);
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -1649,7 +1649,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             param.n2SmInfoType = OpenAPI_n2_sm_info_type_PDU_RES_SETUP_RSP;
             ogs_pkbuf_put_data(param.n2smbuf, transfer->buf, transfer->size);
 
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_sess_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                     amf_nsmf_pdusession_build_update_sm_context,
@@ -1769,7 +1769,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             amf_ue->deactivation.group = NGAP_Cause_PR_nas;
             amf_ue->deactivation.cause = NGAP_CauseNas_normal_release;
 
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_sess_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                     amf_nsmf_pdusession_build_update_sm_context,
@@ -1950,7 +1950,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         param.n2SmInfoType = OpenAPI_n2_sm_info_type_PDU_RES_MOD_RSP;
         ogs_pkbuf_put_data(param.n2smbuf, transfer->buf, transfer->size);
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -2126,7 +2126,7 @@ void ngap_handle_pdu_session_resource_release_response(
         param.n2SmInfoType = OpenAPI_n2_sm_info_type_PDU_RES_REL_RSP;
         ogs_pkbuf_put_data(param.n2smbuf, transfer->buf, transfer->size);
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -2549,7 +2549,7 @@ void ngap_handle_path_switch_request(
         param.n2SmInfoType = OpenAPI_n2_sm_info_type_PATH_SWITCH_REQ;
         ogs_pkbuf_put_data(param.n2smbuf, transfer->buf, transfer->size);
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -2871,7 +2871,7 @@ void ngap_handle_handover_required(
         param.hoState = OpenAPI_ho_state_PREPARING;
         param.TargetID = TargetID;
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -3096,7 +3096,7 @@ void ngap_handle_handover_request_ack(
 
         param.hoState = OpenAPI_ho_state_PREPARED;
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -3342,7 +3342,7 @@ void ngap_handle_handover_cancel(
         param.ngApCause.group = Cause->present;
         param.ngApCause.value = (int)Cause->choice.radioNetwork;
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,
@@ -3623,7 +3623,7 @@ void ngap_handle_handover_notification(
         memset(&param, 0, sizeof(param));
         param.hoState = OpenAPI_ho_state_COMPLETED;
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL,
                 amf_nsmf_pdusession_build_update_sm_context,

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -68,7 +68,7 @@ void amf_nnrf_handle_nf_discover(
             ogs_assert(amf_ue);
             ogs_error("[%s] (NF discover) No [%s]", amf_ue->suci,
                         ogs_sbi_service_type_to_name(service_type));
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_gmm_reject_from_sbi(amf_ue,
                     OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT));
             break;
@@ -78,12 +78,12 @@ void amf_nnrf_handle_nf_discover(
             ogs_error("[%d:%d] (NF discover) No [%s]", sess->psi, sess->pti,
                         ogs_sbi_service_type_to_name(service_type));
             if (sess->payload_container_type) {
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_5gs_send_back_gsm_message(sess,
                         OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                         AMF_NAS_BACKOFF_TIME));
             } else {
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     ngap_send_error_indication2(amf_ue,
                         NGAP_Cause_PR_transport,
                         NGAP_CauseTransport_transport_resource_unavailable));

--- a/src/amf/nnssf-handler.c
+++ b/src/amf/nnssf-handler.c
@@ -44,7 +44,7 @@ int amf_nnssf_nsselection_handle_get(
     if (recvmsg->res_status != OGS_SBI_HTTP_STATUS_OK) {
         ogs_error("[%s] HTTP response error [%d]",
                 amf_ue->supi, recvmsg->res_status);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_status(amf_ue, recvmsg->res_status));
         return OGS_ERROR;
     }
@@ -52,7 +52,7 @@ int amf_nnssf_nsselection_handle_get(
     AuthorizedNetworkSliceInfo = recvmsg->AuthorizedNetworkSliceInfo;
     if (!AuthorizedNetworkSliceInfo) {
         ogs_error("No AuthorizedNetworkSliceInfo");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -61,7 +61,7 @@ int amf_nnssf_nsselection_handle_get(
     NsiInformation = AuthorizedNetworkSliceInfo->nsi_information;
     if (!NsiInformation) {
         ogs_error("No NsiInformation");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -69,7 +69,7 @@ int amf_nnssf_nsselection_handle_get(
 
     if (!NsiInformation->nrf_id) {
         ogs_error("No nrfId");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -112,7 +112,7 @@ int amf_nnssf_nsselection_handle_get(
         OGS_SBI_SETUP_CLIENT(&sess->nssf.nrf, client);
         ogs_freeaddrinfo(addr);
 
-        ogs_assert(true == amf_sess_sbi_discover_by_nsi(
+        ogs_expect(true == amf_sess_sbi_discover_by_nsi(
                     sess, OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION, NULL));
     }
 

--- a/src/amf/npcf-handler.c
+++ b/src/amf/npcf-handler.c
@@ -38,14 +38,14 @@ int amf_npcf_am_policy_control_handle_create(
     if (recvmsg->res_status != OGS_SBI_HTTP_STATUS_CREATED) {
         ogs_error("[%s] HTTP response error [%d]",
                 amf_ue->supi, recvmsg->res_status);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(amf_ue, recvmsg->res_status));
         return OGS_ERROR;
     }
 
     if (!recvmsg->http.location) {
         ogs_error("[%s] No http.location", amf_ue->supi);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -54,7 +54,7 @@ int amf_npcf_am_policy_control_handle_create(
     PolicyAssociation = recvmsg->PolicyAssociation;
     if (!PolicyAssociation) {
         ogs_error("No PolicyAssociation");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -62,7 +62,7 @@ int amf_npcf_am_policy_control_handle_create(
 
     if (!PolicyAssociation->supp_feat) {
         ogs_error("No suppFeat");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -75,7 +75,7 @@ int amf_npcf_am_policy_control_handle_create(
     if (rv != OGS_OK) {
         ogs_error("[%s] Cannot parse http.location [%s]",
                 amf_ue->supi, recvmsg->http.location);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;
@@ -86,7 +86,7 @@ int amf_npcf_am_policy_control_handle_create(
                 amf_ue->supi, recvmsg->http.location);
 
         ogs_sbi_header_free(&header);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
         return OGS_ERROR;

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -38,7 +38,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
 
         if (!recvmsg->http.location) {
             ogs_error("[%d:%d] No http.location", sess->psi, sess->pti);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_back_gsm_message(sess,
                     OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                     AMF_NAS_BACKOFF_TIME));
@@ -53,7 +53,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
         if (rv != OGS_OK) {
             ogs_error("[%d:%d] Cannot parse http.location [%s]",
                     sess->psi, sess->pti, recvmsg->http.location);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_back_gsm_message(sess,
                     OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                     AMF_NAS_BACKOFF_TIME));
@@ -66,7 +66,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
                     sess->psi, sess->pti, recvmsg->http.location);
 
             ogs_sbi_header_free(&header);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_back_gsm_message(sess,
                     OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                     AMF_NAS_BACKOFF_TIME));
@@ -96,7 +96,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
                         sess->psi, sess->pti);
 
                 ogs_sbi_header_free(&header);
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_5gs_send_back_gsm_message(sess,
                         OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                         AMF_NAS_BACKOFF_TIME));
@@ -120,7 +120,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
         SmContextCreateError = recvmsg->SmContextCreateError;
         if (!SmContextCreateError) {
             ogs_error("[%d:%d] No SmContextCreateError", sess->psi, sess->pti);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_back_gsm_message(sess,
                     OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                     AMF_NAS_BACKOFF_TIME));
@@ -129,7 +129,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
         }
         if (!SmContextCreateError->error) {
             ogs_error("[%d:%d] No Error", sess->psi, sess->pti);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_back_gsm_message(sess,
                     OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                     AMF_NAS_BACKOFF_TIME));
@@ -150,7 +150,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
                         sess->psi, sess->pti);
                 n1smbuf = ogs_pkbuf_copy(n1smbuf);
                 ogs_assert(n1smbuf);
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_5gs_send_gsm_reject(sess,
                         OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, n1smbuf));
 
@@ -159,7 +159,7 @@ int amf_nsmf_pdusession_handle_create_sm_context(
         }
 
         ogs_error("[%d:%d] 5GMM was not forwarded", sess->psi, sess->pti);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_back_gsm_message(sess,
                 OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                 AMF_NAS_BACKOFF_TIME));
@@ -231,7 +231,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                             AMF_UPDATE_SM_CONTEXT_REGISTRATION_REQUEST)) {
 
                         if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
-                            ogs_assert(true ==
+                            ogs_expect(true ==
                                 amf_ue_sbi_discover_and_send(
                                     OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
                                     NULL,
@@ -239,7 +239,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                                     amf_ue, NULL));
                         } else {
                             CLEAR_AMF_UE_TIMER(amf_ue->t3550);
-                            ogs_assert(OGS_OK ==
+                            ogs_expect(OGS_OK ==
                                 nas_5gs_send_registration_accept(amf_ue));
 
                             AMF_UE_CLEAR_N2_TRANSFER(
@@ -255,7 +255,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                                 AMF_RELEASE_SM_CONTEXT_SERVICE_ACCEPT) &&
                         AMF_SESSION_SYNC_DONE(amf_ue,
                                 AMF_UPDATE_SM_CONTEXT_SERVICE_REQUEST)) {
-                        ogs_assert(OGS_OK ==
+                        ogs_expect(OGS_OK ==
                             nas_5gs_send_service_accept(amf_ue));
 
                         AMF_UE_CLEAR_N2_TRANSFER(
@@ -267,7 +267,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
                     if (AMF_SESSION_SYNC_DONE(amf_ue,
                                 AMF_UPDATE_SM_CONTEXT_HANDOVER_REQUIRED)) {
-                        ogs_assert(OGS_OK ==
+                        ogs_expect(OGS_OK ==
                             ngap_send_handover_request(amf_ue));
 
                         AMF_UE_CLEAR_N2_TRANSFER(amf_ue, handover_request);
@@ -282,7 +282,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (!n1smbuf) {
                     ogs_error("[%s:%d] No N1 SM Content [%s]",
                             amf_ue->supi, sess->psi, n1SmMsg->content_id);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_back_gsm_message(sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME));
@@ -293,7 +293,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (!n2smbuf) {
                     ogs_error("[%s:%d] No N2 SM Content",
                             amf_ue->supi, sess->psi);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_back_gsm_message(sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME));
@@ -311,7 +311,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 n2smbuf = ogs_pkbuf_copy(n2smbuf);
                 ogs_assert(n2smbuf);
 
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_send_pdu_session_modification_command(
                         sess, n1smbuf, n2smbuf));
                 break;
@@ -321,7 +321,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (!n1smbuf) {
                     ogs_error("[%s:%d] No N1 SM Content [%s]",
                             amf_ue->supi, sess->psi, n1SmMsg->content_id);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_back_gsm_message(sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME));
@@ -332,7 +332,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (!n2smbuf) {
                     ogs_error("[%s:%d] No N2 SM Content",
                             amf_ue->supi, sess->psi);
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         nas_5gs_send_back_gsm_message(sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME));
@@ -350,7 +350,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 n2smbuf = ogs_pkbuf_copy(n2smbuf);
                 ogs_assert(n2smbuf);
 
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_send_pdu_session_release_command(
                         sess, n1smbuf, n2smbuf));
                 break;
@@ -372,7 +372,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_pkbuf_copy(n2smbuf));
 
                 if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         ngap_send_path_switch_ack(sess));
 
                     AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_ack);
@@ -395,7 +395,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         sess, handover_command, ogs_pkbuf_copy(n2smbuf));
 
                 if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         ngap_send_handover_command(amf_ue));
 
                     AMF_UE_CLEAR_N2_TRANSFER(amf_ue, handover_command);
@@ -478,7 +478,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 ogs_warn("PDUSessionResourceSetupResponse(Unsuccessful)");
                 ogs_assert(amf_ue->deactivation.group);
 
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     ngap_send_amf_ue_context_release_command(amf_ue,
                         amf_ue->deactivation.group,
                         amf_ue->deactivation.cause,
@@ -515,7 +515,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
                     ogs_assert(amf_ue->deactivation.group);
 
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         ngap_send_amf_ue_context_release_command(amf_ue,
                             amf_ue->deactivation.group,
                             amf_ue->deactivation.cause,
@@ -597,7 +597,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                     target_ue = source_ue->target_ue;
                     ogs_assert(target_ue);
 
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         ngap_send_ran_ue_context_release_command(target_ue,
                             NGAP_Cause_PR_radioNetwork,
                             NGAP_CauseRadioNetwork_handover_cancelled,
@@ -637,7 +637,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ran_ue_remove(ran_ue);
 
                         if (ogs_list_count(&gnb->ran_ue_list) == 0)
-                            ogs_assert(OGS_OK ==
+                            ogs_expect(OGS_OK ==
                                 ngap_send_ng_reset_ack(gnb, NULL));
 
                     } else {
@@ -752,7 +752,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
                 n1smbuf = ogs_pkbuf_copy(n1smbuf);
                 ogs_assert(n1smbuf);
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_5gs_send_gsm_reject(sess,
                         OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, n1smbuf));
 
@@ -818,13 +818,13 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
                 amf_ue, AMF_UPDATE_SM_CONTEXT_REGISTRATION_REQUEST)) {
 
             if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
-                ogs_assert(true ==
+                ogs_expect(true ==
                     amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
                         amf_npcf_am_policy_control_build_create, amf_ue, NULL));
             } else {
                 CLEAR_AMF_UE_TIMER(amf_ue->t3550);
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     nas_5gs_send_registration_accept(amf_ue));
             }
         }
@@ -837,7 +837,7 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
          */
         if (AMF_SESSION_SYNC_DONE(amf_ue, AMF_RELEASE_SM_CONTEXT_SERVICE_ACCEPT) &&
             AMF_SESSION_SYNC_DONE(amf_ue, AMF_UPDATE_SM_CONTEXT_SERVICE_REQUEST))
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_service_accept(amf_ue));
 
     } else {
@@ -851,7 +851,7 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
                  * 3. UE Context release command
                  * 4. UE Context release complete
                  */
-                ogs_assert(OGS_OK ==
+                ogs_expect(OGS_OK ==
                     ngap_send_amf_ue_context_release_command(amf_ue,
                         NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release,
                         NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0));
@@ -871,7 +871,7 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
 
                 if (OGS_FSM_CHECK(&amf_ue->sm, gmm_state_authentication)) {
 
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_ue_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
                             amf_nausf_auth_build_authenticate, amf_ue, NULL));
@@ -889,7 +889,7 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
                      * 7. UEContextReleaseComplete
                      */
 
-                    ogs_assert(true ==
+                    ogs_expect(true ==
                         amf_ue_sbi_discover_and_send(
                             OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
                             amf_npcf_am_policy_control_build_delete,
@@ -914,7 +914,7 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
                      * 3. UE Context release command
                      * 4. UE Context release complete
                      */
-                    ogs_assert(OGS_OK ==
+                    ogs_expect(OGS_OK ==
                         ngap_send_amf_ue_context_release_command(amf_ue,
                             NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release,
                             NGAP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0));

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -139,7 +139,7 @@ int amf_nudm_sdm_handle_provisioned(
             return OGS_ERROR;
         }
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_ue_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
                 amf_nudm_sdm_build_get,
@@ -212,7 +212,7 @@ int amf_nudm_sdm_handle_provisioned(
                 }
             }
         }
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_ue_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
                 amf_nudm_sdm_build_get,
@@ -224,13 +224,13 @@ int amf_nudm_sdm_handle_provisioned(
         if (amf_ue->data_change_subscription_id) {
             /* we already have a SDM subscription to UDM; continue without
              * subscribing again */
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_ue_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
                     amf_npcf_am_policy_control_build_create, amf_ue, NULL));
         }
         else {
-            ogs_assert(true ==
+            ogs_expect(true ==
                 amf_ue_sbi_discover_and_send(
                     OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
                     amf_nudm_sdm_build_subscription, amf_ue,
@@ -246,7 +246,7 @@ int amf_nudm_sdm_handle_provisioned(
 
         if (!recvmsg->http.location) {
             ogs_error("[%s] No http.location", amf_ue->supi);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_gmm_reject_from_sbi(
                     amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
             return OGS_ERROR;
@@ -259,7 +259,7 @@ int amf_nudm_sdm_handle_provisioned(
         if (rv != OGS_OK) {
             ogs_error("[%s] Cannot parse http.location [%s]",
                 amf_ue->supi, recvmsg->http.location);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_gmm_reject_from_sbi(
                     amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
             return OGS_ERROR;
@@ -270,7 +270,7 @@ int amf_nudm_sdm_handle_provisioned(
                 amf_ue->supi, recvmsg->http.location);
 
             ogs_sbi_header_free(&header);
-            ogs_assert(OGS_OK ==
+            ogs_expect(OGS_OK ==
                 nas_5gs_send_gmm_reject_from_sbi(
                     amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR));
             return OGS_ERROR;
@@ -283,7 +283,7 @@ int amf_nudm_sdm_handle_provisioned(
 
         ogs_sbi_header_free(&header);
 
-        ogs_assert(true ==
+        ogs_expect(true ==
             amf_ue_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL, NULL,
                 amf_npcf_am_policy_control_build_create, amf_ue, NULL));

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -103,7 +103,7 @@ bool amf_ue_sbi_discover_and_send(
             (ogs_sbi_build_f)build, amf_ue, data);
     if (!xact) {
         ogs_error("amf_ue_sbi_discover_and_send() failed");
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT));
         return false;
@@ -112,7 +112,7 @@ bool amf_ue_sbi_discover_and_send(
     if (ogs_sbi_discover_and_send(xact) != true) {
         ogs_error("amf_ue_sbi_discover_and_send() failed");
         ogs_sbi_xact_remove(xact);
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_gmm_reject_from_sbi(
                 amf_ue, OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT));
         return false;
@@ -138,7 +138,7 @@ bool amf_sess_sbi_discover_and_send(
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
-        ogs_assert(OGS_OK == nas_5gs_send_back_gsm_message(sess,
+        ogs_expect(OGS_OK == nas_5gs_send_back_gsm_message(sess,
             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME));
         return false;
     }
@@ -148,7 +148,7 @@ bool amf_sess_sbi_discover_and_send(
     if (ogs_sbi_discover_and_send(xact) != true) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
         ogs_sbi_xact_remove(xact);
-        ogs_assert(OGS_OK == nas_5gs_send_back_gsm_message(sess,
+        ogs_expect(OGS_OK == nas_5gs_send_back_gsm_message(sess,
             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME));
         return false;
     }
@@ -214,7 +214,7 @@ static int client_discover_cb(
     rv = ogs_sbi_parse_response(&message, response);
     if (rv != OGS_OK) {
         ogs_error("cannot parse HTTP response");
-        ogs_assert(OGS_OK == nas_5gs_send_back_gsm_message(sess,
+        ogs_expect(OGS_OK == nas_5gs_send_back_gsm_message(sess,
             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME));
 
         goto cleanup;
@@ -222,7 +222,7 @@ static int client_discover_cb(
 
     if (message.res_status != OGS_SBI_HTTP_STATUS_OK) {
         ogs_error("NF-Discover failed [%d]", message.res_status);
-        ogs_assert(OGS_OK == nas_5gs_send_back_gsm_message(sess,
+        ogs_expect(OGS_OK == nas_5gs_send_back_gsm_message(sess,
             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME));
 
         goto cleanup;
@@ -230,7 +230,7 @@ static int client_discover_cb(
 
     if (!message.SearchResult) {
         ogs_error("No SearchResult");
-        ogs_assert(OGS_OK == nas_5gs_send_back_gsm_message(sess,
+        ogs_expect(OGS_OK == nas_5gs_send_back_gsm_message(sess,
             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME));
 
         goto cleanup;
@@ -245,7 +245,7 @@ static int client_discover_cb(
         ogs_error("[%s:%d] (NF discover) No [%s]",
                     amf_ue->supi, sess->psi,
                     ogs_sbi_service_type_to_name(service_type));
-        ogs_assert(OGS_OK ==
+        ogs_expect(OGS_OK ==
             nas_5gs_send_back_gsm_message(sess,
                 OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                 AMF_NAS_BACKOFF_TIME));


### PR DESCRIPTION
It is possible that AMF receives a response to some SBI message request, which requires an NGAP message to be sent, but UE or even gNB could be disconnected already in the meantime.
This change prevents AMF to crash on assert if ran_ue or gnb contexts are already deallocated.

It is possible that a message from gNB arrives at AMF before AMF successfully registers to the NRF at application startup. In that case, AMF crashes beacuse it can't discover other NF services (for example AUSF).