### PR TITLE
[UPF] Expose GTP metrics on every 100th packet

### DIFF
--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -213,6 +213,21 @@ int upf_sess_remove(upf_sess_t *sess)
 {
     ogs_assert(sess);
 
+    if (sess->gtp_stats.dl_pkts > 0) {
+        upf_metrics_inst_global_add(UPF_METR_GLOB_CTR_GTP_OUTDATAPKTN3UPF,
+                sess->gtp_stats.dl_pkts);
+        upf_metrics_inst_global_add(
+                UPF_METR_GLOB_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
+                sess->gtp_stats.dl_vol);
+    }
+    if (sess->gtp_stats.ul_pkts > 0) {
+        upf_metrics_inst_global_add(UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF,
+                sess->gtp_stats.ul_pkts);
+        upf_metrics_inst_global_add(
+                UPF_METR_GLOB_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF,
+                sess->gtp_stats.ul_vol);
+    }
+
     upf_sess_urr_acc_remove_all(sess);
 
     ogs_list_remove(&self.sess_list, sess);

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -122,6 +122,14 @@ typedef struct upf_sess_s {
 
     /* Accounting: */
     upf_sess_urr_acc_t urr_acc[OGS_MAX_NUM_OF_URR]; /* FIXME: This probably needs to be mved to a hashtable or alike */
+
+#define GTP_EXPOSE_AFTER_PKTS 100
+    struct {
+        uint8_t ul_pkts;
+        uint8_t dl_pkts;
+        uint32_t ul_vol;
+        uint32_t dl_vol;
+    } gtp_stats;
 } upf_sess_t;
 
 void upf_context_init(void);

--- a/src/upf/metrics.c
+++ b/src/upf/metrics.c
@@ -76,6 +76,16 @@ upf_metrics_spec_def_t upf_metrics_spec_def_global[_UPF_METR_GLOB_MAX] = {
     .name = "fivegs_upffunction_sm_n4sessionreportsucc",
     .description = "Number of successful N4 session reports",
 },
+[UPF_METR_GLOB_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_ep_n3_gtp_indatavolumeqosleveln3upf",
+    .description = "Data volume of incoming GTP data packets on the N3 interface",
+},
+[UPF_METR_GLOB_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_ep_n3_gtp_outdatavolumeqosleveln3upf",
+    .description = "Data volume of outgoing GTP data packets on the N3 interface",
+},
 /* Global Gauges: */
 [UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR] = {
     .type = OGS_METRICS_METRIC_TYPE_GAUGE,
@@ -91,81 +101,6 @@ int upf_metrics_init_inst_global(void)
 int upf_metrics_free_inst_global(void)
 {
     return upf_metrics_free_inst(upf_metrics_inst_global, _UPF_METR_GLOB_MAX);
-}
-
-/* BY_QFI */
-const char *labels_qfi[] = {
-    "qfi"
-};
-#define UPF_METR_BY_QFI_CTR_ENTRY(_id, _name, _desc) \
-    [_id] = { \
-        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
-        .name = _name, \
-        .description = _desc, \
-        .num_labels = OGS_ARRAY_SIZE(labels_qfi), \
-        .labels = labels_qfi, \
-    },
-ogs_metrics_spec_t *upf_metrics_spec_by_qfi[_UPF_METR_BY_QFI_MAX];
-ogs_hash_t *metrics_hash_by_qfi = NULL;   /* hash table for QFI label */
-upf_metrics_spec_def_t upf_metrics_spec_def_by_qfi[_UPF_METR_BY_QFI_MAX] = {
-/* Counters: */
-UPF_METR_BY_QFI_CTR_ENTRY(
-    UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF,
-    "fivegs_ep_n3_gtp_indatavolumeqosleveln3upf",
-    "Data volume of incoming GTP data packets per QoS level on the N3 interface")
-UPF_METR_BY_QFI_CTR_ENTRY(
-    UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
-    "fivegs_ep_n3_gtp_outdatavolumeqosleveln3upf",
-    "Data volume of outgoing GTP data packets per QoS level on the N3 interface")
-};
-void upf_metrics_init_by_qfi(void);
-int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst);
-typedef struct upf_metric_key_by_qfi_s {
-    uint8_t                     qfi;
-    upf_metric_type_by_qfi_t    t;
-} upf_metric_key_by_qfi_t;
-
-void upf_metrics_init_by_qfi(void)
-{
-    metrics_hash_by_qfi = ogs_hash_make();
-    ogs_assert(metrics_hash_by_qfi);
-}
-void upf_metrics_inst_by_qfi_add(uint8_t qfi,
-        upf_metric_type_by_qfi_t t, int val)
-{
-    ogs_metrics_inst_t *metrics = NULL;
-    upf_metric_key_by_qfi_t *qfi_key;
-
-    qfi_key = ogs_calloc(1, sizeof(*qfi_key));
-    ogs_assert(qfi_key);
-
-    qfi_key->qfi = qfi;
-    qfi_key->t = t;
-
-    metrics = ogs_hash_get(metrics_hash_by_qfi,
-            qfi_key, sizeof(*qfi_key));
-
-    if (!metrics) {
-        char qfi_str[4];
-        ogs_snprintf(qfi_str, sizeof(qfi_str), "%d", qfi);
-
-        metrics = ogs_metrics_inst_new(upf_metrics_spec_by_qfi[t],
-                upf_metrics_spec_def_by_qfi->num_labels,
-                (const char *[]){ qfi_str });
-
-        ogs_assert(metrics);
-        ogs_hash_set(metrics_hash_by_qfi,
-                qfi_key, sizeof(*qfi_key), metrics);
-    } else {
-        ogs_free(qfi_key);
-    }
-
-    ogs_metrics_inst_add(metrics, val);
-}
-
-int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst)
-{
-    return upf_metrics_free_inst(inst, _UPF_METR_BY_QFI_MAX);
 }
 
 /* BY_CAUSE */
@@ -323,15 +258,12 @@ void upf_metrics_init(void)
 
     upf_metrics_init_spec(ctx, upf_metrics_spec_global, upf_metrics_spec_def_global,
             _UPF_METR_GLOB_MAX);
-    upf_metrics_init_spec(ctx, upf_metrics_spec_by_qfi,
-            upf_metrics_spec_def_by_qfi, _UPF_METR_BY_QFI_MAX);
     upf_metrics_init_spec(ctx, upf_metrics_spec_by_cause,
             upf_metrics_spec_def_by_cause, _UPF_METR_BY_CAUSE_MAX);
     upf_metrics_init_spec(ctx, upf_metrics_spec_by_dnn,
             upf_metrics_spec_def_by_dnn, _UPF_METR_BY_DNN_MAX);
 
     upf_metrics_init_inst_global();
-    upf_metrics_init_by_qfi();
     upf_metrics_init_by_cause();
     upf_metrics_init_by_dnn();
 }
@@ -340,21 +272,6 @@ void upf_metrics_final(void)
 {
     ogs_hash_index_t *hi;
 
-    if (metrics_hash_by_qfi) {
-        for (hi = ogs_hash_first(metrics_hash_by_qfi); hi; hi = ogs_hash_next(hi)) {
-            upf_metric_key_by_qfi_t *key =
-                (upf_metric_key_by_qfi_t *)ogs_hash_this_key(hi);
-            //void *val = ogs_hash_this_val(hi);
-
-            ogs_hash_set(metrics_hash_by_qfi, key, sizeof(*key), NULL);
-
-            ogs_free(key);
-            /* don't free val (metric itself) -
-             * it will be free'd by ogs_metrics_context_final() */
-            //ogs_free(val);
-        }
-        ogs_hash_destroy(metrics_hash_by_qfi);
-    }
     if (metrics_hash_by_cause) {
         for (hi = ogs_hash_first(metrics_hash_by_cause); hi; hi = ogs_hash_next(hi)) {
             upf_metric_key_by_cause_t *key =

--- a/src/upf/metrics.h
+++ b/src/upf/metrics.h
@@ -14,6 +14,8 @@ typedef enum upf_metric_type_global_s {
     UPF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ,
     UPF_METR_GLOB_CTR_SM_N4SESSIONREPORT,
     UPF_METR_GLOB_CTR_SM_N4SESSIONREPORTSUCC,
+    UPF_METR_GLOB_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF,
+    UPF_METR_GLOB_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
     UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR,
     _UPF_METR_GLOB_MAX,
 } upf_metric_type_global_t;
@@ -30,16 +32,6 @@ static inline void upf_metrics_inst_global_inc(upf_metric_type_global_t t)
 { ogs_metrics_inst_inc(upf_metrics_inst_global[t]); }
 static inline void upf_metrics_inst_global_dec(upf_metric_type_global_t t)
 { ogs_metrics_inst_dec(upf_metrics_inst_global[t]); }
-
-/* BY QFI */
-typedef enum upf_metric_type_by_qfi_s {
-    UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF = 0,
-    UPF_METR_CTR_GTP_OUTDATAVOLUMEQOSLEVELN3UPF,
-    _UPF_METR_BY_QFI_MAX,
-} upf_metric_type_by_qfi_t;
-
-void upf_metrics_inst_by_qfi_add(
-    uint8_t qfi, upf_metric_type_by_qfi_t t, int val);
 
 /* BY CAUSE */
 typedef enum upf_metric_type_by_cause_s {


### PR DESCRIPTION
Follow-up on https://github.com/open5gs/open5gs/pull/2219

Metrics exposed the way that does not reduce data plane performance.

qfi label is removed from data volume metrics:

- Data volume of incoming GTP data packets on the N3 interface
```
fivegs_ep_n3_gtp_indatavolumeqosleveln3upf 34310431
```

- Data volume of outgoing GTP data packets on the N3 interface
```
fivegs_ep_n3_gtp_outdatavolumeqosleveln3upf 624076
```