### PR TITLE
[UPF metrics] Use APN/DNN to expose dnn label

### DIFF
--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -227,6 +227,8 @@ int upf_sess_remove(upf_sess_t *sess)
     ogs_pfcp_pool_final(&sess->pfcp);
 
     ogs_pool_free(&upf_sess_pool, sess);
+    if (sess->apn_dnn)
+        ogs_free(sess->apn_dnn);
     upf_metrics_inst_global_dec(UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR);
 
     ogs_info("[Removed] Number of UPF-sessions is now %d",

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -118,6 +118,7 @@ typedef struct upf_sess_s {
 
     /* Accounting: */
     upf_sess_urr_acc_t urr_acc[OGS_MAX_NUM_OF_URR]; /* FIXME: This probably needs to be mved to a hashtable or alike */
+    char            *apn_dnn;            /* APN/DNN Item */
 } upf_sess_t;
 
 void upf_context_init(void);

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -96,17 +96,24 @@ void upf_n4_handle_session_establishment_request(
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
         goto cleanup;
 
+    if (req->apn_dnn.presence) {
+        char apn_dnn[OGS_MAX_DNN_LEN+1];
+
+        ogs_assert(0 < ogs_fqdn_parse(apn_dnn, req->apn_dnn.data,
+                ogs_min(req->apn_dnn.len, OGS_MAX_DNN_LEN)));
+
+        if (sess->apn_dnn)
+            ogs_free(sess->apn_dnn);
+        sess->apn_dnn = ogs_strdup(apn_dnn);
+        ogs_assert(sess->apn_dnn);
+    }
+
     for (i = 0; i < OGS_MAX_NUM_OF_QER; i++) {
         if (ogs_pfcp_handle_create_qer(&sess->pfcp, &req->create_qer[i],
                     &cause_value, &offending_ie_value) == NULL)
             break;
-        if (req->apn_dnn.presence == 1) {
-            upf_metrics_inst_by_dnn_add(req->apn_dnn.data,
-                    UPF_METR_GAUGE_UPF_QOSFLOWS, 1);
-        } else {
-            upf_metrics_inst_by_dnn_add(NULL,
-                    UPF_METR_GAUGE_UPF_QOSFLOWS, 1);
-        }
+        upf_metrics_inst_by_dnn_add(sess->apn_dnn,
+                UPF_METR_GAUGE_UPF_QOSFLOWS, 1);
     }
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
         goto cleanup;
@@ -358,7 +365,7 @@ void upf_n4_handle_session_modification_request(
         if (ogs_pfcp_handle_create_qer(&sess->pfcp, &req->create_qer[i],
                     &cause_value, &offending_ie_value) == NULL)
             break;
-        upf_metrics_inst_by_dnn_add(NULL,
+        upf_metrics_inst_by_dnn_add(sess->apn_dnn,
                 UPF_METR_GAUGE_UPF_QOSFLOWS, 1);
     }
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
@@ -376,7 +383,7 @@ void upf_n4_handle_session_modification_request(
         if (ogs_pfcp_handle_remove_qer(&sess->pfcp, &req->remove_qer[i],
                 &cause_value, &offending_ie_value) == false)
             break;
-        upf_metrics_inst_by_dnn_add(NULL,
+        upf_metrics_inst_by_dnn_add(sess->apn_dnn,
                 UPF_METR_GAUGE_UPF_QOSFLOWS, -1);
     }
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
@@ -507,7 +514,7 @@ void upf_n4_handle_session_deletion_request(
 
     ogs_list_for_each(&sess->pfcp.pdr_list, pdr) {
         ogs_list_for_each(&sess->pfcp.qer_list, qer) {
-            upf_metrics_inst_by_dnn_add(NULL,
+            upf_metrics_inst_by_dnn_add(sess->apn_dnn,
                     UPF_METR_GAUGE_UPF_QOSFLOWS, -1);
         }
         break;


### PR DESCRIPTION
SMF started to provide APN/DNN in PFCP Establishment. APN/DNN is used to provide dnn label of metric fivegs_upffunction_upf_qosflows.