### PR TITLE
[SMF] Fix metric bearers_active

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2030,6 +2030,7 @@ smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess)
     ogs_list_add(&sess->bearer_list, qos_flow);
     smf_metrics_inst_by_5qi_add(&sess->plmn_id, &sess->s_nssai,
             sess->session.qos.index, SMF_METR_GAUGE_SM_QOSFLOWNBR, 1);
+    smf_metrics_inst_global_inc(SMF_METR_GLOB_GAUGE_BEARERS_ACTIVE);
 
     return qos_flow;
 }


### PR DESCRIPTION
Metric 'bearers_active' was incremented in only one code path (smf_bearer_add() for 4G only), while it was decremented from two paths (smf_bearer_remove() for both 4G and 5G).
Increment metric also for 5G path (smf_qos_flow_add()), so it won't get decremented into negative values.