### PR TITLE
[sgwc][smf] make {sgwc,smf}_sess_remove safe to call from any context

### DIFF
--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -114,9 +114,18 @@ typedef unsigned int ogs_index_t;
     if (((pool)->size != (pool)->avail)) \
         ogs_error("%d in '%s[%d]' were not released.", \
                 (pool)->size - (pool)->avail, (pool)->name, (pool)->size); \
-    ogs_free((pool)->free); \
-    ogs_free((pool)->array); \
-    ogs_free((pool)->index); \
+    if ((pool)->free) {\
+    	ogs_free((pool)->free); \
+	(pool)->free = NULL; \
+    } \
+    if ((pool)->array) {\
+        ogs_free((pool)->array); \
+	(pool)->array = NULL; \
+    } \
+    if ((pool)->index) {\
+        ogs_free((pool)->index); \
+	(pool)->index = NULL; \
+    } \
 } while (0)
 
 #ifdef __cplusplus

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -402,13 +402,16 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
 
     sgwc_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);        
+    }
 
     ogs_pfcp_pool_final(&sess->pfcp);
 
-    ogs_assert(sess->session.name);
-    ogs_free(sess->session.name);
+    if (sess->session.name) {
+        ogs_free(sess->session.name);
+        sess->session.name = NULL;
+    }
 
     ogs_pool_free(&sgwc_sess_pool, sess);
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1760,8 +1760,10 @@ void smf_sess_remove(smf_sess_t *sess)
     if (sess->policy_association_id)
         ogs_free(sess->policy_association_id);
 
-    if (sess->session.name)
+    if (sess->session.name) {
         ogs_free(sess->session.name);
+	sess->session.name = NULL;
+    }
 
     if (sess->session.ipv4_framed_routes) {
         for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; i++) {
@@ -1800,8 +1802,9 @@ void smf_sess_remove(smf_sess_t *sess)
 
     smf_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);
+    }
 
     smf_sess_delete_cp_up_data_forwarding(sess);
 


### PR DESCRIPTION
The sgwc_sess_remove() and smf_sess_remove() functions are good entry-point functions used to cleanup and remove a session. However, if they are called on an already freed session, they will segfault because of a double-free situation. These small checks don't break anything or slow anything down, but make the sess_remove() functions completely safe to call in any context (i.e. if the session was already freed, then nothing happens). This is increasingly needed as code grows in complexity and sessions have multiple potential codepaths they can be removed from.