### PR TITLE
[AMF] Expose more metrics

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -522,6 +522,9 @@ ogs_nas_5gmm_cause_t gmm_handle_service_request(amf_ue_t *amf_ue,
     ngksi = &service_request->ngksi;
     ogs_assert(ngksi);
 
+    if (ngksi->type == OGS_NAS_SERVICE_TYPE_MOBILE_TERMINATED_SERVICES)
+        amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_MM_PAGING_5G_SUCC);
+
     /*
      * TS24.501
      * Ch 4.4.6 Protection of initial NAS signalling messages

--- a/src/amf/metrics.c
+++ b/src/amf/metrics.c
@@ -65,6 +65,76 @@ amf_metrics_spec_def_t amf_metrics_spec_def_global[_AMF_METR_GLOB_MAX] = {
     .description = "gNodeBs",
 },
 /* Global Counters: */
+[AMF_METR_GLOB_CTR_RM_REG_INIT_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_reginitreq",
+    .description = "Number of initial registration requests received by the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_INIT_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_reginitsucc",
+    .description = "Number of successful initial registrations at the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_MOB_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regmobreq",
+    .description = "Number of mobility registration update requests received by the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_MOB_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regmobsucc",
+    .description = "Number of successful mobility registration updates at the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_PERIOD_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regperiodreq",
+    .description = "Number of periodic registration update requests received by the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_PERIOD_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regperiodsucc",
+    .description = "Number of successful periodic registration update requests at the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_EMERG_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regemergreq",
+    .description = "Number of emergency registration requests received by the AMF",
+},
+[AMF_METR_GLOB_CTR_RM_REG_EMERG_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_rm_regemergsucc",
+    .description = "Number of successful emergency registrations at the AMF",
+},
+[AMF_METR_GLOB_CTR_MM_PAGING_5G_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_mm_paging5greq",
+    .description = "Number of 5G paging procedures initiated at the AMF",
+},
+[AMF_METR_GLOB_CTR_MM_PAGING_5G_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_mm_paging5gsucc",
+    .description = "Number of successful 5G paging procedures initiated at the AMF",
+},
+[AMF_METR_GLOB_CTR_AMF_AUTH_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_amf_authreq",
+    .description = "Number of authentication requests sent by the AMF",
+},
+[AMF_METR_GLOB_CTR_AMF_AUTH_REJECT] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_amf_authreject",
+    .description = "Number of authentication rejections sent by the AMF",
+},
+[AMF_METR_GLOB_CTR_MM_CONF_UPDATE] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_mm_confupdate",
+    .description = "Number of UE Configuration Update commands requested by the AMF",
+},
+[AMF_METR_GLOB_CTR_MM_CONF_UPDATE_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_amffunction_mm_confupdatesucc",
+    .description = "Number of UE Configuration Update complete messages received by the AMF",
+},
 };
 int amf_metrics_init_inst_global(void)
 {
@@ -95,7 +165,7 @@ ogs_hash_t *metrics_hash_by_slice = NULL;   /* hash table for SLICE labels */
 amf_metrics_spec_def_t amf_metrics_spec_def_by_slice[_AMF_METR_BY_SLICE_MAX] = {
 /* Gauges: */
 AMF_METR_BY_SLICE_GAUGE_ENTRY(
-    AMF_METR_GAUGE_RM_REGISTEREDSUBNBR,
+    AMF_METR_GAUGE_RM_REGISTERED_SUB_NBR,
     "fivegs_amffunction_rm_registeredsubnbr",
     "Number of registered state subscribers per AMF")
 };
@@ -192,9 +262,25 @@ ogs_hash_t *metrics_hash_by_cause = NULL;   /* hash table for CAUSE labels */
 amf_metrics_spec_def_t amf_metrics_spec_def_by_cause[_AMF_METR_BY_CAUSE_MAX] = {
 /* Counters: */
 AMF_METR_BY_CAUSE_CTR_ENTRY(
-    AMF_METR_CTR_RM_REG_INITFAIL,
+    AMF_METR_CTR_RM_REG_INIT_FAIL,
     "fivegs_amffunction_rm_reginitfail",
     "Number of failed initial registrations at the AMF")
+AMF_METR_BY_CAUSE_CTR_ENTRY(
+    AMF_METR_CTR_RM_REG_MOB_FAIL,
+    "fivegs_amffunction_rm_regmobfail",
+    "Number of failed mobility registration updates at the AMF")
+AMF_METR_BY_CAUSE_CTR_ENTRY(
+    AMF_METR_CTR_RM_REG_PERIOD_FAIL,
+    "fivegs_amffunction_rm_regperiodfail",
+    "Number of failed periodic registration update requests at the AMF")
+AMF_METR_BY_CAUSE_CTR_ENTRY(
+    AMF_METR_CTR_RM_REG_EMERG_FAIL,
+    "fivegs_amffunction_rm_regemergfail",
+    "Number of failed emergency registrations at the AMF")
+AMF_METR_BY_CAUSE_CTR_ENTRY(
+    AMF_METR_CTR_AMF_AUTH_FAIL,
+    "fivegs_amffunction_amf_authfail",
+    "Number of authentication failure messages received by the AMF")
 };
 void amf_metrics_init_by_cause(void);
 int amf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst);

--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -11,6 +11,20 @@ typedef enum amf_metric_type_global_s {
     AMF_METR_GLOB_GAUGE_RAN_UE,
     AMF_METR_GLOB_GAUGE_AMF_SESS,
     AMF_METR_GLOB_GAUGE_GNB,
+    AMF_METR_GLOB_CTR_RM_REG_INIT_REQ,
+    AMF_METR_GLOB_CTR_RM_REG_INIT_SUCC,
+    AMF_METR_GLOB_CTR_RM_REG_MOB_REQ,
+    AMF_METR_GLOB_CTR_RM_REG_MOB_SUCC,
+    AMF_METR_GLOB_CTR_RM_REG_PERIOD_REQ,
+    AMF_METR_GLOB_CTR_RM_REG_PERIOD_SUCC,
+    AMF_METR_GLOB_CTR_RM_REG_EMERG_REQ,
+    AMF_METR_GLOB_CTR_RM_REG_EMERG_SUCC,
+    AMF_METR_GLOB_CTR_MM_PAGING_5G_REQ,
+    AMF_METR_GLOB_CTR_MM_PAGING_5G_SUCC,
+    AMF_METR_GLOB_CTR_AMF_AUTH_REQ,
+    AMF_METR_GLOB_CTR_AMF_AUTH_REJECT,
+    AMF_METR_GLOB_CTR_MM_CONF_UPDATE,
+    AMF_METR_GLOB_CTR_MM_CONF_UPDATE_SUCC,
     _AMF_METR_GLOB_MAX,
 } amf_metric_type_global_t;
 extern ogs_metrics_inst_t *amf_metrics_inst_global[_AMF_METR_GLOB_MAX];
@@ -29,7 +43,7 @@ static inline void amf_metrics_inst_global_dec(amf_metric_type_global_t t)
 
 /* BY SLICE */
 typedef enum amf_metric_type_by_slice_s {
-    AMF_METR_GAUGE_RM_REGISTEREDSUBNBR = 0,
+    AMF_METR_GAUGE_RM_REGISTERED_SUB_NBR = 0,
     _AMF_METR_BY_SLICE_MAX,
 } amf_metric_type_by_slice_t;
 
@@ -39,7 +53,11 @@ void amf_metrics_inst_by_slice_add(
 
 /* BY CAUSE */
 typedef enum amf_metric_type_by_cause_s {
-    AMF_METR_CTR_RM_REG_INITFAIL = 0,
+    AMF_METR_CTR_RM_REG_INIT_FAIL = 0,
+    AMF_METR_CTR_RM_REG_MOB_FAIL,
+    AMF_METR_CTR_RM_REG_PERIOD_FAIL,
+    AMF_METR_CTR_RM_REG_EMERG_FAIL,
+    AMF_METR_CTR_AMF_AUTH_FAIL,
     _AMF_METR_BY_CAUSE_MAX,
 } amf_metric_type_by_cause_t;
 

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -449,6 +449,8 @@ int ngap_send_paging(amf_ue_t *amf_ue)
                         return OGS_ERROR;
                     }
 
+                    amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_MM_PAGING_5G_REQ);
+
                     rv = ngap_send_to_gnb(gnb, ngapbuf, NGAP_NON_UE_SIGNALLING);
                     if (rv != OGS_OK) {
                         ogs_error("ngap_send_to_gnb() failed");


### PR DESCRIPTION
[ETSI TS 128 552 V16.9.0](https://www.etsi.org/deliver/etsi_ts/128500_128599/128552/16.09.00_60/ts_128552v160900p.pdf)

5.2.2 Registration procedure related measurements

SNSSAI labels are not provided.

- Number of registration requests received by the AMF is exposed for each registration type.
```
fivegs_amffunction_rm_reginitreq 1
fivegs_amffunction_rm_regmobreq 0
fivegs_amffunction_rm_regperiodreq 0
fivegs_amffunction_rm_regemergreq 0
```

- Number of successful initial registrations at the AMF is exposed for each registration type.
```
fivegs_amffunction_rm_reginitsucc 1
fivegs_amffunction_rm_regmobsucc 0
fivegs_amffunction_rm_regperiodsucc 0
fivegs_amffunction_rm_regemergsucc 0
```

- The existing counter of failed registrations at the AMF is exposed separately for each registration type.
```
fivegs_amffunction_rm_reginitfail
fivegs_amffunction_rm_regmobfail
fivegs_amffunction_rm_regperiodfail
fivegs_amffunction_rm_regemergfail
```

5.2.5.2 Measurements for 5G paging

Number of 5G paging procedures initiated at the AMF:
```
fivegs_amffunction_mm_paging5greq 1
```
Number of successful 5G paging procedures initiated at the AMF:
```
fivegs_amffunction_mm_paging5gsucc 1
```

5.2.11 Authentication procedure related measurements

Number of authentication requests:
```
fivegs_amffunction_amf_authreq 2
```
Number of authentication rejections:
```
fivegs_amffunction_amf_authreject 1
```
Number of failed authentications due to parameter error:
```
fivegs_amffunction_amf_authfail{cause="21"} 1
```

5.2.8 UE Configuration Update procedure related measurements

Number of UE Configuration Update commands requested by the AMF:
```
fivegs_amffunction_mm_confupdate 2
```
Number of UE Configuration Update complete messages received by the AMF:
```
fivegs_amffunction_mm_confupdatesucc 1
```