### PR TITLE
[SBI] Do not treat removed streams as errors when sending responses

### DIFF
--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -406,7 +406,7 @@ static bool server_send_rspmem_persistent(
     stream = ogs_pool_cycle(&stream_pool, stream);
     if (!stream) {
         ogs_error("stream has already been removed");
-        return false;
+        return true;
     }
 
     sbi_sess = stream->session;


### PR DESCRIPTION
This is in line with the implementation with microhttpd server (mhd-server.c).