### PR TITLE
Improve handling of ports in NF_Discovery and NF_Management in case of FQDN

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1297,8 +1297,6 @@ ogs_sbi_nf_service_t *ogs_sbi_nf_service_build_default(
         /* First FQDN is selected */
         if (!hostname) {
             hostname = ogs_gethostname(advertise);
-            if (hostname)
-                continue;
         }
 
         if (nf_service->num_of_addr < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -535,13 +535,15 @@ static OpenAPI_nf_service_t *build_nf_service(
     for (i = 0; i < nf_service->num_of_addr; i++) {
         ogs_sockaddr_t *ipv4 = NULL;
         ogs_sockaddr_t *ipv6 = NULL;
+        int port = 0;
 
         OpenAPI_ip_end_point_t *IpEndPoint = NULL;
 
         ipv4 = nf_service->addr[i].ipv4;
         ipv6 = nf_service->addr[i].ipv6;
+        port = nf_service->addr[i].port;
 
-        if (ipv4 || ipv6) {
+        if (ipv4 || ipv6 || port) {
             IpEndPoint = ogs_calloc(1, sizeof(*IpEndPoint));
             if (!IpEndPoint) {
                 ogs_error("No IpEndPoint");
@@ -574,9 +576,8 @@ static OpenAPI_nf_service_t *build_nf_service(
                     return NULL;
                 }
             }
-            IpEndPoint->is_port =
-                nf_service->addr[i].port ? true : false;
-            IpEndPoint->port = nf_service->addr[i].port;
+            IpEndPoint->is_port = port ? true : false;
+            IpEndPoint->port = port;
             OpenAPI_list_add(IpEndPointList, IpEndPoint);
         }
     }

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -574,7 +574,8 @@ static OpenAPI_nf_service_t *build_nf_service(
                     return NULL;
                 }
             }
-            IpEndPoint->is_port = true;
+            IpEndPoint->is_port =
+                nf_service->addr[i].port ? true : false;
             IpEndPoint->port = nf_service->addr[i].port;
             OpenAPI_list_add(IpEndPointList, IpEndPoint);
         }

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -289,15 +289,10 @@ static void handle_nf_service(
                 }
             }
 
-            if (addr || addr6) {
-                nf_service->addr[nf_service->num_of_addr].
-                    port = port;
-                nf_service->addr[nf_service->num_of_addr].
-                    ipv4 = addr;
-                nf_service->addr[nf_service->num_of_addr].
-                    ipv6 = addr6;
-                nf_service->num_of_addr++;
-            }
+            nf_service->addr[nf_service->num_of_addr].port = port;
+            nf_service->addr[nf_service->num_of_addr].ipv4 = addr;
+            nf_service->addr[nf_service->num_of_addr].ipv6 = addr6;
+            nf_service->num_of_addr++;
         }
     }
 

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -84,13 +84,15 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     for (i = 0; i < nf_service->num_of_addr; i++) {
         ogs_sockaddr_t *ipv4 = NULL;
         ogs_sockaddr_t *ipv6 = NULL;
+        int port = 0;
 
         OpenAPI_ip_end_point_t *IpEndPoint = NULL;
 
         ipv4 = nf_service->addr[i].ipv4;
         ipv6 = nf_service->addr[i].ipv6;
+        port = nf_service->addr[i].port;
 
-        if (ipv4 || ipv6) {
+        if (ipv4 || ipv6 || port) {
             IpEndPoint = ogs_calloc(1, sizeof(*IpEndPoint));
             if (!IpEndPoint) {
                 ogs_error("No IpEndPoint");
@@ -117,8 +119,8 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
                     goto end;
                 }
             }
-            IpEndPoint->is_port = true;
-            IpEndPoint->port = nf_service->addr[i].port;
+            IpEndPoint->is_port = port ? true : false;
+            IpEndPoint->port = port;
             OpenAPI_list_add(PcfIpEndPointList, IpEndPoint);
         }
     }


### PR DESCRIPTION
Current behaviour: 
- When a NF registers to NRF with FQDN, it doesn't advertise its listening port in ipEndPoints.
- For NFDiscovery, if NRF sends a NF_Service with FQDN, consumer NF ignores ipEndPoints and always assumes target NF listens on port 80.

This proposed patch-set implements this behaviour:
- NF always advertises its listening port in ipEndPoints
- For NFDiscovery, if NRF sends a NF_Service with FQDN, consumer NF uses the first found port from ipEndPoints and if missing, it falls back to port 80 or 443, depending on NF_Service scheme.

TS 29.510 - 5G System- Network function repository services, chapter 6.2.6.2.4 - Type: NFService (148), NOTE 5:

```
If the NF Service Consumer, based on the FQDN and IP address related attributes
of the NFProfile and NFService, determines that it needs to use an FQDN to
establish the HTTP connection with the NF Service Producer, it shall use such
FQDN for DNS query and, in absence of any port information in the ipEndPoints
attribute of the NF Service, it shall use the default HTTP port number, i.e.
TCP port 80 for "http" URIs or TCP port 443 for "https" URIs as specified in
IETF RFC 7540 [9] when invoking the service.
```