### PR TITLE
[SMF] Fixed Gy Service-Context-Id

### DIFF
--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -566,7 +566,7 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     struct sess_state *sess_data = NULL, *svg;
     struct session *session = NULL;
     int new;
-    const char *service_context_id = "open5gs-smfd@open5gs.org";
+    const char *service_context_id = "32251@3gpp.org";
     uint32_t timestamp;
 
     ogs_assert(xact);


### PR DESCRIPTION
as per discussion here #2204 the default Service-Context-Id costant is not compliant with 3gpp specs [3GPP 32.299 7.1.12](https://www.etsi.org/deliver/etsi_ts/132200_132299/132299/10.07.00_60/ts_132299v100700p.pdf)