### PR TITLE
feat: n1 ul nas transport lpp and sms delivery and subscription of Nfs

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -183,6 +183,13 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_sdm_subscription_free(message->SDMSubscription);
     if (message->ModificationNotification)
         OpenAPI_modification_notification_free(message->ModificationNotification);
+    if(message->N1N2SubscriptionCreate)
+        OpenAPI_ue_n1_n2_info_subscription_create_data_free(message->N1N2SubscriptionCreate);
+    if(message->N1N2SubscriptionCreated)
+        OpenAPI_ue_n1_n2_info_subscription_created_data_free(message->N1N2SubscriptionCreated);
+    if(message->N1MessageNotification){
+        OpenAPI_n1_message_notification_free(message->N1MessageNotification);
+    }
 
     /* HTTP Part */
     for (i = 0; i < message->num_of_part; i++) {
@@ -1059,6 +1066,18 @@ static char *build_json(ogs_sbi_message_t *message)
         item = OpenAPI_modification_notification_convertToJSON(
             message->ModificationNotification);
         ogs_assert(item);
+    }  else if (message->N1N2SubscriptionCreate) {
+        item = OpenAPI_ue_n1_n2_info_subscription_create_data_convertToJSON(
+            message->N1N2SubscriptionCreate);
+        ogs_assert(item);
+    } else if (message->N1N2SubscriptionCreated) {
+        item = OpenAPI_ue_n1_n2_info_subscription_created_data_convertToJSON(
+            message->N1N2SubscriptionCreated);
+        ogs_assert(item);
+    } else if(message->N1MessageNotification) {
+        item = OpenAPI_n1_message_notification_convertToJSON(
+            message->N1MessageNotification);
+        ogs_assert(item);
     }
 
     if (item) {
@@ -1639,26 +1658,51 @@ static int parse_json(ogs_sbi_message_t *message,
             CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)
                 SWITCH(message->h.resource.component[2])
                 CASE(OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES)
-                    if (message->res_status == 0) {
-                        message->N1N2MessageTransferReqData =
-                            OpenAPI_n1_n2_message_transfer_req_data_parseFromJSON(item);
-                        if (!message->N1N2MessageTransferReqData) {
-                            rv = OGS_ERROR;
-                            ogs_error("JSON parse error");
+                    SWITCH(message->h.resource.component[3])
+                    CASE(OGS_SBI_RESOURCE_NAME_SUBSCRIPTIONS)
+                        if (message->res_status == 0) {
+                            message->N1N2SubscriptionCreate =
+                                OpenAPI_ue_n1_n2_info_subscription_create_data_parseFromJSON(item);
+                            if (!message->N1N2SubscriptionCreate) {
+                                rv = OGS_ERROR;
+                                ogs_error("JSON parse error");
+                            }
+                        } else if (message->res_status ==
+                                    OGS_SBI_HTTP_STATUS_OK ||
+                                    message->res_status ==
+                                        OGS_SBI_HTTP_STATUS_ACCEPTED ||
+                                    message->res_status ==
+                                        OGS_SBI_HTTP_STATUS_CREATED) {
+                            message->N1N2SubscriptionCreated =
+                                OpenAPI_ue_n1_n2_info_subscription_created_data_parseFromJSON(item);
+                            if (!message->N1N2SubscriptionCreated) {
+                                rv = OGS_ERROR;
+                                ogs_error("JSON parse error");
+                            }
                         }
-                    } else if (message->res_status ==
-                                OGS_SBI_HTTP_STATUS_OK ||
-                                message->res_status ==
-                                    OGS_SBI_HTTP_STATUS_ACCEPTED) {
-                        message->N1N2MessageTransferRspData =
-                            OpenAPI_n1_n2_message_transfer_rsp_data_parseFromJSON(item);
-                        if (!message->N1N2MessageTransferRspData) {
-                            rv = OGS_ERROR;
-                            ogs_error("JSON parse error");
-                        }
-                    }
                     break;
-
+                    DEFAULT
+                        if (message->res_status == 0) {
+                            message->N1N2MessageTransferReqData =
+                                OpenAPI_n1_n2_message_transfer_req_data_parseFromJSON(item);
+                            if (!message->N1N2MessageTransferReqData) {
+                                rv = OGS_ERROR;
+                                ogs_error("JSON parse error");
+                            }
+                        } else if (message->res_status ==
+                                    OGS_SBI_HTTP_STATUS_OK ||
+                                    message->res_status ==
+                                        OGS_SBI_HTTP_STATUS_ACCEPTED) {
+                            message->N1N2MessageTransferRspData =
+                                OpenAPI_n1_n2_message_transfer_rsp_data_parseFromJSON(item);
+                            if (!message->N1N2MessageTransferRspData) {
+                                rv = OGS_ERROR;
+                                ogs_error("JSON parse error");
+                            }
+                        }
+                    break;
+                    END
+                break;
                 DEFAULT
                     rv = OGS_ERROR;
                     ogs_error("Unknown resource name [%s]",

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -500,6 +500,10 @@ typedef struct ogs_sbi_message_s {
     OpenAPI_deregistration_data_t *DeregistrationData;
     OpenAPI_sdm_subscription_t *SDMSubscription;
     OpenAPI_modification_notification_t *ModificationNotification;
+    
+    OpenAPI_ue_n1_n2_info_subscription_create_data_t *N1N2SubscriptionCreate;
+    OpenAPI_ue_n1_n2_info_subscription_created_data_t *N1N2SubscriptionCreated;
+    OpenAPI_n1_message_notification_t *N1MessageNotification;
 
     ogs_sbi_links_t *links;
 

--- a/lib/sbi/ogs-sbi.h
+++ b/lib/sbi/ogs-sbi.h
@@ -78,6 +78,10 @@
 #include "model/sdm_subscription.h"
 #include "model/modification_notification.h"
 
+#include "model/ue_n1_n2_info_subscription_create_data.h"
+#include "model/ue_n1_n2_info_subscription_created_data.h"
+#include "model/n1_message_notification.h"
+
 #include "custom/links.h"
 #include "custom/ue_authentication_ctx.h"
 #include "custom/patch_item.h"

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -19,6 +19,8 @@
 
 #include "ngap-path.h"
 
+#include "namf-n1n2-subscription.h"
+
 static amf_context_t self;
 
 int __amf_log_domain;
@@ -1337,6 +1339,8 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
 
     ogs_list_add(&self.amf_ue_list, amf_ue);
 
+    ogs_list_init(&amf_ue->n1_n2_subscriptions);
+
     ogs_info("[Added] Number of AMF-UEs is now %d",
             ogs_list_count(&self.amf_ue_list));
 
@@ -1415,6 +1419,9 @@ void amf_ue_remove(amf_ue_t *amf_ue)
     ogs_timer_delete(amf_ue->t3555.timer);
     ogs_timer_delete(amf_ue->t3560.timer);
     ogs_timer_delete(amf_ue->t3570.timer);
+
+    amf_ue_n1_n2_subscriptions_delete(amf_ue);
+    ogs_list_empty(&amf_ue->n1_n2_subscriptions);
 
     /* Free SBI object memory */
     ogs_sbi_object_free(&amf_ue->sbi);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -396,6 +396,9 @@ struct amf_ue_s {
     /* SubscriptionId of Subscription to Data Change Notification to UDM */
     char *data_change_subscription_id;
 
+    /* N1 UL Notify Subscriptions for specific UE */
+    ogs_list_t n1_n2_subscriptions;
+
     ogs_list_t      sess_list;
 };
 

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -24,6 +24,7 @@
 #include "sbi-path.h"
 
 #include "gmm-handler.h"
+#include "namf-n1n2-subscription.h"
 
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __gmm_log_domain
@@ -1184,6 +1185,12 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                 break;
             }
         }
+        break;
+
+    case OGS_NAS_PAYLOAD_CONTAINER_SMS:
+    case OGS_NAS_PAYLOAD_CONTAINER_LPP:
+        ogs_assert(OGS_OK == amf_ue_n1_n2_subscription_forward(amf_ue,payload_container_type->value,payload_container));
+        return OGS_OK;
         break;
 
     default:

--- a/src/amf/meson.build
+++ b/src/amf/meson.build
@@ -60,6 +60,8 @@ libamf_sources = files('''
 
     init.c
     metrics.c
+
+    namf-n1n2-subscription.c
 '''.split())
 
 libamf = static_library('amf',

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -471,7 +471,7 @@ int amf_namf_comm_handle_n1_n2_message_subscribe(ogs_sbi_stream_t *stream, ogs_s
     newSub->notify_url = ogs_strdup(N1N2SubscriptionData->n1_notify_callback_uri);
 
     amf_ue_n1_n2_subscription_add(amf_ue, newSub);
-    ogs_info("[N1] Registered subscription " PRIu64, newSub->id);
+    ogs_info("[N1] Registered subscription %" PRIu64, newSub->id);
 
 
     N1N2SubscriptionCreatedData.n1n2_notify_subscription_id = ogs_uint64_to_string(newSub->id);
@@ -531,7 +531,7 @@ int amf_namf_comm_handle_n1_n2_message_unsubscribe(ogs_sbi_stream_t *stream, ogs
 
     memset(&message,0,sizeof(message));
 
-    ogs_info("[N1] Removed subscription " PRIu64,sub);
+    ogs_info("[N1] Removed subscription %" PRIu64,sub);
 
     status = OGS_SBI_HTTP_STATUS_NO_CONTENT;
 

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -24,6 +24,8 @@
 #include "ngap-path.h"
 #include "sbi-path.h"
 
+#include "namf-n1n2-subscription.h"
+
 int amf_namf_comm_handle_n1_n2_message_transfer(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {
@@ -406,6 +408,135 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
 
     if (sendmsg.http.location)
         ogs_free(sendmsg.http.location);
+
+    return OGS_OK;
+}
+
+int amf_namf_comm_handle_n1_n2_message_subscribe(ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+{
+    int status;
+
+    amf_ue_t *amf_ue = NULL;
+
+    char *supi = NULL;
+
+    ogs_sbi_message_t sendmsg;
+    ogs_sbi_response_t *response = NULL;
+
+    OpenAPI_ue_n1_n2_info_subscription_create_data_t *N1N2SubscriptionData;
+    OpenAPI_ue_n1_n2_info_subscription_created_data_t N1N2SubscriptionCreatedData;
+
+    ogs_assert(stream);
+    ogs_assert(recvmsg);
+
+    N1N2SubscriptionData = recvmsg->N1N2SubscriptionCreate;
+    if (!N1N2SubscriptionData) {
+        ogs_error("No N1N2SubscriptionReqData");
+        return OGS_ERROR;
+    }
+
+    supi = recvmsg->h.resource.component[1];
+    if (!supi) {
+        ogs_error("No SUPI");
+        return OGS_ERROR;
+    }
+
+    amf_ue = amf_ue_find_by_supi(supi);
+    if (!amf_ue) {
+        ogs_error("No UE context [%s]", supi);
+        return OGS_ERROR;
+    }
+
+    memset(&sendmsg, 0, sizeof(sendmsg));
+    memset(&N1N2SubscriptionCreatedData, 0, sizeof(N1N2SubscriptionCreatedData));
+
+    N1_N2_Subscription_t *newSub;
+    newSub = ogs_calloc(1, sizeof(N1_N2_Subscription_t));
+
+    switch(N1N2SubscriptionData->n1_message_class){
+    case OpenAPI_n1_message_class_LPP:
+        newSub->msg_type = OGS_NAS_PAYLOAD_CONTAINER_LPP;
+        break;
+    case OpenAPI_n1_message_class_SMS:
+        newSub->msg_type = OGS_NAS_PAYLOAD_CONTAINER_SMS;
+        break;
+    default:
+       ogs_error("[%s] Unsupported N1Subscription Class! [%d]",
+                amf_ue->supi, N1N2SubscriptionData->n1_message_class);
+        return OGS_ERROR;
+    }
+
+    newSub->id = amf_ue_n1_n2_subscription_get_next_id();
+    newSub->supi = ogs_strdup(supi);
+    newSub->notify_url = ogs_strdup(N1N2SubscriptionData->n1_notify_callback_uri);
+
+    amf_ue_n1_n2_subscription_add(amf_ue, newSub);
+    ogs_info("[N1] Registered subscription %lu", newSub->id);
+
+
+    N1N2SubscriptionCreatedData.n1n2_notify_subscription_id = ogs_uint64_to_string(newSub->id);
+    sendmsg.N1N2SubscriptionCreated = &N1N2SubscriptionCreatedData;
+
+    status = OGS_SBI_HTTP_STATUS_CREATED;
+
+    response = ogs_sbi_build_response(&sendmsg, status);
+    ogs_assert(response);
+    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    if(N1N2SubscriptionCreatedData.n1n2_notify_subscription_id){
+        ogs_free(N1N2SubscriptionCreatedData.n1n2_notify_subscription_id);
+    }
+
+    return OGS_OK;
+}
+
+int amf_namf_comm_handle_n1_n2_message_unsubscribe(ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+{
+    int status;
+
+    amf_ue_t *amf_ue = NULL;
+
+    char *supi = NULL;
+
+    ogs_sbi_message_t message;
+    ogs_sbi_response_t *response = NULL;
+
+    ogs_assert(stream);
+    ogs_assert(recvmsg);
+
+    supi = recvmsg->h.resource.component[1];
+    if (!supi) {
+        ogs_error("No SUPI");
+        return OGS_ERROR;
+    }
+
+    amf_ue = amf_ue_find_by_supi(supi);
+    if (!amf_ue) {
+        ogs_error("No UE context [%s]", supi);
+        return OGS_ERROR;
+    }
+
+    char *subId = recvmsg->h.resource.component[4];
+    if(!subId){
+            ogs_error("No Subscription ID");
+            return OGS_ERROR;
+    }
+
+    uint64_t sub = ogs_uint64_from_string(subId);
+
+    if((status = amf_ue_n1_n2_subscription_handle_delete(amf_ue, sub)) != OGS_OK){
+        ogs_error("Invalid Return code for deletion %d",status);
+        return status;
+    }
+
+    memset(&message,0,sizeof(message));
+
+    ogs_info("[N1] Removed subscription %lu",sub);
+
+    status = OGS_SBI_HTTP_STATUS_NO_CONTENT;
+
+    response = ogs_sbi_build_response(&message,status);
+    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 
     return OGS_OK;
 }

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -471,7 +471,7 @@ int amf_namf_comm_handle_n1_n2_message_subscribe(ogs_sbi_stream_t *stream, ogs_s
     newSub->notify_url = ogs_strdup(N1N2SubscriptionData->n1_notify_callback_uri);
 
     amf_ue_n1_n2_subscription_add(amf_ue, newSub);
-    ogs_info("[N1] Registered subscription %lu", newSub->id);
+    ogs_info("[N1] Registered subscription " PRIu64, newSub->id);
 
 
     N1N2SubscriptionCreatedData.n1n2_notify_subscription_id = ogs_uint64_to_string(newSub->id);
@@ -531,7 +531,7 @@ int amf_namf_comm_handle_n1_n2_message_unsubscribe(ogs_sbi_stream_t *stream, ogs
 
     memset(&message,0,sizeof(message));
 
-    ogs_info("[N1] Removed subscription %lu",sub);
+    ogs_info("[N1] Removed subscription " PRIu64,sub);
 
     status = OGS_SBI_HTTP_STATUS_NO_CONTENT;
 

--- a/src/amf/namf-handler.h
+++ b/src/amf/namf-handler.h
@@ -34,6 +34,10 @@ int amf_namf_callback_handle_dereg_notify(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 int amf_namf_callback_handle_sdm_data_change_notify(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_comm_handle_n1_n2_message_subscribe(
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_comm_handle_n1_n2_message_unsubscribe(
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/amf/namf-n1n2-subscription.c
+++ b/src/amf/namf-n1n2-subscription.c
@@ -1,0 +1,257 @@
+#include "namf-n1n2-subscription.h"
+
+#include "context.h"
+
+uint64_t actualSubscriptionId = 1;
+
+uint64_t amf_ue_n1_n2_subscription_get_next_id(){
+    if(actualSubscriptionId == 0){
+        //TODO: What to do here?
+        ogs_error("EXCEEDED MAXIMUM SUBSCRIBERS!");
+        return ++actualSubscriptionId;
+    }
+    return actualSubscriptionId++;
+}
+
+void amf_ue_n1_n2_subscription_add(amf_ue_t *ue, N1_N2_Subscription_t *newSub){
+    newSub->client = amf_ue_n1_n2_allocate_client(newSub->notify_url);
+    ogs_list_add(&ue->n1_n2_subscriptions,&newSub->node);
+}
+
+int amf_ue_n1_n2_subscription_get_all_by_type(amf_ue_t *ue, OpenAPI_n1_message_class_e type, ogs_list_t *retListPtr){
+    N1_N2_Subscription_t *spec = NULL;
+    N1_N2_Subscription_t *next = NULL;
+    
+    int count = 0;
+
+    ogs_list_for_each_entry_safe(&(ue->n1_n2_subscriptions), next, spec, node) {
+        if(spec->msg_type == type){
+            count++;
+            ogs_list_add(retListPtr,&spec->node);
+        }
+    }
+
+    return count;
+}
+
+N1_N2_Subscription_t *amf_ue_n1_n2_subscription_get_by_id(amf_ue_t *ue, uint64_t id){
+    N1_N2_Subscription_t *sub = NULL;
+
+    N1_N2_Subscription_t *spec = NULL;
+    N1_N2_Subscription_t *next = NULL;
+
+    ogs_list_for_each_entry_safe(&(ue->n1_n2_subscriptions), next, spec, node) {
+        if(spec->id == id){
+            sub = spec;
+            break;
+        }
+    }
+
+    return sub;
+}
+
+int amf_ue_n1_n2_subscription_handle_delete(amf_ue_t *ue, uint64_t id){
+    N1_N2_Subscription_t *sub = amf_ue_n1_n2_subscription_get_by_id(ue,id);
+    if(!sub){
+        return OGS_ERROR;
+    }
+    ogs_list_remove(&ue->n1_n2_subscriptions,sub);
+    amf_ue_n1_n2_subscription_free(sub);
+    return OGS_OK;
+}
+
+OpenAPI_n1_message_class_e amf_get_sbi_message_class_by_payload_container_type(int payloadContainerType){
+    switch(payloadContainerType){
+        case OGS_NAS_PAYLOAD_CONTAINER_LPP:
+            return OpenAPI_n1_message_class_LPP;
+        case OGS_NAS_PAYLOAD_CONTAINER_SMS:
+            return OpenAPI_n1_message_class_SMS;
+        default:
+            ogs_error("INVALID PAYLOAD CONTAINER TYPE %d",payloadContainerType);
+            ogs_assert_if_reached();
+    }
+    return OpenAPI_n1_message_class_NULL;
+}
+
+
+int amf_ue_n1_n2_subscription_forward(amf_ue_t *ue, int payloadContainerType, ogs_nas_payload_container_t *payloadContainer){
+    ogs_list_t found;
+    ogs_list_init(&found);
+
+    OpenAPI_n1_message_class_e msgType = amf_get_sbi_message_class_by_payload_container_type(payloadContainerType);
+
+    int count = amf_ue_n1_n2_subscription_get_all_by_type(ue,msgType,&found);
+
+    N1_N2_Subscription_t *spec = NULL;
+    N1_N2_Subscription_t *next = NULL;
+
+    if(count > 0){
+        ogs_list_for_each_entry_safe(&(found), next, spec, node) {
+            amf_ue_n1_n2_send_request(spec, payloadContainer, msgType);       
+        }
+    }
+    ogs_list_empty(&found);
+    return OGS_OK;
+}
+
+ogs_sbi_client_t *amf_ue_n1_n2_allocate_client(char *uri){
+    //TODO: is this the correct way to init a http client?
+    //TODO: is this a good practice to initiate the client when the 
+    //      callback is registered?
+    bool rc=false;
+    OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_NULL;
+    ogs_sockaddr_t *addr = NULL;
+    ogs_sbi_client_t *client = NULL;
+
+    rc = ogs_sbi_getaddr_from_uri(&scheme, &addr, uri);
+    if (rc == false || scheme == OpenAPI_uri_scheme_NULL) {
+        ogs_error("Invalid URL [%s]",
+                uri);
+        return NULL;
+    }
+
+    client = ogs_sbi_client_add(scheme, addr);
+    ogs_free(addr);
+
+    return client;
+}
+
+bool amf_ue_n1_n2_send_request(N1_N2_Subscription_t *sub, ogs_nas_payload_container_t *data, OpenAPI_n1_message_class_e messageClass){
+
+    bool rc = false;
+
+    const char *binRefStack = "amf-n1data"; //STATIC ID
+    char *binRefHeap = ogs_strdup(binRefStack);
+
+    char *subscriptionId = ogs_uint64_to_string(sub->id);
+
+    OpenAPI_ref_to_binary_data_t *ref2bin = OpenAPI_ref_to_binary_data_create(binRefHeap);
+
+    OpenAPI_n1_message_container_t *n1container = OpenAPI_n1_message_container_create(
+        messageClass,
+        ref2bin,
+        NULL,
+        NULL
+    );
+    //TODO: are more fields required?
+    OpenAPI_n1_message_notification_t *n1_mess_not = OpenAPI_n1_message_notification_create(
+        subscriptionId,
+        n1container,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        false,
+        0,
+        NULL,
+        NULL
+    );
+    
+    ogs_sbi_message_t *msg;
+    //TODO: I wasn't able to use a new message from the stack
+    msg = ogs_calloc(1,sizeof(ogs_sbi_message_t));
+    msg->N1MessageNotification = n1_mess_not;
+
+    ogs_sbi_part_t part0;
+    part0.content_id = binRefHeap;
+    part0.content_type = ogs_strdup(OGS_SBI_CONTENT_5GNAS_TYPE); //Is this correct?
+
+    ogs_pkbuf_t *pkbuf;
+    pkbuf = ogs_pkbuf_alloc(NULL,  data->length);
+
+    ogs_pkbuf_put_data(pkbuf,
+                data->buffer, data->length);
+
+    part0.pkbuf = pkbuf;
+
+
+    msg->num_of_part = 1;
+    msg->part[0] = part0;
+
+    msg->h.uri = ogs_strdup(sub->notify_url);
+    msg->h.method = ogs_strdup(OGS_SBI_HTTP_METHOD_POST);
+
+    ogs_sbi_request_t *request = ogs_sbi_build_request(msg);
+
+    N1_N2_Notify_Data_t *datap;
+    datap = ogs_calloc(1,sizeof(N1_N2_Notify_Data_t));
+    datap->msg = msg;
+    datap->req = request;
+
+    rc = ogs_sbi_client_send_request(
+            sub->client, amf_ue_n1_n2_request_callback, request, datap);
+
+    if(rc == false){
+        ogs_error("Invalid Response for request");
+        //TODO: I'm cleaning up in callback, is there a possibility
+        //      that the callback might not get called?
+    }
+
+    return rc;
+}
+
+int amf_ue_n1_n2_request_callback(
+        int status, ogs_sbi_response_t *response, void *data)
+{   
+
+    N1_N2_Notify_Data_t *datap = data;
+    
+    //TODO: I tested it and I needed to do this extra cleanup stuff
+    //      what am I doing wrong / what do I need to change?
+    int i=0;
+    for(i=0;i<datap->msg->num_of_part;i++){
+        //Dont need to clean content_id since OpenAPI_ref_to_binary_data_free should do it
+        if(datap->msg->part[i].content_type)
+            ogs_free(datap->msg->part[i].content_type);
+    }
+    //They are not deleted by ogs_sbi_message_free (?)
+    if(datap->msg->h.method)
+        ogs_free(datap->msg->h.method);
+    if(datap->msg->h.uri)
+        ogs_free(datap->msg->h.uri);
+    
+
+    ogs_sbi_message_free(datap->msg);
+    ogs_sbi_request_free(datap->req);
+
+    //Since I create message on heap, I need to free it
+    ogs_free(datap->msg);
+    ogs_free(datap);
+
+    if (status != OGS_OK) {
+        ogs_log_message(
+                status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
+                "ogs_sbi_client_handler() failed [%d]", status);
+        return OGS_ERROR;
+    }
+
+    ogs_assert(response);
+
+    //Ignoring response for now..
+    //TODO: do something with it?
+    //Expect 204 (NO_CONTENT) but maybe handle error / log something
+    ogs_sbi_response_free(response);
+
+    return OGS_OK;
+}
+
+void amf_ue_n1_n2_subscriptions_delete(amf_ue_t *amf_ue){
+    N1_N2_Subscription_t *spec = NULL;
+    N1_N2_Subscription_t *next = NULL;
+
+    ogs_list_for_each_entry_safe(&(amf_ue->n1_n2_subscriptions), next, spec, node) {
+        amf_ue_n1_n2_subscription_free(spec);
+    }
+}
+
+void amf_ue_n1_n2_subscription_free(N1_N2_Subscription_t *sub){
+    
+    ogs_sbi_client_remove(sub->client);
+    
+    if(sub->notify_url)
+        ogs_free(sub->notify_url);
+    if(sub->supi)
+        ogs_free(sub->supi);
+
+    ogs_free(sub);
+}

--- a/src/amf/namf-n1n2-subscription.h
+++ b/src/amf/namf-n1n2-subscription.h
@@ -1,0 +1,43 @@
+#ifndef AMF_SUBS_H
+#define AMF_SUBS_H
+
+#include "context.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct N1_N2_Subscription_s {
+    ogs_lnode_t     node; 
+    uint64_t id;
+    char *supi;
+    OpenAPI_n1_message_class_e msg_type;
+    char *notify_url;
+    ogs_sbi_client_t *client;
+} N1_N2_Subscription_t;
+
+typedef struct N1_N2_Notify_Data_s {
+    ogs_sbi_message_t *msg;
+    ogs_sbi_request_t *req;
+} N1_N2_Notify_Data_t;
+
+uint64_t amf_ue_n1_n2_subscription_get_next_id(void);
+void amf_ue_n1_n2_subscription_add(amf_ue_t *ue,N1_N2_Subscription_t *newSub);
+int amf_ue_n1_n2_subscription_get_all_by_type(amf_ue_t *ue, OpenAPI_n1_message_class_e type, ogs_list_t *retListPtr);
+N1_N2_Subscription_t *amf_ue_n1_n2_subscription_get_by_id(amf_ue_t *ue, uint64_t id);
+int amf_ue_n1_n2_subscription_forward(amf_ue_t *ue, int payloadContainerType, ogs_nas_payload_container_t *payloadContainer);
+bool amf_ue_n1_n2_send_request(N1_N2_Subscription_t *sub, ogs_nas_payload_container_t *data, OpenAPI_n1_message_class_e messageClass);
+int amf_ue_n1_n2_request_callback(int status, ogs_sbi_response_t *response, void *data);
+ogs_sbi_client_t *amf_ue_n1_n2_allocate_client(char *uri);
+OpenAPI_n1_message_class_e amf_get_sbi_message_class_by_payload_container_type(int payloadContainerType);
+
+int amf_ue_n1_n2_subscription_handle_delete(amf_ue_t *ue, uint64_t id);
+void amf_ue_n1_n2_subscriptions_delete(amf_ue_t *amf_ue);
+void amf_ue_n1_n2_subscription_free(N1_N2_Subscription_t *sub);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif 


### PR DESCRIPTION
As described in https://github.com/open5gs/open5gs/pull/1898 I also implemented UL_NAS_Transport LPP and SMS message forwarding to already subscribed NFs.
This PR adds the following two endpoints:
``/ue-contexts/{ueContextId}/n1-n2-messages/subscriptions``
and
``/ue-contexts/{ueContextId}/n1-n2-messages/subscriptions/{subscriptionId}``

to allow other NFs to register subscriptions on N1 UL_NAS_TRANSPORT Messages of specified type.

I came across a few problems and some blemishes in my code and I hope someone wants to help with it. I left comments with ``TODO`` to indicate them.

In addition I need to add tests for the new feature.