### PR TITLE
Support for UPF HA - release/establish new PDU session

### DIFF
--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -377,9 +377,6 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
             return OGS_ERROR;
         }
 
-        if (n1buf)
-            ogs_pkbuf_free(n1buf);
-
         if (CM_IDLE(amf_ue)) {
             if (n2buf)
                 ogs_pkbuf_free(n2buf);
@@ -394,7 +391,7 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
             }
 
         } else if (CM_CONNECTED(amf_ue)) {
-            r = nas_send_pdu_session_release_command(sess, NULL, n2buf);
+            r = nas_send_pdu_session_release_command(sess, n1buf, n2buf);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
         } else {

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -371,6 +371,7 @@ typedef struct smf_sess_s {
 #define SMF_NGAP_STATE_DELETE_TRIGGER_UE_REQUESTED              1
 #define SMF_NGAP_STATE_DELETE_TRIGGER_PCF_INITIATED             2
 #define SMF_NGAP_STATE_ERROR_INDICATION_RECEIVED_FROM_5G_AN     3
+#define SMF_NGAP_STATE_DELETE_TRIGGER_SMF_INITIATED             4
     struct {
         int pdu_session_resource_release;
     } ngap_state;


### PR DESCRIPTION
SMF detects UPF failover by checking PFCP Heartbeats and perform transfer to new UPF (could be same after restart) according to 3GPP 23.502, chapter 4.3.5.1

All PDU sessions on failed UPF are released with cause OGS_5GSM_CAUSE_REACTIVATION_REQUESTED and so UE requests new PDU session that can be establish on some other UPF (if exists)