### PR TITLE
[AMF, SMF] Add RM and SM metrics support

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1396,6 +1396,8 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
     amf_ue->nas.amf.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     amf_ue->abba_len = 2;
 
+    amf_ue->rm_state = RM_STATE_DEREGISTERED;
+
     amf_ue_fsm_init(amf_ue);
 
     ogs_list_add(&self.amf_ue_list, amf_ue);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -408,6 +408,10 @@ struct amf_ue_s {
     char *data_change_subscription_id;
 
     ogs_list_t      sess_list;
+
+#define RM_STATE_DEREGISTERED   0
+#define RM_STATE_REGISTERED     1
+    uint8_t         rm_state;
 };
 
 typedef struct amf_sess_s {

--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -27,6 +27,25 @@ static inline void amf_metrics_inst_global_inc(amf_metric_type_global_t t)
 static inline void amf_metrics_inst_global_dec(amf_metric_type_global_t t)
 { ogs_metrics_inst_dec(amf_metrics_inst_global[t]); }
 
+/* BY SLICE */
+typedef enum amf_metric_type_by_slice_s {
+    AMF_METR_GAUGE_RM_REGISTEREDSUBNBR = 0,
+    _AMF_METR_BY_SLICE_MAX,
+} amf_metric_type_by_slice_t;
+
+void amf_metrics_inst_by_slice_add(
+    ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+    amf_metric_type_by_slice_t t, int val);
+
+/* BY CAUSE */
+typedef enum amf_metric_type_by_cause_s {
+    AMF_METR_CTR_RM_REG_INITFAIL = 0,
+    _AMF_METR_BY_CAUSE_MAX,
+} amf_metric_type_by_cause_t;
+
+void amf_metrics_inst_by_cause_add(
+    uint8_t cause, amf_metric_type_by_cause_t t, int val);
+
 int amf_metrics_open(void);
 int amf_metrics_close(void);
 

--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -158,6 +158,8 @@ int nas_5gs_send_registration_reject(
     int rv;
     ogs_pkbuf_t *gmmbuf = NULL;
 
+    amf_metrics_inst_by_cause_add(gmm_cause, AMF_METR_CTR_RM_REG_INITFAIL, 1);
+
     ogs_assert(amf_ue);
 
     ogs_warn("[%s] Registration reject [%d]", amf_ue->suci, gmm_cause);
@@ -378,6 +380,8 @@ int nas_5gs_send_authentication_reject(amf_ue_t *amf_ue)
 {
     int rv;
     ogs_pkbuf_t *gmmbuf = NULL;
+
+    amf_metrics_inst_by_cause_add(0, AMF_METR_CTR_RM_REG_INITFAIL, 1);
 
     ogs_assert(amf_ue);
 

--- a/src/smf/metrics.c
+++ b/src/smf/metrics.c
@@ -84,16 +84,26 @@ smf_metrics_spec_def_t smf_metrics_spec_def_global[_SMF_METR_GLOB_MAX] = {
     .name = "s5c_rx_deletesession",
     .description = "Received GTPv2C DeleteSessionRequest messages",
 },
+[SMF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_smffunction_sm_n4sessionestabreq",
+    .description = "Number of requested N4 session establishments evidented by SMF",
+},
+[SMF_METR_GLOB_CTR_SM_N4SESSIONREPORT] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_smffunction_sm_n4sessionreport",
+    .description = "Number of requested N4 session reports evidented by SMF",
+},
+[SMF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_smffunction_sm_n4sessionreportsucc",
+    .description = "Number of successful N4 session reports evidented by SMF",
+},
 /* Global Gauges: */
 [SMF_METR_GLOB_GAUGE_UES_ACTIVE] = {
     .type = OGS_METRICS_METRIC_TYPE_GAUGE,
     .name = "ues_active",
     .description = "Active User Equipments",
-},
-[SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE] = {
-    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
-    .name = "sessions_active",
-    .description = "Active Sessions",
 },
 [SMF_METR_GLOB_GAUGE_BEARERS_ACTIVE] = {
     .type = OGS_METRICS_METRIC_TYPE_GAUGE,
@@ -177,6 +187,281 @@ int smf_metrics_free_inst_gtp_node(ogs_metrics_inst_t **inst)
     return smf_metrics_free_inst(inst, _SMF_METR_GTP_NODE_MAX);
 }
 
+/* BY SLICE */
+const char *labels_slice[] = {
+    "plmnid",
+    "snssai"
+};
+
+#define SMF_METR_BY_SLICE_GAUGE_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_slice), \
+        .labels = labels_slice, \
+    },
+ogs_metrics_spec_t *smf_metrics_spec_by_slice[_SMF_METR_BY_SLICE_MAX];
+ogs_hash_t *metrics_hash_by_slice = NULL;   /* hash table for SLICE labels */
+smf_metrics_spec_def_t smf_metrics_spec_def_by_slice[_SMF_METR_BY_SLICE_MAX] = {
+/* Gauges: */
+SMF_METR_BY_SLICE_GAUGE_ENTRY(
+    SMF_METR_GAUGE_SM_SESSIONNBR,
+    "fivegs_smffunction_sm_sessionnbr",
+    "Active Sessions")
+};
+void smf_metrics_init_by_slice(void);
+int smf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst);
+typedef struct smf_metric_key_by_slice_s {
+    ogs_plmn_id_t               plmn_id;
+    ogs_s_nssai_t               snssai;
+    smf_metric_type_by_slice_t  t;
+} smf_metric_key_by_slice_t;
+
+void smf_metrics_init_by_slice(void)
+{
+    metrics_hash_by_slice = ogs_hash_make();
+    ogs_assert(metrics_hash_by_slice);
+}
+
+void smf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
+        ogs_s_nssai_t *snssai, smf_metric_type_by_slice_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    smf_metric_key_by_slice_t *slice_key;
+
+    slice_key = ogs_calloc(1, sizeof(*slice_key));
+    ogs_assert(slice_key);
+
+    if (plmn) {
+        slice_key->plmn_id = *plmn;
+    }
+
+    if (snssai) {
+        slice_key->snssai = *snssai;
+    } else {
+        slice_key->snssai.sst = 0;
+        slice_key->snssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+    }
+
+    slice_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_slice,
+            slice_key, sizeof(*slice_key));
+
+    if (!metrics) {
+        char plmn_id[OGS_PLMNIDSTRLEN] = "";
+        char *s_nssai = NULL;
+
+        if (plmn) {
+            ogs_plmn_id_to_string(plmn, plmn_id);
+        }
+
+        if (snssai) {
+            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+        } else {
+            s_nssai = ogs_strdup("");
+        }
+
+        metrics = ogs_metrics_inst_new(smf_metrics_spec_by_slice[t],
+                smf_metrics_spec_def_by_slice->num_labels,
+                (const char *[]){ plmn_id, s_nssai });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_slice,
+                slice_key, sizeof(*slice_key), metrics);
+
+        if (s_nssai)
+            ogs_free(s_nssai);
+    } else {
+        ogs_free(slice_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int smf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst)
+{
+    return smf_metrics_free_inst(inst, _SMF_METR_BY_SLICE_MAX);
+}
+
+/* BY SLICE and 5QI */
+const char *labels_5qi[] = {
+    "plmnid",
+    "snssai",
+    "fiveqi"
+};
+
+#define SMF_METR_BY_5QI_GAUGE_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_5qi), \
+        .labels = labels_5qi, \
+    },
+ogs_metrics_spec_t *smf_metrics_spec_by_5qi[_SMF_METR_BY_5QI_MAX];
+ogs_hash_t *metrics_hash_by_5qi = NULL;   /* hash table for 5QI label */
+smf_metrics_spec_def_t smf_metrics_spec_def_by_5qi[_SMF_METR_BY_5QI_MAX] = {
+/* Gauges: */
+SMF_METR_BY_5QI_GAUGE_ENTRY(
+    SMF_METR_GAUGE_SM_QOSFLOWNBR,
+    "fivegs_smffunction_sm_qos_flow_nbr",
+    "Number of QoS flows at the SMF")
+};
+void smf_metrics_init_by_5qi(void);
+int smf_metrics_free_inst_by_5qi(ogs_metrics_inst_t **inst);
+typedef struct smf_metric_key_by_5qi_s {
+    ogs_plmn_id_t               plmn_id;
+    ogs_s_nssai_t               snssai;
+    uint8_t                     fiveqi;
+    smf_metric_type_by_5qi_t    t;
+} smf_metric_key_by_5qi_t;
+
+void smf_metrics_init_by_5qi(void)
+{
+    metrics_hash_by_5qi = ogs_hash_make();
+    ogs_assert(metrics_hash_by_5qi);
+}
+void smf_metrics_inst_by_5qi_add(ogs_plmn_id_t *plmn,
+        ogs_s_nssai_t *snssai, uint8_t fiveqi,
+        smf_metric_type_by_5qi_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    smf_metric_key_by_5qi_t *fiveqi_key;
+
+    fiveqi_key = ogs_calloc(1, sizeof(*fiveqi_key));
+    ogs_assert(fiveqi_key);
+
+    if (plmn) {
+        fiveqi_key->plmn_id = *plmn;
+    }
+
+    if (snssai) {
+        fiveqi_key->snssai = *snssai;
+    } else {
+        fiveqi_key->snssai.sst = 0;
+        fiveqi_key->snssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+    }
+
+    fiveqi_key->fiveqi = fiveqi;
+    fiveqi_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_5qi,
+            fiveqi_key, sizeof(*fiveqi_key));
+
+    if (!metrics) {
+        char plmn_id[OGS_PLMNIDSTRLEN] = "";
+        char *s_nssai = NULL;
+        char fiveqi_str[4];
+
+        if (plmn) {
+            ogs_plmn_id_to_string(plmn, plmn_id);
+        }
+
+        if (snssai) {
+            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+        } else {
+            s_nssai = ogs_strdup("");
+        }
+
+        ogs_snprintf(fiveqi_str, sizeof(fiveqi_str), "%d", fiveqi);
+
+        metrics = ogs_metrics_inst_new(smf_metrics_spec_by_5qi[t],
+                smf_metrics_spec_def_by_5qi->num_labels,
+                (const char *[]){ plmn_id, s_nssai, fiveqi_str });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_5qi,
+                fiveqi_key, sizeof(*fiveqi_key), metrics);
+
+        if (s_nssai)
+            ogs_free(s_nssai);
+    } else {
+        ogs_free(fiveqi_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int smf_metrics_free_inst_by_5qi(ogs_metrics_inst_t **inst)
+{
+    return smf_metrics_free_inst(inst, _SMF_METR_BY_5QI_MAX);
+}
+
+/* BY CAUSE */
+const char *labels_cause[] = {
+    "cause"
+};
+
+#define SMF_METR_BY_CAUSE_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_cause), \
+        .labels = labels_cause, \
+    },
+ogs_metrics_spec_t *smf_metrics_spec_by_cause[_SMF_METR_BY_CAUSE_MAX];
+ogs_hash_t *metrics_hash_by_cause = NULL;   /* hash table for CAUSE labels */
+smf_metrics_spec_def_t smf_metrics_spec_def_by_cause[_SMF_METR_BY_CAUSE_MAX] = {
+/* Counters: */
+SMF_METR_BY_CAUSE_CTR_ENTRY(
+    SMF_METR_CTR_SM_N4SESSIONESTABFAIL,
+    "fivegs_smffunction_sm_n4sessionestabfail",
+    "Number of failed N4 session establishments evidented by SMF")
+};
+void smf_metrics_init_by_cause(void);
+int smf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst);
+typedef struct smf_metric_key_by_cause_s {
+    uint8_t                     cause;
+    smf_metric_type_by_cause_t  t;
+} smf_metric_key_by_cause_t;
+
+void smf_metrics_init_by_cause(void)
+{
+    metrics_hash_by_cause = ogs_hash_make();
+    ogs_assert(metrics_hash_by_cause);
+}
+
+void smf_metrics_inst_by_cause_add(uint8_t cause,
+        smf_metric_type_by_cause_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    smf_metric_key_by_cause_t *cause_key;
+
+    cause_key = ogs_calloc(1, sizeof(*cause_key));
+    ogs_assert(cause_key);
+
+    cause_key->cause = cause;
+    cause_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_cause,
+            cause_key, sizeof(*cause_key));
+
+    if (!metrics) {
+        char cause_str[4];
+        ogs_snprintf(cause_str, sizeof(cause_str), "%d", cause);
+
+        metrics = ogs_metrics_inst_new(smf_metrics_spec_by_cause[t],
+                smf_metrics_spec_def_by_cause->num_labels,
+                (const char *[]){ cause_str });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_cause,
+                cause_key, sizeof(*cause_key), metrics);
+    } else {
+        ogs_free(cause_key);
+    }
+
+    ogs_metrics_inst_add(metrics, val);
+}
+
+int smf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst)
+{
+    return smf_metrics_free_inst(inst, _SMF_METR_BY_CAUSE_MAX);
+}
+
 int smf_metrics_open(void)
 {
     ogs_metrics_context_t *ctx = ogs_metrics_self();
@@ -188,13 +473,71 @@ int smf_metrics_open(void)
     smf_metrics_init_spec(ctx, smf_metrics_spec_gtp_node, smf_metrics_spec_def_gtp_node,
             _SMF_METR_GTP_NODE_MAX);
 
+    smf_metrics_init_spec(ctx, smf_metrics_spec_by_slice,
+            smf_metrics_spec_def_by_slice, _SMF_METR_BY_SLICE_MAX);
+    smf_metrics_init_spec(ctx, smf_metrics_spec_by_5qi,
+            smf_metrics_spec_def_by_5qi, _SMF_METR_BY_5QI_MAX);
+    smf_metrics_init_spec(ctx, smf_metrics_spec_by_cause,
+            smf_metrics_spec_def_by_cause, _SMF_METR_BY_CAUSE_MAX);
+
     smf_metrics_init_inst_global();
+    smf_metrics_init_by_slice();
+    smf_metrics_init_by_5qi();
+    smf_metrics_init_by_cause();
     return 0;
 }
 
 int smf_metrics_close(void)
 {
+    ogs_hash_index_t *hi;
     ogs_metrics_context_t *ctx = ogs_metrics_self();
+
+    if (metrics_hash_by_slice) {
+        for (hi = ogs_hash_first(metrics_hash_by_slice); hi; hi = ogs_hash_next(hi)) {
+            smf_metric_key_by_slice_t *key =
+                (smf_metric_key_by_slice_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_slice, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_slice);
+    }
+    if (metrics_hash_by_5qi) {
+        for (hi = ogs_hash_first(metrics_hash_by_5qi); hi; hi = ogs_hash_next(hi)) {
+            smf_metric_key_by_5qi_t *key =
+                (smf_metric_key_by_5qi_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_5qi, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_5qi);
+    }
+    if (metrics_hash_by_cause) {
+        for (hi = ogs_hash_first(metrics_hash_by_cause); hi; hi = ogs_hash_next(hi)) {
+            smf_metric_key_by_cause_t *key =
+                (smf_metric_key_by_cause_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_cause, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric itself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_cause);
+    }
+
     ogs_metrics_context_close(ctx);
     return OGS_OK;
 }

--- a/src/smf/metrics.h
+++ b/src/smf/metrics.h
@@ -16,8 +16,10 @@ typedef enum smf_metric_type_global_s {
     SMF_METR_GLOB_CTR_S5C_RX_PARSE_FAILED,
     SMF_METR_GLOB_CTR_S5C_RX_CREATESESSIONREQ,
     SMF_METR_GLOB_CTR_S5C_RX_DELETESESSIONREQ,
+    SMF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ,
+    SMF_METR_GLOB_CTR_SM_N4SESSIONREPORT,
+    SMF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC,
     SMF_METR_GLOB_GAUGE_UES_ACTIVE,
-    SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE,
     SMF_METR_GLOB_GAUGE_BEARERS_ACTIVE,
     SMF_METR_GLOB_GAUGE_GTP1_PDPCTXS_ACTIVE,
     SMF_METR_GLOB_GAUGE_GTP2_SESSIONS_ACTIVE,
@@ -63,6 +65,34 @@ static inline void smf_metrics_inst_gtp_node_dec(
     ogs_metrics_inst_t **inst, smf_metric_type_gtp_node_t t)
 { ogs_metrics_inst_dec(inst[t]); }
 
+/* BY SLICE */
+typedef enum smf_metric_type_by_slice_s {
+    SMF_METR_GAUGE_SM_SESSIONNBR = 0,
+    _SMF_METR_BY_SLICE_MAX,
+} smf_metric_type_by_slice_t;
+
+void smf_metrics_inst_by_slice_add(
+    ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+    smf_metric_type_by_slice_t t, int val);
+
+/* BY SLICE and 5QI */
+typedef enum smf_metric_type_by_5qi_s {
+    SMF_METR_GAUGE_SM_QOSFLOWNBR = 0,
+    _SMF_METR_BY_5QI_MAX,
+} smf_metric_type_by_5qi_t;
+
+void smf_metrics_inst_by_5qi_add(
+    ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+    uint8_t fiveqi, smf_metric_type_by_5qi_t t, int val);
+
+/* BY CAUSE */
+typedef enum smf_metric_type_by_cause_s {
+    SMF_METR_CTR_SM_N4SESSIONESTABFAIL = 0,
+    _SMF_METR_BY_CAUSE_MAX,
+} smf_metric_type_by_cause_t;
+
+void smf_metrics_inst_by_cause_add(
+    uint8_t cause, smf_metric_type_by_cause_t t, int val);
 int smf_metrics_open(void);
 int smf_metrics_close(void);
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -178,6 +178,8 @@ uint8_t smf_5gc_n4_handle_session_establishment_response(
         if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
             ogs_error("PFCP Cause [%d] : Not Accepted", rsp->cause.u8);
             cause_value = rsp->cause.u8;
+            smf_metrics_inst_by_cause_add(cause_value,
+                    SMF_METR_CTR_SM_N4SESSIONESTABFAIL, 1);
         }
     } else {
         ogs_error("No Cause");
@@ -1146,6 +1148,8 @@ void smf_n4_handle_session_report_request(
     uint16_t pdr_id = 0;
     unsigned int i;
 
+    smf_metrics_inst_global_inc(SMF_METR_GLOB_CTR_SM_N4SESSIONREPORT);
+
     ogs_assert(pfcp_xact);
     ogs_assert(pfcp_req);
 
@@ -1321,6 +1325,7 @@ void smf_n4_handle_session_report_request(
         ogs_assert(OGS_OK ==
             smf_pfcp_send_session_report_response(
                 pfcp_xact, sess, OGS_PFCP_CAUSE_REQUEST_ACCEPTED));
+        smf_metrics_inst_global_inc(SMF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC);
     } else {
         ogs_error("Not supported Report Type[%d]", report_type.value);
         ogs_assert(OGS_OK ==

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -181,6 +181,9 @@ bool smf_nsmf_handle_create_sm_context(
                                     SmContextCreateData->hplmn_snssai->sd);
     }
 
+    smf_metrics_inst_by_slice_add(&sess->plmn_id, &sess->s_nssai,
+            SMF_METR_GAUGE_SM_SESSIONNBR, 1);
+
     if (sess->sm_context_status_uri)
         ogs_free(sess->sm_context_status_uri);
     sess->sm_context_status_uri =


### PR DESCRIPTION
Expose RM and SM metrics with labels according to ETSI TS 128 552 V16.13.0 by using hash.

The metrics are named respecting the rule:
<generation>_<measurement_object_class>_<measurement_family_name>_<metric_name_as_in_TS_128_552>
Existing SMF gauge sessions_active is renamed!