### PR TITLE
[AMF] Implicit Network-initiated Deregistration

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -368,6 +368,8 @@ struct amf_ue_s {
         CLEAR_AMF_UE_TIMER((__aMF)->t3555); \
         CLEAR_AMF_UE_TIMER((__aMF)->t3560); \
         CLEAR_AMF_UE_TIMER((__aMF)->t3570); \
+        CLEAR_AMF_UE_TIMER((__aMF)->mobile_reachable); \
+        CLEAR_AMF_UE_TIMER((__aMF)->implicit_deregistration); \
     } while(0);
 #define CLEAR_AMF_UE_TIMER(__aMF_UE_TIMER) \
     do { \
@@ -382,7 +384,7 @@ struct amf_ue_s {
         ogs_pkbuf_t     *pkbuf;
         ogs_timer_t     *timer;
         uint32_t        retry_count;;
-    } t3513, t3522, t3550, t3555, t3560, t3570;
+    } t3513, t3522, t3550, t3555, t3560, t3570, mobile_reachable, implicit_deregistration;
 
     /* UE Radio Capability */
     OCTET_STRING_t  ueRadioCapability;

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -369,6 +369,30 @@ int ngap_send_paging(amf_ue_t *amf_ue)
     int i, j;
     int rv;
 
+    if (amf_ue->implicit_deregistration.timer->running) {
+        /* Mobile Reachable timer has expired if implicit de-registration
+         * timer is running
+         * TS 24.501
+         * 5.3.7 Handling of the periodic registration update timer and
+         * mobile reachable timer
+         * The network behaviour upon expiry of the mobile reachable timer
+         * is network dependent, but typically the network stops sending
+         * paging messages to the UE on the first expiry
+         */
+        ogs_info("[%s] Paging ignored due to Mobile Reachable timer expiration",
+                amf_ue->supi);
+        /* Clear Paging Info */
+        AMF_UE_CLEAR_PAGING_INFO(amf_ue);
+
+        /* Clear N2 Transfer */
+        AMF_UE_CLEAR_N2_TRANSFER(
+                amf_ue, pdu_session_resource_setup_request);
+
+        /* Clear 5GSM Message */
+        AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
+        return OGS_OK;
+    }
+
     ogs_list_for_each(&amf_self()->gnb_list, gnb) {
         for (i = 0; i < gnb->num_of_supported_ta_list; i++) {
             for (j = 0; j < gnb->supported_ta_list[i].num_of_bplmn_list; j++) {

--- a/src/amf/timer.c
+++ b/src/amf/timer.c
@@ -93,6 +93,10 @@ const char *amf_timer_get_name(int timer_id)
         return "AMF_TIMER_T3570";
     case AMF_TIMER_NG_HOLDING:
         return "AMF_TIMER_NG_HOLDING";
+    case AMF_TIMER_MOBILE_REACHABLE:
+        return "AMF_TIMER_MOBILE_REACHABLE";
+    case AMF_TIMER_IMPLICIT_DEREGISTRATION:
+        return "AMF_TIMER_IMPLICIT_DEREGISTRATION";
     default: 
         break;
     }
@@ -182,4 +186,14 @@ void amf_timer_ng_holding_timer_expire(void *data)
         ogs_error("ogs_queue_push() failed:%d", (int)rv);
         ogs_event_free(e);
     }
+}
+
+void amf_timer_mobile_reachable_expire(void *data)
+{
+    gmm_timer_event_send(AMF_TIMER_MOBILE_REACHABLE, data);
+}
+
+void amf_timer_implicit_deregistration_expire(void *data)
+{
+    gmm_timer_event_send(AMF_TIMER_IMPLICIT_DEREGISTRATION, data);
 }

--- a/src/amf/timer.h
+++ b/src/amf/timer.h
@@ -39,6 +39,8 @@ typedef enum {
     AMF_TIMER_T3555,
     AMF_TIMER_T3560,
     AMF_TIMER_T3570,
+    AMF_TIMER_MOBILE_REACHABLE,
+    AMF_TIMER_IMPLICIT_DEREGISTRATION,
 
     MAX_NUM_OF_AMF_TIMER,
 
@@ -64,6 +66,9 @@ void amf_timer_t3560_expire(void *data);
 void amf_timer_t3570_expire(void *data);
 
 void amf_timer_ng_holding_timer_expire(void *data);
+
+void amf_timer_mobile_reachable_expire(void *data);
+void amf_timer_implicit_deregistration_expire(void *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Two timers are introduced (both with duration of T3512 + 4 min):

-MOBILE_REACHABLE

-IMPLICIT_DEREGISTRATION

MOBILE_REACHABLE is set when NAS connection for the UE is released.
IMPLICIT_DEREGISTRATION is set when MOBILE_REACHABLE expires.

On MOBILE_REACHABLE expiry Paging is ignored.
On IMPLICIT_DEREGISTRATION expiry:

-UE's RM_State is set to DEREGISTERED

-UE is Nudm_SDM_Unsubscribed

-UE is Nudm_UECM_Deregistered

-PDU sessions are released

-AM policies are deleted

Existing flag amf_ue->network_initiated_de_reg is used.