### PR TITLE
[NAS/GTP/PFCP] Upgrade IE to Release-17

### DIFF
--- a/lib/gtp/v2/types.h
+++ b/lib/gtp/v2/types.h
@@ -236,14 +236,19 @@ ED8(uint8_t create_session_request_message_forwarded_indication:1;,
     uint8_t _5g_srvcc_ho_indication:1;,
     uint8_t ethernet_pdn_support_indication:1;)
 
-ED8(uint8_t spare1:1;,
-    uint8_t spare2:1;,
-    uint8_t spare3:1;,
-    uint8_t spare4:1;,
+ED8(uint8_t notify_start_pause_of_charging_via_user_plane_support_indication:1;,
+    uint8_t pgw_redirection_due_to_mismatch_with_network_slice_subscribed_by_ue_support_indication:1;,
+    uint8_t restoration_of_pdn_connections_after_an_pgw_c_smf_change_support_indication:1;,
+    uint8_t pgw_change_indication:1;,
     uint8_t same_iwk_scef_selected_for_monitoring_event_indication:1;,
     uint8_t notify_source_enodeb_indication:1;,
     uint8_t indirect_data_forwarding_with_upf_indication:1;,
     uint8_t emergency_pdu_session_indication:1;)
+
+ED4(uint8_t spare1:5;,
+    uint8_t lte_m_satellite_access_indication:1;,
+    uint8_t satellite_rat_type_reporting_to_pgw_indication:1;,
+    uint8_t user_plane_integrity_protection_support_indication:1;)
 } __attribute__ ((packed)) ogs_gtp2_indication_t;
 
 /* 8.13 Protocol Configuration Options (PCO)

--- a/lib/nas/5gs/types.h
+++ b/lib/nas/5gs/types.h
@@ -104,12 +104,30 @@ ED8(uint8_t radio_capability_signalling_optimization_capability:1;,
     uint8_t v2x_capability:1;,
     uint8_t up_ciot_5gs_optimization:1;,
     uint8_t srvcc_5g_capability:1;)
-ED5(uint8_t spare4:4;,
+ED8(uint8_t fiveg_prose_layer_2_ue_to_network_relay:1;,
+    uint8_t fiveg_prose_direct_communication:1;,
+    uint8_t fiveg_prose_direct_discovery:1;,
+    uint8_t extended_rejected_nssai_support:1;,
     uint8_t ethernet_header_compression_cp_ciot_5gs_optimization:1;,
     uint8_t multiple_user_plane_resource_support:1;,
     uint8_t wusa_information_reception_capability:1;,
     uint8_t closed_access_group_capability:1;)
-    uint8_t spare[10];
+ED8(uint8_t paging_restriction:1;,
+    uint8_t reject_paging_request:1;,
+    uint8_t paging_indication_for_voice_services:1;,
+    uint8_t n1_nas_signalling_connection_release:1;,
+    uint8_t nr_paging_subgroup_support_indication:1;,
+    uint8_t five_prose_layer_3_ue_to_network_remote:1;,
+    uint8_t five_prose_layer_2_ue_to_network_remote:1;,
+    uint8_t five_prose_layer_3_ue_to_network_relay:1;)
+ED7(uint8_t spare1:2;,
+    uint8_t nsag:1;,
+    uint8_t extended_cag_information_list_support:1;,
+    uint8_t sor_snpn_si:1;,
+    uint8_t event_notification:1;,
+    uint8_t minimization_of_service_interruption:1;,
+    uint8_t nssrg:1;)
+    uint8_t spare2[8];
 } __attribute__ ((packed)) ogs_nas_5gmm_capability_t;
 
 /* 9.11.3.2 5GMM cause
@@ -240,24 +258,38 @@ typedef struct ogs_nas_5gs_mobile_identity_s {
  * M LV 2 */
 typedef struct ogs_nas_5gs_network_feature_support_s {
     uint8_t length;
-ED6(uint8_t mpsi:1;,
-    uint8_t iwk_n26:1;,
-    uint8_t emf:2;,
-    uint8_t msc:2;,
-    uint8_t ims_vops_n3gpp:1;,
-    uint8_t ims_vops_3gpp:1;)
-ED3(uint8_t spare:6;,
-    uint8_t mcsi:1;,
-    uint8_t emcn :1;)
-    uint8_t spare2;
+ED6(uint8_t mps_indicator:1;,
+    uint8_t interworking_without_n26_interface_indicator:1;,
+    uint8_t emergency_services_fallback_indicator_for_3gpp_access:2;,
+    uint8_t emergency_service_support_indicator_for_3gpp_access:2;,
+    uint8_t ims_voice_over_ps_session_over_non_3gpp_access_indicator:1;,
+    uint8_t ims_voice_over_ps_session_over_3gpp_access_indicator:1;)
+ED7(uint8_t user_plane_ciot_5gs_optimization:1;,
+    uint8_t ip_header_compression_for_control_plane_ciot_5gs_optimization:1;,
+    uint8_t n3_data_transfer:1;,
+    uint8_t control_plane_ciot_5gs_optimization:1;,
+    uint8_t restriction_on_enhanced_coverage:2;,
+    uint8_t mcs_indicator:1;,
+    uint8_t emergency_service_support_for_non_3gpp_access_indicator:1;)
+ED8(uint8_t spare:1;,
+    uint8_t paging_restriction:1;,
+    uint8_t reject_paging_request:1;,
+    uint8_t paging_indication_for_voice_services:1;,
+    uint8_t n1_nas_signalling_connection_release:1;,
+    uint8_t ethernet_header_compression_for_control_plane_ciot_5gs_optimization:1;,
+    uint8_t atsss_support_indicator:1;,
+    uint8_t location_services_indicator_in_5gc:1;)
 } ogs_nas_5gs_network_feature_support_t;
 
 /* 9.11.3.6 5GS registration result
  * O TLV 3-5 */
 typedef struct ogs_nas_5gs_registration_result_s {
     uint8_t length;
-ED3(uint8_t spare:4;,
-    uint8_t sms_allowed:1;,
+ED6(uint8_t spare:1;,
+    uint8_t disaster_roaming_registration_result_value:1;,
+    uint8_t emergency_registered:1;,
+    uint8_t network_slice_specific_authentication_and_authorization_is_to_be_performed:1;,
+    uint8_t sms_over_nas_transport_allowed:1;,
     uint8_t value:3;)
 } ogs_nas_5gs_registration_result_t;
 
@@ -373,6 +405,7 @@ ED3(uint8_t spare:6;,
 typedef struct ogs_nas_allowed_pdu_session_status_s {
     uint8_t length;
     uint16_t psi;
+    uint8_t spare[30];
 } __attribute__ ((packed)) ogs_nas_allowed_pdu_session_status_t;
 
 /* 9.11.3.18 Configuration update indication
@@ -430,6 +463,7 @@ typedef struct ogs_nas_eps_nas_message_container_s {
 } ogs_nas_eps_nas_message_container_t;
 
 /* 9.11.3.25 EPS NAS security algorithms
+ * See subclause 9.9.3.23 in 3GPP TS 24.301 [15].
  * O TV 2 */
 typedef ogs_nas_security_algorithms_t ogs_nas_eps_nas_security_algorithms_t;
 
@@ -482,8 +516,8 @@ typedef struct ogs_nas_message_container_s {
 typedef struct ogs_nas_network_slicing_indication_s {
 ED4(uint8_t type:4;,
     uint8_t spare:2;,
-    uint8_t dcni:1;,
-    uint8_t nssci:1;)
+    uint8_t default_configured_nssai_indication:1;,
+    uint8_t network_slicing_subscription_change_indication:1;)
 }  __attribute__ ((packed)) ogs_nas_network_slicing_indication_t;
 
 /* 9.11.3.37 NSSAI
@@ -622,13 +656,14 @@ typedef struct ogs_nas_sor_transparent_container_s {
 } ogs_nas_sor_transparent_container_t;
 
 /* 9.11.3.48 S1 UE network capability
+ * See subclause 9.9.3.34 in 3GPP TS 24.301 [15].
  * O TLV 4-15 */
 typedef ogs_nas_ue_network_capability_t ogs_nas_s1_ue_network_capability_t;
 
-/* 9.9.3.36 UE security capability
- * M LV 3-6
- * 9.11.3.48A S1 UE security capability
- * O TLV 4-7 */
+/* 9.11.3.48A S1 UE security capability
+ * O TLV 4-7
+ * 9.9.3.36 UE security capability
+ * M LV 3-6 */
 typedef ogs_nas_ue_security_capability_t ogs_nas_s1_ue_security_capability_t;
 
 /* 9.11.3.55 UE usage setting
@@ -707,11 +742,7 @@ typedef struct ogs_nas_peips_assistance_information_s {
 
 /* 9.11.3.81 5GS additional request result
  * O TLV 3 */
-typedef struct ogs_nas_5gs_additional_request_result_s {
-    uint8_t length;
-ED2(uint8_t spare:6;,
-    uint8_t prd:2;)
-} __attribute__ ((packed)) ogs_nas_5gs_additional_request_result_t;
+typedef struct ogs_nas_additional_request_result_s ogs_nas_5gs_additional_request_result_t;
 
 /* 9.11.3.82 NSSRG information
  * O TLV-E 7-65538 */
@@ -759,16 +790,23 @@ typedef struct ogs_nas_nsag_information_s {
 /* 9.11.3.91 Priority indicator
  * O TV 1 */
 typedef struct ogs_nas_priority_indicator_s {
-    uint8_t type;
+ED3(uint8_t type:4;,
+    uint8_t spare:1;,
+    uint8_t mps_indicator:3;)
 } __attribute__ ((packed)) ogs_nas_priority_indicator_t;
 
 /* 9.11.4.1 5GSM capability
  * O TLV 3-15 */
 typedef struct ogs_nas_5gsm_capability_s {
     uint8_t length;
-ED3(uint8_t spare:6;,
-    uint8_t mh6_pdu:1;,
-    uint8_t rqos:1;)
+ED5(uint8_t transfer_of_port_management_information_containers:1;,
+    uint8_t supported_atsss_steering_functionalities_and_steering_modes:4;,
+    uint8_t ethernet_pdn_type_in_s1_mode:1;,
+    uint8_t multi_homed_ipv6_pdu_session:1;,
+    uint8_t reflective_QoS:1;)
+ED2(uint8_t spare1:7;,
+    uint8_t access_performance_measurements_per_qos_flow_rule:1;)
+    uint8_t spare2[11];
 } __attribute__ ((packed)) ogs_nas_5gsm_capability_t;
 
 /* 9.11.4.2 5GSM cause
@@ -827,16 +865,17 @@ typedef uint8_t ogs_nas_5gsm_cause_t;
  * O TLV 3 */
 typedef struct ogs_nas_5gsm_congestion_re_attempt_indicator_s {
     uint8_t length;
-ED2(uint8_t spare:7;,
-    uint8_t abo:1;)
+ED3(uint8_t spare:6;,
+    uint8_t current_access_type_back_off_timer:1;,
+    uint8_t all_plmns_back_off_timer:1;)
 } __attribute__ ((packed)) ogs_nas_5gsm_congestion_re_attempt_indicator_t;
 
 /* 9.11.4.3 Always-on PDU session indication
  * O TV 1 */
 typedef struct ogs_nas_always_on_pdu_session_indication_s {
 ED3(uint8_t type:4;,
-    uint8_t spare:1;,
-    uint8_t apsi:3;)
+    uint8_t spare:3;,
+    uint8_t always_on_pdu_session_indication:1;)
 } __attribute__ ((packed)) ogs_nas_always_on_pdu_session_indication_t;
 
 /* 9.11.4.4 Always-on PDU session requested
@@ -844,7 +883,7 @@ ED3(uint8_t type:4;,
 typedef struct ogs_nas_always_on_pdu_session_requested_s {
 ED3(uint8_t type:4;,
     uint8_t spare:3;,
-    uint8_t apsr:1;)
+    uint8_t always_on_pdu_session_requested:1;)
 } __attribute__ ((packed)) ogs_nas_always_on_pdu_session_requested_t;
 
 /* 9.11.4.5 Allowed SSC mode
@@ -1036,7 +1075,7 @@ ED3(uint8_t type:4;,
 typedef struct ogs_nas_5gsm_network_feature_support_s {
     uint8_t length;
 ED2(uint8_t spare1:7;,
-    uint8_t s1:1;)
+    uint8_t ethernet_pdn_type_in_s1_mode:1;)
     uint8_t spare2[12];
 } __attribute__ ((packed)) ogs_nas_5gsm_network_feature_support_t;
 

--- a/lib/nas/common/types.h
+++ b/lib/nas/common/types.h
@@ -495,6 +495,18 @@ ED8(uint8_t signalling_for_a_maximum_number_of_15_eps_bearer_contexts:1;,
     uint8_t retstriction_on_use_of_enhanced_coverage:1;,
     uint8_t v2x_communication_over_pc5:1;,
     uint8_t multiple_drb:1;)
+ED8(uint8_t reject_paging_request:1;,
+    uint8_t paging_indication_for_voice_services:1;,
+    uint8_t nas_signalling_connection_release:1;,
+    uint8_t v2x_communication_over_nr_pc5:1;,
+    uint8_t user_plane_mobile_terminated_early_data_transmission:1;,
+    uint8_t control_plane_mobile_terminated_early_data_transmission:1;,
+    uint8_t wake_up_signal_assistance:1;,
+    uint8_t radio_capability_signalling_optimisation_capability:1;)
+ED3(uint8_t spare1:6;,
+    uint8_t paging_timing_collision_control:1;,
+    uint8_t paging_restriction:1;)
+    char spare2[4];
 } __attribute__ ((packed)) ogs_nas_ue_network_capability_t;
 
 /* 9.9.3.36 UE security capability
@@ -711,6 +723,7 @@ typedef struct ogs_nas_extended_drx_parameters_s {
     uint8_t length;
 ED2(uint8_t paging_time_window:4;,
     uint8_t e_drx_value:4;)
+    uint8_t extended_paging_time_window;
 } __attribute__ ((packed)) ogs_nas_extended_drx_parameters_t;
 
 /* 9.9.3.60 UE radio capability ID
@@ -751,9 +764,24 @@ typedef struct ogs_nas_paging_restriction_s {
     uint8_t length;
 ED2(uint8_t spare1:4;,
     uint8_t type:4;)
-    uint16_t ebi;
+    union {
+        uint16_t ebi;
+        uint16_t psimask;
+    };
     uint8_t spare2[30];
 } __attribute__ ((packed)) ogs_nas_paging_restriction_t;
+
+/* 9.9.3.67 EPS additional request result
+ * 9.11.3.81 5GS additional request result
+ * O TLV 3 */
+#define OGS_NAS_ADDITIONAL_REQUEST_RESULT_NO_ADDITIONAL_INFORMATION 0
+#define OGS_NAS_ADDITIONAL_REQUEST_RESULT_PAGING_RESTRICTION_IS_ACCEPTED 1
+#define OGS_NAS_ADDITIONAL_REQUEST_RESULT_PAGING_RESTRICTION_IS_REJECTED 2
+typedef struct ogs_nas_additional_request_result_s {
+    uint8_t length;
+ED2(uint8_t spare:6;,
+    uint8_t paging_restriction_decision:2;)
+} __attribute__ ((packed)) ogs_nas_additional_request_result_t;
 
 /* 9.9.4.2 APN aggregate maximum bit rate
  * O TLV 4-8  */
@@ -803,7 +831,8 @@ void eps_qos_build(ogs_nas_eps_quality_of_service_t *eps_qos,
 #define OGS_NAS_PDU_ADDRESS_IPV4V6_LEN 13
 typedef struct ogs_nas_pdu_address_s {
     uint8_t length;
-ED2(uint8_t reserved:5;,
+ED3(uint8_t spare:4;,
+    uint8_t smf_ipv6_link_local_address_presence:1;,
     uint8_t pdn_type:3;)
     union {
         uint32_t addr;
@@ -849,8 +878,8 @@ ED3(uint8_t type:4;,
 typedef struct ogs_nas_re_attempt_indicator_s {
     uint8_t length;
 ED3(uint8_t spare:3;,  /* allowed in A/Gb mode or Iu mode */
-    uint8_t eplmnc:1;, /* allowed in an equivalent PLMN */
-    uint8_t ratc:1;) 
+    uint8_t ue_is_not_allowed_to_re_attempt_the_procedure_in_an_equivalent_plmn:1;,
+    uint8_t ue_is_not_allowed_to_re_attempt_the_procedure_in_A_Gb_mode_or_Iu_mode_or_N1:1;)
 } __attribute__ ((packed)) ogs_nas_re_attempt_indicator_t;
 
 /* 9.9.4.19 NBIFOM container
@@ -908,22 +937,7 @@ typedef struct ogs_nas_extended_protocol_configuration_options_s {
  * O TLV 4 */
 typedef struct ogs_nas_serving_plmn_rate_control_s {
     uint8_t length;
-ED8(uint8_t ebi7:1;,
-    uint8_t ebi6:1;,
-    uint8_t ebi5:1;,
-    uint8_t ebi4:1;,
-    uint8_t ebi3:1;,
-    uint8_t ebi2:1;,
-    uint8_t ebi1:1;,
-    uint8_t ebi0:1;)
-ED8(uint8_t ebi15:1;,
-    uint8_t ebi14:1;,
-    uint8_t ebi13:1;,
-    uint8_t ebi12:1;,
-    uint8_t ebi11:1;,
-    uint8_t ebi10:1;,
-    uint8_t ebi9:1;,
-    uint8_t ebi8:1;)
+    uint16_t value;
 } __attribute__ ((packed)) ogs_nas_serving_plmn_rate_control_t;
 
 /* 9.9.4.29 Extended APN aggregate maximum bit rate

--- a/lib/nas/eps/types.h
+++ b/lib/nas/eps/types.h
@@ -122,7 +122,7 @@ typedef struct ogs_nas_mobile_identity_s {
 /*9.9.2.5 Mobile station classmark 3
  * See subclause 10.5.1.7 in 3GPP TS 24.008 [13].
  * O TLV 2-34 */
-#define OGS_NAS_MAX_MOBILE_STATION_CLASSMARK_3_LEN 32
+#define OGS_NAS_MAX_MOBILE_STATION_CLASSMARK_3_LEN 33
 typedef struct ogs_nas_mobile_station_classmark_3_s {
     uint8_t length;
     uint8_t buffer[OGS_NAS_MAX_MOBILE_STATION_CLASSMARK_3_LEN];
@@ -144,9 +144,9 @@ ED3(uint8_t type:4;,
 #define OGS_NAS_ADDITIONAL_UPDATE_TYPE_CIOT_RESERVED 3
 typedef struct ogs_nas_additional_update_type_s {
 ED4(uint8_t type:4;,
-    uint8_t pnb_ciot:2;,
-    uint8_t saf:1;,
-    uint8_t autv:1;)
+    uint8_t preferred_ciot_network_behaviour:2;,
+    uint8_t signalling_active_flag:1;,
+    uint8_t additional_update_type_value:1;)
 } __attribute__ ((packed)) ogs_nas_additional_update_type_t;
 
 /* 9.9.3.4a Ciphering key sequence number
@@ -343,6 +343,12 @@ ED8(uint8_t signalling_for_a_maximum_number_of_16_eps_bearer_contexts:1;,
     uint8_t header_compression_for_control_plan_ciot_eps_optimization:1;,
     uint8_t s1_u_data_transfer:1;,
     uint8_t user_plane_ciot_eps_optimization :1;)
+ED6(uint8_t spare:3;,
+    uint8_t paging_timing_collision_control:1;,
+    uint8_t paging_restriction:1;,
+    uint8_t reject_paging_request:1;,
+    uint8_t paging_indication_for_voice_services:1;,
+    uint8_t nas_signalling_connection_release:1;)
 } __attribute__ ((packed)) ogs_nas_eps_network_feature_support_t;
 
 /* 9.9.3.13 EPS update result
@@ -426,12 +432,15 @@ ED8(uint8_t ps_inter_rat_ho_from_geran_to_utran_iu_mode_capability:1;,
     uint8_t epc_capability:1;,
     uint8_t nf_capability:1;,
     uint8_t geran_network_sharing_capability:1;)
-ED6(uint8_t user_plane_integrity_protection_support:1;,
+ED8(uint8_t user_plane_integrity_protection_support:1;,
     uint8_t gia4:1;,
     uint8_t gia5:1;,
     uint8_t gia6:1;,
     uint8_t gia7:1;,
-    uint8_t spare:3;)
+    uint8_t epco_ie_indicator:1;,
+    uint8_t restriction_on_usex_of_enhanced_coverage_capability:1;,
+    uint8_t dual_connectivity_of_e_utra_with_nr_capability:1;)
+    uint8_t spare2[4];
 } __attribute__ ((packed)) ogs_nas_ms_network_capability_t;
 
 /* 9.9.3.20A MS network feature support
@@ -779,11 +788,7 @@ typedef struct ogs_nas_imsi_offset_s {
 
 /* 9.9.3.67 EPS additional request result
  * O TLV 3 */
-typedef struct ogs_nas_eps_additional_request_result_s {
-    uint8_t length;
-ED2(uint8_t spare:6;,
-    uint8_t prd:2;)
-} __attribute__ ((packed)) ogs_nas_eps_additional_request_result_t;
+typedef struct ogs_nas_additional_request_result_s ogs_nas_eps_additional_request_result_t;
 
 /* 9.9.4.1 Access point name
  * See subclause 10.5.6.1 in 3GPP TS 24.008 [13].

--- a/lib/pfcp/types.h
+++ b/lib/pfcp/types.h
@@ -284,13 +284,84 @@ ED8(uint8_t rds:1;,
     union {
         struct {
 /*
+ * 10/8 DNSTS N4
+ *   UP function support DNS Traffic Steering based on
+ *   FQDN in the DNS Query message (see
+ *   clause 5.33.4)
+ * 10/7 IPREP N4
+ *   UP function supports IP Address and Port number
+ *   replacement (see clause 5.33.3).
+ * 10/6 RESPS Sxb, N4
+ *   UP function supports Restoration of PFCP Sessions
+ *   associated with one or more PGW-C/SMF FQ-
+ *   CSID(s), Group Id(s) or CP IP address(es) (see
+ *   clause 5.22.4)
+ * 10/5 UPBER N4
+ *   UP function supports the uplink packets buffering
+ *   during EAS relocation.
+ * 10/4 L2TP Sxb, N4
+ *   UP function supports the L2TP feature as described
+ *   in clause 5.31.
+ * 10/3 NSPOC Sxa, Sxb, N4
+ *   UP function supports notifying start of Pause of
+ *   Charging via user plane.
+ * 10/2 QUASF Sxb, Sxc, N4
+ *   The UP function supports being provisioned in a
+ *   URR with an Exempted Application ID for Quota
+ *   Action or an Exempted SDF Filter for Quota Action
+ *   which is to be used when the quota is exhausted.
+ *   See also clauses 5.2.2.2.1 and 5.2.2.3.1.
  * 10/1 RTTWP N4
  *   UPF support of RTT measurements towards the UE Without PMF.
  */
-ED2(uint8_t reserved:7;,
+ED8(uint8_t dnsts:1;,
+    uint8_t iprep:1;,
+    uint8_t resps:1;,
+    uint8_t upber:1;,
+    uint8_t l2tp:1;,
+    uint8_t nspoc:1;,
+    uint8_t quasf:1;,
     uint8_t rttwp:1;)
         };
         uint8_t octet10;
+    };
+    union {
+        struct {
+
+/*
+ * 11/6 UPIDP N4
+ *   UP function supports User Plane Inactivity Detection
+ *   and reporting per PDR feature as specified in
+ *   clause 5.11.3.
+ * 11/5 RATP Sxb, N4
+ *   UP function supports Redirection Address Types set
+ *   to "Port", "IPv4 address and Port", "IPv6 address
+ *   and Port", or "IPv4 and IPv6 addresses and Port".
+ * 11/4 EPPPI N4
+ *   UP function supports Enhanced Provisioning of
+ *   Paging Policy Indicator feature as specified in
+ *   clause 5.36.2.
+ * 11/3 PSUPRM N4, N4mb
+ *   UP function supports Per Slice UP Resource
+ *   Management (see clause 5.35).3GPP TS 29.244 version 17.7.1 Release 17
+ * 11/2 MBSN4 N4
+ *   UPF supports sending MBS multicast session data
+ *   to associated PDU sessions using 5GC individual
+ *   delivery.
+ * 11/1 DRQOS N4
+ *   UP function supports Direct Reporting of QoS
+ *   monitoring events to Local NEF or AF (see
+ *   clause 5.33.5).
+ */
+ED7(uint8_t spare:2;,
+    uint8_t upidp:1;,
+    uint8_t ratp:1;,
+    uint8_t epppi:1;,
+    uint8_t psuprm:1;,
+    uint8_t mbsn4:1;,
+    uint8_t drqos:1;)
+        };
+        uint8_t octet11;
     };
 } __attribute__ ((packed)) ogs_pfcp_up_function_features_t;
 
@@ -331,7 +402,16 @@ ED2(uint8_t reserved:7;,
  * DL packet for downlink data delivery status notification if the DL Buffering
  * Duration or DL Buffering Suggested Packet Count is exceeded or
  * it is discarded directly. See clause 5.2.3.1.
- * Bit 4 to 8 – Spare, for future use and seto to "0".
+ *
+ * Bit 4 - FSSM (Forward packets to lower layer SSM): when set to "1",
+ * this indicates a request to the MB-UPF to forward MBS session data
+ * towards a low layer SSM address allocated by the MB-UPF
+ * using multicast transport.
+ * Bit 5 – MBSU (Forward and replicate MBS data using Unicast transport):
+ * when set to "1", this indicates a request to forward and replicate
+ * MBS session data towards multiple remote GTP-U peers using unicast transport.
+ * Bit 6 to 8 – Spare, for future use and seto to "0".
+
  *
  * One and only one of the DROP, FORW, BUFF, IPMA and IPMD flags shall be
  * set to "1".
@@ -341,6 +421,10 @@ ED2(uint8_t reserved:7;,
  * The DFRN flag may only be set if the FORW flag is set.
  * The EDRT flag may be set if the FORW flag is set.
  * The DDPN flag may be set with any of the DROP and BUFF flags.
+ *
+ * Both the MBSU flag and the FSSM flag may be set
+ * (to require the MB-UPF to forward MBS session data
+ * using both multicast and unicast transports).
  */
 #define OGS_PFCP_APPLY_ACTION_DROP                          (1<<8)
 #define OGS_PFCP_APPLY_ACTION_FORW                          (1<<9)
@@ -353,6 +437,8 @@ ED2(uint8_t reserved:7;,
 #define OGS_PFCP_APPLY_ACTION_EDRT                          (1<<0)
 #define OGS_PFCP_APPLY_ACTION_BDPN                          (1<<1)
 #define OGS_PFCP_APPLY_ACTION_DDPN                          (1<<2)
+#define OGS_PFCP_APPLY_ACTION_FSSM                          (1<<3)
+#define OGS_PFCP_APPLY_ACTION_MBSU                          (1<<4)
 typedef uint16_t  ogs_pfcp_apply_action_t;
 
 
@@ -361,7 +447,6 @@ typedef uint16_t  ogs_pfcp_apply_action_t;
 typedef struct ogs_pfcp_cp_function_features_s {
     union {
         struct {
-
 /*
  * 5/8 UIAUR Sxb, N4
  *   CP function supports the UE IP Address Usage Reporting feature,
@@ -396,6 +481,26 @@ ED8(uint8_t uiaur:1;,
     uint8_t load:1;)
         };
         uint8_t octet5;
+    };
+    union {
+        struct {
+
+/*
+ * 6/2 RPGUR Sxa, Sxb, N4, N4mb
+ *   CP function supports the Peer GTP-U Entity Restart
+ *   Reporting as specified in clause 20.3.4a of
+ *   3GPP TS 23.007 [24] and in clause 5.5 of 3GPP TS 23.527 [40].
+ * 6/1 PSUCC Sxb, Sxc, N4, N4mb
+ *   CP function supports PFCP session establishment
+ *   or modification with Partial Success, i.e. with UP
+ *   function reporting rules that cannot be activated.
+ *   See clause 5.2.9.
+ */
+ED3(uint8_t spare:6;,
+    uint8_t rpgur:1;,
+    uint8_t psucc:1;)
+        };
+        uint8_t octet6;
     };
 } __attribute__ ((packed)) ogs_pfcp_cp_function_features_t;
 
@@ -659,7 +764,10 @@ ED8(uint8_t     stag:1;,
     uint8_t     udp4:1;,
     uint8_t     gtpu6:1;,
     uint8_t     gtpu4:1;)
-    uint8_t     spare;
+ED4(uint8_t     spare:5;,
+    uint8_t     ssm_c_teid:1;,
+    uint8_t     n6:1;,
+    uint8_t     n19:1;)
     uint32_t    teid;
     union {
         uint32_t addr;
@@ -913,7 +1021,8 @@ ED8(uint8_t quota_validity_time:1;,
     };
     union {
         struct {
-ED2(uint8_t spare:7;,
+ED3(uint8_t spare:6;,
+    uint8_t user_plane_inactivity_timer:1;,
     uint8_t report_the_end_marker_reception:1;)
         };
         uint8_t reptri_7;
@@ -932,14 +1041,25 @@ ED2(uint8_t spare:7;,
  *           this indicates an Error Indication Report.
  * - Bit 4 – UPIR (User Plane Inactivity Report): when set to 1,
  *           this indicates a User Plane Inactivity Report.
- * - Bit 5 to 8 – Spare, for future use and set to 0.
+ * - Bit 5 – TMIR (TSC Management Information Report): when set to "1",
+ *           this indicates a TSC Management Information Report.
+ * - Bit 6 – Session Report (SESR): when set to "1",
+ *           this indicates a Session Report.
+ * - Bit 7 – UISR (UP Initiated Session Request): when set to "1",
+ *           this indicates it is a UP function initiated request
+ *           for a reason which is indicated by the PFCPSRReq-Flags,
+ *           for the PFCP session.
+ * - Bit 8 – Spare, for future use and set to "0".
  *
  * At least one bit shall be set to 1. Several bits may be set to 1.
  */
 typedef struct ogs_pfcp_report_type_s {
     union {
         struct {
-ED5(uint8_t     spare:4;,
+ED8(uint8_t     spare:1;,
+    uint8_t     up_initiated_session_request:1;,
+    uint8_t     session_report:1;,
+    uint8_t     tsc_management_information_report:1;,
     uint8_t     user_plane_inactivity_report:1;,
     uint8_t     error_indication_report:1;,
     uint8_t     usage_report:1;,
@@ -949,6 +1069,9 @@ ED5(uint8_t     spare:4;,
     };
 } __attribute__ ((packed)) ogs_pfcp_report_type_t;
 
+/*
+ * 8.2.27 Downlink Data Service Information
+ */
 typedef struct ogs_pfcp_downlink_data_service_information_s {
     struct {
 ED3(uint8_t     spare:6;,
@@ -980,13 +1103,30 @@ ED3(uint8_t     spare:6;,
  * - Bit 3 – QAURR (Query All URRs): if this bit is set to 1, it indicates
  *   that the UP function shall return immediate usage report(s)
  *   for all the URRs previously provisioned for this PFCP session.
- * - Bit 4 to 8 – Spare, for future use, shall be set to 0 by the sender and
- *   discarded by the receiver.
+ * - Bit 4 - SUMPC (Stop of Usage Measurement to Pause Charging):
+ *   if this bit is set to "1", it indicates that the UP function
+ *   shall stop the usage measurement for all URRs
+ *   with the "ASPOC" flag set to "1".
+ * - Bit 5 - RUMUC (Resume of Usage Measurement to Un-pause of Charging):
+ *   if this bit is set to "1", it indicates that the UP function
+ *   shall resume the usage measurement for all URRs
+ *   with the "ASPOC" flag set to "1".
+ * - Bit 6 - DETEID (Delete All DL N3mb and/or N19mb F-TEIDs):
+ *   if this bit is set to "1", it indicates that the MB-UPF
+ *   shall delete all NG-RAN N3mb DL F-TEIDs
+ *   and all UPF N19mb DL F-TEIDs which were provisioned
+ *   in Add MBS Unicast Parameters IEs for the MBS session
+ *   (see clause 5.34.2.4).
+ * - Bit 7 to 8 – Spare, for future use, shall be set to "0" by the sender
+ *   and discarded by the receiver.
  */
 typedef struct ogs_pfcp_smreq_flags_s {
     union {
         struct {
-ED4(uint8_t     spare:5;,
+ED7(uint8_t     spare:2;,
+    uint8_t     delete_all_dl_n3mb_and_or_n19mb_f_teids:1;,
+    uint8_t     resume_of_usage_measurement_to_un_pause_of_charging:1;,
+    uint8_t     stop_of_usage_measurement_to_pause_charging:1;,
     uint8_t     query_all_urrs:1;,
     uint8_t     send_end_marker_packets:1;,
     uint8_t     drop_buffered_packets:1;)
@@ -1049,7 +1189,8 @@ ED8(uint8_t event_threshold:1;,
     };
     union {
         struct {
-ED6(uint8_t spare:3;,
+ED7(uint8_t spare:2;,
+    uint8_t user_plane_inactivity_timer:1;,
     uint8_t report_the_end_marker_reception:1;,
     uint8_t quota_validity_time:1;,
     uint8_t ip_multicast_join_leave:1;,
@@ -1407,27 +1548,27 @@ int16_t ogs_pfcp_parse_volume_measurement(
  *
  * The following flags are coded within Octet 5:
  *
- * -Bit 1 – IMSIF: If this bit is set to "1",
- *  then the Length of IMSI and IMSI fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 2 – IMEIF: If this bit is set to "1",
- *  then the Length of IMEI and IMEI fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 3 – MSISDNF: If this bit is set to "1",
- *  then the Length of MSISDN and MSISDN fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 4 – NAIF: If this bit is set to "1",
- *  then the Length of NAI and NAI fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 5 – SUPIF: If this bit is set to "1",
- *  then the Length of SUPI and SUPI fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 6 – GPSIF: If this bit is set to "1",
- *  then the Length of GPSI and GPSI fields shall be present,
- *  otherwise these fields shall not be present.
- * -Bit 7 – PEIF: If this bit is set to "1",
- *  then the Length of PEI and PEI fields shall be present,
- *  otherwise these fields shall not be present.
+ * - Bit 1 – IMSIF: If this bit is set to "1",
+ *   then the Length of IMSI and IMSI fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 2 – IMEIF: If this bit is set to "1",
+ *   then the Length of IMEI and IMEI fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 3 – MSISDNF: If this bit is set to "1",
+ *   then the Length of MSISDN and MSISDN fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 4 – NAIF: If this bit is set to "1",
+ *   then the Length of NAI and NAI fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 5 – SUPIF: If this bit is set to "1",
+ *   then the Length of SUPI and SUPI fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 6 – GPSIF: If this bit is set to "1",
+ *   then the Length of GPSI and GPSI fields shall be present,
+ *   otherwise these fields shall not be present.
+ * - Bit 7 – PEIF: If this bit is set to "1",
+ *   then the Length of PEI and PEI fields shall be present,
+ *   otherwise these fields shall not be present.
  * - Bit 8: Spare, for future use and set to "0".
  *
  * One or more flags may be set to "1".

--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -125,7 +125,8 @@ ogs_pkbuf_t *gmm_build_registration_accept(amf_ue_t *amf_ue)
     registration_accept->presencemask |=
         OGS_NAS_5GS_REGISTRATION_ACCEPT_5GS_NETWORK_FEATURE_SUPPORT_PRESENT;
     network_feature_support->length = 2;
-    network_feature_support->ims_vops_3gpp = 1;
+    network_feature_support->
+        ims_voice_over_ps_session_over_3gpp_access_indicator = 1;
 
     /* Set T3512 */
     if (amf_self()->time.t3512.value) {

--- a/tests/common/emm-build.c
+++ b/tests/common/emm-build.c
@@ -198,7 +198,7 @@ ogs_pkbuf_t *testemm_build_attach_request(
     if (test_ue->attach_request_param.additional_update_type) {
         attach_request->presencemask |=
             OGS_NAS_EPS_ATTACH_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT;
-        additional_update_type->autv = 1;
+        additional_update_type->additional_update_type_value = 1;
     }
 
     if (test_ue->attach_request_param.ue_usage_setting) {
@@ -734,7 +734,7 @@ ogs_pkbuf_t *testemm_build_tau_request(
     if (test_ue->tau_request_param.additional_update_type) {
         tau_request->presencemask |=
             OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_ADDITIONAL_UPDATE_TYPE_PRESENT;
-        additional_update_type->autv = 1;
+        additional_update_type->additional_update_type_value = 1;
     }
 
     if (test_ue->tau_request_param.ue_usage_setting) {


### PR DESCRIPTION
As raised in #2147, AMF fails to decode S1 UE Network Capability.

So I reviewed all IE in NAS, GTP and PFCP and fixed it for Release-17.