### PR TITLE
React to sdmsubscription-notify modifications of am-data/subscribedUeAmbr and am-data/ratRestrictions

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -1213,6 +1213,8 @@ static int parse_json(ogs_sbi_message_t *message,
                         }
                     }
                     break;
+                CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                    break;
                 DEFAULT
                     rv = OGS_ERROR;
                     ogs_error("Unknown method [%s]", message->h.method);

--- a/lib/sbi/openapi/include/list.h
+++ b/lib/sbi/openapi/include/list.h
@@ -29,8 +29,11 @@ typedef struct OpenAPI_list_s {
 
 OpenAPI_list_t *OpenAPI_list_create(void);
 void OpenAPI_list_free(OpenAPI_list_t *listToFree);
+void OpenAPI_list_clear(OpenAPI_list_t *list);
 
 void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList);
+void OpenAPI_list_insert_prev(
+    OpenAPI_list_t *list, OpenAPI_lnode_t *lnode, void *dataToAddInList);
 OpenAPI_lnode_t *OpenAPI_list_find(OpenAPI_list_t *list, long indexOfElement);
 void OpenAPI_list_remove(
     OpenAPI_list_t *list, OpenAPI_lnode_t *elementToRemove);

--- a/lib/sbi/openapi/src/list.c
+++ b/lib/sbi/openapi/src/list.c
@@ -101,6 +101,16 @@ void OpenAPI_list_free(OpenAPI_list_t *list)
     }
 }
 
+void OpenAPI_list_clear(OpenAPI_list_t *list)
+{
+    if (list) {
+        OpenAPI_list_iterate_forward(list, OpenAPI_lnode_free, NULL);
+        list->first = NULL;
+        list->last = NULL;
+        list->count = 0;
+    }
+}
+
 void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList)
 {
     OpenAPI_lnode_t *newListEntry = listEntry_create(dataToAddInList);
@@ -125,6 +135,27 @@ void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList)
     newListEntry->next = NULL;
     list->last = newListEntry;
 
+    list->count++;
+}
+
+void OpenAPI_list_insert_prev(OpenAPI_list_t *list, OpenAPI_lnode_t *lnode,
+                              void *dataToAddInList)
+{
+    OpenAPI_lnode_t *newListEntry = listEntry_create(dataToAddInList);
+    if (newListEntry == NULL) {
+        ogs_assert_if_reached();
+        return;
+    } else if (lnode->prev == NULL) {
+        list->first = newListEntry;
+        lnode->prev = newListEntry;
+        newListEntry->prev = NULL;
+        newListEntry->next = lnode;
+    } else {
+        lnode->prev->next = newListEntry;
+        newListEntry->prev = lnode->prev;
+        newListEntry->next = lnode;
+        lnode->prev = newListEntry;
+    }
     list->count++;
 }
 

--- a/lib/sbi/support/20210629/openapi-generator/templates/list.c.mustache
+++ b/lib/sbi/support/20210629/openapi-generator/templates/list.c.mustache
@@ -101,6 +101,16 @@ void OpenAPI_list_free(OpenAPI_list_t *list)
     }
 }
 
+void OpenAPI_list_clear(OpenAPI_list_t *list)
+{
+    if (list) {
+        OpenAPI_list_iterate_forward(list, OpenAPI_lnode_free, NULL);
+        list->first = NULL;
+        list->last = NULL;
+        list->count = 0;
+    }
+}
+
 void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList)
 {
     OpenAPI_lnode_t *newListEntry = listEntry_create(dataToAddInList);
@@ -125,6 +135,27 @@ void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList)
     newListEntry->next = NULL;
     list->last = newListEntry;
 
+    list->count++;
+}
+
+void OpenAPI_list_insert_prev(OpenAPI_list_t *list, OpenAPI_lnode_t *lnode,
+                              void *dataToAddInList)
+{
+    OpenAPI_lnode_t *newListEntry = listEntry_create(dataToAddInList);
+    if (newListEntry == NULL) {
+        ogs_assert_if_reached();
+        return;
+    } else if (lnode->prev == NULL) {
+        list->first = newListEntry;
+        lnode->prev = newListEntry;
+        newListEntry->prev = NULL;
+        newListEntry->next = lnode;
+    } else {
+        lnode->prev->next = newListEntry;
+        newListEntry->prev = lnode->prev;
+        newListEntry->next = lnode;
+        lnode->prev = newListEntry;
+    }
     list->count++;
 }
 

--- a/lib/sbi/support/20210629/openapi-generator/templates/list.h.mustache
+++ b/lib/sbi/support/20210629/openapi-generator/templates/list.h.mustache
@@ -29,8 +29,11 @@ typedef struct OpenAPI_list_s {
 
 OpenAPI_list_t *OpenAPI_list_create(void);
 void OpenAPI_list_free(OpenAPI_list_t *listToFree);
+void OpenAPI_list_clear(OpenAPI_list_t *list);
 
 void OpenAPI_list_add(OpenAPI_list_t *list, void *dataToAddInList);
+void OpenAPI_list_insert_prev(
+    OpenAPI_list_t *list, OpenAPI_lnode_t *lnode, void *dataToAddInList);
 OpenAPI_lnode_t *OpenAPI_list_find(OpenAPI_list_t *list, long indexOfElement);
 void OpenAPI_list_remove(
     OpenAPI_list_t *list, OpenAPI_lnode_t *elementToRemove);

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1325,6 +1325,8 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
     OGS_SBI_FEATURES_SET(amf_ue->am_policy_control_features,
             OGS_SBI_NPCF_AM_POLICY_CONTROL_UE_AMBR_AUTHORIZATION);
 
+    amf_ue->rat_restrictions = OpenAPI_list_create();
+
     ogs_list_init(&amf_ue->sess_list);
 
     /* Initialization */
@@ -1361,6 +1363,8 @@ void amf_ue_remove(amf_ue_t *amf_ue)
 
     /* Clear 5GSM Message */
     AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
+
+    OpenAPI_list_free(amf_ue->rat_restrictions);
 
     /* Remove all session context */
     amf_sess_remove_all(amf_ue);
@@ -2518,4 +2522,21 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
     }
 
     return true;
+}
+
+bool amf_ue_is_rat_restricted(amf_ue_t *amf_ue)
+{
+    OpenAPI_lnode_t *node = NULL;
+    OpenAPI_rat_type_e rat;
+
+    ogs_assert(amf_ue);
+
+    rat = amf_ue_rat_type(amf_ue);
+
+    OpenAPI_list_for_each(amf_ue->rat_restrictions, node) {
+        if (node->data == (void *)rat) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -337,6 +337,7 @@ struct amf_ue_s {
     /* SubscribedInfo */
     ogs_bitrate_t   ue_ambr;
     int num_of_slice;
+    OpenAPI_list_t *rat_restrictions;
     ogs_slice_data_t slice[OGS_MAX_NUM_OF_SLICE];
 
     uint64_t        am_policy_control_features; /* SBI Features */
@@ -777,6 +778,7 @@ uint8_t amf_selected_enc_algorithm(amf_ue_t *amf_ue);
 void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 
 bool amf_update_allowed_nssai(amf_ue_t *amf_ue);
+bool amf_ue_is_rat_restricted(amf_ue_t *amf_ue);
 
 #ifdef __cplusplus
 }

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -273,6 +273,11 @@ ogs_nas_5gmm_cause_t gmm_handle_registration_request(amf_ue_t *amf_ue,
         return OGS_5GMM_CAUSE_UE_SECURITY_CAPABILITIES_MISMATCH;
     }
 
+    if (amf_ue_is_rat_restricted(amf_ue)) {
+        ogs_error("Registration rejected due to RAT restrictions");
+        return OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED;
+    }
+
     return OGS_5GMM_CAUSE_REQUEST_ACCEPTED;
 }
 

--- a/src/amf/nausf-build.c
+++ b/src/amf/nausf-build.c
@@ -80,6 +80,25 @@ end:
     return request;
 }
 
+ogs_sbi_request_t *amf_nausf_auth_build_authenticate_delete(
+        amf_ue_t *amf_ue, void *data)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(amf_ue->confirmation_url_for_5g_aka);
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
+    message.h.uri = amf_ue->confirmation_url_for_5g_aka;
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+    return request;
+}
+
 ogs_sbi_request_t *amf_nausf_auth_build_authenticate_confirmation(
         amf_ue_t *amf_ue, void *data)
 {

--- a/src/amf/nausf-build.h
+++ b/src/amf/nausf-build.h
@@ -28,6 +28,8 @@ extern "C" {
 
 ogs_sbi_request_t *amf_nausf_auth_build_authenticate(
         amf_ue_t *amf_ue, void *data);
+ogs_sbi_request_t *amf_nausf_auth_build_authenticate_delete(
+        amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nausf_auth_build_authenticate_confirmation(
         amf_ue_t *amf_ue, void *data);
 

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -380,9 +380,9 @@ ogs_pkbuf_t *ngap_build_downlink_nas_transport(
      * The UE Aggregate Maximum Bit Rate IE should be sent to the NG-RAN node
      * if the AMF has not sent it previously
      */
-    if (ran_ue->ue_ambr_sent == false && ue_ambr) {
+    if (ran_ue->ue_ambr_sent == false && ue_ambr &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
         ogs_assert(amf_ue);
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
 
         ie = CALLOC(1, sizeof(NGAP_DownlinkNASTransport_IEs_t));
         ASN_SEQUENCE_ADD(&DownlinkNASTransport->protocolIEs, ie);
@@ -520,8 +520,8 @@ ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
      *
      * SHOULD NOT CHECK PREVIOUSLY SENT
      */
-    if (PDU_RES_SETUP_REQ_TRANSFER_NEEDED(amf_ue) == true) {
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
+    if (PDU_RES_SETUP_REQ_TRANSFER_NEEDED(amf_ue) == true &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
 
         ie = CALLOC(1, sizeof(NGAP_InitialContextSetupRequestIEs_t));
         ASN_SEQUENCE_ADD(&InitialContextSetupRequest->protocolIEs, ie);
@@ -840,8 +840,8 @@ ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
      *
      * SHOULD NOT CHECK PREVIOUSLY SENT
      */
-    if (gmmbuf || n2smbuf) {
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
+    if ((gmmbuf || n2smbuf) &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
 
         ie = CALLOC(1, sizeof(NGAP_InitialContextSetupRequestIEs_t));
         ASN_SEQUENCE_ADD(&InitialContextSetupRequest->protocolIEs, ie);
@@ -1270,8 +1270,8 @@ ogs_pkbuf_t *ngap_ue_build_pdu_session_resource_setup_request(
      * if the AMF has not sent it previously.
      */
     if (ran_ue->ue_ambr_sent == false &&
-        PDU_RES_SETUP_REQ_TRANSFER_NEEDED(amf_ue) == true) {
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
+        PDU_RES_SETUP_REQ_TRANSFER_NEEDED(amf_ue) == true &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
 
         ie = CALLOC(1, sizeof(NGAP_PDUSessionResourceSetupRequestIEs_t));
         ASN_SEQUENCE_ADD(&PDUSessionResourceSetupRequest->protocolIEs, ie);
@@ -1415,8 +1415,8 @@ ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
      * The UE Aggregate Maximum Bit Rate IE should be sent to the NG-RAN node
      * if the AMF has not sent it previously.
      */
-    if (ran_ue->ue_ambr_sent == false) {
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
+    if (ran_ue->ue_ambr_sent == false &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
 
         ie = CALLOC(1, sizeof(NGAP_PDUSessionResourceSetupRequestIEs_t));
         ASN_SEQUENCE_ADD(&PDUSessionResourceSetupRequest->protocolIEs, ie);
@@ -2021,8 +2021,8 @@ ogs_pkbuf_t *ngap_build_handover_request(ran_ue_t *target_ue)
     ogs_debug("    Group[%d] Cause[%d]",
             Cause->present, (int)Cause->choice.radioNetwork);
 
-    if (HANDOVER_REQUEST_TRANSFER_NEEDED(amf_ue) == true) {
-        ogs_assert(amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink);
+    if (HANDOVER_REQUEST_TRANSFER_NEEDED(amf_ue) == true &&
+        amf_ue->ue_ambr.downlink && amf_ue->ue_ambr.uplink) {
 
         ie = CALLOC(1, sizeof(NGAP_HandoverRequestIEs_t));
         ogs_assert(ie);

--- a/src/amf/ngap-build.h
+++ b/src/amf/ngap-build.h
@@ -39,6 +39,7 @@ ogs_pkbuf_t *ngap_build_downlink_nas_transport(
 
 ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
     amf_ue_t *amf_ue, ogs_pkbuf_t *gmmbuf);
+ogs_pkbuf_t *ngap_build_ue_context_modification_request(amf_ue_t *amf_ue);
 ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
     amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
 ogs_pkbuf_t *ngap_build_ue_context_release_command(

--- a/src/amf/ngap-sm.c
+++ b/src/amf/ngap-sm.c
@@ -145,11 +145,9 @@ void ngap_state_operational(ogs_fsm_t *s, amf_event_t *e)
             case NGAP_ProcedureCode_id_PDUSessionResourceRelease:
                 ngap_handle_pdu_session_resource_release_response(gnb, pdu);
                 break;
-#if 0
             case NGAP_ProcedureCode_id_UEContextModification:
                 ngap_handle_ue_context_modification_response(gnb, pdu);
                 break;
-#endif
             case NGAP_ProcedureCode_id_UEContextRelease:
                 ngap_handle_ue_context_release_complete(gnb, pdu);
                 break;
@@ -170,11 +168,9 @@ void ngap_state_operational(ogs_fsm_t *s, amf_event_t *e)
             case NGAP_ProcedureCode_id_InitialContextSetup :
                 ngap_handle_initial_context_setup_failure(gnb, pdu);
                 break;
-#if 0
             case NGAP_ProcedureCode_id_UEContextModification:
                 ngap_handle_ue_context_modification_failure(gnb, pdu);
                 break;
-#endif
             case NGAP_ProcedureCode_id_HandoverResourceAllocation :
                 ngap_handle_handover_failure(gnb, pdu);
                 break;

--- a/src/amf/nudm-build.c
+++ b/src/amf/nudm-build.c
@@ -239,3 +239,28 @@ end:
 
     return request;
 }
+
+ogs_sbi_request_t *amf_nudm_sdm_build_subscription_delete(
+        amf_ue_t *amf_ue, void *data)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(amf_ue->supi);
+    ogs_assert(amf_ue->data_change_subscription_id);
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
+    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NUDM_SDM;
+    message.h.api.version = (char *)OGS_SBI_API_V2;
+    message.h.resource.component[0] = amf_ue->supi;
+    message.h.resource.component[1] =
+            (char *)OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS;
+    message.h.resource.component[2] = amf_ue->data_change_subscription_id;
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+    return request;
+}

--- a/src/amf/nudm-build.h
+++ b/src/amf/nudm-build.h
@@ -33,6 +33,8 @@ ogs_sbi_request_t *amf_nudm_uecm_build_registration_delete(
 ogs_sbi_request_t *amf_nudm_sdm_build_get(amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nudm_sdm_build_subscription(
         amf_ue_t *amf_ue, void *data);
+ogs_sbi_request_t *amf_nudm_sdm_build_subscription_delete(
+        amf_ue_t *amf_ue, void *data);
 
 #ifdef __cplusplus
 }

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -39,6 +39,8 @@ int amf_nudm_sdm_handle_provisioned(
                 recvmsg->AccessAndMobilitySubscriptionData->subscribed_ue_ambr;
             OpenAPI_nssai_t *NSSAI =
                 recvmsg->AccessAndMobilitySubscriptionData->nssai;
+            OpenAPI_list_t *RatRestrictions =
+                recvmsg->AccessAndMobilitySubscriptionData->rat_restrictions;
 
             OpenAPI_lnode_t *node = NULL;
 
@@ -132,10 +134,22 @@ int amf_nudm_sdm_handle_provisioned(
                     }
                 }
             }
+
+            OpenAPI_list_clear(amf_ue->rat_restrictions);
+            if (RatRestrictions) {
+                OpenAPI_list_for_each(RatRestrictions, node) {
+                    OpenAPI_list_add(amf_ue->rat_restrictions, node->data);
+                }
+            }
         }
 
         if (amf_update_allowed_nssai(amf_ue) == false) {
             ogs_error("No Allowed-NSSAI");
+            return OGS_ERROR;
+        }
+
+        if (amf_ue_is_rat_restricted(amf_ue)) {
+            ogs_error("Registration rejected due to RAT restrictions");
             return OGS_ERROR;
         }
 

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -133,6 +133,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                     }
                 }
                 break;
+            CASE(OGS_SBI_HTTP_METHOD_DELETE)
             CASE(OGS_SBI_HTTP_METHOD_PUT)
                 if (message.h.resource.component[1]) {
                     ausf_ue = ausf_ue_find_by_ctx_id(

--- a/src/ausf/nausf-handler.c
+++ b/src/ausf/nausf-handler.c
@@ -112,3 +112,19 @@ bool ausf_nausf_auth_handle_authenticate_confirmation(ausf_ue_t *ausf_ue,
 
     return true;
 }
+
+bool ausf_nausf_auth_handle_authenticate_delete(ausf_ue_t *ausf_ue,
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+{
+    ogs_assert(ausf_ue);
+    ogs_assert(stream);
+    ogs_assert(recvmsg);
+
+    ogs_assert(true ==
+        ausf_sbi_discover_and_send(
+            OGS_SBI_SERVICE_TYPE_NUDM_UEAU, NULL,
+            ausf_nudm_ueau_build_auth_removal_ind,
+            ausf_ue, stream, NULL));
+
+    return true;
+}

--- a/src/ausf/nausf-handler.h
+++ b/src/ausf/nausf-handler.h
@@ -30,6 +30,8 @@ bool ausf_nausf_auth_handle_authenticate(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 bool ausf_nausf_auth_handle_authenticate_confirmation(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+bool ausf_nausf_auth_handle_authenticate_delete(ausf_ue_t *ausf_ue,
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/ausf/nudm-build.c
+++ b/src/ausf/nudm-build.c
@@ -117,3 +117,56 @@ end:
 
     return request;
 }
+
+ogs_sbi_request_t *ausf_nudm_ueau_build_auth_removal_ind(
+        ausf_ue_t *ausf_ue, void *data)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    OpenAPI_auth_event_t *AuthEvent = NULL;
+
+    ogs_assert(ausf_ue);
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_PUT;
+    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NUDM_UEAU;
+    message.h.api.version = (char *)OGS_SBI_API_V1;
+    message.h.resource.component[0] = ausf_ue->supi;
+    message.h.resource.component[1] = (char *)OGS_SBI_RESOURCE_NAME_AUTH_EVENTS;
+
+    AuthEvent = ogs_calloc(1, sizeof(*AuthEvent));
+    if (!AuthEvent) {
+        ogs_error("No AuthEvent");
+        goto end;
+    }
+
+    AuthEvent->time_stamp = ogs_sbi_localtime_string(ogs_time_now());
+    if (!AuthEvent->time_stamp) {
+        ogs_error("No time_stamp");
+        goto end;
+    }
+
+    AuthEvent->nf_instance_id = NF_INSTANCE_ID(ogs_sbi_self()->nf_instance);
+    AuthEvent->success = true;
+    AuthEvent->auth_type = ausf_ue->auth_type;
+    AuthEvent->serving_network_name = ausf_ue->serving_network_name;
+
+    AuthEvent->is_auth_removal_ind = true;
+    AuthEvent->auth_removal_ind = true;
+
+    message.AuthEvent = AuthEvent;
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+end:
+
+    if (AuthEvent) {
+        if (AuthEvent->time_stamp)
+            ogs_free(AuthEvent->time_stamp);
+        ogs_free(AuthEvent);
+    }
+
+    return request;
+}

--- a/src/ausf/nudm-build.h
+++ b/src/ausf/nudm-build.h
@@ -29,6 +29,8 @@ extern "C" {
 ogs_sbi_request_t *ausf_nudm_ueau_build_get(ausf_ue_t *ausf_ue, void *data);
 ogs_sbi_request_t *ausf_nudm_ueau_build_result_confirmation_inform(
         ausf_ue_t *ausf_ue, void *data);
+ogs_sbi_request_t *ausf_nudm_ueau_build_auth_removal_ind(
+        ausf_ue_t *ausf_ue, void *data);
 
 #ifdef __cplusplus
 }

--- a/src/ausf/nudm-handler.c
+++ b/src/ausf/nudm-handler.c
@@ -214,6 +214,25 @@ bool ausf_nudm_ueau_handle_get(ausf_ue_t *ausf_ue,
     return true;
 }
 
+bool ausf_nudm_ueau_handle_auth_removal_ind(ausf_ue_t *ausf_ue,
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+{
+    ogs_sbi_message_t sendmsg;
+    ogs_sbi_response_t *response = NULL;
+
+    ogs_assert(ausf_ue);
+    ogs_assert(stream);
+
+    ausf_ue_remove(ausf_ue);
+
+    memset(&sendmsg, 0, sizeof(sendmsg));
+    response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+    ogs_assert(response);
+    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    return true;
+}
+
 bool ausf_nudm_ueau_handle_result_confirmation_inform(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {

--- a/src/ausf/nudm-handler.h
+++ b/src/ausf/nudm-handler.h
@@ -30,6 +30,8 @@ bool ausf_nudm_ueau_handle_get(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 bool ausf_nudm_ueau_handle_result_confirmation_inform(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+bool ausf_nudm_ueau_handle_auth_removal_ind(ausf_ue_t *ausf_ue,
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 #ifdef __cplusplus
 }
 #endif

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -98,6 +98,15 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                 OGS_FSM_TRAN(s, ausf_ue_state_exception);
             }
             break;
+        CASE(OGS_SBI_HTTP_METHOD_DELETE)
+            handled = ausf_nausf_auth_handle_authenticate_delete(
+                    ausf_ue, stream, message);
+            if (!handled) {
+                ogs_error("[%s] Cannot handle SBI message",
+                        ausf_ue->suci);
+                OGS_FSM_TRAN(s, ausf_ue_state_exception);
+            }
+            break;
         DEFAULT
             ogs_error("[%s] Invalid HTTP method [%s]",
                     ausf_ue->suci, message->h.method);
@@ -136,20 +145,37 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                 break;
             }
 
-            SWITCH(message->h.resource.component[1])
-            CASE(OGS_SBI_RESOURCE_NAME_SECURITY_INFORMATION)
-                ausf_nudm_ueau_handle_get(ausf_ue, stream, message);
-                break;
+            SWITCH(message->h.method)
+            CASE(OGS_SBI_HTTP_METHOD_PUT)
+                SWITCH(message->h.resource.component[1])
+                CASE(OGS_SBI_RESOURCE_NAME_AUTH_EVENTS)
+                    ausf_nudm_ueau_handle_auth_removal_ind(
+                            ausf_ue, stream, message);
+                    break;
 
-            CASE(OGS_SBI_RESOURCE_NAME_AUTH_EVENTS)
-                ausf_nudm_ueau_handle_result_confirmation_inform(
-                        ausf_ue, stream, message);
+                DEFAULT
+                    ogs_error("[%s] Invalid HTTP method [%s]",
+                            ausf_ue->suci, message->h.method);
+                    ogs_assert_if_reached();
+                END
                 break;
-
             DEFAULT
-                ogs_error("[%s] Invalid HTTP method [%s]",
-                        ausf_ue->suci, message->h.method);
-                ogs_assert_if_reached();
+                SWITCH(message->h.resource.component[1])
+                CASE(OGS_SBI_RESOURCE_NAME_SECURITY_INFORMATION)
+                    ausf_nudm_ueau_handle_get(ausf_ue, stream, message);
+                    break;
+
+                CASE(OGS_SBI_RESOURCE_NAME_AUTH_EVENTS)
+                    ausf_nudm_ueau_handle_result_confirmation_inform(
+                            ausf_ue, stream, message);
+                    break;
+
+                DEFAULT
+                    ogs_error("[%s] Invalid HTTP method [%s]",
+                            ausf_ue->suci, message->h.method);
+                    ogs_assert_if_reached();
+                END
+                break;
             END
             break;
 

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -229,6 +229,11 @@ bool udm_nudm_ueau_handle_result_confirmation_inform(
         return false;
     }
 
+    if (udm_ue->auth_event) {
+        OpenAPI_auth_event_free(udm_ue->auth_event);
+        udm_ue->auth_event = NULL;
+    }
+
     udm_ue->auth_event = OpenAPI_auth_event_copy(
             udm_ue->auth_event, message->AuthEvent);
 

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -561,3 +561,30 @@ bool udm_nudm_sdm_handle_subscription_create(
 
     return true;
 }
+
+bool udm_nudm_sdm_handle_subscription_delete(
+    udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+{
+    ogs_sbi_message_t sendmsg;
+    ogs_sbi_response_t *response = NULL;
+    ogs_sbi_server_t *server = NULL;
+
+    ogs_assert(udm_ue);
+    ogs_assert(stream);
+    ogs_assert(recvmsg);
+
+    if (udm_ue->data_change_callback_uri) {
+        ogs_free(udm_ue->data_change_callback_uri);
+        udm_ue->data_change_callback_uri = NULL;
+    }
+
+    server = ogs_sbi_server_from_stream(stream);
+    ogs_assert(server);
+
+    memset(&sendmsg, 0, sizeof(sendmsg));
+    response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+    ogs_assert(response);
+    ogs_sbi_server_send_response(stream, response);
+
+    return true;
+}

--- a/src/udm/nudm-handler.h
+++ b/src/udm/nudm-handler.h
@@ -40,6 +40,8 @@ bool udm_nudm_sdm_handle_subscription_provisioned(
     udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 bool udm_nudm_sdm_handle_subscription_create(
     udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+bool udm_nudm_sdm_handle_subscription_delete(
+    udm_ue_t *udm_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/udm/nudr-build.c
+++ b/src/udm/nudr-build.c
@@ -103,8 +103,12 @@ ogs_sbi_request_t *udm_nudr_dr_build_update_authentication_status(
     message.h.resource.component[3] =
         (char *)OGS_SBI_RESOURCE_NAME_AUTHENTICATION_STATUS;
 
-    message.AuthEvent = OpenAPI_auth_event_copy(
-            message.AuthEvent, udm_ue->auth_event);
+    if (udm_ue->auth_event->auth_removal_ind) {
+            message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
+    } else {
+        message.AuthEvent = OpenAPI_auth_event_copy(
+                message.AuthEvent, udm_ue->auth_event);
+    }
 
     request = ogs_sbi_build_request(&message);
     ogs_assert(request);

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -338,20 +338,27 @@ bool udm_nudr_dr_handle_subscription_authentication(
 
         memset(&sendmsg, 0, sizeof(sendmsg));
 
-        memset(&header, 0, sizeof(header));
-        header.service.name = (char *)OGS_SBI_SERVICE_NAME_NUDM_UEAU;
-        header.api.version = (char *)OGS_SBI_API_V1;
-        header.resource.component[0] = udm_ue->supi;
-        header.resource.component[1] =
-            (char *)OGS_SBI_RESOURCE_NAME_AUTH_EVENTS;
-        header.resource.component[2] = udm_ue->ctx_id;
+        if (AuthEvent->auth_removal_ind) {
+            OpenAPI_auth_event_free(AuthEvent);
+            udm_ue->auth_event = NULL;
+            response = ogs_sbi_build_response(&sendmsg,
+                    OGS_SBI_HTTP_STATUS_NO_CONTENT);
+        } else {
+            memset(&header, 0, sizeof(header));
+            header.service.name = (char *)OGS_SBI_SERVICE_NAME_NUDM_UEAU;
+            header.api.version = (char *)OGS_SBI_API_V1;
+            header.resource.component[0] = udm_ue->supi;
+            header.resource.component[1] =
+                (char *)OGS_SBI_RESOURCE_NAME_AUTH_EVENTS;
+            header.resource.component[2] = udm_ue->ctx_id;
 
-        sendmsg.http.location = ogs_sbi_server_uri(server, &header);
-        sendmsg.AuthEvent = OpenAPI_auth_event_copy(
-                sendmsg.AuthEvent, udm_ue->auth_event);
+            sendmsg.http.location = ogs_sbi_server_uri(server, &header);
+            sendmsg.AuthEvent = OpenAPI_auth_event_copy(
+                    sendmsg.AuthEvent, udm_ue->auth_event);
 
-        response = ogs_sbi_build_response(&sendmsg,
-                OGS_SBI_HTTP_STATUS_CREATED);
+            response = ogs_sbi_build_response(&sendmsg,
+                    OGS_SBI_HTTP_STATUS_CREATED);
+        }
         ogs_assert(response);
         ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -83,6 +83,22 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
                 END
                 break;
 
+            CASE(OGS_SBI_HTTP_METHOD_PUT)
+                SWITCH(message->h.resource.component[1])
+                CASE(OGS_SBI_RESOURCE_NAME_AUTH_EVENTS)
+                    udm_nudm_ueau_handle_result_confirmation_inform(
+                            udm_ue, stream, message);
+                    break;
+                DEFAULT
+                    ogs_error("[%s] Invalid resource name [%s]",
+                            udm_ue->suci, message->h.resource.component[1]);
+                    ogs_assert(true ==
+                        ogs_sbi_server_send_error(stream,
+                            OGS_SBI_HTTP_STATUS_BAD_REQUEST, message,
+                            "Invalid resource name", message->h.method));
+                END
+                break;
+
             DEFAULT
                 ogs_error("[%s] Invalid HTTP method [%s]",
                         udm_ue->suci, message->h.method);

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -180,6 +180,23 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
                             "Invalid resource name", message->h.method));
                 END
                 break;
+
+            CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                SWITCH(message->h.resource.component[1])
+                CASE(OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS)
+                    udm_nudm_sdm_handle_subscription_delete(
+                            udm_ue, stream, message);
+                    break;
+
+                DEFAULT
+                    ogs_error("[%s] Invalid resource name [%s]",
+                            udm_ue->suci, message->h.resource.component[1]);
+                    ogs_assert(true ==
+                        ogs_sbi_server_send_error(stream,
+                            OGS_SBI_HTTP_STATUS_BAD_REQUEST, message,
+                            "Invalid resource name", message->h.method));
+                END
+                break;
             DEFAULT
                 ogs_error("[%s] Invalid HTTP method [%s]",
                         udm_ue->supi, message->h.method);

--- a/src/udr/nudr-handler.c
+++ b/src/udr/nudr-handler.c
@@ -195,10 +195,12 @@ bool udr_nudr_dr_handle_subscription_authentication(
     CASE(OGS_SBI_RESOURCE_NAME_AUTHENTICATION_STATUS)
         SWITCH(recvmsg->h.method)
         CASE(OGS_SBI_HTTP_METHOD_PUT)
+        CASE(OGS_SBI_HTTP_METHOD_DELETE)
             OpenAPI_auth_event_t *AuthEvent = NULL;
 
             AuthEvent = recvmsg->AuthEvent;
-            if (!AuthEvent) {
+            if (!AuthEvent &&
+                !strcmp(recvmsg->h.method, OGS_SBI_HTTP_METHOD_PUT)) {
                 ogs_error("[%s] No AuthEvent", supi);
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(


### PR DESCRIPTION
When AMF recieves `sdmsubscription-notify` (from UDM) that am-data/subscribedUeAmbr has changed for an UE:
- AMF informs GNB of new subscribedUeAmbr.

When AMF recieves `sdmsubscription-notify` (from UDM) that am-data/ratRestrictions has changed for an UE and AMF sees that UE has become restricted in this network:
1. AMF sends NAS deregistration to UE.
2. At the same time, AMF sends session release for all UE's sessions to SMF.
3. At the same time, AMF sends policy deletion for UE to PCF.
4. At the same time, AMF unsubscribes to sdm notifications from UDM.
5. After unsubscribe from UDM is finishd, AMF deletes UE registration from UDM.
6. After that, it deletes UA authentication form AUSF.