### PR TITLE
[sgwc] silently handle downlink data ack when ue already reattached

### DIFF
--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -1184,7 +1184,8 @@ void sgwc_s11_handle_downlink_data_notification_ack(
         ogs_assert(cause);
 
         cause_value = cause->value;
-        if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED)
+        if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED && 
+            cause_value != OGS_GTP2_CAUSE_UE_ALREADY_RE_ATTACHED)
             ogs_warn("GTP Cause [Value:%d] - PFCP_CAUSE[%d]",
                     cause_value, pfcp_cause_from_gtp(cause_value));
     } else {


### PR DESCRIPTION
In this context GTP hasn't failed, it's actually working correctly. When a UE rejoins the network due to buffered data, there's essentially a slight "race condition" between the UE rejoining the network via MME and the SGWC sending a downlink data notification to the MME. if the UE wins, then the MME simply tells the SGWC that the UE has already re-attached. This is essentially a no-op operation and IMO should be handled silently, not logged as a GTP Failure.