### PR TITLE
[SMF] Release PDU session with skipInd

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -919,7 +919,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                                     NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release);
                             ogs_assert(param.n2smbuf);
 
-                            param.skip_ind = false;
+                            param.skip_ind = true;
 
                             smf_namf_comm_send_n1_n2_message_transfer(sess, &param);
                         } else {


### PR DESCRIPTION
Follow-up on [#2048](https://github.com/open5gs/open5gs/pull/2048)

AMF crashes when 'skipInd' field is missing:
```
amf  | 03/21 07:45:04.092: [amf] FATAL: [imsi-001010000000000] No skipInd (../src/amf/namf-handler.c:392)
amf  | 03/21 07:45:04.092: [amf] FATAL: amf_namf_comm_handle_n1_n2_message_transfer: should not be reached. (../src/amf/namf-handler.c:393)
```
In case of CM_CONNECTED skipInd is not important.
In case of CM_IDLE the proper relase would contain skipInd.