### PR TITLE
[SMF] fix crash due free-ing invalid pointer

### DIFF
--- a/src/smf/npcf-build.c
+++ b/src/smf/npcf-build.c
@@ -47,6 +47,8 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
     message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_SM_POLICIES;
 
     memset(&SmPolicyContextData, 0, sizeof(SmPolicyContextData));
+    memset(&sNssai, 0, sizeof(sNssai));
+    memset(&SubsSessAmbr, 0, sizeof(SubsSessAmbr));
 
     SmPolicyContextData.supi = smf_ue->supi;
     if (!SmPolicyContextData.supi) {
@@ -105,7 +107,6 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
         }
     }
 
-    memset(&SubsSessAmbr, 0, sizeof(SubsSessAmbr));
     if (OGS_SBI_FEATURES_IS_SET(sess->smpolicycontrol_features,
                 OGS_SBI_NPCF_SMPOLICYCONTROL_DN_AUTHORIZATION)) {
         if (sess->session.ambr.uplink) {
@@ -161,7 +162,6 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
         }
     }
 
-    memset(&sNssai, 0, sizeof(sNssai));
     sNssai.sst = sess->s_nssai.sst;
     sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
     SmPolicyContextData.slice_info = &sNssai;


### PR DESCRIPTION
In case that database is (manually) corrupted for a specific UE, SSC mode and ARP preemption vulnerability fields are not set correctly, SMF will crash when trying to build a request to create PCF association.

Function smf_npcf_smpolicycontrol_build_create() will end prematurely, and when cleaning up resources it will try to free() up invalid pointer, which was not set to 0 at beginning of the function.

[smf] ERROR: SSCMode is not allowed (../src/smf/nudm-handler.c:165) [sbi] DEBUG: STATUS [201] (../lib/sbi/nghttp2-server.c:443) [sbi] DEBUG: SENDING...: 3 (../lib/sbi/nghttp2-server.c:451) [sbi] DEBUG: {
} (../lib/sbi/nghttp2-server.c:452)
[sbi] DEBUG: STREAM closed [1] (../lib/sbi/nghttp2-server.c:962) [smf] ERROR: No Arp.preempt_cap (../src/smf/npcf-build.c:132) <crash>

0  __GI_abort () at ./stdlib/abort.c:107
1  0x00007f9348fe43b1 in ?? () from /lib/x86_64-linux-gnu/libtalloc.so.2 2  0x00007f9349aef745 in ogs_talloc_free (ptr=0x7f9348e38dab <_int_free+1675>,
    location=0x5591b8675d27 "../src/smf/npcf-build.c:181") at ../lib/core/ogs-memory.c:107
3  0x00005591b8653c45 in smf_npcf_smpolicycontrol_build_create (sess=0x7f9343070010, data=0x0)
    at ../src/smf/npcf-build.c:181
4  0x00007f9349abc2b4 in ogs_sbi_xact_add (sbi_object=0x7f9343070010,
    service_type=OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL, discovery_option=0x7f9338006d90,
    build=0x5591b86531d0 <smf_npcf_smpolicycontrol_build_create>, context=0x7f9343070010, data=0x0)
    at ../lib/sbi/context.c:1699
5  0x00005591b86580be in smf_sbi_discover_and_send (service_type=OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL,
    discovery_option=0x0, build=0x5591b86531d0 <smf_npcf_smpolicycontrol_build_create>, sess=0x7f9343070010,
    stream=0x7f9344fce0a0, state=0, data=0x0) at ../src/smf/sbi-path.c:110
6  0x00005591b864e9da in smf_nudm_sdm_handle_get (sess=0x7f9343070010, stream=0x7f9344fce0a0,
    recvmsg=0x7f933f52d5a0) at ../src/smf/nudm-handler.c:290
7  0x00005591b8600c96 in smf_gsm_state_wait_5gc_sm_policy_association (s=0x7f9343070610, e=0x7f9338076730)
    at ../src/smf/gsm-sm.c:523
...