### PR TITLE
[smf][sgwc] improve upf/sgwc assignment when no_pfcp_rr_select: true

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -363,8 +363,9 @@ static ogs_pfcp_node_t *selected_sgwu_node(
         }
     }
 
-    ogs_error("No SGWUs are PFCP associated that are suited to RR");
-    return ogs_list_first(&ogs_pfcp_self()->pfcp_peer_list);
+    // If we get here, it means no suitable SGWU can be found
+    ogs_error("No SGWUs are PFCP associated that are suited to RR for UE TAC %u", sess->sgwc_ue->e_tai.tac);
+    return NULL;
 }
 
 void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
@@ -384,6 +385,11 @@ void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
     /* setup GTP session with selected SGW-U */
     ogs_pfcp_self()->pfcp_node =
         selected_sgwu_node(ogs_pfcp_self()->pfcp_node, sess);
+
+    if (ogs_pfcp_self()->pfcp_node == NULL) {
+        return;
+    }
+
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
     ogs_debug("UE using SGW-U on IP[%s]",

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -258,8 +258,7 @@ void sgwc_s11_handle_create_session_request(
     sgwc_sess_select_sgwu(sess);
 
     /* Check if selected SGW-U is associated with SGW-C */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1155,8 +1155,9 @@ static ogs_pfcp_node_t *selected_upf_node(
         }
     }
 
-    ogs_error("No UPFs are PFCP associated that are suited to RR");
-    return ogs_list_first(&ogs_pfcp_self()->pfcp_peer_list);
+    // If we get here, it means no suitable UPF can be found
+    ogs_error("No UPFs are PFCP associated that are suited to RR for UE TAC %u", sess->e_tai.tac);
+    return NULL;
 }
 
 void smf_sess_select_upf(smf_sess_t *sess)
@@ -1176,6 +1177,11 @@ void smf_sess_select_upf(smf_sess_t *sess)
     /* setup GTP session with selected UPF */
     ogs_pfcp_self()->pfcp_node =
         selected_upf_node(ogs_pfcp_self()->pfcp_node, sess);
+
+    if (ogs_pfcp_self()->pfcp_node == NULL) {
+        return;
+    }
+
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
     ogs_debug("UE using UPF on IP[%s]",

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -285,10 +285,9 @@ uint8_t smf_gn_handle_create_pdp_context_request(
     smf_sess_select_upf(sess);
 
     /* Check if selected PGW is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
         return OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE;
-
+    
     if ((pfcp_cause = smf_sess_set_ue_ip(sess)) != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
         cause_value = gtp_cause_from_pfcp(pfcp_cause, 1);
         return cause_value;

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -443,8 +443,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
     smf_sess_select_upf(sess);
 
     /* Check if selected UPF is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
         ogs_error("[%s] No associated UPF", smf_ue->supi);
         return false;
     }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -234,8 +234,7 @@ uint8_t smf_s5c_handle_create_session_request(
     smf_sess_select_upf(sess);
 
     /* Check if selected PGW is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
         return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
 
     /* UE IP Address */


### PR DESCRIPTION
Currently the upf/sgwc logic is a bit unpredictable when no_pfcp_rr_select = true. It goes through the list searching for an acceptable match, but if none is found it simply returns the first pfcp association in the list, regardless of whether it's an acceptable match or even if it's in the correct state (associated). 

This PR is a simple fix that returns NULL if no acceptable PFCP match is found, and then if NULL is returned, the calling function rejects the UE attach. Much easier to understand/reason about, and (IMO) far more correct behavior for no_pfcp_rr_select = true.