### PR TITLE
[mongo] Use "ping" command instead of "serverStatus" during mongo initialization

### DIFF
--- a/lib/dbi/ogs-mongoc.c
+++ b/lib/dbi/ogs-mongoc.c
@@ -40,7 +40,7 @@ ogs_mongoc_mongoc_client_get_server_status (mongoc_client_t *client, /* IN */
 
    BSON_ASSERT (client);
 
-   BSON_APPEND_INT32 (&cmd, "serverStatus", 1);
+   BSON_APPEND_INT32 (&cmd, "ping", 1);
    ret = mongoc_client_command_simple (
       client, "admin", &cmd, read_prefs, reply, error);
    bson_destroy (&cmd);


### PR DESCRIPTION
If one restricts mongo by creating a separate user for the "open5gs" database, OGS NFs may not have sufficient privileges on the "admin" database, to perform the "serverStatus" command.