### PR TITLE
[AMF] Clear security context on network initiated deregistration

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -294,6 +294,12 @@ struct amf_ue_s {
     ((__aMF)->security_context_available == 1) && \
      ((__aMF)->mac_failed == 0) && \
      ((__aMF)->nas.ue.ksi != OGS_NAS_KSI_NO_KEY_IS_AVAILABLE))
+
+#define SECURITY_CONTEXT_CLEAR(__aMF) \
+    (__aMF)->security_context_available = 0; \
+    (__aMF)->mac_failed = 0; \
+    (__aMF)->nas.ue.ksi = 0
+
     int             security_context_available;
     int             mac_failed;
 

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -522,6 +522,8 @@ static int network_deregister (
         }
 
         OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_de_registered);
+        SECURITY_CONTEXT_CLEAR(amf_ue);
+
         return OGS_OK;
     }
     else if (CM_IDLE(amf_ue)) {
@@ -529,7 +531,7 @@ static int network_deregister (
         /*ngap_send_paging(amf_ue);*/
         return OGS_OK;
     } else {
-      return OGS_ERROR;
+        return OGS_ERROR;
     }
 }
 
@@ -590,10 +592,10 @@ int amf_namf_callback_handle_dereg_notify(
 
     if (network_deregister(
             amf_ue, DeregistrationData->dereg_reason) == -1) {
-      status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-      ogs_error("[%s] Deregistration notification for UE in wrong state",
+        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        ogs_error("[%s] Deregistration notification for UE in wrong state",
                 amf_ue->supi);
-      goto cleanup;
+        goto cleanup;
     }
 
 cleanup:


### PR DESCRIPTION
Clear security context so the UE will have to register and authenticate to the core again.
If security context is not cleared, UE might connect to AMF again, and issue only a Service Request, which AMF would happily serve without prior re-registration.