### PR TITLE
[SBI] Fixed an issue with FQDN/TLS (#2252)

### DIFF
--- a/docs/_pages/support.md
+++ b/docs/_pages/support.md
@@ -21,7 +21,7 @@ If your legal department has policies regarding use of software licensed under t
 
 We work with leading partners in mobile communications to offer our customers complete solutions.
 
-**[NextEPC](https://nextepc.com/)**: Established in U.S. in 2019, NextEPC Inc. provides the latest wireless telecommunications technologies and outstanding support to wireless solution providers and vendors around the world. Their solutions include scalable and versatile 4G/5G core network systems. They also offer professional development and customization services for Enterprise users.
+**[NextEPC](https://nextepc.com/)**: Established in U.S. in 2019, NextEPC Inc. provides the latest wireless telecommunications technologies and outstanding support to wireless solution providers and vendors around the world. Their solutions include scalable and versatile 4G/5G core network systems, recently a commercial-grade DPDK-accelerated UPF is also available. They offer professional development and customization services for Enterprise users.
 
 Please contact [sales@nextepc.com](mailto:sales@nextepc.com) for more informations.
 

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -58,8 +58,6 @@ typedef struct ogs_sbi_context_s {
         uint8_t key[OGS_ECCKEY_LEN]; /* 32 bytes Private Key */
     } hnet[OGS_HOME_NETWORK_PKI_VALUE_MAX+1]; /* PKI Value : 1 ~ 254 */
 
-    uint16_t sbi_port;                      /* SBI local port */
-
     ogs_list_t server_list;
     ogs_list_t client_list;
 
@@ -218,6 +216,7 @@ typedef struct ogs_sbi_nf_service_s {
     struct {
         ogs_sockaddr_t *ipv4;
         ogs_sockaddr_t *ipv6;
+        bool is_port;
         int port;
     } addr[OGS_SBI_MAX_NUM_OF_IP_ADDRESS];
 
@@ -401,7 +400,10 @@ ogs_sbi_client_t *ogs_sbi_client_find_by_service_type(
 
 void ogs_sbi_client_associate(ogs_sbi_nf_instance_t *nf_instance);
 
-OpenAPI_uri_scheme_e ogs_sbi_default_uri_scheme(void);
+OpenAPI_uri_scheme_e ogs_sbi_server_default_scheme(void);
+OpenAPI_uri_scheme_e ogs_sbi_client_default_scheme(void);
+int ogs_sbi_server_default_port(void);
+int ogs_sbi_client_default_port(void);
 
 #define OGS_SBI_SETUP_NF_INSTANCE(__cTX, __nFInstance) \
     do { \

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -569,7 +569,7 @@ static OpenAPI_nf_service_t *build_nf_service(
                     return NULL;
                 }
             }
-            IpEndPoint->is_port = true;
+            IpEndPoint->is_port = nf_service->addr[i].is_port;
             IpEndPoint->port = nf_service->addr[i].port;
             OpenAPI_list_add(IpEndPointList, IpEndPoint);
         }

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -83,7 +83,7 @@ void ogs_nnrf_nfm_handle_nf_profile(
         if (nf_instance->num_of_ipv4 < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {
 
             rv = ogs_getaddrinfo(&addr, AF_UNSPEC,
-                    node->data, ogs_sbi_self()->sbi_port, 0);
+                    node->data, ogs_sbi_client_default_port(), 0);
             if (rv != OGS_OK) continue;
 
             nf_instance->ipv4[nf_instance->num_of_ipv4] = addr;
@@ -101,7 +101,7 @@ void ogs_nnrf_nfm_handle_nf_profile(
         if (nf_instance->num_of_ipv6 < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {
 
             rv = ogs_getaddrinfo(&addr, AF_UNSPEC,
-                    node->data, ogs_sbi_self()->sbi_port, 0);
+                    node->data, ogs_sbi_client_default_port(), 0);
             if (rv != OGS_OK) continue;
 
             nf_instance->ipv6[nf_instance->num_of_ipv6] = addr;
@@ -257,18 +257,10 @@ static void handle_nf_service(
         }
 
         if (nf_service->num_of_addr < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {
-            if (!IpEndPoint->is_port) {
-                if (nf_service->scheme == OpenAPI_uri_scheme_http)
-                    port = OGS_SBI_HTTP_PORT;
-                else if (nf_service->scheme == OpenAPI_uri_scheme_https)
-                    port = OGS_SBI_HTTPS_PORT;
-                else {
-                    ogs_error("Invalid scheme [%d]", nf_service->scheme);
-                    continue;
-                }
-            } else {
+            if (!IpEndPoint->is_port)
+                port = ogs_sbi_client_default_port();
+            else
                 port = IpEndPoint->port;
-            }
 
             if (IpEndPoint->ipv4_address) {
                 rv = ogs_getaddrinfo(&addr, AF_UNSPEC,
@@ -290,6 +282,8 @@ static void handle_nf_service(
             }
 
             if (addr || addr6) {
+                nf_service->addr[nf_service->num_of_addr].
+                    is_port = IpEndPoint->is_port;
                 nf_service->addr[nf_service->num_of_addr].
                     port = port;
                 nf_service->addr[nf_service->num_of_addr].

--- a/src/bsf/context.h
+++ b/src/bsf/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -71,6 +71,7 @@ typedef struct bsf_sess_s {
     struct {
         char *addr;
         char *addr6;
+        bool is_port;
         int port;
     } pcf_ip[OGS_SBI_MAX_NUM_OF_IP_ADDRESS];
 

--- a/src/bsf/nbsf-handler.c
+++ b/src/bsf/nbsf-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -148,27 +148,10 @@ bool bsf_nbsf_management_handle_pcf_binding(
 
                 OpenAPI_list_for_each(PcfIpEndPointList, node) {
                     OpenAPI_ip_end_point_t *IpEndPoint = node->data;
-                    int port = 0;
 
                     if (!IpEndPoint) continue;
 
                     if (sess->num_of_pcf_ip < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {
-                        if (!IpEndPoint->is_port) {
-                            if (ogs_sbi_default_uri_scheme() ==
-                                    OpenAPI_uri_scheme_http)
-                                port = OGS_SBI_HTTP_PORT;
-                            else if (ogs_sbi_default_uri_scheme() ==
-                                    OpenAPI_uri_scheme_https)
-                                port = OGS_SBI_HTTPS_PORT;
-                            else {
-                                ogs_fatal("Invalid scheme [%d]",
-                                    ogs_sbi_default_uri_scheme());
-                                ogs_assert_if_reached();
-                            }
-                        } else {
-                            port = IpEndPoint->port;
-                        }
-
                         if (IpEndPoint->ipv4_address ||
                             IpEndPoint->ipv6_address) {
                             if (IpEndPoint->ipv4_address) {
@@ -179,7 +162,12 @@ bool bsf_nbsf_management_handle_pcf_binding(
                                 sess->pcf_ip[sess->num_of_pcf_ip].addr6 =
                                     ogs_strdup(IpEndPoint->ipv6_address);
                             }
-                            sess->pcf_ip[sess->num_of_pcf_ip].port = port;
+                            if (IpEndPoint->is_port) {
+                                sess->pcf_ip[sess->num_of_pcf_ip].is_port =
+                                    IpEndPoint->is_port;
+                                sess->pcf_ip[sess->num_of_pcf_ip].port =
+                                    IpEndPoint->port;
+                            }
                             sess->num_of_pcf_ip++;
                         }
                     }
@@ -259,7 +247,7 @@ bool bsf_nbsf_management_handle_pcf_binding(
                     PcfIpEndPoint->ipv4_address = sess->pcf_ip[i].addr;
                     PcfIpEndPoint->ipv6_address = sess->pcf_ip[i].addr6;
 
-                    PcfIpEndPoint->is_port = true;
+                    PcfIpEndPoint->is_port = sess->pcf_ip[i].is_port;
                     PcfIpEndPoint->port = sess->pcf_ip[i].port;
 
                     OpenAPI_list_add(PcfIpEndPointList, PcfIpEndPoint);

--- a/src/nssf/context.c
+++ b/src/nssf/context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -110,7 +110,7 @@ int nssf_context_parse_config(void)
                         int family = AF_UNSPEC;
                         int i, num = 0;
                         const char *hostname[OGS_MAX_NUM_OF_HOSTNAME];
-                        uint16_t port = ogs_sbi_self()->sbi_port;
+                        uint16_t port = ogs_sbi_server_default_port();
                         const char *dev = NULL;
                         ogs_sockaddr_t *addr = NULL;
                         const char *sst = NULL, *sd = NULL;

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -121,7 +121,7 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
                     goto end;
                 }
             }
-            IpEndPoint->is_port = true;
+            IpEndPoint->is_port = nf_service->addr[i].is_port;
             IpEndPoint->port = nf_service->addr[i].port;
             OpenAPI_list_add(PcfIpEndPointList, IpEndPoint);
         }

--- a/tests/af/context.c
+++ b/tests/af/context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -267,17 +267,21 @@ af_sess_t *af_sess_find_by_pcf_app_session_id(char *pcf_app_session_id)
 }
 
 static ogs_sbi_client_t *find_client_by_fqdn(
-        OpenAPI_uri_scheme_e scheme, char *fqdn, int port)
+        OpenAPI_uri_scheme_e scheme, char *fqdn)
 {
     int rv;
     ogs_sockaddr_t *addr = NULL;
     ogs_sbi_client_t *client = NULL;
 
-    ogs_assert(scheme);
+    ogs_assert(scheme == OpenAPI_uri_scheme_https ||
+                scheme == OpenAPI_uri_scheme_http);
     ogs_assert(fqdn);
 
-    rv = ogs_getaddrinfo(&addr, AF_UNSPEC, fqdn,
-            port ? port : ogs_sbi_self()->sbi_port, 0);
+    rv = ogs_getaddrinfo(
+            &addr, AF_UNSPEC, fqdn,
+            scheme == OpenAPI_uri_scheme_https ?
+                OGS_SBI_HTTPS_PORT : OGS_SBI_HTTP_PORT,
+            0);
     if (rv != OGS_OK) {
         ogs_error("Invalid NFProfile.fqdn");
         return NULL;
@@ -306,7 +310,7 @@ void af_sess_associate_pcf_client(af_sess_t *sess)
                 OpenAPI_uri_scheme_https : OpenAPI_uri_scheme_http;
 
     if (sess->pcf.fqdn && strlen(sess->pcf.fqdn))
-        client = find_client_by_fqdn(scheme, sess->pcf.fqdn, 0);
+        client = find_client_by_fqdn(scheme, sess->pcf.fqdn);
 
     if (!client) {
         /* At this point, CLIENT selection method is very simple. */

--- a/tests/af/context.h
+++ b/tests/af/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -72,6 +72,7 @@ typedef struct af_sess_s {
         struct {
             ogs_sockaddr_t *addr;
             ogs_sockaddr_t *addr6;
+            bool is_port;
             int port;
         } ip[OGS_SBI_MAX_NUM_OF_IP_ADDRESS];
 

--- a/tests/af/nbsf-handler.c
+++ b/tests/af/nbsf-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -67,21 +67,10 @@ void af_nbsf_management_handle_pcf_binding(
         if (!IpEndPoint) continue;
 
         if (sess->pcf.num_of_ip < OGS_SBI_MAX_NUM_OF_IP_ADDRESS) {
-            if (!IpEndPoint->is_port) {
-                if (ogs_sbi_default_uri_scheme() ==
-                        OpenAPI_uri_scheme_http)
-                    port = OGS_SBI_HTTP_PORT;
-                else if (ogs_sbi_default_uri_scheme() ==
-                        OpenAPI_uri_scheme_https)
-                    port = OGS_SBI_HTTPS_PORT;
-                else {
-                    ogs_fatal("Invalid scheme [%d]",
-                        ogs_sbi_default_uri_scheme());
-                    ogs_assert_if_reached();
-                }
-            } else {
+            if (!IpEndPoint->is_port)
+                port = ogs_sbi_client_default_port();
+            else
                 port = IpEndPoint->port;
-            }
 
             if (IpEndPoint->ipv4_address) {
                 rv = ogs_getaddrinfo(&addr, AF_UNSPEC,
@@ -95,6 +84,7 @@ void af_nbsf_management_handle_pcf_binding(
             }
 
             if (addr || addr6) {
+                sess->pcf.ip[sess->pcf.num_of_ip].is_port = IpEndPoint->is_port;
                 sess->pcf.ip[sess->pcf.num_of_ip].port = port;
                 sess->pcf.ip[sess->pcf.num_of_ip].addr = addr;
                 sess->pcf.ip[sess->pcf.num_of_ip].addr6 = addr6;


### PR DESCRIPTION
If FQDN is used, the default ports (HTTP:80, HTTPS:443) are used. HTTP:80 works fine, but HTTPS:443 fails to connect when using TLS. Fixed an issue where SBI connections do not work properly when FQDN and TLS are used together.