### PR TITLE
amf: fix regression for smf selection

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1092,12 +1092,13 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                                 NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
                     ogs_assert(requester_nf_type);
 
-                    nf_instance = ogs_sbi_nf_instance_find_by_service_type(
-                                    service_type, requester_nf_type);
-                    if (nf_instance)
-                        OGS_SBI_SETUP_NF_INSTANCE(
-                                sess->sbi.service_type_array[service_type],
-                                nf_instance);
+                    amf_sbi_select_nf(
+                            &sess->sbi,
+                            OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION,
+                            requester_nf_type,
+                            NULL);
+                    nf_instance = sess->sbi.
+                        service_type_array[service_type].nf_instance;
                 }
 
                 if (nf_instance) {


### PR DESCRIPTION
Hey @acetcom,

Unfortunately commit https://github.com/open5gs/open5gs/commit/5295c108adc2fc5ae97ee5007760334ef7a6297b broke smf selection on the amf based on the defined smf configuration info (tac, S-NSSAI, DNN, etc). Use case is described by @s5uishida in https://github.com/s5uishida/open5gs_5gc_ueransim_nearby_upf_sample_config (link from the open5gs documentation).

This sounds like a regression to me since according to the documentation on the `smf.yaml` configuration files (https://github.com/open5gs/open5gs/blob/main/configs/open5gs/smf.yaml.in#L363-L490) this is supposed to work.