### PR TITLE
[AMF] Confirm UE deregistration if PCF crashes

### DIFF
--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -933,6 +933,10 @@ int nas_5gs_send_gmm_reject(
         rv = nas_5gs_send_service_reject(amf_ue, gmm_cause);
         ogs_expect(rv == OGS_OK);
         break;
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE:
+        rv = nas_5gs_send_de_registration_accept(amf_ue);
+        ogs_expect(rv == OGS_OK);
+        break;
     default:
         ogs_error("Unknown message type [%d]", amf_ue->nas.message_type);
         rv = OGS_ERROR;


### PR DESCRIPTION
AMF crashed when trying to send a GMM reject message to UE on UE deregistration when PCF crashed;
```
ERROR: [suci-0-001-01-1234-0-1-0000000000] Cannot receive SBI message (../src/amf/amf-sm.c:673)
ERROR: Unknown message type [69] (../src/amf/nas-path.c:948)
ERROR: nas_5gs_send_gmm_reject_from_sbi: Expectation `rv == OGS_OK' failed. (../src/amf/nas-path.c:995)
ERROR: amf_state_operational: Expectation `r == OGS_OK' failed. (../src/amf/amf-sm.c:676)
FATAL: amf_state_operational: Assertion `r != OGS_ERROR' failed. (../src/amf/amf-sm.c:677)
```

OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE case added. DEREGISTRATION ACCEPT is sent (nas_5gs_send_de_registration_accept, which already respects switch_off flag, is called).

[ETSI TS 124 501 V16.5.1](https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/16.05.01_60/ts_124501v160501p.pdf), 5.5.2.2.2 UE-initiated de-registration procedure completion: When the DEREGISTRATION REQUEST message is received by the AMF, the AMF shall send a DEREGISTRATION ACCEPT message to the UE, if the De-registration type IE does not indicate "switch off". Otherwise, the procedure is completed when the AMF receives the DEREGISTRATION REQUEST message.

The only exceptions to sending ACCEPT are the 4 abnormal cases (5.5.2.2.7 Abnormal cases in the network side) related to unsufficient UE's subscribed rights when DEREGISTRATION REQUEST(cause #74 - #76) is sent.