### PR TITLE
[AMF] Expose time of registration procedure

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -27,11 +27,23 @@
 #include "nnssf-handler.h"
 #include "nas-security.h"
 
+static ogs_timer_t *t_metrics_granularity_period = NULL;
+#define METRICS_GRANULARITY_PERIOD_TIME 30
+
 void amf_state_initial(ogs_fsm_t *s, amf_event_t *e)
 {
     amf_sm_debug(e);
 
     ogs_assert(s);
+
+    /* Starting metrics_granularity_period timer */
+    t_metrics_granularity_period = ogs_timer_add(
+            ogs_app()->timer_mgr,
+            amf_timer_metrics_granularity_period_expire,
+            t_metrics_granularity_period);
+    ogs_assert(t_metrics_granularity_period);
+    /* The closest we can do is to schedule the timer to fire in 1 us. */
+    ogs_timer_start(t_metrics_granularity_period, 1);
 
     OGS_FSM_TRAN(s, &amf_state_operational);
 }
@@ -41,6 +53,8 @@ void amf_state_final(ogs_fsm_t *s, amf_event_t *e)
     amf_sm_debug(e);
 
     ogs_assert(s);
+
+    ogs_timer_delete(t_metrics_granularity_period);
 }
 
 void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
@@ -941,15 +955,25 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
         break;
 
     case AMF_EVENT_5GMM_TIMER:
-        amf_ue = amf_ue_cycle(e->amf_ue);
-        if (!amf_ue) {
-            ogs_error("UE(amf_ue) Context has already been removed");
+        switch (e->h.timer_id) {
+        case AMF_TIMER_METRICS_GRANULARITY_PERIOD:
+            ogs_timer_start(t_metrics_granularity_period,
+                    ogs_time_from_sec(METRICS_GRANULARITY_PERIOD_TIME));
+
+            amf_metrics_reg_time_expose();
             break;
+        default:
+
+            amf_ue = amf_ue_cycle(e->amf_ue);
+            if (!amf_ue) {
+                ogs_error("UE(amf_ue) Context has already been removed");
+                break;
+            }
+
+            ogs_assert(OGS_FSM_STATE(&amf_ue->sm));
+
+            ogs_fsm_dispatch(&amf_ue->sm, e);
         }
-
-        ogs_assert(OGS_FSM_STATE(&amf_ue->sm));
-
-        ogs_fsm_dispatch(&amf_ue->sm, e);
         break;
 
     default:

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1432,6 +1432,8 @@ void amf_ue_remove(amf_ue_t *amf_ue)
 
     amf_ue_fsm_fini(amf_ue);
 
+    amf_metrics_reg_time_stop(amf_ue);
+
     /* Clear Paging Info */
     AMF_UE_CLEAR_PAGING_INFO(amf_ue);
 

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -168,6 +168,7 @@ ogs_nas_5gmm_cause_t gmm_handle_registration_request(amf_ue_t *amf_ue,
         break;
     }
 
+    amf_metrics_reg_time_start(amf_ue);
 
     /* Set 5GS Registration Type */
     memcpy(&amf_ue->nas.registration, registration_type,
@@ -882,6 +883,8 @@ int gmm_handle_identity_response(amf_ue_t *amf_ue,
         ogs_error("Not supported Identity type[%d]",
                 mobile_identity_header->type);
     }
+
+    amf_metrics_reg_time_start(amf_ue);
 
     return OGS_OK;
 }

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2142,6 +2142,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         AMF_UE_CLEAR_N2_TRANSFER(amf_ue, pdu_session_resource_setup_request);
         AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
         CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
+        amf_metrics_reg_time_stop(amf_ue);
 
         xact_count = amf_sess_xact_count(amf_ue);
 

--- a/src/amf/metrics.c
+++ b/src/amf/metrics.c
@@ -333,6 +333,225 @@ int amf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst)
     return amf_metrics_free_inst(inst, _AMF_METR_BY_CAUSE_MAX);
 }
 
+/* BY REG_TYPE */
+const char *labels_reg_type[] = {
+    "reg_type"
+};
+
+#define AMF_METR_BY_REG_TYPE_GAUGE_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_GAUGE, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_reg_type), \
+        .labels = labels_reg_type, \
+    },
+ogs_metrics_spec_t *amf_metrics_spec_by_reg_type[_AMF_METR_BY_REG_TYPE_MAX];
+ogs_hash_t *metrics_hash_by_reg_type = NULL; /* hash table for REG_TYPE labels */
+ogs_hash_t *metrics_hash_reg_req = NULL;     /* REG REQ timestamps hash table */
+amf_metrics_spec_def_t amf_metrics_spec_def_by_reg_type[_AMF_METR_BY_REG_TYPE_MAX] =
+{
+/* Gauges: */
+AMF_METR_BY_REG_TYPE_GAUGE_ENTRY(
+    AMF_METR_GAUGE_RM_REG_TIME_MEAN,
+    "fivegs_amffunction_rm_regtimemean",
+    "Mean time of registration procedure during each granularity period")
+AMF_METR_BY_REG_TYPE_GAUGE_ENTRY(
+    AMF_METR_GAUGE_RM_REG_TIME_MAX,
+    "fivegs_amffunction_rm_regtimemax",
+    "Max time of registration procedure during each granularity period")
+};
+
+void amf_metrics_init_by_reg_type(void);
+int amf_metrics_free_inst_by_reg_type(ogs_metrics_inst_t **inst);
+typedef struct amf_metric_key_by_reg_type_s {
+    int reg_type;
+    amf_metric_type_by_reg_type_t t;
+} amf_metric_key_by_reg_type_t;
+
+void amf_metrics_init_by_reg_type(void)
+{
+    metrics_hash_by_reg_type = ogs_hash_make();
+    ogs_assert(metrics_hash_by_reg_type);
+    metrics_hash_reg_req = ogs_hash_make();
+    ogs_assert(metrics_hash_reg_req);
+}
+
+void amf_metrics_inst_by_reg_type_set(int reg_type,
+        amf_metric_type_by_reg_type_t t, int val)
+{
+    ogs_metrics_inst_t *metrics = NULL;
+    amf_metric_key_by_reg_type_t *reg_type_key;
+
+    reg_type_key = ogs_calloc(1, sizeof(*reg_type_key));
+    ogs_assert(reg_type_key);
+
+    reg_type_key->reg_type = reg_type;
+    reg_type_key->t = t;
+
+    metrics = ogs_hash_get(metrics_hash_by_reg_type,
+            reg_type_key, sizeof(*reg_type_key));
+
+    if (!metrics) {
+        const char *reg_type_str = "";
+        switch (reg_type) {
+        case OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL:
+            reg_type_str = "initialreg";
+            break;
+        case OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING:
+            reg_type_str = "mobilityregupdate";
+            break;
+        case OGS_NAS_5GS_REGISTRATION_TYPE_PERIODIC_UPDATING:
+            reg_type_str = "periodicregupdate";
+            break;
+        case OGS_NAS_5GS_REGISTRATION_TYPE_EMERGENCY:
+            reg_type_str = "emergencyreg";
+            break;
+        default:
+            reg_type_str = "unknown";
+            ogs_error("Unknown reg_type [%d]", reg_type);
+        }
+
+        metrics = ogs_metrics_inst_new(amf_metrics_spec_by_reg_type[t],
+                amf_metrics_spec_def_by_reg_type->num_labels,
+                (const char *[]){ reg_type_str });
+
+        ogs_assert(metrics);
+        ogs_hash_set(metrics_hash_by_reg_type,
+                reg_type_key, sizeof(*reg_type_key), metrics);
+    } else {
+        ogs_free(reg_type_key);
+    }
+
+    ogs_metrics_inst_set(metrics, val);
+}
+
+int amf_metrics_free_inst_by_reg_type(ogs_metrics_inst_t **inst)
+{
+    return amf_metrics_free_inst(inst, _AMF_METR_BY_REG_TYPE_MAX);
+}
+
+typedef struct amf_metric_reg_req_s {
+    int timestamp_ms;
+} amf_metric_reg_req_t;
+
+void amf_metrics_reg_time_start(amf_ue_t *amf_ue)
+{
+    amf_metric_reg_req_t *reg_req;
+
+    ogs_assert(amf_ue);
+
+    if (!amf_ue->suci)
+        return;
+
+    amf_metrics_reg_time_stop(amf_ue);
+
+    reg_req = ogs_calloc(1, sizeof(*reg_req));
+    ogs_assert(reg_req);
+    reg_req->timestamp_ms = ogs_time_now() / 1000;
+
+    ogs_hash_set(metrics_hash_reg_req,
+            amf_ue->suci, strlen(amf_ue->suci), reg_req);
+}
+
+int amf_metrics_reg_time_stop(amf_ue_t *amf_ue)
+{
+    amf_metric_reg_req_t *reg_req = NULL;
+    int timestamp = 0;
+    int now_ms;
+
+    ogs_assert(amf_ue);
+
+    if (!amf_ue->suci)
+        return 0;
+
+    reg_req = ogs_hash_get(metrics_hash_reg_req,
+            amf_ue->suci, strlen(amf_ue->suci));
+    if (reg_req) {
+        timestamp = reg_req->timestamp_ms;
+        ogs_hash_set(metrics_hash_reg_req, amf_ue->suci,
+                strlen(amf_ue->suci), NULL);
+        ogs_free(reg_req);
+    }
+
+    now_ms = ogs_time_now() / 1000;
+    if ((now_ms < timestamp) || (timestamp == 0))
+        return 0;
+
+    return now_ms - timestamp;
+}
+
+#define AMF_METRICS_REGISTRATION_TYPE_IDX_MAX 4
+
+static int amf_metrics_reg_time_all
+        [AMF_METRICS_REGISTRATION_TYPE_IDX_MAX] = {0};
+static int amf_metrics_reg_time_nr_reg
+        [AMF_METRICS_REGISTRATION_TYPE_IDX_MAX] = {0};
+static int amf_metrics_reg_time_max
+        [AMF_METRICS_REGISTRATION_TYPE_IDX_MAX] = {0};
+
+static int amf_metrics_reg_type_to_idx(int regtype)
+{
+    switch (regtype) {
+    case OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL:
+        return 0;
+    case OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING:
+        return 1;
+    case OGS_NAS_5GS_REGISTRATION_TYPE_PERIODIC_UPDATING:
+        return 2;
+    case OGS_NAS_5GS_REGISTRATION_TYPE_EMERGENCY:
+        return 3;
+    default:
+        ogs_error("Unknown registration type");
+        return -1;
+    }
+}
+
+void amf_metrics_reg_time_add(int diff, uint8_t reg_type)
+{
+    int idx;
+
+    idx = amf_metrics_reg_type_to_idx(reg_type);
+    if ((idx < 0) || (idx >= AMF_METRICS_REGISTRATION_TYPE_IDX_MAX))
+        return;
+
+    amf_metrics_reg_time_all[idx] += diff;
+    amf_metrics_reg_time_nr_reg[idx] += 1;
+
+    if (diff > amf_metrics_reg_time_max[idx])
+        amf_metrics_reg_time_max[idx] = diff;
+}
+
+void amf_metrics_reg_time_expose(void)
+{
+    int reg_type;
+
+    for (reg_type = OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+        reg_type <= OGS_NAS_5GS_REGISTRATION_TYPE_EMERGENCY;
+        reg_type++)
+    {
+        int idx = amf_metrics_reg_type_to_idx(reg_type);
+        if ((idx < 0) || (idx >= AMF_METRICS_REGISTRATION_TYPE_IDX_MAX))
+            continue;
+
+        if (amf_metrics_reg_time_nr_reg[idx] > 0) {
+            amf_metrics_inst_by_reg_type_set(reg_type,
+                    AMF_METR_GAUGE_RM_REG_TIME_MEAN,
+                    amf_metrics_reg_time_all[idx] /
+                    amf_metrics_reg_time_nr_reg[idx]);
+        } else {
+            amf_metrics_inst_by_reg_type_set(reg_type,
+                    AMF_METR_GAUGE_RM_REG_TIME_MEAN, 0);
+        }
+        amf_metrics_inst_by_reg_type_set(reg_type,
+                AMF_METR_GAUGE_RM_REG_TIME_MAX,
+                amf_metrics_reg_time_max[idx]);
+        amf_metrics_reg_time_all[idx] = 0;
+        amf_metrics_reg_time_nr_reg[idx] = 0;
+        amf_metrics_reg_time_max[idx] = 0;
+    }
+}
+
 void amf_metrics_init(void)
 {
     ogs_metrics_context_t *ctx = ogs_metrics_self();
@@ -345,11 +564,14 @@ void amf_metrics_init(void)
             amf_metrics_spec_def_by_slice, _AMF_METR_BY_SLICE_MAX);
     amf_metrics_init_spec(ctx, amf_metrics_spec_by_cause,
             amf_metrics_spec_def_by_cause, _AMF_METR_BY_CAUSE_MAX);
+    amf_metrics_init_spec(ctx, amf_metrics_spec_by_reg_type,
+            amf_metrics_spec_def_by_reg_type, _AMF_METR_BY_REG_TYPE_MAX);
 
     amf_metrics_init_inst_global();
 
     amf_metrics_init_by_slice();
     amf_metrics_init_by_cause();
+    amf_metrics_init_by_reg_type();
 }
 
 void amf_metrics_final(void)
@@ -385,6 +607,31 @@ void amf_metrics_final(void)
             //ogs_free(val);
         }
         ogs_hash_destroy(metrics_hash_by_cause);
+    }
+    if (metrics_hash_by_reg_type) {
+        for (hi = ogs_hash_first(metrics_hash_by_reg_type);
+                hi; hi = ogs_hash_next(hi)) {
+            amf_metric_key_by_reg_type_t *key =
+                (amf_metric_key_by_reg_type_t *)ogs_hash_this_key(hi);
+            //void *val = ogs_hash_this_val(hi);
+
+            ogs_hash_set(metrics_hash_by_reg_type, key, sizeof(*key), NULL);
+
+            ogs_free(key);
+            /* don't free val (metric ifself) -
+             * it will be free'd by ogs_metrics_context_final() */
+            //ogs_free(val);
+        }
+        ogs_hash_destroy(metrics_hash_by_reg_type);
+    }
+    if (metrics_hash_reg_req) {
+        for (hi = ogs_hash_first(metrics_hash_reg_req);
+                hi; hi = ogs_hash_next(hi)) {
+            char *key = (char *)ogs_hash_this_key(hi);
+
+            ogs_hash_set(metrics_hash_reg_req, key, sizeof(*key), NULL);
+        }
+        ogs_hash_destroy(metrics_hash_reg_req);
     }
 
     ogs_metrics_context_final();

--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -64,6 +64,21 @@ typedef enum amf_metric_type_by_cause_s {
 void amf_metrics_inst_by_cause_add(
     uint8_t cause, amf_metric_type_by_cause_t t, int val);
 
+/* BY REG_TYPE */
+typedef enum amf_metric_type_by_reg_type_s {
+    AMF_METR_GAUGE_RM_REG_TIME_MEAN = 0,
+    AMF_METR_GAUGE_RM_REG_TIME_MAX,
+    _AMF_METR_BY_REG_TYPE_MAX,
+} amf_metric_type_by_reg_type_t;
+
+void amf_metrics_inst_by_reg_type_set(
+    int reg_type, amf_metric_type_by_reg_type_t t, int val);
+
+void amf_metrics_reg_time_start(amf_ue_t *amf_ue);
+int amf_metrics_reg_time_stop(amf_ue_t *amf_ue);
+void amf_metrics_reg_time_add(int reg_req_ms, uint8_t reg_type);
+void amf_metrics_reg_time_expose(void);
+
 void amf_metrics_init(void);
 void amf_metrics_final(void);
 

--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -75,7 +75,7 @@ int nas_5gs_send_to_downlink_nas_transport(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
 
 int nas_5gs_send_registration_accept(amf_ue_t *amf_ue)
 {
-    int rv;
+    int rv, reg_duration_ms;
     bool transfer_needed = false;
 
     ran_ue_t *ran_ue = NULL;
@@ -87,6 +87,8 @@ int nas_5gs_send_registration_accept(amf_ue_t *amf_ue)
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
+
+    reg_duration_ms = amf_metrics_reg_time_stop(amf_ue);
 
     ran_ue = ran_ue_cycle(amf_ue->ran_ue);
     if (!ran_ue) {
@@ -180,6 +182,11 @@ int nas_5gs_send_registration_accept(amf_ue_t *amf_ue)
         }
     }
 
+    if (reg_duration_ms > 0) {
+        amf_metrics_reg_time_add(reg_duration_ms,
+                amf_ue->nas.registration.value);
+    }
+
     return rv;
 }
 
@@ -193,6 +200,8 @@ int nas_5gs_send_registration_reject(
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
+
+    amf_metrics_reg_time_stop(amf_ue);
 
     switch (amf_ue->nas.registration.value) {
     case OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL:

--- a/src/amf/timer.c
+++ b/src/amf/timer.c
@@ -197,3 +197,19 @@ void amf_timer_implicit_deregistration_expire(void *data)
 {
     gmm_timer_event_send(AMF_TIMER_IMPLICIT_DEREGISTRATION, data);
 }
+
+void amf_timer_metrics_granularity_period_expire(void *data)
+{
+    int rv;
+    amf_event_t *e = NULL;
+
+    e = amf_event_new(AMF_EVENT_5GMM_TIMER);
+    ogs_assert(e);
+    e->h.timer_id = AMF_TIMER_METRICS_GRANULARITY_PERIOD;
+
+    rv = ogs_queue_push(ogs_app()->queue, e);
+    if (rv != OGS_OK) {
+        ogs_error("ogs_queue_push() failed:%d", (int)rv);
+        ogs_event_free(e);
+    }
+}

--- a/src/amf/timer.h
+++ b/src/amf/timer.h
@@ -41,6 +41,7 @@ typedef enum {
     AMF_TIMER_T3570,
     AMF_TIMER_MOBILE_REACHABLE,
     AMF_TIMER_IMPLICIT_DEREGISTRATION,
+    AMF_TIMER_METRICS_GRANULARITY_PERIOD,
 
     MAX_NUM_OF_AMF_TIMER,
 
@@ -69,6 +70,8 @@ void amf_timer_ng_holding_timer_expire(void *data);
 
 void amf_timer_mobile_reachable_expire(void *data);
 void amf_timer_implicit_deregistration_expire(void *data);
+
+void amf_timer_metrics_granularity_period_expire(void *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Registration time and histogram as separate pull request.
Memory leaks solved and VARIABLE type of buckets support added comparing to original [PR #2126](https://github.com/open5gs/open5gs/pull/2126).