### PR TITLE
[AMF, PCF] Don't free unallocated memory

### DIFF
--- a/src/amf/npcf-build.c
+++ b/src/amf/npcf-build.c
@@ -47,6 +47,8 @@ ogs_sbi_request_t *amf_npcf_am_policy_control_build_create(
     message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_POLICIES;
 
     memset(&PolicyAssociationRequest, 0, sizeof(PolicyAssociationRequest));
+    memset(&ueLocation, 0, sizeof(ueLocation));
+    memset(&UeAmbr, 0, sizeof(UeAmbr));
 
     server = ogs_list_first(&ogs_sbi_self()->server_list);
     if (!server) {
@@ -83,7 +85,6 @@ ogs_sbi_request_t *amf_npcf_am_policy_control_build_create(
     PolicyAssociationRequest.access_type = amf_ue->nas.access_type; 
     PolicyAssociationRequest.pei = amf_ue->pei;
 
-    memset(&ueLocation, 0, sizeof(ueLocation));
     ueLocation.nr_location = ogs_sbi_build_nr_location(
             &amf_ue->nr_tai, &amf_ue->nr_cgi);
     if (!ueLocation.nr_location) {
@@ -114,7 +115,6 @@ ogs_sbi_request_t *amf_npcf_am_policy_control_build_create(
 
     PolicyAssociationRequest.rat_type = amf_ue_rat_type(amf_ue);
 
-    memset(&UeAmbr, 0, sizeof(UeAmbr));
     if (OGS_SBI_FEATURES_IS_SET(amf_ue->am_policy_control_features,
                 OGS_SBI_NPCF_AM_POLICY_CONTROL_UE_AMBR_AUTHORIZATION)) {
         if (amf_ue->ue_ambr.uplink) {

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -51,6 +51,10 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
         (char *)OGS_SBI_RESOURCE_NAME_SM_CONTEXTS;
 
     memset(&SmContextCreateData, 0, sizeof(SmContextCreateData));
+    memset(&sNssai, 0, sizeof(sNssai));
+    memset(&hplmnSnssai, 0, sizeof(hplmnSnssai));
+    memset(&header, 0, sizeof(header));
+    memset(&ueLocation, 0, sizeof(ueLocation));
 
     SmContextCreateData.serving_nf_id =
         NF_INSTANCE_ID(ogs_sbi_self()->nf_instance);
@@ -86,12 +90,10 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     }
     SmContextCreateData.dnn = sess->dnn;
 
-    memset(&sNssai, 0, sizeof(sNssai));
     sNssai.sst = sess->s_nssai.sst;
     sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
     SmContextCreateData.s_nssai = &sNssai;
 
-    memset(&hplmnSnssai, 0, sizeof(hplmnSnssai));
     if (sess->mapped_hplmn.sst) {
         hplmnSnssai.sst = sess->mapped_hplmn.sst;
         hplmnSnssai.sd = ogs_s_nssai_sd_to_string(sess->mapped_hplmn.sd);
@@ -105,7 +107,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     }
     SmContextCreateData.an_type = amf_ue->nas.access_type; 
 
-    memset(&header, 0, sizeof(header));
     header.service.name = (char *)OGS_SBI_SERVICE_NAME_NAMF_CALLBACK;
     header.api.version = (char *)OGS_SBI_API_V1;
     header.resource.component[0] = amf_ue->supi;
@@ -130,7 +131,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
 
     SmContextCreateData.rat_type = amf_ue_rat_type(amf_ue);
 
-    memset(&ueLocation, 0, sizeof(ueLocation));
     ueLocation.nr_location = ogs_sbi_build_nr_location(
             &amf_ue->nr_tai, &amf_ue->nr_cgi);
     if (!ueLocation.nr_location) {
@@ -244,6 +244,7 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
     message.h.resource.component[1] = sess->sm_context_ref;
     message.h.resource.component[2] = (char *)OGS_SBI_RESOURCE_NAME_MODIFY;
 
+    memset(&ueLocation, 0, sizeof(ueLocation));
     memset(&SmContextUpdateData, 0, sizeof(SmContextUpdateData));
 
     message.SmContextUpdateData = &SmContextUpdateData;
@@ -301,7 +302,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
         ngApCause.value = param->ngApCause.value;
     }
 
-    memset(&ueLocation, 0, sizeof(ueLocation));
     if (param->ue_location) {
         ueLocation.nr_location = ogs_sbi_build_nr_location(
                 &amf_ue->nr_tai, &amf_ue->nr_cgi);

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -52,6 +52,7 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
         (char *)OGS_SBI_RESOURCE_NAME_PCF_BINDINGS;
 
     memset(&PcfBinding, 0, sizeof(PcfBinding));
+    memset(&sNssai, 0, sizeof(sNssai));
 
     PcfBinding.supi = pcf_ue->supi;
     PcfBinding.gpsi = pcf_ue->gpsi;
@@ -135,7 +136,6 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     else
         OpenAPI_list_free(PcfIpEndPointList);
 
-    memset(&sNssai, 0, sizeof(sNssai));
     sNssai.sst = sess->s_nssai.sst;
     sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
     PcfBinding.snssai = &sNssai;

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -475,6 +475,9 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);
 
+    memset(&ims_data, 0, sizeof(ims_data));
+    memset(&session_data, 0, sizeof(ogs_session_data_t));
+
     AppSessionContext = recvmsg->AppSessionContext;
     if (!AppSessionContext) {
         strerror = ogs_msprintf("[%s:%d] No AppSessionContext",
@@ -529,8 +532,6 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
             ogs_uint64_to_string(sess->policyauthorization_features);
         ogs_assert(AscReqData->supp_feat);
     }
-
-    memset(&ims_data, 0, sizeof(ims_data));
 
     MediaComponentList = AscReqData->med_components;
     OpenAPI_list_for_each(MediaComponentList, node) {
@@ -613,7 +614,6 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     OGS_SBI_SETUP_CLIENT(&app_session->naf, client);
     ogs_freeaddrinfo(addr);
 
-    memset(&session_data, 0, sizeof(ogs_session_data_t));
     rv = ogs_dbi_session_data(
             pcf_ue->supi, &sess->s_nssai, sess->dnn, &session_data);
     if (rv != OGS_OK) {
@@ -941,6 +941,9 @@ bool pcf_npcf_policyauthorization_handle_update(
     ogs_assert(stream);
     ogs_assert(recvmsg);
 
+    memset(&ims_data, 0, sizeof(ims_data));
+    memset(&session_data, 0, sizeof(ogs_session_data_t));
+
     AppSessionContextUpdateDataPatch =
         recvmsg->AppSessionContextUpdateDataPatch;
     if (!AppSessionContextUpdateDataPatch) {
@@ -964,8 +967,6 @@ bool pcf_npcf_policyauthorization_handle_update(
         status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
-
-    memset(&ims_data, 0, sizeof(ims_data));
 
     MediaComponentList = AscUpdateData->med_components;
     OpenAPI_list_for_each(MediaComponentList, node) {
@@ -1033,7 +1034,6 @@ bool pcf_npcf_policyauthorization_handle_update(
         }
     }
 
-    memset(&session_data, 0, sizeof(ogs_session_data_t));
     rv = ogs_dbi_session_data(
             pcf_ue->supi, &sess->s_nssai, sess->dnn, &session_data);
     if (rv != OGS_OK) {

--- a/src/pcf/nsmf-build.c
+++ b/src/pcf/nsmf-build.c
@@ -34,6 +34,9 @@ ogs_sbi_request_t *pcf_nsmf_callback_build_smpolicycontrol_update(
     ogs_assert(sess->sm_policy_id);
     ogs_assert(sess->notification_uri);
 
+    memset(&SmPolicyNotification, 0, sizeof(SmPolicyNotification));
+    memset(&message, 0, sizeof(message));
+
     server = ogs_list_first(&ogs_sbi_self()->server_list);
     if (!server) {
         ogs_error("No server");
@@ -47,8 +50,6 @@ ogs_sbi_request_t *pcf_nsmf_callback_build_smpolicycontrol_update(
     header.resource.component[1] = sess->sm_policy_id;
     header.resource.component[2] = (char *)OGS_SBI_RESOURCE_NAME_UPDATE;
 
-    memset(&SmPolicyNotification, 0, sizeof(SmPolicyNotification));
-
     SmPolicyNotification.resource_uri = ogs_sbi_server_uri(server, &header);
     if (!SmPolicyNotification.resource_uri) {
         ogs_error("No resource_uri");
@@ -60,7 +61,6 @@ ogs_sbi_request_t *pcf_nsmf_callback_build_smpolicycontrol_update(
 
     SmPolicyNotification.sm_policy_decision = SmPolicyDecision;
 
-    memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
     message.h.uri = ogs_msprintf("%s/%s",
             sess->notification_uri, OGS_SBI_RESOURCE_NAME_UPDATE);


### PR DESCRIPTION
SMF already handles the freeing in labels correctly. In the same manner the memsets are moved to the beginning of the problematic functions in AMF and PCF.