### PR TITLE
Add NF load to NRF Heartbeat

### DIFF
--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -1217,7 +1217,8 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_update(void)
     ogs_sbi_request_t *request = NULL;
 
     OpenAPI_list_t *PatchItemList;
-    OpenAPI_patch_item_t item;
+    OpenAPI_patch_item_t StatusItem;
+    OpenAPI_patch_item_t LoadItem;
 
     nf_instance = ogs_sbi_self()->nf_instance;
     ogs_assert(nf_instance);
@@ -1239,17 +1240,28 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_update(void)
         goto end;
     }
 
-    memset(&item, 0, sizeof(item));
-    item.op = OpenAPI_patch_operation_replace;
-    item.path = (char *)"/nfStatus";
-    item.value = OpenAPI_any_type_create_string(
+    memset(&StatusItem, 0, sizeof(StatusItem));
+    StatusItem.op = OpenAPI_patch_operation_replace;
+    StatusItem.path = (char *)"/nfStatus";
+    StatusItem.value = OpenAPI_any_type_create_string(
         OpenAPI_nf_status_ToString(OpenAPI_nf_status_REGISTERED));
-    if (!item.value) {
-        ogs_error("No item.value");
+    if (!StatusItem.value) {
+        ogs_error("No status item.value");
         goto end;
     }
 
-    OpenAPI_list_add(PatchItemList, &item);
+    OpenAPI_list_add(PatchItemList, &StatusItem);
+
+    memset(&LoadItem, 0, sizeof(LoadItem));
+    LoadItem.op = OpenAPI_patch_operation_replace;
+    LoadItem.path = (char *)"/load";
+    LoadItem.value = OpenAPI_any_type_create_number(ogs_sbi_self()->nf_instance->load);
+    if (!LoadItem.value) {
+        ogs_error("No load item.value");
+        goto end;
+    }
+
+    OpenAPI_list_add(PatchItemList, &LoadItem);
 
     message.PatchItemList = PatchItemList;
 
@@ -1258,7 +1270,8 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_update(void)
 
 end:
     OpenAPI_list_free(PatchItemList);
-    OpenAPI_any_type_free(item.value);
+    OpenAPI_any_type_free(StatusItem.value);
+    OpenAPI_any_type_free(LoadItem.value);
 
     return request;
 }

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -567,6 +567,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_ran_ue_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2313,6 +2313,13 @@ static void stats_remove_ran_ue(void)
     ogs_info("[Removed] Number of gNB-UEs is now %d", num_of_ran_ue);
 }
 
+int get_ran_ue_load()
+{
+    return (((ogs_pool_size(&ran_ue_pool) -
+            ogs_pool_avail(&ran_ue_pool)) * 100) /
+            ogs_pool_size(&ran_ue_pool));
+}
+
 static void stats_add_amf_session(void)
 {
     amf_metrics_inst_global_inc(AMF_METR_GLOB_GAUGE_AMF_SESS);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -793,6 +793,7 @@ void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 
 bool amf_update_allowed_nssai(amf_ue_t *amf_ue);
 bool amf_ue_is_rat_restricted(amf_ue_t *amf_ue);
+int get_ran_ue_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -332,6 +332,8 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_ue_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/ausf/context.c
+++ b/src/ausf/context.c
@@ -224,3 +224,10 @@ ausf_ue_t *ausf_ue_cycle(ausf_ue_t *ausf_ue)
 {
     return ogs_pool_cycle(&ausf_ue_pool, ausf_ue);
 }
+
+int get_ue_load()
+{
+    return (((ogs_pool_size(&ausf_ue_pool) -
+            ogs_pool_avail(&ausf_ue_pool)) * 100) /
+            ogs_pool_size(&ausf_ue_pool));
+}

--- a/src/ausf/context.h
+++ b/src/ausf/context.h
@@ -77,6 +77,7 @@ ausf_ue_t *ausf_ue_find_by_suci_or_supi(char *suci_or_supi);
 ausf_ue_t *ausf_ue_find_by_ctx_id(char *ctx_id);
 
 ausf_ue_t *ausf_ue_cycle(ausf_ue_t *ausf_ue);
+int get_ue_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -316,6 +316,8 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_sess_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/bsf/context.c
+++ b/src/bsf/context.c
@@ -322,3 +322,10 @@ bsf_sess_t *bsf_sess_find_by_ipv6prefix(char *ipv6prefix_string)
     return ogs_hash_get(self.ipv6prefix_hash,
             &ipv6prefix, (ipv6prefix.len >> 3) + 1);
 }
+
+int get_sess_load()
+{
+    return (((ogs_pool_size(&bsf_sess_pool) -
+            ogs_pool_avail(&bsf_sess_pool)) * 100) /
+            ogs_pool_size(&bsf_sess_pool));
+}

--- a/src/bsf/context.h
+++ b/src/bsf/context.h
@@ -95,6 +95,7 @@ bsf_sess_t *bsf_sess_find_by_snssai_and_dnn(ogs_s_nssai_t *s_nssai, char *dnn);
 bsf_sess_t *bsf_sess_find_by_binding_id(char *binding_id);
 bsf_sess_t *bsf_sess_find_by_ipv4addr(char *ipv4addr_string);
 bsf_sess_t *bsf_sess_find_by_ipv6prefix(char *ipv6prefix_string);
+int get_sess_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/nssf/context.c
+++ b/src/nssf/context.c
@@ -346,3 +346,10 @@ char *nssf_nsi_nrf_uri(nssf_nsi_t *nsi)
 
     return ogs_uridup(ogs_app_tls_server_enabled() == true, nsi->addr, &h);
 }
+
+int get_nsi_load()
+{
+    return (((ogs_pool_size(&nssf_nsi_pool) -
+            ogs_pool_avail(&nssf_nsi_pool)) * 100) /
+            ogs_pool_size(&nssf_nsi_pool));
+}

--- a/src/nssf/context.h
+++ b/src/nssf/context.h
@@ -60,6 +60,7 @@ void nssf_nsi_remove_all(void);
 nssf_nsi_t *nssf_nsi_find_by_s_nssai(ogs_s_nssai_t *s_nssai);
 
 char *nssf_nsi_nrf_uri(nssf_nsi_t *nsi);
+int get_nsi_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -232,6 +232,8 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_nsi_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -572,3 +572,18 @@ pcf_app_t *pcf_app_find_by_app_session_id(char *app_session_id)
     ogs_assert(app_session_id);
     return pcf_app_find(atoll(app_session_id));
 }
+
+int get_pcf_load()
+{
+    if (ogs_pool_avail(&pcf_ue_pool) / ogs_pool_size(&pcf_ue_pool) <
+            ogs_pool_avail(&pcf_sess_pool) /
+            ogs_pool_avail(&pcf_sess_pool)) {
+        return (((ogs_pool_size(&pcf_ue_pool) -
+                ogs_pool_avail(&pcf_ue_pool)) * 100) /
+                ogs_pool_size(&pcf_ue_pool));
+    } else {
+        return (((ogs_pool_size(&pcf_sess_pool) -
+                ogs_pool_avail(&pcf_sess_pool)) * 100) /
+                ogs_pool_size(&pcf_sess_pool));
+    }
+}

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -171,6 +171,7 @@ int pcf_app_remove(pcf_app_t *app);
 void pcf_app_remove_all(pcf_sess_t *sess);
 pcf_app_t *pcf_app_find(uint32_t index);
 pcf_app_t *pcf_app_find_by_app_session_id(char *app_session_id);
+int get_pcf_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -562,6 +562,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_pcf_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3103,6 +3103,13 @@ static void stats_remove_smf_session(smf_sess_t *sess)
     ogs_info("[Removed] Number of SMF-Sessions is now %d", num_of_smf_sess);
 }
 
+int get_sess_load()
+{
+    return (((ogs_pool_size(&smf_sess_pool) -
+            ogs_pool_avail(&smf_sess_pool)) * 100) /
+            ogs_pool_size(&smf_sess_pool));
+}
+
 int smf_integrity_protection_indication_value2enum(const char *value)
 {
     ogs_assert(value);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -525,6 +525,7 @@ int smf_maximum_integrity_protected_data_rate_uplink_value2enum(
         const char *value);
 int smf_maximum_integrity_protected_data_rate_downlink_value2enum(
         const char *value);
+int get_sess_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -806,6 +806,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_sess_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",

--- a/src/udm/context.c
+++ b/src/udm/context.c
@@ -233,3 +233,10 @@ udm_ue_t *udm_ue_cycle(udm_ue_t *udm_ue)
 {
     return ogs_pool_cycle(&udm_ue_pool, udm_ue);
 }
+
+int get_ue_load()
+{
+    return (((ogs_pool_size(&udm_ue_pool) -
+            ogs_pool_avail(&udm_ue_pool)) * 100) /
+            ogs_pool_size(&udm_ue_pool));
+}

--- a/src/udm/context.h
+++ b/src/udm/context.h
@@ -87,6 +87,7 @@ udm_ue_t *udm_ue_find_by_suci_or_supi(char *suci_or_supi);
 udm_ue_t *udm_ue_find_by_ctx_id(char *ctx_id);
 
 udm_ue_t *udm_ue_cycle(udm_ue_t *udm_ue);
+int get_ue_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -373,6 +373,8 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
+            ogs_sbi_self()->nf_instance->load = get_ue_load();
+
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))
                 ogs_error("[%s:%s] State machine exception [%d]",


### PR DESCRIPTION
The current load percentage of the NF Service Consumer is provided in the payload body of the PATCH request when periodically contacting the NRF (heart-beat).

- AMF: ratio between currently connected ran_ue and maximum number of them
- SMF: ratio between current PDU sessions and maximum available
- PCF: ratio between current AM+SM policy associations and maximum available
    or ratio between currently connected UEs and maximum number of them
    (the load which is higher)
- AUSF, UDM: ratio between currently connected UE and maximum number of them
- BSF: ratio between current sessions and maximum available
- NSSF: ratio between currently used NSIs and maximum number of them

NRF currently doesn't determine that the NF Profile has changed.