### PR TITLE
Solved upf 'core dumped' if a session was active when upf exits

### DIFF
--- a/src/upf/init.c
+++ b/src/upf/init.c
@@ -88,12 +88,13 @@ void upf_terminate(void)
 
     upf_pfcp_close();
     upf_gtp_close();
-    upf_metrics_close();
 
     upf_context_final();
 
     ogs_pfcp_context_final();
     ogs_gtp_context_final();
+
+    upf_metrics_close();
     ogs_metrics_context_final();
 
     ogs_pfcp_xact_final();


### PR DESCRIPTION
If a PDU session is active on UPF and we kill UPF with CTRL+C, a core dump is created due to segmentation fault. The UPF log is:
```
^C01/03 10:03:47.193: [app] INFO: SIGINT received (../src/main.c:53)
01/03 10:03:47.193: [app] INFO: Open5GS daemon terminating... (../src/main.c:226)
...
01/03 10:03:47.194: [upf] DEBUG: upf_pfcp_state_associated(): EXIT (../src/upf/pfcp-sm.c:166)
01/03 10:03:47.194: [upf] INFO: PFCP de-associated [10.15.199.101]:8805 (../src/upf/pfcp-sm.c:182)
01/03 10:03:47.194: [upf] DEBUG: upf_pfcp_state_final(): EXIT (../src/upf/pfcp-sm.c:60)
Segmentation fault (core dumped)
```
The situation is solved with a small correction.