### PR TITLE
New AMF ID in SMF session context for 'inter-AMF change or mobility'

### DIFF
--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -618,6 +618,20 @@ bool smf_nsmf_handle_update_sm_context(
                     stream, OGS_SBI_HTTP_STATUS_NOT_FOUND,
                     "No PolicyAssociationId", NULL, NULL, NULL);
         }
+    } else if (SmContextUpdateData->serving_nf_id) {
+        if (sess->serving_nf_id) {
+            ogs_free(sess->serving_nf_id);
+        }
+        ogs_debug("Old serving_nf_id: %s, new serving_nf_id: %s",
+            sess->serving_nf_id, SmContextUpdateData->serving_nf_id);
+        sess->serving_nf_id = ogs_strdup(SmContextUpdateData->serving_nf_id);
+        ogs_assert(sess->serving_nf_id);
+
+        memset(&sendmsg, 0, sizeof(sendmsg));
+        response = ogs_sbi_build_response(
+            &sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+        ogs_assert(response);
+        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
     } else {
         ogs_error("[%s:%d] No UpdateData", smf_ue->supi, sess->psi);
         smf_sbi_send_sm_context_update_error(stream,


### PR DESCRIPTION
Implementation on SMF only, for now:

From TS 23.502 release 16, chapter 5.2.8.2.1 General:

... UE is handed-over from an (old) AMF towards another (new) AMF, the old AMF provides the new AMF with the SMF addressing information corresponding to the AMF-SMF association related with each PDU Session of that UE. The new AMF can thus further act upon the association with the SMF via Nsmf_PDUSession_UpdateSMContext and Nsmf_PDUSession_ReleaseSMContext operations. This may take place:
-	at inter AMF change due to AMF planned maintenance or due to AMF failure described in clause 5.21.2 of TS 23.501 [2];
