### PR TITLE
PathSwitch: 3gpp release 16  mandatory parameters

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -470,6 +470,7 @@ typedef struct amf_sess_s {
         ogs_pkbuf_t *pdu_session_resource_setup_request;
         ogs_pkbuf_t *pdu_session_resource_modification_command;
         ogs_pkbuf_t *path_switch_request_ack;
+        ogs_pkbuf_t *path_switch_request_fail;
         ogs_pkbuf_t *handover_request;
         ogs_pkbuf_t *handover_command;
     } transfer;

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -1928,6 +1928,7 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
     NGAP_RAN_UE_NGAP_ID_t *RAN_UE_NGAP_ID = NULL;
     NGAP_SecurityContext_t *SecurityContext = NULL;
     NGAP_PDUSessionResourceSwitchedList_t *PDUSessionResourceSwitchedList;
+    NGAP_PDUSessionResourceReleasedListPSAck_t *PDUSessionResourceReleasedListPSAck;
     NGAP_AllowedNSSAI_t *AllowedNSSAI = NULL;
 
     amf_ue = amf_ue_cycle(amf_ue);
@@ -2035,6 +2036,37 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
                 transfer->size);
     }
 
+    ogs_list_for_each(&amf_ue->sess_list, sess) {
+       if (!sess->transfer.path_switch_request_fail) continue;
+
+        OCTET_STRING_t *transfer = NULL;
+        NGAP_PDUSessionResourceReleasedItemPSAck_t *PDUSessionResourceReleasedItem = NULL;
+
+        if (!PDUSessionResourceReleasedListPSAck) {
+            ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestAcknowledgeIEs_t));
+            ASN_SEQUENCE_ADD(&PathSwitchRequestAcknowledge->protocolIEs, ie);
+
+            ie->id = NGAP_ProtocolIE_ID_id_PDUSessionResourceReleasedListPSAck;
+            ie->criticality = NGAP_Criticality_ignore;
+            ie->value.present = NGAP_PathSwitchRequestAcknowledgeIEs__value_PR_PDUSessionResourceReleasedListPSAck;
+
+            PDUSessionResourceReleasedListPSAck =
+                &ie->value.choice.PDUSessionResourceReleasedListPSAck;
+        }
+
+        PDUSessionResourceReleasedItem =
+            CALLOC(1, sizeof(NGAP_PDUSessionResourceReleasedItemPSAck_t));
+         ASN_SEQUENCE_ADD(&PDUSessionResourceReleasedListPSAck->list, PDUSessionResourceReleasedItem);
+
+        PDUSessionResourceReleasedItem->pDUSessionID = sess->psi;
+
+        transfer = &PDUSessionResourceReleasedItem->pathSwitchRequestUnsuccessfulTransfer;
+        transfer->size = sess->transfer.path_switch_request_fail->len;
+        transfer->buf = CALLOC(transfer->size, sizeof(uint8_t));
+        memcpy(transfer->buf, sess->transfer.path_switch_request_fail->data,
+            transfer->size);
+    }
+
     ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestAcknowledgeIEs_t));
     ASN_SEQUENCE_ADD(&PathSwitchRequestAcknowledge->protocolIEs, ie);
 
@@ -2066,6 +2098,97 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
         }
 
         ASN_SEQUENCE_ADD(&AllowedNSSAI->list, NGAP_AllowedNSSAI_Item);
+    }
+
+    return ogs_ngap_encode(&pdu);
+}
+
+ogs_pkbuf_t *ngap_build_path_switch_fail(amf_ue_t *amf_ue)
+{
+    ran_ue_t *ran_ue = NULL;
+    amf_sess_t *sess = NULL;
+
+    NGAP_NGAP_PDU_t pdu;
+    NGAP_UnsuccessfulOutcome_t *unsuccessfulOutcome = NULL;
+    NGAP_PathSwitchRequestFailure_t *PathSwitchRequestFailure = NULL;
+
+    NGAP_PathSwitchRequestFailureIEs_t *ie = NULL;
+    NGAP_AMF_UE_NGAP_ID_t *AMF_UE_NGAP_ID = NULL;
+    NGAP_RAN_UE_NGAP_ID_t *RAN_UE_NGAP_ID = NULL;
+
+    NGAP_PDUSessionResourceReleasedListPSFail_t *PDUSessionResourceReleasedListPSFail;
+
+    amf_ue = amf_ue_cycle(amf_ue);
+    ogs_assert(amf_ue);
+    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ogs_assert(ran_ue);
+
+    ogs_debug("PathSwitchFailure: RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
+        ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+
+    memset(&pdu, 0, sizeof (NGAP_NGAP_PDU_t));
+    pdu.present = NGAP_NGAP_PDU_PR_unsuccessfulOutcome;
+    pdu.choice.unsuccessfulOutcome = CALLOC(1, sizeof(NGAP_UnsuccessfulOutcome_t));
+
+    unsuccessfulOutcome = pdu.choice.unsuccessfulOutcome;
+    unsuccessfulOutcome->procedureCode = NGAP_ProcedureCode_id_PathSwitchRequest;
+    unsuccessfulOutcome->criticality = NGAP_Criticality_reject;
+    unsuccessfulOutcome->value.present =
+        NGAP_UnsuccessfulOutcome__value_PR_PathSwitchRequestFailure;
+
+    PathSwitchRequestFailure =
+        &unsuccessfulOutcome->value.choice.PathSwitchRequestFailure;
+
+    ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestFailureIEs_t));
+    ASN_SEQUENCE_ADD(&PathSwitchRequestFailure->protocolIEs, ie);
+
+    ie->id = NGAP_ProtocolIE_ID_id_AMF_UE_NGAP_ID;
+    ie->criticality = NGAP_Criticality_ignore;
+    ie->value.present =
+        NGAP_PathSwitchRequestFailureIEs__value_PR_AMF_UE_NGAP_ID;
+
+    AMF_UE_NGAP_ID = &ie->value.choice.AMF_UE_NGAP_ID;
+
+    ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestFailureIEs_t));
+    ASN_SEQUENCE_ADD(&PathSwitchRequestFailure->protocolIEs, ie);
+
+    ie->id = NGAP_ProtocolIE_ID_id_RAN_UE_NGAP_ID;
+    ie->criticality = NGAP_Criticality_ignore;
+    ie->value.present =
+        NGAP_PathSwitchRequestFailureIEs__value_PR_RAN_UE_NGAP_ID;
+
+    RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
+
+    asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
+    *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
+
+    ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestFailureIEs_t));
+    ASN_SEQUENCE_ADD(&PathSwitchRequestFailure->protocolIEs, ie);
+
+    ie->id = NGAP_ProtocolIE_ID_id_PDUSessionResourceReleasedListPSFail;
+    ie->criticality = NGAP_Criticality_ignore;
+    ie->value.present = NGAP_PathSwitchRequestFailureIEs__value_PR_PDUSessionResourceReleasedListPSFail;
+
+    PDUSessionResourceReleasedListPSFail =
+        &ie->value.choice.PDUSessionResourceReleasedListPSFail;
+
+    ogs_list_for_each(&amf_ue->sess_list, sess) {
+        OCTET_STRING_t *transfer = NULL;
+        NGAP_PDUSessionResourceReleasedItemPSFail_t *PDUSessionResourceReleasedItem = NULL;
+
+        if (!sess->transfer.path_switch_request_fail) continue;
+
+        PDUSessionResourceReleasedItem =
+            CALLOC(1, sizeof(NGAP_PDUSessionResourceReleasedItemPSFail_t));
+        ASN_SEQUENCE_ADD(&PDUSessionResourceReleasedListPSFail->list, PDUSessionResourceReleasedItem);
+
+        PDUSessionResourceReleasedItem->pDUSessionID = sess->psi;
+
+        transfer = &PDUSessionResourceReleasedItem->pathSwitchRequestUnsuccessfulTransfer;
+        transfer->size = sess->transfer.path_switch_request_fail->len;
+        transfer->buf = CALLOC(transfer->size, sizeof(uint8_t));
+        memcpy(transfer->buf, sess->transfer.path_switch_request_fail->data,
+                transfer->size);
     }
 
     return ogs_ngap_encode(&pdu);

--- a/src/amf/ngap-build.h
+++ b/src/amf/ngap-build.h
@@ -60,6 +60,7 @@ ogs_pkbuf_t *ngap_build_downlink_ran_configuration_transfer(
     NGAP_SONConfigurationTransfer_t *transfer);
 
 ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue);
+ogs_pkbuf_t *ngap_build_path_switch_fail(amf_ue_t *amf_ue);
 
 ogs_pkbuf_t *ngap_build_handover_request(ran_ue_t *target_ue);
 ogs_pkbuf_t *ngap_build_handover_preparation_failure(

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -438,6 +438,26 @@ int ngap_send_path_switch_ack(amf_sess_t *sess)
     return rv;
 }
 
+int ngap_send_path_switch_failure(amf_sess_t *sess)
+{
+    int rv;
+
+    amf_ue_t *amf_ue = NULL;
+    ogs_pkbuf_t *ngapbuf = NULL;
+
+    ogs_assert(sess);
+    amf_ue = sess->amf_ue;
+    ogs_assert(amf_ue);
+
+    ngapbuf = ngap_build_path_switch_fail(amf_ue);
+    ogs_expect_or_return_val(ngapbuf, OGS_ERROR);
+
+    rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
+    ogs_expect(rv == OGS_OK);
+
+    return rv;
+}
+
 int ngap_send_handover_request(amf_ue_t *amf_ue)
 {
     int rv;

--- a/src/amf/ngap-path.h
+++ b/src/amf/ngap-path.h
@@ -67,6 +67,7 @@ int ngap_send_downlink_ran_configuration_transfer(
         amf_gnb_t *target_gnb, NGAP_SONConfigurationTransfer_t *transfer);
 
 int ngap_send_path_switch_ack(amf_sess_t *sess);
+int ngap_send_path_switch_failure(amf_sess_t *sess);
 
 int ngap_send_handover_request(amf_ue_t *amf_ue);
 int ngap_send_handover_preparation_failure(

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -181,7 +181,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
             ogs_msprintf("%s: \"%s\"",
                     OGS_SBI_SERVICE_NAME_NNRF_DISC, param->nrf_uri.nrf.id);
     }
-
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
 
@@ -333,7 +332,17 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
     }
     SmContextUpdateData.cause = param->cause;
 
+    if (param->toBeSwitched){
+        SmContextUpdateData.is_to_be_switched = true;
+        SmContextUpdateData.to_be_switched = param->toBeSwitched;
+    }
+
+    if (param->failedToBeSwitched){
+        SmContextUpdateData.is_failed_to_be_switched = true;
+        SmContextUpdateData.failed_to_be_switched = param->failedToBeSwitched;
+    }
     request = ogs_sbi_build_request(&message);
+
     ogs_expect(request);
 
 end:

--- a/src/amf/nsmf-build.h
+++ b/src/amf/nsmf-build.h
@@ -57,6 +57,9 @@ typedef struct amf_nsmf_pdusession_sm_context_param_s {
             char *id;
         } nrf;
     } nrf_uri;
+
+    int toBeSwitched;
+    int failedToBeSwitched;
 } amf_nsmf_pdusession_sm_context_param_t;
 
 ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -316,7 +316,6 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         sess, n1smbuf, n2smbuf));
                 break;
 
-
             case OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD:
                 if (!n1smbuf) {
                     ogs_error("[%s:%d] No N1 SM Content [%s]",
@@ -376,6 +375,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ngap_send_path_switch_ack(sess));
 
                     AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_ack);
+                    AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_fail);
                 }
                 break;
 
@@ -574,8 +574,26 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
             } else if (state == AMF_UPDATE_SM_CONTEXT_PATH_SWITCH_REQUEST) {
 
-                /* Not reached here */
-                ogs_assert_if_reached();
+                /* Transfer msg is already stored */
+                if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
+
+                    int counter_path_switch_ack_msg = 0;
+                    ogs_list_for_each(&amf_ue->sess_list, sess) {
+                        if (sess->transfer.path_switch_request_ack)
+                            counter_path_switch_ack_msg++;
+                    }
+                    if (!counter_path_switch_ack_msg) {
+                        ogs_assert(OGS_OK ==
+                            ngap_send_path_switch_failure(sess));
+
+                    } else {
+                        ogs_assert(OGS_OK ==
+                            ngap_send_path_switch_ack(sess));
+
+                        AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_fail);
+                        AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_ack);
+                    }
+                }
 
             } else if (state == AMF_UPDATE_SM_CONTEXT_HANDOVER_REQUIRED) {
 
@@ -719,6 +737,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
         ogs_assert(amf_ue);
 
         SmContextUpdateError = recvmsg->SmContextUpdateError;
+
+        AMF_UE_CLEAR_N2_TRANSFER(amf_ue, path_switch_request_fail);
+
         if (!SmContextUpdateError) {
             ogs_error("[%d:%d] No SmContextUpdateError [%d]",
                     sess->psi, sess->pti, recvmsg->res_status);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -1272,7 +1272,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
 
                     } else if (trigger == OGS_PFCP_DELETE_TRIGGER_RAN_INITIATED) {
 
-                        OGS_FSM_TRAN(s, smf_gsm_state_session_will_deregister);
+                        OGS_FSM_TRAN(s, smf_gsm_state_session_will_release);
 
                     } else {
                         ogs_fatal("Unknown trigger [%d]", trigger);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -180,6 +180,7 @@ static bool send_sbi_message_from_delete_trigger(
         smf_sbi_send_sm_context_updated_data_n1_n2_message(sess, stream,
                 n1smbuf, OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD, n2smbuf);
     } else if (trigger == OGS_PFCP_DELETE_TRIGGER_AMF_UPDATE_SM_CONTEXT ||
+                trigger == OGS_PFCP_DELETE_TRIGGER_RAN_INITIATED ||
                 trigger == OGS_PFCP_DELETE_TRIGGER_AMF_RELEASE_SM_CONTEXT) {
         memset(&sendmsg, 0, sizeof(sendmsg));
 
@@ -1111,6 +1112,20 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
             }
             break;
 
+        case OpenAPI_n2_sm_info_type_PATH_SWITCH_SETUP_FAIL:
+            /*
+            * Upon receipt of such a request, the SMF shall return a "204 No Content" response.
+            * The SMF shall decide whether to release the PDU session or deactivate the user plane
+            * connection of the PDU session, as specified in clause 4.9.1.2 of 3GPP TS 23.502.
+            */
+            rv = ngap_handle_path_switch_request_setup_failed_transfer(sess, stream, pkbuf);
+            if (rv != OGS_OK) {
+                ogs_error("[%s:%d] Cannot handle NGAP message",
+                        smf_ue->supi, sess->psi);
+                OGS_FSM_TRAN(s, smf_gsm_state_exception);
+            }
+            break;
+
         case OpenAPI_n2_sm_info_type_HANDOVER_REQUIRED:
             rv = ngap_handle_handover_required_transfer(sess, stream, pkbuf);
             if (rv != OGS_OK) {
@@ -1254,6 +1269,10 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                             OGS_PFCP_DELETE_TRIGGER_AMF_RELEASE_SM_CONTEXT) {
 
                         OGS_FSM_TRAN(s, smf_gsm_state_session_will_release);
+
+                    } else if (trigger == OGS_PFCP_DELETE_TRIGGER_RAN_INITIATED) {
+
+                        OGS_FSM_TRAN(s, smf_gsm_state_session_will_deregister);
 
                     } else {
                         ogs_fatal("Unknown trigger [%d]", trigger);

--- a/src/smf/ngap-handler.h
+++ b/src/smf/ngap-handler.h
@@ -34,6 +34,8 @@ int ngap_handle_pdu_session_resource_modify_response_transfer(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_pkbuf_t *pkbuf);
 int ngap_handle_path_switch_request_transfer(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_pkbuf_t *pkbuf);
+int ngap_handle_path_switch_request_setup_failed_transfer(
+        smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_pkbuf_t *pkbuf);
 int ngap_handle_handover_required_transfer(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_pkbuf_t *pkbuf);
 int ngap_handle_handover_request_ack(


### PR DESCRIPTION
Support for PathSwitchRequest and PathswitchRequestAcknowledge, PathSwitchRequestFailure messages mandatory parameters and logic in:

 - AMF,

 - SMF.