### PR TITLE
[nnrf-handler] Fix fqdn leaking memory

### DIFF
--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -522,8 +522,11 @@ static OpenAPI_nf_service_t *build_nf_service(
     NFService->scheme = nf_service->scheme;
     NFService->nf_service_status = nf_service->status;
 
-    if (nf_service->fqdn)
+    if (nf_service->fqdn) {
+        if (NFService->fqdn)
+            ogs_free(NFService->fqdn);
         NFService->fqdn = ogs_strdup(nf_service->fqdn);
+    }
 
     IpEndPointList = OpenAPI_list_create();
     if (!IpEndPointList) {

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -243,8 +243,11 @@ static void handle_nf_service(
                     NFServiceVersion->expiry);
     }
 
-    if (NFService->fqdn)
+    if (NFService->fqdn) {
+        if (nf_service->fqdn)
+            ogs_free(nf_service->fqdn);
         nf_service->fqdn = ogs_strdup(NFService->fqdn);
+    }
 
     OpenAPI_list_for_each(NFService->ip_end_points, node) {
         OpenAPI_ip_end_point_t *IpEndPoint = node->data;


### PR DESCRIPTION
Leak happens when updating an existing nf_service or if, in NfProfileList received from NRF, fqdn is specified multiple times in the same NfProfile.
