### PR TITLE
[PCF, UPF] Add metrics support

### DIFF
--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -200,10 +200,20 @@ tls:
 #  o Don't use SCP server => App fails if no NRF available.
 #      delegated: no
 #
+#  <Metrics Server>
+#
+#  o Metrics Server(http://<any address>:9090)
+#    metrics:
+#    - addr: 0.0.0.0
+#      port: 9090
+#
 pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 #
 # scp:

--- a/configs/open5gs/upf.yaml.in
+++ b/configs/open5gs/upf.yaml.in
@@ -164,6 +164,13 @@ logger:
 #        dnn: ims
 #        dev: ogstun3
 #
+#  <Metrics Server>
+#
+#  o Metrics Server(http://<any address>:9090)
+#    metrics:
+#    - addr: 0.0.0.0
+#      port: 9090
+#
 upf:
     pfcp:
       - addr: 127.0.0.7
@@ -172,6 +179,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 #
 # smf:

--- a/configs/sample.yaml.in
+++ b/configs/sample.yaml.in
@@ -263,6 +263,9 @@ pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 nssf:
     sbi:

--- a/configs/sample.yaml.in
+++ b/configs/sample.yaml.in
@@ -196,6 +196,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 hss:
     freeDiameter:

--- a/configs/slice.yaml.in
+++ b/configs/slice.yaml.in
@@ -166,6 +166,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 hss:
     freeDiameter:

--- a/configs/slice.yaml.in
+++ b/configs/slice.yaml.in
@@ -228,6 +228,9 @@ pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 nssf:
     sbi:

--- a/configs/srslte.yaml.in
+++ b/configs/srslte.yaml.in
@@ -162,6 +162,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 hss:
     freeDiameter:

--- a/configs/srslte.yaml.in
+++ b/configs/srslte.yaml.in
@@ -224,6 +224,9 @@ pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 nssf:
     sbi:

--- a/configs/volte.yaml.in
+++ b/configs/volte.yaml.in
@@ -165,6 +165,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 hss:
     freeDiameter:

--- a/configs/volte.yaml.in
+++ b/configs/volte.yaml.in
@@ -231,6 +231,9 @@ pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 nssf:
     sbi:

--- a/configs/vonr.yaml.in
+++ b/configs/vonr.yaml.in
@@ -165,6 +165,9 @@ upf:
     subnet:
       - addr: 10.45.0.1/16
       - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090
 
 hss:
     freeDiameter:

--- a/configs/vonr.yaml.in
+++ b/configs/vonr.yaml.in
@@ -234,6 +234,9 @@ pcf:
     sbi:
       - addr: 127.0.0.13
         port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090
 
 nssf:
     sbi:

--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -939,3 +939,17 @@ void ogs_sbi_free_qos_data(OpenAPI_qos_data_t *QosData)
 
     ogs_free(QosData);
 }
+
+char *ogs_sbi_s_nssai_to_string_plain(ogs_s_nssai_t *s_nssai)
+{
+    ogs_assert(s_nssai);
+    if (s_nssai->sd.v !=
+            OGS_S_NSSAI_NO_SD_VALUE) {
+        return ogs_msprintf("%d%06x",
+            s_nssai->sst,
+            s_nssai->sd.v);
+    } else {
+        return ogs_msprintf("%d",
+            s_nssai->sst);
+    }
+}

--- a/lib/sbi/conv.h
+++ b/lib/sbi/conv.h
@@ -88,6 +88,7 @@ OpenAPI_pcc_rule_t *ogs_sbi_build_pcc_rule(
 void ogs_sbi_free_pcc_rule(OpenAPI_pcc_rule_t *PccRule);
 OpenAPI_qos_data_t *ogs_sbi_build_qos_data(ogs_pcc_rule_t *pcc_rule);
 void ogs_sbi_free_qos_data(OpenAPI_qos_data_t *QosData);
+char *ogs_sbi_s_nssai_to_string_plain(ogs_s_nssai_t *s_nssai);
 
 #ifdef __cplusplus
 }

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -121,6 +121,8 @@ int pcf_context_parse_config(void)
                     /* handle config in sbi library */
                 } else if (!strcmp(pcf_key, "discovery")) {
                     /* handle config in sbi library */
+                } else if (!strcmp(pcf_key, "metrics")) {
+                    /* handle config in metrics library */
                 } else
                     ogs_warn("unknown key `%s`", pcf_key);
             }
@@ -318,6 +320,11 @@ void pcf_sess_remove(pcf_sess_t *sess)
         OpenAPI_subscribed_default_qos_free(sess->subscribed_default_qos);
 
     ogs_pool_free(&pcf_sess_pool, sess);
+
+    if (sess->s_nssai.sst != 0) {
+        pcf_metrics_inst_by_slice_add(&sess->pcf_ue->guami.plmn_id,
+                &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, -1);
+    }
 }
 
 void pcf_sess_remove_all(pcf_ue_t *pcf_ue)

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -26,6 +26,7 @@
 #include "ogs-dbi.h"
 
 #include "pcf-sm.h"
+#include "metrics.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/pcf/init.c
+++ b/src/pcf/init.c
@@ -18,6 +18,7 @@
  */
 
 #include "sbi-path.h"
+#include "metrics.h"
 
 static ogs_thread_t *thread;
 static void pcf_main(void *data);
@@ -28,14 +29,20 @@ int pcf_initialize()
     int rv;
 
     ogs_sbi_context_init();
-
+    ogs_metrics_context_init();
     pcf_context_init();
 
     rv = ogs_sbi_context_parse_config("pcf", "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_metrics_context_parse_config("pcf");
+    if (rv != OGS_OK) return rv;
+
     rv = pcf_context_parse_config();
     if (rv != OGS_OK) return rv;
+
+    rv = pcf_metrics_open();
+    if (rv != 0) return OGS_ERROR;
 
     rv = ogs_log_config_domain(
             ogs_app()->logger.domain, ogs_app()->logger.level);
@@ -90,6 +97,8 @@ void pcf_terminate(void)
     ogs_dbi_final();
 
     pcf_context_final();
+
+    pcf_metrics_close();
     ogs_sbi_context_final();
 }
 

--- a/src/pcf/meson.build
+++ b/src/pcf/meson.build
@@ -17,6 +17,7 @@
 
 libpcf_sources = files('''
     context.c
+    metrics.c
     event.c
 
     nnrf-handler.c
@@ -44,12 +45,14 @@ libpcf_sources = files('''
 libpcf = static_library('pcf',
     sources : libpcf_sources,
     dependencies : [libdbi_dep,
+                    libmetrics_dep,
                     libsbi_dep],
     install : false)
 
 libpcf_dep = declare_dependency(
     link_with : libpcf,
     dependencies : [libdbi_dep,
+                    libmetrics_dep,
                     libsbi_dep])
 
 pcf_sources = files('''

--- a/src/pcf/metrics.c
+++ b/src/pcf/metrics.c
@@ -1,0 +1,320 @@
+#include "ogs-app.h"
+#include "context.h"
+
+#include "metrics.h"
+
+typedef struct pcf_metrics_spec_def_s {
+    unsigned int type;
+    const char *name;
+    const char *description;
+    int initial_val;
+    unsigned int num_labels;
+    const char **labels;
+} pcf_metrics_spec_def_t;
+
+/* Helper generic functions: */
+static int pcf_metrics_init_inst(ogs_metrics_inst_t **inst,
+        ogs_metrics_spec_t **specs, unsigned int len,
+        unsigned int num_labels, const char **labels)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        inst[i] = ogs_metrics_inst_new(specs[i], num_labels, labels);
+    return OGS_OK;
+}
+
+static int pcf_metrics_free_inst(ogs_metrics_inst_t **inst,
+        unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        ogs_metrics_inst_free(inst[i]);
+    memset(inst, 0, sizeof(inst[0]) * len);
+    return OGS_OK;
+}
+
+static int pcf_metrics_init_spec(ogs_metrics_context_t *ctx,
+        ogs_metrics_spec_t **dst, pcf_metrics_spec_def_t *src, unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++) {
+        dst[i] = ogs_metrics_spec_new(ctx, src[i].type,
+                src[i].name, src[i].description,
+                src[i].initial_val, src[i].num_labels, src[i].labels);
+    }
+    return OGS_OK;
+}
+
+/* GLOBAL */
+ogs_metrics_spec_t *pcf_metrics_spec_global[_PCF_METR_GLOB_MAX];
+ogs_metrics_inst_t *pcf_metrics_inst_global[_PCF_METR_GLOB_MAX];
+pcf_metrics_spec_def_t pcf_metrics_spec_def_global[_PCF_METR_GLOB_MAX] = {
+/* Global Counters: */
+/* Global Gauges: */
+};
+static int pcf_metrics_init_inst_global(void)
+{
+    return pcf_metrics_init_inst(pcf_metrics_inst_global,
+            pcf_metrics_spec_global, _PCF_METR_GLOB_MAX, 0, NULL);
+}
+static int pcf_metrics_free_inst_global(void)
+{
+    return pcf_metrics_free_inst(pcf_metrics_inst_global, _PCF_METR_GLOB_MAX);
+}
+
+/* BY_PLMN */
+const char *labels_plmn[] = {
+    "plmnid"
+};
+#define PCF_METR_BY_PLMN_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_plmn), \
+        .labels = labels_plmn, \
+    },
+ogs_metrics_spec_t *pcf_metrics_spec_by_plmn[_PCF_METR_BY_PLMN_MAX];
+ogs_hash_t *metrics_hash_by_plmn = NULL;   /* hash table for PLMN label */
+pcf_metrics_spec_def_t pcf_metrics_spec_def_by_plmn[_PCF_METR_BY_PLMN_MAX] = {
+/* Counters: */
+PCF_METR_BY_PLMN_CTR_ENTRY(
+    PCF_METR_CTR_PA_POLICYAMASSOREQ,
+    "fivegs_pcffunction_pa_policyamassoreq",
+    "Number of AM policy association requests")
+PCF_METR_BY_PLMN_CTR_ENTRY(
+    PCF_METR_CTR_PA_POLICYAMASSOSUCC,
+    "fivegs_pcffunction_pa_policyamassosucc",
+    "Number of successful AM policy associations")
+};
+void pcf_metrics_init_by_plmn(void);
+int pcf_metrics_free_inst_by_plmn(ogs_metrics_inst_t **inst);
+typedef struct pcf_metric_key_by_plmn_s {
+    ogs_plmn_id_t               plmn_id;
+    pcf_metric_type_by_plmn_t   t;
+} pcf_metric_key_by_plmn_t;
+
+void pcf_metrics_init_by_plmn(void)
+{
+    metrics_hash_by_plmn = ogs_hash_make();
+    ogs_assert(metrics_hash_by_plmn);
+}
+void pcf_metrics_inst_by_plmn_add(ogs_plmn_id_t *plmn,
+        pcf_metric_type_by_plmn_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    pcf_metric_key_by_plmn_t *plmn_key;
+
+    plmn_key = ogs_calloc(1, sizeof(*plmn_key));
+    ogs_assert(plmn_key);
+
+    if (plmn) {
+        plmn_key->plmn_id = *plmn;
+    }
+
+    plmn_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_plmn,
+            plmn_key, sizeof(*plmn_key));
+
+    if (!metrics) {
+        char plmn_id[OGS_PLMNIDSTRLEN] = "";
+
+        if (plmn) {
+            ogs_plmn_id_to_string(plmn, plmn_id);
+        }
+
+        metrics = ogs_metrics_inst_new(pcf_metrics_spec_by_plmn[t],
+                pcf_metrics_spec_def_by_plmn->num_labels,
+                (const char *[]){ plmn_id });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_plmn,
+                plmn_key, sizeof(*plmn_key), metrics);
+    } else {
+        ogs_free(plmn_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int pcf_metrics_free_inst_by_plmn(ogs_metrics_inst_t **inst)
+{
+    return pcf_metrics_free_inst(inst, _PCF_METR_BY_PLMN_MAX);
+}
+
+/* BY_SLICE */
+const char *labels_slice[] = {
+    "plmnid",
+    "snssai"
+};
+
+#define PCF_METR_BY_SLICE_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_slice), \
+        .labels = labels_slice, \
+    },
+#define PCF_METR_BY_SLICE_GAUGE_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_slice), \
+        .labels = labels_slice, \
+    },
+ogs_metrics_spec_t *pcf_metrics_spec_by_slice[_PCF_METR_BY_SLICE_MAX];
+ogs_hash_t *metrics_hash_by_slice = NULL;   /* hash table for SLICE labels */
+pcf_metrics_spec_def_t pcf_metrics_spec_def_by_slice[_PCF_METR_BY_SLICE_MAX] = {
+/* Counters: */
+PCF_METR_BY_SLICE_CTR_ENTRY(
+    PCF_METR_CTR_PA_POLICYSMASSOREQ,
+    "fivegs_pcffunction_pa_policysmassoreq",
+    "Number of SM policy association requests")
+PCF_METR_BY_SLICE_CTR_ENTRY(
+    PCF_METR_CTR_PA_POLICYSMASSOSUCC,
+    "fivegs_pcffunction_pa_policysmassosucc",
+    "Number of successful SM policy associations")
+/* Gauges: */
+PCF_METR_BY_SLICE_GAUGE_ENTRY(
+    PCF_METR_GAUGE_PA_SESSIONNBR,
+    "fivegs_pcffunction_pa_sessionnbr",
+    "Active Sessions")
+};
+void pcf_metrics_init_by_slice(void);
+int pcf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst);
+typedef struct pcf_metric_key_by_slice_s {
+    ogs_plmn_id_t               plmn_id;
+    ogs_s_nssai_t               snssai;
+    pcf_metric_type_by_slice_t  t;
+} pcf_metric_key_by_slice_t;
+
+void pcf_metrics_init_by_slice(void)
+{
+    metrics_hash_by_slice = ogs_hash_make();
+    ogs_assert(metrics_hash_by_slice);
+}
+
+void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
+        ogs_s_nssai_t *snssai, pcf_metric_type_by_slice_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    pcf_metric_key_by_slice_t *slice_key;
+
+    slice_key = ogs_calloc(1, sizeof(*slice_key));
+    ogs_assert(slice_key);
+
+    if (plmn) {
+        slice_key->plmn_id = *plmn;
+    }
+
+    if (snssai) {
+        slice_key->snssai = *snssai;
+    } else {
+        slice_key->snssai.sst = 0;
+        slice_key->snssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+    }
+
+    slice_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_slice,
+            slice_key, sizeof(*slice_key));
+
+    if (!metrics) {
+        char plmn_id[OGS_PLMNIDSTRLEN] = "";
+        char *s_nssai = NULL;
+
+        if (plmn) {
+            ogs_plmn_id_to_string(plmn, plmn_id);
+        }
+
+        if (snssai) {
+            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+        } else {
+            s_nssai = ogs_strdup("");
+        }
+
+        metrics = ogs_metrics_inst_new(pcf_metrics_spec_by_slice[t],
+                pcf_metrics_spec_def_by_slice->num_labels,
+                (const char *[]){ plmn_id, s_nssai });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_slice,
+                slice_key, sizeof(*slice_key), metrics);
+
+        if (s_nssai)
+            ogs_free(s_nssai);
+    } else {
+        ogs_free(slice_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int pcf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst)
+{
+    return pcf_metrics_free_inst(inst, _PCF_METR_BY_SLICE_MAX);
+}
+
+int pcf_metrics_open(void)
+{
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+    ogs_metrics_context_open(ctx);
+
+    pcf_metrics_init_spec(ctx, pcf_metrics_spec_global,
+            pcf_metrics_spec_def_global, _PCF_METR_GLOB_MAX);
+    pcf_metrics_init_spec(ctx, pcf_metrics_spec_by_plmn,
+            pcf_metrics_spec_def_by_plmn, _PCF_METR_BY_PLMN_MAX);
+    pcf_metrics_init_spec(ctx, pcf_metrics_spec_by_slice,
+            pcf_metrics_spec_def_by_slice, _PCF_METR_BY_SLICE_MAX);
+
+    pcf_metrics_init_inst_global();
+    pcf_metrics_init_by_plmn();
+    pcf_metrics_init_by_slice();
+
+    return 0;
+}
+
+int pcf_metrics_close(void)
+{
+    ogs_hash_index_t *hi;
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+
+    pcf_metrics_free_inst_global();
+
+    if (metrics_hash_by_slice) {
+        for (hi = ogs_hash_first(metrics_hash_by_slice); hi; hi = ogs_hash_next(hi)) {
+            pcf_metric_key_by_slice_t *key =
+                (pcf_metric_key_by_slice_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_slice, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_slice);
+    }
+    if (metrics_hash_by_plmn) {
+        for (hi = ogs_hash_first(metrics_hash_by_plmn); hi; hi = ogs_hash_next(hi)) {
+            pcf_metric_key_by_plmn_t *key =
+                (pcf_metric_key_by_plmn_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_plmn, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric ifself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_plmn);
+    }
+
+    ogs_metrics_context_close(ctx);
+    return OGS_OK;
+}

--- a/src/pcf/metrics.h
+++ b/src/pcf/metrics.h
@@ -1,0 +1,53 @@
+#ifndef PCF_METRICS_H
+#define PCF_METRICS_H
+
+#include "ogs-metrics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum pcf_metric_type_global_s {
+    _PCF_METR_GLOB_MAX,
+} pcf_metric_type_global_t;
+extern ogs_metrics_inst_t *pcf_metrics_inst_global[_PCF_METR_GLOB_MAX];
+
+static inline void pcf_metrics_inst_global_set(pcf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_set(pcf_metrics_inst_global[t], val); }
+static inline void pcf_metrics_inst_global_add(pcf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_add(pcf_metrics_inst_global[t], val); }
+static inline void pcf_metrics_inst_global_inc(pcf_metric_type_global_t t)
+{ ogs_metrics_inst_inc(pcf_metrics_inst_global[t]); }
+static inline void pcf_metrics_inst_global_dec(pcf_metric_type_global_t t)
+{ ogs_metrics_inst_dec(pcf_metrics_inst_global[t]); }
+
+/* BY_PLMN */
+typedef enum pcf_metric_type_by_plmn_s {
+    PCF_METR_CTR_PA_POLICYAMASSOREQ = 0,
+    PCF_METR_CTR_PA_POLICYAMASSOSUCC,
+    _PCF_METR_BY_PLMN_MAX,
+} pcf_metric_type_by_plmn_t;
+
+void pcf_metrics_inst_by_plmn_add(
+    ogs_plmn_id_t *plmn, pcf_metric_type_by_plmn_t t, int val);
+
+/* BY_SLICE */
+typedef enum pcf_metric_type_by_slice_s {
+    PCF_METR_CTR_PA_POLICYSMASSOREQ = 0,
+    PCF_METR_CTR_PA_POLICYSMASSOSUCC,
+    PCF_METR_GAUGE_PA_SESSIONNBR,
+    _PCF_METR_BY_SLICE_MAX,
+} pcf_metric_type_by_slice_t;
+
+void pcf_metrics_inst_by_slice_add(
+    ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+    pcf_metric_type_by_slice_t t, int val);
+
+int pcf_metrics_open(void);
+int pcf_metrics_close(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PCF_METRICS_H */

--- a/src/pcf/nbsf-handler.c
+++ b/src/pcf/nbsf-handler.c
@@ -384,6 +384,9 @@ bool pcf_nbsf_management_handle_register(
     if (SmPolicyDecision.supp_feat)
         ogs_free(SmPolicyDecision.supp_feat);
 
+    pcf_metrics_inst_by_slice_add(&sess->pcf_ue->guami.plmn_id,
+            &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOSUCC, 1);
+
     ogs_session_data_free(&session_data);
 
     return true;

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -35,6 +35,8 @@ bool pcf_npcf_am_policy_contrtol_handle_create(pcf_ue_t *pcf_ue,
     OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_NULL;
     ogs_sockaddr_t *addr = NULL;
 
+    pcf_metrics_inst_by_plmn_add(NULL, PCF_METR_CTR_PA_POLICYAMASSOREQ, 1);
+
     ogs_assert(pcf_ue);
     ogs_assert(stream);
     ogs_assert(message);
@@ -138,6 +140,9 @@ bool pcf_npcf_am_policy_contrtol_handle_create(pcf_ue_t *pcf_ue,
         ogs_sbi_parse_guami(&pcf_ue->guami, PolicyAssociationRequest->guami);
     }
 
+    pcf_metrics_inst_by_plmn_add(&pcf_ue->guami.plmn_id,
+            PCF_METR_CTR_PA_POLICYAMASSOREQ, 1);
+
     if (PolicyAssociationRequest->rat_type)
         pcf_ue->rat_type = PolicyAssociationRequest->rat_type;
 
@@ -171,6 +176,8 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
     ogs_sbi_client_t *client = NULL;
     OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_NULL;
     ogs_sockaddr_t *addr = NULL;
+
+    pcf_metrics_inst_by_slice_add(NULL, NULL, PCF_METR_CTR_PA_POLICYSMASSOREQ, 1);
 
     ogs_assert(sess);
     pcf_ue = sess->pcf_ue;
@@ -291,6 +298,11 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
 
     sess->s_nssai.sst = sliceInfo->sst;
     sess->s_nssai.sd = ogs_s_nssai_sd_from_string(sliceInfo->sd);
+
+    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+            &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, 1);
+    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+            &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOREQ, 1);
 
     if (SmPolicyContextData->subs_sess_ambr)
         sess->subscribed_sess_ambr = OpenAPI_ambr_copy(

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -147,6 +147,9 @@ bool pcf_nudr_dr_handle_query_am_data(
 
         ogs_subscription_data_free(&subscription_data);
 
+        pcf_metrics_inst_by_plmn_add(&pcf_ue->guami.plmn_id,
+                PCF_METR_CTR_PA_POLICYAMASSOSUCC, 1);
+
         return true;
 
     DEFAULT

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -132,6 +132,8 @@ int upf_context_parse_config(void)
                     /* handle config in pfcp library */
                 } else if (!strcmp(upf_key, "subnet")) {
                     /* handle config in pfcp library */
+                } else if (!strcmp(upf_key, "metrics")) {
+                    /* handle config in metrics library */
                 } else
                     ogs_warn("unknown key `%s`", upf_key);
             }
@@ -174,6 +176,7 @@ upf_sess_t *upf_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
             sizeof(sess->smf_n4_f_seid.seid), sess);
 
     ogs_list_add(&self.sess_list, sess);
+    upf_metrics_inst_global_inc(UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR);
 
     ogs_info("[Added] Number of UPF-Sessions is now %d",
             ogs_list_count(&self.sess_list));
@@ -208,6 +211,7 @@ int upf_sess_remove(upf_sess_t *sess)
     ogs_pfcp_pool_final(&sess->pfcp);
 
     ogs_pool_free(&upf_sess_pool, sess);
+    upf_metrics_inst_global_dec(UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR);
 
     ogs_info("[Removed] Number of UPF-sessions is now %d",
             ogs_list_count(&self.sess_list));

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -34,6 +34,7 @@
 
 #include "timer.h"
 #include "upf-sm.h"
+#include "metrics.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -182,6 +182,10 @@ static void _gtpv1_tun_recv_common_cb(
     ogs_assert(true == ogs_pfcp_up_handle_pdr(
                 pdr, OGS_GTPU_MSGTYPE_GPDU, recvbuf, &report));
 
+    upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_GTP_OUTDATAPKTN3UPF);
+    upf_metrics_inst_by_qfi_add(pdr->qer->qfi,
+        UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF, recvbuf->len);
+
     if (report.type.downlink_data_report) {
         ogs_assert(pdr->sess);
         sess = UPF_SESS(pdr->sess);
@@ -358,6 +362,10 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
 
         ip_h = (struct ip *)pkbuf->data;
         ogs_assert(ip_h);
+
+        upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF);
+        upf_metrics_inst_by_qfi_add(qfi,
+                UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF, pkbuf->len);
 
         pfcp_object = ogs_pfcp_object_find_by_teid(teid);
         if (!pfcp_object) {

--- a/src/upf/meson.build
+++ b/src/upf/meson.build
@@ -48,6 +48,7 @@ libupf_sources = files('''
     rule-match.h
     event.h
     timer.h
+    metrics.h
     context.h
     upf-sm.h
     gtp-path.h
@@ -57,6 +58,7 @@ libupf_sources = files('''
 
     rule-match.c
     init.c
+    metrics.c
     event.c
     timer.c
     context.c
@@ -86,6 +88,7 @@ libarp_nd_dep = declare_dependency(
 libupf = static_library('upf',
     sources : libupf_sources,
     dependencies : [
+        libmetrics_dep,
         libpfcp_dep,
         libtun_dep,
         libarp_nd_dep,
@@ -95,6 +98,7 @@ libupf = static_library('upf',
 libupf_dep = declare_dependency(
     link_with : libupf,
     dependencies : [
+        libmetrics_dep,
         libpfcp_dep,
         libtun_dep,
         libarp_nd_dep,

--- a/src/upf/metrics.c
+++ b/src/upf/metrics.c
@@ -1,0 +1,394 @@
+#include "ogs-app.h"
+#include "context.h"
+
+#include "metrics.h"
+
+typedef struct upf_metrics_spec_def_s {
+    unsigned int type;
+    const char *name;
+    const char *description;
+    int initial_val;
+    unsigned int num_labels;
+    const char **labels;
+} upf_metrics_spec_def_t;
+
+/* Helper generic functions: */
+static int upf_metrics_init_inst(ogs_metrics_inst_t **inst,
+        ogs_metrics_spec_t **specs, unsigned int len,
+        unsigned int num_labels, const char **labels)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        inst[i] = ogs_metrics_inst_new(specs[i], num_labels, labels);
+    return OGS_OK;
+}
+
+static int upf_metrics_free_inst(ogs_metrics_inst_t **inst,
+        unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        ogs_metrics_inst_free(inst[i]);
+    memset(inst, 0, sizeof(inst[0]) * len);
+    return OGS_OK;
+}
+
+static int upf_metrics_init_spec(ogs_metrics_context_t *ctx,
+        ogs_metrics_spec_t **dst, upf_metrics_spec_def_t *src, unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++) {
+        dst[i] = ogs_metrics_spec_new(ctx, src[i].type,
+                src[i].name, src[i].description,
+                src[i].initial_val, src[i].num_labels, src[i].labels);
+    }
+    return OGS_OK;
+}
+
+/* GLOBAL */
+ogs_metrics_spec_t *upf_metrics_spec_global[_UPF_METR_GLOB_MAX];
+ogs_metrics_inst_t *upf_metrics_inst_global[_UPF_METR_GLOB_MAX];
+upf_metrics_spec_def_t upf_metrics_spec_def_global[_UPF_METR_GLOB_MAX] = {
+/* Global Counters: */
+[UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_ep_n3_gtp_indatapktn3upf",
+    .description = "Number of incoming GTP data packets on the N3 interface",
+},
+[UPF_METR_GLOB_CTR_GTP_OUTDATAPKTN3UPF] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_ep_n3_gtp_outdatapktn3upf",
+    .description = "Number of outgoing GTP data packets on the N3 interface",
+},
+[UPF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_upffunction_sm_n4sessionestabreq",
+    .description = "Number of requested N4 session establishments",
+},
+[UPF_METR_GLOB_CTR_SM_N4SESSIONREPORT] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_upffunction_sm_n4sessionreport",
+    .description = "Number of requested N4 session reports",
+},
+[UPF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_upffunction_sm_n4sessionreportsucc",
+    .description = "Number of successful N4 session reports",
+},
+/* Global Gauges: */
+[UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "fivegs_upffunction_upf_sessionnbr",
+    .description = "Active Sessions",
+},
+};
+static int upf_metrics_init_inst_global(void)
+{
+    return upf_metrics_init_inst(upf_metrics_inst_global, upf_metrics_spec_global,
+                _UPF_METR_GLOB_MAX, 0, NULL);
+}
+static int upf_metrics_free_inst_global(void)
+{
+    return upf_metrics_free_inst(upf_metrics_inst_global, _UPF_METR_GLOB_MAX);
+}
+
+/* BY_QFI */
+const char *labels_qfi[] = {
+    "qfi"
+};
+#define UPF_METR_BY_QFI_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_qfi), \
+        .labels = labels_qfi, \
+    },
+ogs_metrics_spec_t *upf_metrics_spec_by_qfi[_UPF_METR_BY_QFI_MAX];
+ogs_hash_t *metrics_hash_by_qfi = NULL;   /* hash table for QFI label */
+upf_metrics_spec_def_t upf_metrics_spec_def_by_qfi[_UPF_METR_BY_QFI_MAX] = {
+/* Counters: */
+UPF_METR_BY_QFI_CTR_ENTRY(
+    UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF,
+    "fivegs_ep_n3_gtp_indatavolumeqosleveln3upf",
+    "Data volume of incoming GTP data packets per QoS level on the N3 interface")
+UPF_METR_BY_QFI_CTR_ENTRY(
+    UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
+    "fivegs_ep_n3_gtp_outdatavolumeqosleveln3upf",
+    "Data volume of outgoing GTP data packets per QoS level on the N3 interface")
+};
+void upf_metrics_init_by_qfi(void);
+int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst);
+typedef struct upf_metric_key_by_qfi_s {
+    uint8_t                     qfi;
+    upf_metric_type_by_qfi_t    t;
+} upf_metric_key_by_qfi_t;
+
+void upf_metrics_init_by_qfi(void)
+{
+    metrics_hash_by_qfi = ogs_hash_make();
+    ogs_assert(metrics_hash_by_qfi);
+}
+void upf_metrics_inst_by_qfi_add(uint8_t qfi,
+        upf_metric_type_by_qfi_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    upf_metric_key_by_qfi_t *qfi_key;
+
+    qfi_key = ogs_calloc(1, sizeof(*qfi_key));
+    ogs_assert(qfi_key);
+
+    qfi_key->qfi = qfi;
+    qfi_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_qfi,
+            qfi_key, sizeof(*qfi_key));
+
+    if (!metrics) {
+        char qfi_str[4];
+        ogs_snprintf(qfi_str, sizeof(qfi_str), "%d", qfi);
+
+        metrics = ogs_metrics_inst_new(upf_metrics_spec_by_qfi[t],
+                upf_metrics_spec_def_by_qfi->num_labels,
+                (const char *[]){ qfi_str });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_qfi,
+                qfi_key, sizeof(*qfi_key), metrics);
+    } else {
+        ogs_free(qfi_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst)
+{
+    return upf_metrics_free_inst(inst, _UPF_METR_BY_QFI_MAX);
+}
+
+/* BY_CAUSE */
+const char *labels_cause[] = {
+    "cause"
+};
+
+#define UPF_METR_BY_CAUSE_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_cause), \
+        .labels = labels_cause, \
+    },
+ogs_metrics_spec_t *upf_metrics_spec_by_cause[_UPF_METR_BY_CAUSE_MAX];
+ogs_hash_t *metrics_hash_by_cause = NULL;   /* hash table for CAUSE labels */
+upf_metrics_spec_def_t upf_metrics_spec_def_by_cause[_UPF_METR_BY_CAUSE_MAX] = {
+/* Counters: */
+UPF_METR_BY_CAUSE_CTR_ENTRY(
+    UPF_METR_CTR_SM_N4SESSIONESTABFAIL,
+    "fivegs_upffunction_sm_n4sessionestabfail",
+    "Number of failed N4 session establishments")
+};
+void upf_metrics_init_by_cause(void);
+int upf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst);
+typedef struct upf_metric_key_by_cause_s {
+    uint8_t                     cause;
+    upf_metric_type_by_cause_t  t;
+} upf_metric_key_by_cause_t;
+
+void upf_metrics_init_by_cause(void)
+{
+    metrics_hash_by_cause = ogs_hash_make();
+    ogs_assert(metrics_hash_by_cause);
+}
+
+void upf_metrics_inst_by_cause_add(uint8_t cause,
+        upf_metric_type_by_cause_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    upf_metric_key_by_cause_t *cause_key;
+
+    cause_key = ogs_calloc(1, sizeof(*cause_key));
+    ogs_assert(cause_key);
+
+    cause_key->cause = cause;
+    cause_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_cause,
+            cause_key, sizeof(*cause_key));
+
+    if (!metrics) {
+        char cause_str[4];
+        ogs_snprintf(cause_str, sizeof(cause_str), "%d", cause);
+
+        metrics = ogs_metrics_inst_new(upf_metrics_spec_by_cause[t],
+                upf_metrics_spec_def_by_cause->num_labels,
+                (const char *[]){ cause_str });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_cause,
+                cause_key, sizeof(*cause_key), metrics);
+    } else {
+        ogs_free(cause_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int upf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst)
+{
+    return upf_metrics_free_inst(inst, _UPF_METR_BY_CAUSE_MAX);
+}
+
+/* BY_DNN */
+const char *labels_dnn[] = {
+    "dnn"
+};
+
+#define UPF_METR_BY_DNN_GAUGE_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_dnn), \
+        .labels = labels_dnn, \
+    },
+ogs_metrics_spec_t *upf_metrics_spec_by_dnn[_UPF_METR_BY_DNN_MAX];
+ogs_hash_t *metrics_hash_by_dnn = NULL;   /* hash table for DNN labels */
+upf_metrics_spec_def_t upf_metrics_spec_def_by_dnn[_UPF_METR_BY_DNN_MAX] = {
+/* Gauges: */
+UPF_METR_BY_DNN_GAUGE_ENTRY(
+    UPF_METR_GAUGE_UPF_QOSFLOWS,
+    "fivegs_upffunction_upf_qosflows",
+    "Number of QoS flows of UPF")
+};
+void upf_metrics_init_by_dnn(void);
+int upf_metrics_free_inst_by_dnn(ogs_metrics_inst_t **inst);
+typedef struct upf_metric_key_by_dnn_s {
+    char                        dnn[OGS_MAX_DNN_LEN+1];
+    upf_metric_type_by_dnn_t    t;
+} upf_metric_key_by_dnn_t;
+
+void upf_metrics_init_by_dnn(void)
+{
+    metrics_hash_by_dnn = ogs_hash_make();
+    ogs_assert(metrics_hash_by_dnn);
+}
+
+void upf_metrics_inst_by_dnn_add(char *dnn,
+        upf_metric_type_by_dnn_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    upf_metric_key_by_dnn_t *dnn_key;
+
+    dnn_key = ogs_calloc(1, sizeof(*dnn_key));
+    ogs_assert(dnn_key);
+
+    if (dnn) {
+        strcpy(dnn_key->dnn, dnn);
+    } else {
+        dnn_key->dnn[0] = '\0';
+    }
+
+    dnn_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_dnn,
+            dnn_key, sizeof(*dnn_key));
+
+    if (!metrics) {
+        metrics = ogs_metrics_inst_new(upf_metrics_spec_by_dnn[t],
+                upf_metrics_spec_def_by_dnn->num_labels,
+                (const char *[]){ dnn_key->dnn });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_dnn,
+                dnn_key, sizeof(*dnn_key), metrics);
+    } else {
+        ogs_free(dnn_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int upf_metrics_free_inst_by_dnn(ogs_metrics_inst_t **inst)
+{
+    return upf_metrics_free_inst(inst, _UPF_METR_BY_DNN_MAX);
+}
+
+int upf_metrics_open(void)
+{
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+    ogs_metrics_context_open(ctx);
+
+    upf_metrics_init_spec(ctx, upf_metrics_spec_global, upf_metrics_spec_def_global,
+            _UPF_METR_GLOB_MAX);
+    upf_metrics_init_spec(ctx, upf_metrics_spec_by_qfi,
+            upf_metrics_spec_def_by_qfi, _UPF_METR_BY_QFI_MAX);
+    upf_metrics_init_spec(ctx, upf_metrics_spec_by_cause,
+            upf_metrics_spec_def_by_cause, _UPF_METR_BY_CAUSE_MAX);
+    upf_metrics_init_spec(ctx, upf_metrics_spec_by_dnn,
+            upf_metrics_spec_def_by_dnn, _UPF_METR_BY_DNN_MAX);
+
+    upf_metrics_init_inst_global();
+    upf_metrics_init_by_qfi();
+    upf_metrics_init_by_cause();
+    upf_metrics_init_by_dnn();
+
+    return 0;
+}
+
+int upf_metrics_close(void)
+{
+    ogs_hash_index_t *hi;
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+    upf_metrics_free_inst_global();
+
+    if (metrics_hash_by_qfi) {
+        for (hi = ogs_hash_first(metrics_hash_by_qfi); hi; hi = ogs_hash_next(hi)) {
+            upf_metric_key_by_qfi_t *key =
+                (upf_metric_key_by_qfi_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_qfi, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_qfi);
+    }
+    if (metrics_hash_by_cause) {
+        for (hi = ogs_hash_first(metrics_hash_by_cause); hi; hi = ogs_hash_next(hi)) {
+            upf_metric_key_by_cause_t *key =
+                (upf_metric_key_by_cause_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_cause, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_cause);
+    }
+    if (metrics_hash_by_dnn) {
+        for (hi = ogs_hash_first(metrics_hash_by_dnn); hi; hi = ogs_hash_next(hi)) {
+            upf_metric_key_by_dnn_t *key =
+                (upf_metric_key_by_dnn_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_dnn, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_dnn);
+    }
+
+    ogs_metrics_context_close(ctx);
+    return OGS_OK;
+}

--- a/src/upf/metrics.h
+++ b/src/upf/metrics.h
@@ -1,0 +1,66 @@
+#ifndef UPF_METRICS_H
+#define UPF_METRICS_H
+
+#include "ogs-metrics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* GLOBAL */
+typedef enum upf_metric_type_global_s {
+    UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF = 0,
+    UPF_METR_GLOB_CTR_GTP_OUTDATAPKTN3UPF,
+    UPF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ,
+    UPF_METR_GLOB_CTR_SM_N4SESSIONREPORT,
+    UPF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC,
+    UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR,
+    _UPF_METR_GLOB_MAX,
+} upf_metric_type_global_t;
+extern ogs_metrics_inst_t *upf_metrics_inst_global[_UPF_METR_GLOB_MAX];
+
+static inline void upf_metrics_inst_global_set(upf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_set(upf_metrics_inst_global[t], val); }
+static inline void upf_metrics_inst_global_add(upf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_add(upf_metrics_inst_global[t], val); }
+static inline void upf_metrics_inst_global_inc(upf_metric_type_global_t t)
+{ ogs_metrics_inst_inc(upf_metrics_inst_global[t]); }
+static inline void upf_metrics_inst_global_dec(upf_metric_type_global_t t)
+{ ogs_metrics_inst_dec(upf_metrics_inst_global[t]); }
+
+/* BY QFI */
+typedef enum upf_metric_type_by_qfi_s {
+    UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF = 0,
+    UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
+    _UPF_METR_BY_QFI_MAX,
+} upf_metric_type_by_qfi_t;
+
+void upf_metrics_inst_by_qfi_add(
+    uint8_t qfi, upf_metric_type_by_qfi_t t, int val);
+
+/* BY CAUSE */
+typedef enum upf_metric_type_by_cause_s {
+    UPF_METR_CTR_SM_N4SESSIONESTABFAIL = 0,
+    _UPF_METR_BY_CAUSE_MAX,
+} upf_metric_type_by_cause_t;
+
+void upf_metrics_inst_by_cause_add(
+    uint8_t cause, upf_metric_type_by_cause_t t, int val);
+
+/* BY DNN */
+typedef enum upf_metric_type_by_dnn_s {
+    UPF_METR_GAUGE_UPF_QOSFLOWS = 0,
+    _UPF_METR_BY_DNN_MAX,
+} upf_metric_type_by_dnn_t;
+
+void upf_metrics_inst_by_dnn_add(
+    char *dnn, upf_metric_type_by_dnn_t t, int val);
+
+int upf_metrics_open(void);
+int upf_metrics_close(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UPF_METRICS_H */

--- a/src/upf/pfcp-path.c
+++ b/src/upf/pfcp-path.c
@@ -268,6 +268,8 @@ int upf_pfcp_send_session_report_request(
     ogs_pfcp_header_t h;
     ogs_pfcp_xact_t *xact = NULL;
 
+    upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_SM_N4SESSIONREPORT);
+
     ogs_assert(sess);
     ogs_assert(report);
 


### PR DESCRIPTION
Expose metrics with labels according to ETSI TS 128 552 V16.13.0 in
PCF and UPF by using hash.
The metrics are named respecting the rule:
<generation>_<measurement_object_class>_<measurement_family_name>_<metric_name_as_in_TS_128_552>