### PR TITLE
[AMF] Expose connected gNodeBs by IP address

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1170,7 +1170,8 @@ amf_gnb_t *amf_gnb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     ogs_fsm_init(&gnb->sm, ngap_state_initial, ngap_state_final, &e);
 
     ogs_list_add(&self.gnb_list, gnb);
-    amf_metrics_inst_global_inc(AMF_METR_GLOB_GAUGE_GNB);
+    amf_metrics_inst_by_addr_add(gnb->sctp.addr,
+            AMF_METR_GAUGE_GNB, 1);
 
     ogs_info("[Added] Number of gNBs is now %d",
             ogs_list_count(&self.gnb_list));
@@ -1195,10 +1196,13 @@ void amf_gnb_remove(amf_gnb_t *gnb)
             gnb->sctp.addr, sizeof(ogs_sockaddr_t), NULL);
     ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
 
+    amf_metrics_inst_by_addr_add(gnb->sctp.addr,
+            AMF_METR_GAUGE_GNB, -1);
+
     ogs_sctp_flush_and_destroy(&gnb->sctp);
 
     ogs_pool_free(&amf_gnb_pool, gnb);
-    amf_metrics_inst_global_dec(AMF_METR_GLOB_GAUGE_GNB);
+
     ogs_info("[Removed] Number of gNBs is now %d",
             ogs_list_count(&self.gnb_list));
 }

--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -10,7 +10,6 @@ extern "C" {
 typedef enum amf_metric_type_global_s {
     AMF_METR_GLOB_GAUGE_RAN_UE,
     AMF_METR_GLOB_GAUGE_AMF_SESS,
-    AMF_METR_GLOB_GAUGE_GNB,
     AMF_METR_GLOB_CTR_RM_REG_INIT_REQ,
     AMF_METR_GLOB_CTR_RM_REG_INIT_SUCC,
     AMF_METR_GLOB_CTR_RM_REG_MOB_REQ,
@@ -64,6 +63,15 @@ typedef enum amf_metric_type_by_cause_s {
 
 void amf_metrics_inst_by_cause_add(
     uint8_t cause, amf_metric_type_by_cause_t t, int val);
+
+/* BY ADDR */
+typedef enum amf_metric_type_by_addr_s {
+    AMF_METR_GAUGE_GNB = 0,
+    _AMF_METR_BY_ADDR_MAX,
+} amf_metric_type_by_addr_t;
+
+void amf_metrics_inst_by_addr_add(
+    ogs_sockaddr_t *addr, amf_metric_type_by_addr_t t, int val);
 
 void amf_metrics_init(void);
 void amf_metrics_final(void);


### PR DESCRIPTION
Existing gnb metric is exposed with IP address label: gnb{addr="10.15.199.106"} 1