### PR TITLE
[UPF] Remove Metrics in Data Plane (#2210)

### DIFF
--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -214,9 +214,18 @@ static void _gtpv1_tun_recv_common_cb(
     ogs_assert(true == ogs_pfcp_up_handle_pdr(
                 pdr, OGS_GTPU_MSGTYPE_GPDU, recvbuf, &report));
 
+    /*
+     * Issue #2210, Discussion #2208, #2209
+     *
+     * Metrics reduce data plane performance.
+     * It should not be used on the UPF/SGW-U data plane
+     * until this issue is resolved.
+     */
+#if 0
     upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_GTP_OUTDATAPKTN3UPF);
     upf_metrics_inst_by_qfi_add(pdr->qer->qfi,
         UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF, recvbuf->len);
+#endif
 
     if (report.type.downlink_data_report) {
         ogs_assert(pdr->sess);
@@ -395,9 +404,18 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
         ip_h = (struct ip *)pkbuf->data;
         ogs_assert(ip_h);
 
+        /*
+         * Issue #2210, Discussion #2208, #2209
+         *
+         * Metrics reduce data plane performance.
+         * It should not be used on the UPF/SGW-U data plane
+         * until this issue is resolved.
+         */
+#if 0
         upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF);
         upf_metrics_inst_by_qfi_add(qfi,
                 UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF, pkbuf->len);
+#endif
 
         pfcp_object = ogs_pfcp_object_find_by_teid(teid);
         if (!pfcp_object) {


### PR DESCRIPTION
Discussion #2208, #2209

Metrics reduce data plane performance.
It should not be used on the UPF/SGW-U data plane until this issue is resolved.

close #2210 