### PR TITLE
FIX:  22.04 (jammy) gpg keyring addition

### DIFF
--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -81,9 +81,18 @@ $ sudo apt update
 $ sudo apt install wget gnupg
 $ wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
 ```
+alternatively
+```bash
+$ wget -qO - https://pgp.mongodb.com/server-6.0.asc | sudo apt-key add -
+````
 
 Create the list file /etc/apt/sources.list.d/mongodb-org-6.0.list for your version of Ubuntu.
 
+On ubuntu 22.04 (Jammy)
+```bash
+$ echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+```
+On ubuntu 20.04 (Focal)
 ```bash
 $ echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 ```


### PR DESCRIPTION
On ubuntu 22.04 (Jammy)
```bash
$ echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
```