### PR TITLE
[AMF] Fix handling Service Request

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1142,6 +1142,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
+                break;
             }
 
             OGS_FSM_TRAN(s, gmm_state_registered);


### PR DESCRIPTION
In case that handling Service Request results in an error, AMF sends a Service Reject and sets UE's context to exception state. Without the 'break', the code would set UE's context to registered state.