### PR TITLE
changed error tagged log to info tagged log for handling 5g guti info…

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -756,7 +756,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e)
             if (amf_ue->next.m_tmsi) {
                 amf_ue_confirm_guti(amf_ue);
             } else {
-                ogs_error("[%s] No GUTI allocated", amf_ue->supi);
+                ogs_info("[%s] No GUTI allocated", amf_ue->supi);
             }
 
             CLEAR_AMF_UE_TIMER(amf_ue->t3555);


### PR DESCRIPTION
according to TS25.501 Table 8.2.19.1.1, the 5G-GUTI is optional in Configuration Update Command message content. 

After Registration Accept, AMF sent Configuration Update Command to UE. In this message, there is no 5G-GUTI. After AMF received Configuration Update Complete from UE, AMF recorded an "no GUTI allocated" error in the amf log(see line #2071 in amf_log.txt). This situation should not be treated as error since 5G-GUTI already allocated in the Registration Complete message. (see packet #274 in trace.zip). 

Therefore, the "No GUTI Allocated" notification is changed to "info". 

[trace.zip](https://github.com/open5gs/open5gs/files/10379704/trace.zip)
[amf_log.txt](https://github.com/open5gs/open5gs/files/10379646/amf_log.txt)

