### PR TITLE
[AMF] Fix Network Initiated Deregistration

### DIFF
--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -944,17 +944,20 @@ int amf_namf_callback_handle_sdm_data_change_notify(
             }
 
             if (UDM_SDM_SUBSCRIBED(amf_ue)) {
-                ogs_assert(true == amf_ue_sbi_discover_and_send(
+                r = amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
                         amf_nudm_sdm_build_subscription_delete,
-                        amf_ue, state, NULL));
+                        amf_ue, state, NULL);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
             } else if (PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
-                ogs_assert(true ==
-                    amf_ue_sbi_discover_and_send(
+                r = amf_ue_sbi_discover_and_send(
                         OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
                         NULL,
                         amf_npcf_am_policy_control_build_delete,
-                        amf_ue, state, NULL));
+                        amf_ue, state, NULL);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
             }
 
         } else if (ambr_changed) {


### PR DESCRIPTION
When UDM issues a SDM Data Change Notification with request to modify RAT restrictions, AMF would crash when it tried to send a SDM subscription delete as part of Network Initiated Deregistration.

Function amf_ue_sbi_discover_and_send() changed from returning boolean, to returning integer (one of OGS_OK/OGS_ERROR/...).