### PR TITLE
Handle NF_PROFILE_CHANGED with the entire new NF Profile.

### DIFF
--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -575,13 +575,25 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
     }
 
     if (NotificationData->event ==
-            OpenAPI_notification_event_type_NF_REGISTERED) {
+            OpenAPI_notification_event_type_NF_REGISTERED ||
+        NotificationData->event ==
+            OpenAPI_notification_event_type_NF_PROFILE_CHANGED) {
 
         OpenAPI_nf_profile_t *NFProfile = NULL;
 
         NFProfile = NotificationData->nf_profile;
         if (!NFProfile) {
-            ogs_error("No NFProfile");
+            if (NotificationData->event ==
+                    OpenAPI_notification_event_type_NF_REGISTERED) {
+                ogs_error("No NFProfile");
+            } else {
+                if (!NotificationData->profile_changes) {
+                    ogs_error("No nfProfile neither profileChanges");
+                } else {
+                    /* TODO: Handle "delta" changes */
+                    ogs_error("profileChanges not supported");
+                }
+            }
             ogs_assert(true ==
                 ogs_sbi_server_send_error(
                     stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,


### PR DESCRIPTION
Consumers include nfProfileChangesSupportInd:true in their NF Profiles.
So they have to support notification when a certain NF Instance changes its profile.

Event NF_PROFILE_CHANGED is supported.
Only notification of changes by sending the entire new NF Profile is supported (nfProfile).
Consumers do not include nfProfileChangesInd in their NF Profile. So they do not have to support notification by sending "delta" (profileChanges).