### PR TITLE
[AMF] Fix N2 Handover - copy PDU session info

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -3140,6 +3140,8 @@ void ngap_handle_handover_required(
     target_ue->initial_context_setup_request_sent =
             source_ue->initial_context_setup_request_sent;
 
+    target_ue->psimask.activated = source_ue->psimask.activated;
+
     ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
         target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
 


### PR DESCRIPTION
After N2 Handover (1 AMF, multiple gNB's) was successfully executed, the PDU session was not properly released afterwards on PDU Session Release Request from UE.

The reason was that after N2 Handover the new 'ran_ue' context did not have any information about the active PDU sessions.

Copy the information about PDU sessions from old ran_ue context to the new one.