### PR TITLE
[core] allow fine-grained setting of message timers

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -532,7 +532,9 @@ usrsctp:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for AMF to send UEContextReleaseCommand

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -351,5 +351,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -353,5 +353,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -420,7 +420,9 @@ usrsctp:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for MME to send UEContextReleaseCommand

--- a/configs/open5gs/nrf.yaml.in
+++ b/configs/open5gs/nrf.yaml.in
@@ -254,5 +254,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -402,5 +402,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -366,5 +366,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/sgwc.yaml.in
+++ b/configs/open5gs/sgwc.yaml.in
@@ -158,5 +158,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/sgwu.yaml.in
+++ b/configs/open5gs/sgwu.yaml.in
@@ -145,5 +145,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -748,7 +748,9 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for SMF to send

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -404,5 +404,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -357,5 +357,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/upf.yaml.in
+++ b/configs/open5gs/upf.yaml.in
@@ -229,5 +229,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -136,7 +136,10 @@ typedef struct ogs_app_context_s {
         } subscription;
 
         struct {
-            ogs_time_t duration;
+            ogs_time_t sbi_duration;
+            ogs_time_t gtp_duration;
+            ogs_time_t pfcp_duration;
+
             struct {
                 ogs_time_t client_wait_duration;
                 ogs_time_t connection_deadline;

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -576,9 +576,9 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
     ogs_sbi_header_set(request->http.headers,
             OGS_SBI_OPTIONAL_CUSTOM_SENDER_TIMESTAMP, sender_timestamp);
 
-    ogs_assert(ogs_time_to_msec(ogs_app()->time.message.duration));
+    ogs_assert(ogs_time_to_msec(ogs_app()->time.message.sbi_duration));
     max_rsp_time = ogs_msprintf("%d",
-            (int)ogs_time_to_msec(ogs_app()->time.message.duration));
+            (int)ogs_time_to_msec(ogs_app()->time.message.sbi_duration));
     ogs_sbi_header_set(request->http.headers,
             OGS_SBI_OPTIONAL_CUSTOM_MAX_RSP_TIME, max_rsp_time);
     ogs_free(max_rsp_time);


### PR DESCRIPTION
Right now the timeout/retransmit values for all message types (GTP, PFCP, SBI) are set to message.duration (default value 10sec). Having all these timers set to the same value can create weird race-conditions when something times out; to this point the 3GPP specifically recommends fine-tuning these parameters to appropriate values. For example, mme->sgwc GTPv2 messages should naturally have a longer timeout than sgwc->smf GTPv2 messages, which in turn should have a longer timeout than sgwc->sgwu PFCP messages.

This PR removes this limitation by breaking up the message.duration parameter into (gtp_duration, sbi_duration, pfcp_duration), each of which can be set individually.