### PR TITLE
[SBI] Fixed a bug with encoder/decoder of scpPorts

### DIFF
--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -178,6 +178,51 @@ sbi:
 #          l_onoff: true
 #          l_linger: 10
 #
+#  <SCP Information>
+#
+#  o SCP port number(s) WITHOUT SCP Domain
+#    - If no SCP port information is present in ScpInfo or
+#      in ScpDomainInfo for a specific SCP domain,
+#      the HTTP client shall use the default HTTP port number,
+#      i.e. TCP port 80 for "http" URIs or TCP port 443
+#      for "https" URIs as specified in IETF RFC 7540 [9]
+#      when sending a request to the SCP within the specific SCP domain.
+#  scp:
+#    info:
+#      port:
+#        http: 7777
+#        https: 8888
+#
+#  o SCP port number(s) WITH SCP Domain
+#    - If this attribute is present,
+#      it has precedence over the scpPorts attribute of ScpInfo.
+#  scp:
+#    info:
+#      domain:
+#        - name: SCP_Domain_1
+#          fqdn: scp.localdomain
+#          port:
+#            http: 7777
+#            https: 8888
+#
+#  o Complex Example
+#  scp:
+#    info:
+#      port:
+#        http: 7777
+#        https: 8888
+#      domain:
+#        - name: SCP_Domain_1
+#          fqdn: scp.hplmndomain
+#          port:
+#            http: 3333
+#            https: 4444
+#        - name: SCP_Domain_2
+#          fqdn: scp.vplmndomain
+#          port:
+#            http: 5555
+#            https: 6666
+#
 #  <For Indirect Communication with Delegated Discovery>
 #
 #  o (Default) If you do not set Delegated Discovery as shown below,

--- a/lib/core/ogs-conv.c
+++ b/lib/core/ogs-conv.c
@@ -239,3 +239,16 @@ uint64_t ogs_uint64_from_string(char *str)
 
     return x;
 }
+
+double *ogs_alloc_double(double value)
+{
+    double *mem = (double *)ogs_calloc(1, sizeof(double));
+    if (!mem) {
+        ogs_error("No memory");
+        return NULL;
+    }
+
+    *mem = value;
+
+    return mem;
+}

--- a/lib/core/ogs-conv.h
+++ b/lib/core/ogs-conv.h
@@ -55,6 +55,8 @@ char *ogs_uint64_to_string(uint64_t x);
 ogs_uint24_t ogs_uint24_from_string(char *str);
 uint64_t ogs_uint64_from_string(char *str);
 
+double *ogs_alloc_double(double value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -795,6 +795,11 @@ typedef struct ogs_datum_s {
     unsigned int size;
 } ogs_datum_t;
 
+typedef struct ogs_port_s {
+    bool presence;
+    uint16_t port;
+} ogs_port_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1259,6 +1259,11 @@ static void smf_info_free(ogs_sbi_smf_info_t *smf_info)
     ogs_pool_free(&smf_info_pool, smf_info);
 }
 
+static void scp_info_free(ogs_sbi_scp_info_t *scp_info)
+{
+    scp_info->num_of_domain = 0;
+}
+
 void ogs_sbi_nf_info_remove(ogs_list_t *list, ogs_sbi_nf_info_t *nf_info)
 {
     ogs_assert(list);
@@ -1272,6 +1277,9 @@ void ogs_sbi_nf_info_remove(ogs_list_t *list, ogs_sbi_nf_info_t *nf_info)
         break;
     case OpenAPI_nf_type_SMF:
         smf_info_free(&nf_info->smf);
+        break;
+    case OpenAPI_nf_type_SCP:
+        scp_info_free(&nf_info->scp);
         break;
     default:
         ogs_fatal("Not implemented NF-type[%s]",

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 #define OGS_MAX_NUM_OF_NF_INFO 8
+#define OGS_MAX_NUM_OF_SCP_DOMAIN 8
 
 typedef struct ogs_sbi_client_s ogs_sbi_client_t;
 typedef struct ogs_sbi_smf_info_s ogs_sbi_smf_info_t;
@@ -297,6 +298,18 @@ typedef struct ogs_sbi_smf_info_s {
     } nr_tai_range[OGS_MAX_NUM_OF_TAI];
 } ogs_sbi_smf_info_t;
 
+typedef struct ogs_sbi_scp_info_s {
+    ogs_port_t http, https;
+
+    int num_of_domain;
+    struct {
+        char *name;
+        char *fqdn;
+        ogs_port_t http, https;
+    } domain[OGS_MAX_NUM_OF_SCP_DOMAIN];
+
+} ogs_sbi_scp_info_t;
+
 typedef struct ogs_sbi_amf_info_s {
     int amf_set_id;
     int amf_region_id;
@@ -328,6 +341,7 @@ typedef struct ogs_sbi_nf_info_s {
     union {
         ogs_sbi_smf_info_t smf;
         ogs_sbi_amf_info_t amf;
+        ogs_sbi_scp_info_t scp;
     };
 } ogs_sbi_nf_info_t;
 

--- a/lib/sbi/openapi/model/acceptable_service_info.c
+++ b/lib/sbi/openapi/model/acceptable_service_info.c
@@ -69,6 +69,14 @@ cJSON *OpenAPI_acceptable_service_info_convertToJSON(OpenAPI_acceptable_service_
     if (acceptable_service_info->acc_bw_med_comps) {
         OpenAPI_list_for_each(acceptable_service_info->acc_bw_med_comps, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_acceptable_service_info_convertToJSON() failed [acc_bw_med_comps]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_acceptable_service_info_convertToJSON() failed [acc_bw_med_comps]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_media_component_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -400,6 +400,14 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
     if (access_and_mobility_subscription_data->shared_vn_group_data_ids) {
         OpenAPI_list_for_each(access_and_mobility_subscription_data->shared_vn_group_data_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [inner]");
                 goto end;
@@ -834,6 +842,14 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
     if (access_and_mobility_subscription_data->adjacent_plmn_restrictions) {
         OpenAPI_list_for_each(access_and_mobility_subscription_data->adjacent_plmn_restrictions, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [adjacent_plmn_restrictions]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [adjacent_plmn_restrictions]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_plmn_restriction_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -400,6 +400,14 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
     if (access_and_mobility_subscription_data_1->shared_vn_group_data_ids) {
         OpenAPI_list_for_each(access_and_mobility_subscription_data_1->shared_vn_group_data_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [inner]");
                 goto end;
@@ -834,6 +842,14 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
     if (access_and_mobility_subscription_data_1->adjacent_plmn_restrictions) {
         OpenAPI_list_for_each(access_and_mobility_subscription_data_1->adjacent_plmn_restrictions, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [adjacent_plmn_restrictions]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [adjacent_plmn_restrictions]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_plmn_restriction_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/am_policy_data.c
+++ b/lib/sbi/openapi/model/am_policy_data.c
@@ -66,6 +66,14 @@ cJSON *OpenAPI_am_policy_data_convertToJSON(OpenAPI_am_policy_data_t *am_policy_
     if (am_policy_data->pra_infos) {
         OpenAPI_list_for_each(am_policy_data->pra_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_am_policy_data_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_am_policy_data_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/am_requested_value_rep.c
+++ b/lib/sbi/openapi/model/am_requested_value_rep.c
@@ -106,6 +106,14 @@ cJSON *OpenAPI_am_requested_value_rep_convertToJSON(OpenAPI_am_requested_value_r
     if (am_requested_value_rep->pra_statuses) {
         OpenAPI_list_for_each(am_requested_value_rep->pra_statuses, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_am_requested_value_rep_convertToJSON() failed [pra_statuses]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_am_requested_value_rep_convertToJSON() failed [pra_statuses]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/amf_event.c
+++ b/lib/sbi/openapi/model/amf_event.c
@@ -272,6 +272,14 @@ cJSON *OpenAPI_amf_event_convertToJSON(OpenAPI_amf_event_t *amf_event)
     if (amf_event->presence_info_list) {
         OpenAPI_list_for_each(amf_event->presence_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_amf_event_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_amf_event_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/amf_event_subscription_add_info.c
+++ b/lib/sbi/openapi/model/amf_event_subscription_add_info.c
@@ -123,6 +123,14 @@ cJSON *OpenAPI_amf_event_subscription_add_info_convertToJSON(OpenAPI_amf_event_s
     if (amf_event_subscription_add_info->aoi_state_list) {
         OpenAPI_list_for_each(amf_event_subscription_add_info->aoi_state_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_amf_event_subscription_add_info_convertToJSON() failed [aoi_state_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_amf_event_subscription_add_info_convertToJSON() failed [aoi_state_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_area_of_interest_event_state_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/app_descriptor_1.c
+++ b/lib/sbi/openapi/model/app_descriptor_1.c
@@ -75,6 +75,14 @@ cJSON *OpenAPI_app_descriptor_1_convertToJSON(OpenAPI_app_descriptor_1_t *app_de
     if (app_descriptor_1->app_ids) {
         OpenAPI_list_for_each(app_descriptor_1->app_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_app_descriptor_1_convertToJSON() failed [app_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_app_descriptor_1_convertToJSON() failed [app_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_app_descriptor_1_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/app_session_context_req_data.c
+++ b/lib/sbi/openapi/model/app_session_context_req_data.c
@@ -304,6 +304,14 @@ cJSON *OpenAPI_app_session_context_req_data_convertToJSON(OpenAPI_app_session_co
     if (app_session_context_req_data->med_components) {
         OpenAPI_list_for_each(app_session_context_req_data->med_components, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_app_session_context_req_data_convertToJSON() failed [med_components]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_app_session_context_req_data_convertToJSON() failed [med_components]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_media_component_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/app_session_context_update_data.c
+++ b/lib/sbi/openapi/model/app_session_context_update_data.c
@@ -215,6 +215,14 @@ cJSON *OpenAPI_app_session_context_update_data_convertToJSON(OpenAPI_app_session
     if (app_session_context_update_data->med_components) {
         OpenAPI_list_for_each(app_session_context_update_data->med_components, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [med_components]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [med_components]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_media_component_rm_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/area_scope.c
+++ b/lib/sbi/openapi/model/area_scope.c
@@ -126,6 +126,14 @@ cJSON *OpenAPI_area_scope_convertToJSON(OpenAPI_area_scope_t *area_scope)
     if (area_scope->tac_info_per_plmn) {
         OpenAPI_list_for_each(area_scope->tac_info_per_plmn, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_area_scope_convertToJSON() failed [tac_info_per_plmn]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_area_scope_convertToJSON() failed [tac_info_per_plmn]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_tac_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/assign_ebi_data.c
+++ b/lib/sbi/openapi/model/assign_ebi_data.c
@@ -98,7 +98,11 @@ cJSON *OpenAPI_assign_ebi_data_convertToJSON(OpenAPI_assign_ebi_data_t *assign_e
         goto end;
     }
     OpenAPI_list_for_each(assign_ebi_data->released_ebi_list, node) {
-        if (cJSON_AddNumberToObject(released_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_assign_ebi_data_convertToJSON() failed [released_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(released_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_assign_ebi_data_convertToJSON() failed [released_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/assigned_ebi_data.c
+++ b/lib/sbi/openapi/model/assigned_ebi_data.c
@@ -119,7 +119,11 @@ cJSON *OpenAPI_assigned_ebi_data_convertToJSON(OpenAPI_assigned_ebi_data_t *assi
         goto end;
     }
     OpenAPI_list_for_each(assigned_ebi_data->released_ebi_list, node) {
-        if (cJSON_AddNumberToObject(released_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_assigned_ebi_data_convertToJSON() failed [released_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(released_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_assigned_ebi_data_convertToJSON() failed [released_ebi_list]");
             goto end;
         }
@@ -133,7 +137,11 @@ cJSON *OpenAPI_assigned_ebi_data_convertToJSON(OpenAPI_assigned_ebi_data_t *assi
         goto end;
     }
     OpenAPI_list_for_each(assigned_ebi_data->modified_ebi_list, node) {
-        if (cJSON_AddNumberToObject(modified_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_assigned_ebi_data_convertToJSON() failed [modified_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(modified_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_assigned_ebi_data_convertToJSON() failed [modified_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/authorized_network_slice_info.c
+++ b/lib/sbi/openapi/model/authorized_network_slice_info.c
@@ -288,6 +288,14 @@ cJSON *OpenAPI_authorized_network_slice_info_convertToJSON(OpenAPI_authorized_ne
     if (authorized_network_slice_info->nrf_oauth2_required) {
         OpenAPI_list_for_each(authorized_network_slice_info->nrf_oauth2_required, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_authorized_network_slice_info_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_authorized_network_slice_info_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
             if (cJSON_AddBoolToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_authorized_network_slice_info_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/cag_data.c
+++ b/lib/sbi/openapi/model/cag_data.c
@@ -66,6 +66,14 @@ cJSON *OpenAPI_cag_data_convertToJSON(OpenAPI_cag_data_t *cag_data)
     if (cag_data->cag_infos) {
         OpenAPI_list_for_each(cag_data->cag_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_cag_data_convertToJSON() failed [cag_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_cag_data_convertToJSON() failed [cag_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_cag_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/cag_data_1.c
+++ b/lib/sbi/openapi/model/cag_data_1.c
@@ -66,6 +66,14 @@ cJSON *OpenAPI_cag_data_1_convertToJSON(OpenAPI_cag_data_1_t *cag_data_1)
     if (cag_data_1->cag_infos) {
         OpenAPI_list_for_each(cag_data_1->cag_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_cag_data_1_convertToJSON() failed [cag_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_cag_data_1_convertToJSON() failed [cag_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_cag_info_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/default_notification_subscription.c
+++ b/lib/sbi/openapi/model/default_notification_subscription.c
@@ -163,6 +163,14 @@ cJSON *OpenAPI_default_notification_subscription_convertToJSON(OpenAPI_default_n
     if (default_notification_subscription->service_info_list) {
         OpenAPI_list_for_each(default_notification_subscription->service_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_default_notification_subscription_convertToJSON() failed [service_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_default_notification_subscription_convertToJSON() failed [service_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_def_sub_service_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/dnn_upf_info_item.c
+++ b/lib/sbi/openapi/model/dnn_upf_info_item.c
@@ -215,6 +215,14 @@ cJSON *OpenAPI_dnn_upf_info_item_convertToJSON(OpenAPI_dnn_upf_info_item_t *dnn_
     if (dnn_upf_info_item->dnai_nw_instance_list) {
         OpenAPI_list_for_each(dnn_upf_info_item->dnai_nw_instance_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_dnn_upf_info_item_convertToJSON() failed [dnai_nw_instance_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_dnn_upf_info_item_convertToJSON() failed [dnai_nw_instance_list]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_dnn_upf_info_item_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/eap_auth_method_200_response.c
+++ b/lib/sbi/openapi/model/eap_auth_method_200_response.c
@@ -75,6 +75,14 @@ cJSON *OpenAPI_eap_auth_method_200_response_convertToJSON(OpenAPI_eap_auth_metho
     if (eap_auth_method_200_response->_links) {
         OpenAPI_list_for_each(eap_auth_method_200_response->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_eap_auth_method_200_response_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_eap_auth_method_200_response_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/eap_session.c
+++ b/lib/sbi/openapi/model/eap_session.c
@@ -114,6 +114,14 @@ cJSON *OpenAPI_eap_session_convertToJSON(OpenAPI_eap_session_t *eap_session)
     if (eap_session->_links) {
         OpenAPI_list_for_each(eap_session->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_eap_session_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_eap_session_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ee_group_profile_data.c
+++ b/lib/sbi/openapi/model/ee_group_profile_data.c
@@ -104,6 +104,14 @@ cJSON *OpenAPI_ee_group_profile_data_convertToJSON(OpenAPI_ee_group_profile_data
     if (ee_group_profile_data->allowed_mtc_provider) {
         OpenAPI_list_for_each(ee_group_profile_data->allowed_mtc_provider, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ee_group_profile_data_convertToJSON() failed [allowed_mtc_provider]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ee_group_profile_data_convertToJSON() failed [allowed_mtc_provider]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mtc_provider_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ee_profile_data.c
+++ b/lib/sbi/openapi/model/ee_profile_data.c
@@ -111,6 +111,14 @@ cJSON *OpenAPI_ee_profile_data_convertToJSON(OpenAPI_ee_profile_data_t *ee_profi
     if (ee_profile_data->allowed_mtc_provider) {
         OpenAPI_list_for_each(ee_profile_data->allowed_mtc_provider, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ee_profile_data_convertToJSON() failed [allowed_mtc_provider]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ee_profile_data_convertToJSON() failed [allowed_mtc_provider]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mtc_provider_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ee_subscription.c
+++ b/lib/sbi/openapi/model/ee_subscription.c
@@ -157,6 +157,14 @@ cJSON *OpenAPI_ee_subscription_convertToJSON(OpenAPI_ee_subscription_t *ee_subsc
     if (ee_subscription->monitoring_configurations) {
         OpenAPI_list_for_each(ee_subscription->monitoring_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ee_subscription_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ee_subscription_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_monitoring_configuration_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ee_subscription_1.c
+++ b/lib/sbi/openapi/model/ee_subscription_1.c
@@ -157,6 +157,14 @@ cJSON *OpenAPI_ee_subscription_1_convertToJSON(OpenAPI_ee_subscription_1_t *ee_s
     if (ee_subscription_1->monitoring_configurations) {
         OpenAPI_list_for_each(ee_subscription_1->monitoring_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ee_subscription_1_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ee_subscription_1_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_monitoring_configuration_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ee_subscription_ext.c
+++ b/lib/sbi/openapi/model/ee_subscription_ext.c
@@ -178,6 +178,14 @@ cJSON *OpenAPI_ee_subscription_ext_convertToJSON(OpenAPI_ee_subscription_ext_t *
     if (ee_subscription_ext->monitoring_configurations) {
         OpenAPI_list_for_each(ee_subscription_ext->monitoring_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ee_subscription_ext_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ee_subscription_ext_convertToJSON() failed [monitoring_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_monitoring_configuration_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/eps_interworking_info.c
+++ b/lib/sbi/openapi/model/eps_interworking_info.c
@@ -57,6 +57,14 @@ cJSON *OpenAPI_eps_interworking_info_convertToJSON(OpenAPI_eps_interworking_info
     if (eps_interworking_info->eps_iwk_pgws) {
         OpenAPI_list_for_each(eps_interworking_info->eps_iwk_pgws, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_eps_interworking_info_convertToJSON() failed [eps_iwk_pgws]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_eps_interworking_info_convertToJSON() failed [eps_iwk_pgws]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_eps_iwk_pgw_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/event_subscription.c
+++ b/lib/sbi/openapi/model/event_subscription.c
@@ -585,7 +585,11 @@ cJSON *OpenAPI_event_subscription_convertToJSON(OpenAPI_event_subscription_t *ev
         goto end;
     }
     OpenAPI_list_for_each(event_subscription->nsi_level_thrds, node) {
-        if (cJSON_AddNumberToObject(nsi_level_thrdsList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_event_subscription_convertToJSON() failed [nsi_level_thrds]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(nsi_level_thrdsList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_event_subscription_convertToJSON() failed [nsi_level_thrds]");
             goto end;
         }

--- a/lib/sbi/openapi/model/ext_amf_event_subscription.c
+++ b/lib/sbi/openapi/model/ext_amf_event_subscription.c
@@ -404,6 +404,14 @@ cJSON *OpenAPI_ext_amf_event_subscription_convertToJSON(OpenAPI_ext_amf_event_su
     if (ext_amf_event_subscription->aoi_state_list) {
         OpenAPI_list_for_each(ext_amf_event_subscription->aoi_state_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ext_amf_event_subscription_convertToJSON() failed [aoi_state_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ext_amf_event_subscription_convertToJSON() failed [aoi_state_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_area_of_interest_event_state_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/flows.c
+++ b/lib/sbi/openapi/model/flows.c
@@ -62,7 +62,11 @@ cJSON *OpenAPI_flows_convertToJSON(OpenAPI_flows_t *flows)
         goto end;
     }
     OpenAPI_list_for_each(flows->cont_vers, node) {
-        if (cJSON_AddNumberToObject(cont_versList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_flows_convertToJSON() failed [cont_vers]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(cont_versList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_flows_convertToJSON() failed [cont_vers]");
             goto end;
         }
@@ -76,7 +80,11 @@ cJSON *OpenAPI_flows_convertToJSON(OpenAPI_flows_t *flows)
         goto end;
     }
     OpenAPI_list_for_each(flows->f_nums, node) {
-        if (cJSON_AddNumberToObject(f_numsList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_flows_convertToJSON() failed [f_nums]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(f_numsList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_flows_convertToJSON() failed [f_nums]");
             goto end;
         }

--- a/lib/sbi/openapi/model/hsmf_update_data.c
+++ b/lib/sbi/openapi/model/hsmf_update_data.c
@@ -609,7 +609,11 @@ cJSON *OpenAPI_hsmf_update_data_convertToJSON(OpenAPI_hsmf_update_data_t *hsmf_u
         goto end;
     }
     OpenAPI_list_for_each(hsmf_update_data->eps_bearer_id, node) {
-        if (cJSON_AddNumberToObject(eps_bearer_idList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [eps_bearer_id]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(eps_bearer_idList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [eps_bearer_id]");
             goto end;
         }
@@ -630,7 +634,11 @@ cJSON *OpenAPI_hsmf_update_data_convertToJSON(OpenAPI_hsmf_update_data_t *hsmf_u
         goto end;
     }
     OpenAPI_list_for_each(hsmf_update_data->revoke_ebi_list, node) {
-        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [revoke_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [revoke_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/identity_data.c
+++ b/lib/sbi/openapi/model/identity_data.c
@@ -126,6 +126,14 @@ cJSON *OpenAPI_identity_data_convertToJSON(OpenAPI_identity_data_t *identity_dat
     if (identity_data->application_port_ids) {
         OpenAPI_list_for_each(identity_data->application_port_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_identity_data_convertToJSON() failed [application_port_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_identity_data_convertToJSON() failed [application_port_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_identity_data_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/ie_info.c
+++ b/lib/sbi/openapi/model/ie_info.c
@@ -116,6 +116,14 @@ cJSON *OpenAPI_ie_info_convertToJSON(OpenAPI_ie_info_t *ie_info)
     if (ie_info->is_modifiable_by_ipx) {
         OpenAPI_list_for_each(ie_info->is_modifiable_by_ipx, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ie_info_convertToJSON() failed [is_modifiable_by_ipx]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ie_info_convertToJSON() failed [is_modifiable_by_ipx]");
+                goto end;
+            }
             if (cJSON_AddBoolToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_ie_info_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/inter_freq_target_info.c
+++ b/lib/sbi/openapi/model/inter_freq_target_info.c
@@ -58,7 +58,11 @@ cJSON *OpenAPI_inter_freq_target_info_convertToJSON(OpenAPI_inter_freq_target_in
         goto end;
     }
     OpenAPI_list_for_each(inter_freq_target_info->cell_id_list, node) {
-        if (cJSON_AddNumberToObject(cell_id_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_inter_freq_target_info_convertToJSON() failed [cell_id_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(cell_id_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_inter_freq_target_info_convertToJSON() failed [cell_id_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/inter_freq_target_info_1.c
+++ b/lib/sbi/openapi/model/inter_freq_target_info_1.c
@@ -58,7 +58,11 @@ cJSON *OpenAPI_inter_freq_target_info_1_convertToJSON(OpenAPI_inter_freq_target_
         goto end;
     }
     OpenAPI_list_for_each(inter_freq_target_info_1->cell_id_list, node) {
-        if (cJSON_AddNumberToObject(cell_id_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_inter_freq_target_info_1_convertToJSON() failed [cell_id_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(cell_id_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_inter_freq_target_info_1_convertToJSON() failed [cell_id_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/iptv_config_data.c
+++ b/lib/sbi/openapi/model/iptv_config_data.c
@@ -160,6 +160,14 @@ cJSON *OpenAPI_iptv_config_data_convertToJSON(OpenAPI_iptv_config_data_t *iptv_c
     if (iptv_config_data->multi_acc_ctrls) {
         OpenAPI_list_for_each(iptv_config_data->multi_acc_ctrls, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_iptv_config_data_convertToJSON() failed [multi_acc_ctrls]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_iptv_config_data_convertToJSON() failed [multi_acc_ctrls]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_multicast_access_control_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/iptv_config_data_patch.c
+++ b/lib/sbi/openapi/model/iptv_config_data_patch.c
@@ -57,6 +57,14 @@ cJSON *OpenAPI_iptv_config_data_patch_convertToJSON(OpenAPI_iptv_config_data_pat
     if (iptv_config_data_patch->multi_acc_ctrls) {
         OpenAPI_list_for_each(iptv_config_data_patch->multi_acc_ctrls, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_iptv_config_data_patch_convertToJSON() failed [multi_acc_ctrls]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_iptv_config_data_patch_convertToJSON() failed [multi_acc_ctrls]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_multicast_access_control_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/mb_smf_info.c
+++ b/lib/sbi/openapi/model/mb_smf_info.c
@@ -99,6 +99,14 @@ cJSON *OpenAPI_mb_smf_info_convertToJSON(OpenAPI_mb_smf_info_t *mb_smf_info)
     if (mb_smf_info->s_nssai_info_list) {
         OpenAPI_list_for_each(mb_smf_info->s_nssai_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_snssai_mb_smf_info_item_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -121,6 +129,14 @@ cJSON *OpenAPI_mb_smf_info_convertToJSON(OpenAPI_mb_smf_info_t *mb_smf_info)
     if (mb_smf_info->tmgi_range_list) {
         OpenAPI_list_for_each(mb_smf_info->tmgi_range_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [tmgi_range_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [tmgi_range_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_tmgi_range_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -175,6 +191,14 @@ cJSON *OpenAPI_mb_smf_info_convertToJSON(OpenAPI_mb_smf_info_t *mb_smf_info)
     if (mb_smf_info->mbs_session_list) {
         OpenAPI_list_for_each(mb_smf_info->mbs_session_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [mbs_session_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_mb_smf_info_convertToJSON() failed [mbs_session_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mbs_session_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/mbs_session.c
+++ b/lib/sbi/openapi/model/mbs_session.c
@@ -78,6 +78,14 @@ cJSON *OpenAPI_mbs_session_convertToJSON(OpenAPI_mbs_session_t *mbs_session)
     if (mbs_session->mbs_area_sessions) {
         OpenAPI_list_for_each(mbs_session->mbs_area_sessions, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_mbs_session_convertToJSON() failed [mbs_area_sessions]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_mbs_session_convertToJSON() failed [mbs_area_sessions]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mbs_service_area_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/media_component.c
+++ b/lib/sbi/openapi/model/media_component.c
@@ -396,6 +396,14 @@ cJSON *OpenAPI_media_component_convertToJSON(OpenAPI_media_component_t *media_co
     if (media_component->med_sub_comps) {
         OpenAPI_list_for_each(media_component->med_sub_comps, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_media_component_convertToJSON() failed [med_sub_comps]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_media_component_convertToJSON() failed [med_sub_comps]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_media_sub_component_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/media_component_rm.c
+++ b/lib/sbi/openapi/model/media_component_rm.c
@@ -404,6 +404,14 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
     if (media_component_rm->med_sub_comps) {
         OpenAPI_list_for_each(media_component_rm->med_sub_comps, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [med_sub_comps]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [med_sub_comps]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_media_sub_component_rm_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/n2_information_notification.c
+++ b/lib/sbi/openapi/model/n2_information_notification.c
@@ -136,7 +136,11 @@ cJSON *OpenAPI_n2_information_notification_convertToJSON(OpenAPI_n2_information_
         goto end;
     }
     OpenAPI_list_for_each(n2_information_notification->to_release_session_list, node) {
-        if (cJSON_AddNumberToObject(to_release_session_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_n2_information_notification_convertToJSON() failed [to_release_session_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(to_release_session_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_n2_information_notification_convertToJSON() failed [to_release_session_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/n4_information.c
+++ b/lib/sbi/openapi/model/n4_information.c
@@ -128,7 +128,11 @@ cJSON *OpenAPI_n4_information_convertToJSON(OpenAPI_n4_information_t *n4_informa
         goto end;
     }
     OpenAPI_list_for_each(n4_information->n9_ul_pdr_id_list, node) {
-        if (cJSON_AddNumberToObject(n9_ul_pdr_id_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_n4_information_convertToJSON() failed [n9_ul_pdr_id_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(n9_ul_pdr_id_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_n4_information_convertToJSON() failed [n9_ul_pdr_id_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/nf_instance_info.c
+++ b/lib/sbi/openapi/model/nf_instance_info.c
@@ -89,7 +89,19 @@ cJSON *OpenAPI_nf_instance_info_convertToJSON(OpenAPI_nf_instance_info_t *nf_ins
     if (nf_instance_info->nrf_altered_priorities) {
         OpenAPI_list_for_each(nf_instance_info->nrf_altered_priorities, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_instance_info_convertToJSON() failed [nrf_altered_priorities]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_instance_info_convertToJSON() failed [nrf_altered_priorities]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_nf_instance_info_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_nf_instance_info_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/nf_profile.c
+++ b/lib/sbi/openapi/model/nf_profile.c
@@ -1028,6 +1028,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->udr_info_list) {
         OpenAPI_list_for_each(nf_profile->udr_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udr_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udr_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_udr_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1063,6 +1071,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->udm_info_list) {
         OpenAPI_list_for_each(nf_profile->udm_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udm_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udm_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_udm_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1098,6 +1114,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->ausf_info_list) {
         OpenAPI_list_for_each(nf_profile->ausf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [ausf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [ausf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_ausf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1133,6 +1157,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->amf_info_list) {
         OpenAPI_list_for_each(nf_profile->amf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [amf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [amf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_amf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1168,6 +1200,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->smf_info_list) {
         OpenAPI_list_for_each(nf_profile->smf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [smf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [smf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_smf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1203,6 +1243,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->upf_info_list) {
         OpenAPI_list_for_each(nf_profile->upf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [upf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [upf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_upf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1238,6 +1286,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->pcf_info_list) {
         OpenAPI_list_for_each(nf_profile->pcf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [pcf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [pcf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_pcf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1273,6 +1329,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->bsf_info_list) {
         OpenAPI_list_for_each(nf_profile->bsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [bsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [bsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_bsf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1308,6 +1372,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->chf_info_list) {
         OpenAPI_list_for_each(nf_profile->chf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [chf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [chf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_chf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1369,6 +1441,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->udsf_info_list) {
         OpenAPI_list_for_each(nf_profile->udsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [udsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_udsf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1404,6 +1484,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->nwdaf_info_list) {
         OpenAPI_list_for_each(nf_profile->nwdaf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nwdaf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nwdaf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nwdaf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1426,6 +1514,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->pcscf_info_list) {
         OpenAPI_list_for_each(nf_profile->pcscf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [pcscf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [pcscf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_pcscf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1448,6 +1544,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->hss_info_list) {
         OpenAPI_list_for_each(nf_profile->hss_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [hss_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [hss_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_hss_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1513,6 +1617,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->nf_service_list) {
         OpenAPI_list_for_each(nf_profile->nf_service_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nf_service_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nf_service_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nf_service_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1633,6 +1745,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->nf_set_recovery_time_list) {
         OpenAPI_list_for_each(nf_profile->nf_set_recovery_time_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nf_set_recovery_time_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nf_set_recovery_time_list]");
+                goto end;
+            }
         }
     }
     }
@@ -1647,6 +1767,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->service_set_recovery_time_list) {
         OpenAPI_list_for_each(nf_profile->service_set_recovery_time_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [service_set_recovery_time_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [service_set_recovery_time_list]");
+                goto end;
+            }
         }
     }
     }
@@ -1708,6 +1836,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->supported_vendor_specific_features) {
         OpenAPI_list_for_each(nf_profile->supported_vendor_specific_features, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [supported_vendor_specific_features]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [supported_vendor_specific_features]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_vendor_specific_feature_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1730,6 +1866,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->aanf_info_list) {
         OpenAPI_list_for_each(nf_profile->aanf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [aanf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [aanf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_aanf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1778,6 +1922,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->easdf_info_list) {
         OpenAPI_list_for_each(nf_profile->easdf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [easdf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [easdf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_easdf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1813,6 +1965,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->nsacf_info_list) {
         OpenAPI_list_for_each(nf_profile->nsacf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nsacf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nsacf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nsacf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1835,6 +1995,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->mb_smf_info_list) {
         OpenAPI_list_for_each(nf_profile->mb_smf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [mb_smf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [mb_smf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mb_smf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1857,6 +2025,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->tsctsf_info_list) {
         OpenAPI_list_for_each(nf_profile->tsctsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [tsctsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [tsctsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_tsctsf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1879,6 +2055,14 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
     if (nf_profile->mb_upf_info_list) {
         OpenAPI_list_for_each(nf_profile->mb_upf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [mb_upf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [mb_upf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mb_upf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nf_service.c
+++ b/lib/sbi/openapi/model/nf_service.c
@@ -440,6 +440,14 @@ cJSON *OpenAPI_nf_service_convertToJSON(OpenAPI_nf_service_t *nf_service)
     if (nf_service->allowed_operations_per_nf_type) {
         OpenAPI_list_for_each(nf_service->allowed_operations_per_nf_type, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [allowed_operations_per_nf_type]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [allowed_operations_per_nf_type]");
+                goto end;
+            }
         }
     }
     }
@@ -454,6 +462,14 @@ cJSON *OpenAPI_nf_service_convertToJSON(OpenAPI_nf_service_t *nf_service)
     if (nf_service->allowed_operations_per_nf_instance) {
         OpenAPI_list_for_each(nf_service->allowed_operations_per_nf_instance, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [allowed_operations_per_nf_instance]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [allowed_operations_per_nf_instance]");
+                goto end;
+            }
         }
     }
     }
@@ -563,6 +579,14 @@ cJSON *OpenAPI_nf_service_convertToJSON(OpenAPI_nf_service_t *nf_service)
     if (nf_service->supported_vendor_specific_features) {
         OpenAPI_list_for_each(nf_service->supported_vendor_specific_features, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [supported_vendor_specific_features]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nf_service_convertToJSON() failed [supported_vendor_specific_features]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_vendor_specific_feature_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nrf_info.c
+++ b/lib/sbi/openapi/model/nrf_info.c
@@ -525,6 +525,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udr_info) {
         OpenAPI_list_for_each(nrf_info->served_udr_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udr_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udr_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udr_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -547,6 +555,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udr_info_list) {
         OpenAPI_list_for_each(nrf_info->served_udr_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udr_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udr_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udr_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -569,6 +585,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udm_info) {
         OpenAPI_list_for_each(nrf_info->served_udm_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udm_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udm_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udm_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -591,6 +615,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udm_info_list) {
         OpenAPI_list_for_each(nrf_info->served_udm_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udm_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udm_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udm_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -613,6 +645,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_ausf_info) {
         OpenAPI_list_for_each(nrf_info->served_ausf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_ausf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_ausf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_ausf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -635,6 +675,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_ausf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_ausf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_ausf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_ausf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_ausf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -657,6 +705,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_amf_info) {
         OpenAPI_list_for_each(nrf_info->served_amf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_amf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_amf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_amf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -679,6 +735,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_amf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_amf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_amf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_amf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_amf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -701,6 +765,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_smf_info) {
         OpenAPI_list_for_each(nrf_info->served_smf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_smf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_smf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_smf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -723,6 +795,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_smf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_smf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_smf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_smf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_smf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -745,6 +825,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_upf_info) {
         OpenAPI_list_for_each(nrf_info->served_upf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_upf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_upf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_upf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -767,6 +855,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_upf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_upf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_upf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_upf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_upf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -789,6 +885,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_pcf_info) {
         OpenAPI_list_for_each(nrf_info->served_pcf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_pcf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -811,6 +915,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_pcf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_pcf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_pcf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -833,6 +945,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_bsf_info) {
         OpenAPI_list_for_each(nrf_info->served_bsf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_bsf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_bsf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_bsf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -855,6 +975,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_bsf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_bsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_bsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_bsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_bsf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -877,6 +1005,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_chf_info) {
         OpenAPI_list_for_each(nrf_info->served_chf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_chf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_chf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_chf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -899,6 +1035,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_chf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_chf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_chf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_chf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_chf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -921,6 +1065,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_nef_info) {
         OpenAPI_list_for_each(nrf_info->served_nef_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nef_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nef_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_nef_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -943,6 +1095,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_nwdaf_info) {
         OpenAPI_list_for_each(nrf_info->served_nwdaf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nwdaf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nwdaf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_nwdaf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -965,6 +1125,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_nwdaf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_nwdaf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nwdaf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nwdaf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nwdaf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -987,6 +1155,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_pcscf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_pcscf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcscf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_pcscf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_pcscf_info_list_value_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1009,6 +1185,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_gmlc_info) {
         OpenAPI_list_for_each(nrf_info->served_gmlc_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_gmlc_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_gmlc_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_gmlc_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1031,6 +1215,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_lmf_info) {
         OpenAPI_list_for_each(nrf_info->served_lmf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_lmf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_lmf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_lmf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1053,6 +1245,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_nf_info) {
         OpenAPI_list_for_each(nrf_info->served_nf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1075,6 +1275,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_hss_info_list) {
         OpenAPI_list_for_each(nrf_info->served_hss_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_hss_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_hss_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_hss_info_list_value_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1097,6 +1305,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udsf_info) {
         OpenAPI_list_for_each(nrf_info->served_udsf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udsf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udsf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udsf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1119,6 +1335,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_udsf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_udsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_udsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_udsf_info_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1141,6 +1365,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_scp_info_list) {
         OpenAPI_list_for_each(nrf_info->served_scp_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_scp_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_scp_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1163,6 +1395,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_sepp_info_list) {
         OpenAPI_list_for_each(nrf_info->served_sepp_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_sepp_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_sepp_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1185,6 +1425,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_aanf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_aanf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_aanf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_aanf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_aanf_info_list_value_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1207,6 +1455,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served5g_ddnmf_info) {
         OpenAPI_list_for_each(nrf_info->served5g_ddnmf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served5g_ddnmf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served5g_ddnmf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_model_5_g_ddnmf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1229,6 +1485,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_mfaf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_mfaf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mfaf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mfaf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mfaf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1251,6 +1515,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_easdf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_easdf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_easdf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_easdf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_easdf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1273,6 +1545,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_dccf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_dccf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_dccf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_dccf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_dccf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1295,6 +1575,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_mb_smf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_mb_smf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mb_smf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mb_smf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1317,6 +1605,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_tsctsf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_tsctsf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_tsctsf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_tsctsf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_tsctsf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1339,6 +1635,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_mb_upf_info_list) {
         OpenAPI_list_for_each(nrf_info->served_mb_upf_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mb_upf_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_mb_upf_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mb_upf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1361,6 +1665,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_trust_af_info) {
         OpenAPI_list_for_each(nrf_info->served_trust_af_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_trust_af_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_trust_af_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_trust_af_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1383,6 +1695,14 @@ cJSON *OpenAPI_nrf_info_convertToJSON(OpenAPI_nrf_info_t *nrf_info)
     if (nrf_info->served_nssaaf_info) {
         OpenAPI_list_for_each(nrf_info->served_nssaaf_info, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nssaaf_info]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_convertToJSON() failed [served_nssaaf_info]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nssaaf_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nrf_info_served_mb_smf_info_list_value_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_mb_smf_info_list_value_value.c
@@ -99,6 +99,14 @@ cJSON *OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON(OpenAP
     if (nrf_info_served_mb_smf_info_list_value_value->s_nssai_info_list) {
         OpenAPI_list_for_each(nrf_info_served_mb_smf_info_list_value_value->s_nssai_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_snssai_mb_smf_info_item_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -121,6 +129,14 @@ cJSON *OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON(OpenAP
     if (nrf_info_served_mb_smf_info_list_value_value->tmgi_range_list) {
         OpenAPI_list_for_each(nrf_info_served_mb_smf_info_list_value_value->tmgi_range_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [tmgi_range_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [tmgi_range_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_tmgi_range_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -175,6 +191,14 @@ cJSON *OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON(OpenAP
     if (nrf_info_served_mb_smf_info_list_value_value->mbs_session_list) {
         OpenAPI_list_for_each(nrf_info_served_mb_smf_info_list_value_value->mbs_session_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [mbs_session_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_convertToJSON() failed [mbs_session_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_mbs_session_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
@@ -155,6 +155,14 @@ cJSON *OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON(OpenAPI_nrf_inf
     if (nrf_info_served_scp_info_list_value->scp_domain_info_list) {
         OpenAPI_list_for_each(nrf_info_served_scp_info_list_value->scp_domain_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [scp_domain_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [scp_domain_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_scp_domain_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -184,7 +192,19 @@ cJSON *OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON(OpenAPI_nrf_inf
     if (nrf_info_served_scp_info_list_value->scp_ports) {
         OpenAPI_list_for_each(nrf_info_served_scp_info_list_value->scp_ports, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/nrf_info_served_sepp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_sepp_info_list_value.c
@@ -88,7 +88,19 @@ cJSON *OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON(OpenAPI_nrf_in
     if (nrf_info_served_sepp_info_list_value->sepp_ports) {
         OpenAPI_list_for_each(nrf_info_served_sepp_info_list_value->sepp_ports, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON() failed [sepp_ports]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON() failed [sepp_ports]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_nrf_info_served_sepp_info_list_value_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/nrf_info_served_udsf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_udsf_info_value.c
@@ -95,6 +95,14 @@ cJSON *OpenAPI_nrf_info_served_udsf_info_value_convertToJSON(OpenAPI_nrf_info_se
     if (nrf_info_served_udsf_info_value->storage_id_ranges) {
         OpenAPI_list_for_each(nrf_info_served_udsf_info_value->storage_id_ranges, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_udsf_info_value_convertToJSON() failed [storage_id_ranges]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nrf_info_served_udsf_info_value_convertToJSON() failed [storage_id_ranges]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_identity_range_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nsag_info.c
+++ b/lib/sbi/openapi/model/nsag_info.c
@@ -81,7 +81,11 @@ cJSON *OpenAPI_nsag_info_convertToJSON(OpenAPI_nsag_info_t *nsag_info)
         goto end;
     }
     OpenAPI_list_for_each(nsag_info->nsag_ids, node) {
-        if (cJSON_AddNumberToObject(nsag_idsList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_nsag_info_convertToJSON() failed [nsag_ids]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(nsag_idsList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_nsag_info_convertToJSON() failed [nsag_ids]");
             goto end;
         }

--- a/lib/sbi/openapi/model/nsi_information.c
+++ b/lib/sbi/openapi/model/nsi_information.c
@@ -111,6 +111,14 @@ cJSON *OpenAPI_nsi_information_convertToJSON(OpenAPI_nsi_information_t *nsi_info
     if (nsi_information->nrf_oauth2_required) {
         OpenAPI_list_for_each(nsi_information->nrf_oauth2_required, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nsi_information_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nsi_information_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
             if (cJSON_AddBoolToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_nsi_information_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/nssai.c
+++ b/lib/sbi/openapi/model/nssai.c
@@ -139,6 +139,14 @@ cJSON *OpenAPI_nssai_convertToJSON(OpenAPI_nssai_t *nssai)
     if (nssai->additional_snssai_data) {
         OpenAPI_list_for_each(nssai->additional_snssai_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nssai_convertToJSON() failed [additional_snssai_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nssai_convertToJSON() failed [additional_snssai_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_additional_snssai_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/nssai_1.c
+++ b/lib/sbi/openapi/model/nssai_1.c
@@ -139,6 +139,14 @@ cJSON *OpenAPI_nssai_1_convertToJSON(OpenAPI_nssai_1_t *nssai_1)
     if (nssai_1->additional_snssai_data) {
         OpenAPI_list_for_each(nssai_1->additional_snssai_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_nssai_1_convertToJSON() failed [additional_snssai_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_nssai_1_convertToJSON() failed [additional_snssai_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_additional_snssai_data_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/pdu_session_create_data.c
+++ b/lib/sbi/openapi/model/pdu_session_create_data.c
@@ -527,7 +527,11 @@ cJSON *OpenAPI_pdu_session_create_data_convertToJSON(OpenAPI_pdu_session_create_
         goto end;
     }
     OpenAPI_list_for_each(pdu_session_create_data->eps_bearer_id, node) {
-        if (cJSON_AddNumberToObject(eps_bearer_idList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_pdu_session_create_data_convertToJSON() failed [eps_bearer_id]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(eps_bearer_idList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_pdu_session_create_data_convertToJSON() failed [eps_bearer_id]");
             goto end;
         }

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -246,6 +246,14 @@ cJSON *OpenAPI_policy_association_convertToJSON(OpenAPI_policy_association_t *po
     if (policy_association->pras) {
         OpenAPI_list_for_each(policy_association->pras, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_association_convertToJSON() failed [pras]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_association_convertToJSON() failed [pras]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -346,6 +346,14 @@ cJSON *OpenAPI_policy_association_update_request_convertToJSON(OpenAPI_policy_as
     if (policy_association_update_request->pra_statuses) {
         OpenAPI_list_for_each(policy_association_update_request->pra_statuses, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [pra_statuses]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [pra_statuses]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/policy_data_change_notification.c
+++ b/lib/sbi/openapi/model/policy_data_change_notification.c
@@ -275,6 +275,14 @@ cJSON *OpenAPI_policy_data_change_notification_convertToJSON(OpenAPI_policy_data
     if (policy_data_change_notification->op_spec_data_map) {
         OpenAPI_list_for_each(policy_data_change_notification->op_spec_data_map, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_data_change_notification_convertToJSON() failed [op_spec_data_map]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_data_change_notification_convertToJSON() failed [op_spec_data_map]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_operator_specific_data_container_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/policy_data_for_individual_ue.c
+++ b/lib/sbi/openapi/model/policy_data_for_individual_ue.c
@@ -126,6 +126,14 @@ cJSON *OpenAPI_policy_data_for_individual_ue_convertToJSON(OpenAPI_policy_data_f
     if (policy_data_for_individual_ue->um_data) {
         OpenAPI_list_for_each(policy_data_for_individual_ue->um_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_data_for_individual_ue_convertToJSON() failed [um_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_data_for_individual_ue_convertToJSON() failed [um_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -148,6 +156,14 @@ cJSON *OpenAPI_policy_data_for_individual_ue_convertToJSON(OpenAPI_policy_data_f
     if (policy_data_for_individual_ue->operator_specific_data_set) {
         OpenAPI_list_for_each(policy_data_for_individual_ue->operator_specific_data_set, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_data_for_individual_ue_convertToJSON() failed [operator_specific_data_set]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_data_for_individual_ue_convertToJSON() failed [operator_specific_data_set]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_operator_specific_data_container_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -236,6 +236,14 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
     if (policy_update->pras) {
         OpenAPI_list_for_each(policy_update->pras, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_policy_update_convertToJSON() failed [pras]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_policy_update_convertToJSON() failed [pras]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_rm_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/pp5g_vn_group_profile_data.c
+++ b/lib/sbi/openapi/model/pp5g_vn_group_profile_data.c
@@ -63,6 +63,14 @@ cJSON *OpenAPI_pp5g_vn_group_profile_data_convertToJSON(OpenAPI_pp5g_vn_group_pr
     if (pp5g_vn_group_profile_data->allowed_mtc_providers) {
         OpenAPI_list_for_each(pp5g_vn_group_profile_data->allowed_mtc_providers, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_pp5g_vn_group_profile_data_convertToJSON() failed [allowed_mtc_providers]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_pp5g_vn_group_profile_data_convertToJSON() failed [allowed_mtc_providers]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_allowed_mtc_provider_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/pp_profile_data.c
+++ b/lib/sbi/openapi/model/pp_profile_data.c
@@ -63,6 +63,14 @@ cJSON *OpenAPI_pp_profile_data_convertToJSON(OpenAPI_pp_profile_data_t *pp_profi
     if (pp_profile_data->allowed_mtc_providers) {
         OpenAPI_list_for_each(pp_profile_data->allowed_mtc_providers, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_pp_profile_data_convertToJSON() failed [allowed_mtc_providers]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_pp_profile_data_convertToJSON() failed [allowed_mtc_providers]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_allowed_mtc_provider_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/pro_se_authentication_ctx.c
+++ b/lib/sbi/openapi/model/pro_se_authentication_ctx.c
@@ -83,6 +83,14 @@ cJSON *OpenAPI_pro_se_authentication_ctx_convertToJSON(OpenAPI_pro_se_authentica
     if (pro_se_authentication_ctx->_links) {
         OpenAPI_list_for_each(pro_se_authentication_ctx->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_pro_se_authentication_ctx_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_pro_se_authentication_ctx_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/pro_se_eap_session.c
+++ b/lib/sbi/openapi/model/pro_se_eap_session.c
@@ -105,6 +105,14 @@ cJSON *OpenAPI_pro_se_eap_session_convertToJSON(OpenAPI_pro_se_eap_session_t *pr
     if (pro_se_eap_session->_links) {
         OpenAPI_list_for_each(pro_se_eap_session->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_pro_se_eap_session_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_pro_se_eap_session_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/qos_flow_tunnel.c
+++ b/lib/sbi/openapi/model/qos_flow_tunnel.c
@@ -60,7 +60,11 @@ cJSON *OpenAPI_qos_flow_tunnel_convertToJSON(OpenAPI_qos_flow_tunnel_t *qos_flow
         goto end;
     }
     OpenAPI_list_for_each(qos_flow_tunnel->qfi_list, node) {
-        if (cJSON_AddNumberToObject(qfi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_qos_flow_tunnel_convertToJSON() failed [qfi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(qfi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_qos_flow_tunnel_convertToJSON() failed [qfi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/qos_monitoring_report.c
+++ b/lib/sbi/openapi/model/qos_monitoring_report.c
@@ -94,7 +94,11 @@ cJSON *OpenAPI_qos_monitoring_report_convertToJSON(OpenAPI_qos_monitoring_report
         goto end;
     }
     OpenAPI_list_for_each(qos_monitoring_report->ul_delays, node) {
-        if (cJSON_AddNumberToObject(ul_delaysList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [ul_delays]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(ul_delaysList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [ul_delays]");
             goto end;
         }
@@ -108,7 +112,11 @@ cJSON *OpenAPI_qos_monitoring_report_convertToJSON(OpenAPI_qos_monitoring_report
         goto end;
     }
     OpenAPI_list_for_each(qos_monitoring_report->dl_delays, node) {
-        if (cJSON_AddNumberToObject(dl_delaysList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [dl_delays]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(dl_delaysList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [dl_delays]");
             goto end;
         }
@@ -122,7 +130,11 @@ cJSON *OpenAPI_qos_monitoring_report_convertToJSON(OpenAPI_qos_monitoring_report
         goto end;
     }
     OpenAPI_list_for_each(qos_monitoring_report->rt_delays, node) {
-        if (cJSON_AddNumberToObject(rt_delaysList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [rt_delays]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(rt_delaysList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_qos_monitoring_report_convertToJSON() failed [rt_delays]");
             goto end;
         }

--- a/lib/sbi/openapi/model/release_session_info.c
+++ b/lib/sbi/openapi/model/release_session_info.c
@@ -56,7 +56,11 @@ cJSON *OpenAPI_release_session_info_convertToJSON(OpenAPI_release_session_info_t
         goto end;
     }
     OpenAPI_list_for_each(release_session_info->release_session_list, node) {
-        if (cJSON_AddNumberToObject(release_session_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_release_session_info_convertToJSON() failed [release_session_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(release_session_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_release_session_info_convertToJSON() failed [release_session_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/rule_report.c
+++ b/lib/sbi/openapi/model/rule_report.c
@@ -110,7 +110,11 @@ cJSON *OpenAPI_rule_report_convertToJSON(OpenAPI_rule_report_t *rule_report)
         goto end;
     }
     OpenAPI_list_for_each(rule_report->cont_vers, node) {
-        if (cJSON_AddNumberToObject(cont_versList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_rule_report_convertToJSON() failed [cont_vers]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(cont_versList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_rule_report_convertToJSON() failed [cont_vers]");
             goto end;
         }

--- a/lib/sbi/openapi/model/scheduled_communication_time.c
+++ b/lib/sbi/openapi/model/scheduled_communication_time.c
@@ -63,7 +63,11 @@ cJSON *OpenAPI_scheduled_communication_time_convertToJSON(OpenAPI_scheduled_comm
         goto end;
     }
     OpenAPI_list_for_each(scheduled_communication_time->days_of_week, node) {
-        if (cJSON_AddNumberToObject(days_of_weekList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_scheduled_communication_time_convertToJSON() failed [days_of_week]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(days_of_weekList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_scheduled_communication_time_convertToJSON() failed [days_of_week]");
             goto end;
         }

--- a/lib/sbi/openapi/model/scheduled_communication_time_1.c
+++ b/lib/sbi/openapi/model/scheduled_communication_time_1.c
@@ -63,7 +63,11 @@ cJSON *OpenAPI_scheduled_communication_time_1_convertToJSON(OpenAPI_scheduled_co
         goto end;
     }
     OpenAPI_list_for_each(scheduled_communication_time_1->days_of_week, node) {
-        if (cJSON_AddNumberToObject(days_of_weekList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_scheduled_communication_time_1_convertToJSON() failed [days_of_week]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(days_of_weekList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_scheduled_communication_time_1_convertToJSON() failed [days_of_week]");
             goto end;
         }

--- a/lib/sbi/openapi/model/scheduled_communication_time_rm.c
+++ b/lib/sbi/openapi/model/scheduled_communication_time_rm.c
@@ -63,7 +63,11 @@ cJSON *OpenAPI_scheduled_communication_time_rm_convertToJSON(OpenAPI_scheduled_c
         goto end;
     }
     OpenAPI_list_for_each(scheduled_communication_time_rm->days_of_week, node) {
-        if (cJSON_AddNumberToObject(days_of_weekList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_scheduled_communication_time_rm_convertToJSON() failed [days_of_week]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(days_of_weekList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_scheduled_communication_time_rm_convertToJSON() failed [days_of_week]");
             goto end;
         }

--- a/lib/sbi/openapi/model/scp_domain_info.c
+++ b/lib/sbi/openapi/model/scp_domain_info.c
@@ -108,7 +108,19 @@ cJSON *OpenAPI_scp_domain_info_convertToJSON(OpenAPI_scp_domain_info_t *scp_doma
     if (scp_domain_info->scp_ports) {
         OpenAPI_list_for_each(scp_domain_info->scp_ports, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_scp_domain_info_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_scp_domain_info_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_scp_domain_info_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_scp_domain_info_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/scp_domain_routing_information.c
+++ b/lib/sbi/openapi/model/scp_domain_routing_information.c
@@ -60,6 +60,14 @@ cJSON *OpenAPI_scp_domain_routing_information_convertToJSON(OpenAPI_scp_domain_r
     if (scp_domain_routing_information->scp_domain_list) {
         OpenAPI_list_for_each(scp_domain_routing_information->scp_domain_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_scp_domain_routing_information_convertToJSON() failed [scp_domain_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_scp_domain_routing_information_convertToJSON() failed [scp_domain_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_scp_domain_connectivity_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/scp_info.c
+++ b/lib/sbi/openapi/model/scp_info.c
@@ -155,6 +155,14 @@ cJSON *OpenAPI_scp_info_convertToJSON(OpenAPI_scp_info_t *scp_info)
     if (scp_info->scp_domain_info_list) {
         OpenAPI_list_for_each(scp_info->scp_domain_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_scp_info_convertToJSON() failed [scp_domain_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_scp_info_convertToJSON() failed [scp_domain_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_scp_domain_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -184,7 +192,19 @@ cJSON *OpenAPI_scp_info_convertToJSON(OpenAPI_scp_info_t *scp_info)
     if (scp_info->scp_ports) {
         OpenAPI_list_for_each(scp_info->scp_ports, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_scp_info_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_scp_info_convertToJSON() failed [scp_ports]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_scp_info_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_scp_info_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/search_result.c
+++ b/lib/sbi/openapi/model/search_result.c
@@ -161,6 +161,14 @@ cJSON *OpenAPI_search_result_convertToJSON(OpenAPI_search_result_t *search_resul
     if (search_result->nf_instance_list) {
         OpenAPI_list_for_each(search_result->nf_instance_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_search_result_convertToJSON() failed [nf_instance_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_search_result_convertToJSON() failed [nf_instance_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_nf_instance_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sepp_info.c
+++ b/lib/sbi/openapi/model/sepp_info.c
@@ -88,7 +88,19 @@ cJSON *OpenAPI_sepp_info_convertToJSON(OpenAPI_sepp_info_t *sepp_info)
     if (sepp_info->sepp_ports) {
         OpenAPI_list_for_each(sepp_info->sepp_ports, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sepp_info_convertToJSON() failed [sepp_ports]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sepp_info_convertToJSON() failed [sepp_ports]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_sepp_info_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_sepp_info_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/sequence_number.c
+++ b/lib/sbi/openapi/model/sequence_number.c
@@ -85,7 +85,19 @@ cJSON *OpenAPI_sequence_number_convertToJSON(OpenAPI_sequence_number_t *sequence
     if (sequence_number->last_indexes) {
         OpenAPI_list_for_each(sequence_number->last_indexes, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sequence_number_convertToJSON() failed [last_indexes]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sequence_number_convertToJSON() failed [last_indexes]");
+                goto end;
+            }
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_sequence_number_convertToJSON() failed [inner]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_sequence_number_convertToJSON() failed [inner]");
                 goto end;
             }

--- a/lib/sbi/openapi/model/session_management_subscription_data.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data.c
@@ -155,6 +155,14 @@ cJSON *OpenAPI_session_management_subscription_data_convertToJSON(OpenAPI_sessio
     if (session_management_subscription_data->dnn_configurations) {
         OpenAPI_list_for_each(session_management_subscription_data->dnn_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [dnn_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [dnn_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_dnn_configuration_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -191,6 +199,14 @@ cJSON *OpenAPI_session_management_subscription_data_convertToJSON(OpenAPI_sessio
     if (session_management_subscription_data->shared_vn_group_data_ids) {
         OpenAPI_list_for_each(session_management_subscription_data->shared_vn_group_data_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [inner]");
                 goto end;
@@ -243,6 +259,14 @@ cJSON *OpenAPI_session_management_subscription_data_convertToJSON(OpenAPI_sessio
     if (session_management_subscription_data->expected_ue_behaviours_list) {
         OpenAPI_list_for_each(session_management_subscription_data->expected_ue_behaviours_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [expected_ue_behaviours_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [expected_ue_behaviours_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_expected_ue_behaviour_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -265,6 +289,14 @@ cJSON *OpenAPI_session_management_subscription_data_convertToJSON(OpenAPI_sessio
     if (session_management_subscription_data->suggested_packet_num_dl_list) {
         OpenAPI_list_for_each(session_management_subscription_data->suggested_packet_num_dl_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [suggested_packet_num_dl_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [suggested_packet_num_dl_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_suggested_packet_num_dl_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/session_management_subscription_data_1.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data_1.c
@@ -155,6 +155,14 @@ cJSON *OpenAPI_session_management_subscription_data_1_convertToJSON(OpenAPI_sess
     if (session_management_subscription_data_1->dnn_configurations) {
         OpenAPI_list_for_each(session_management_subscription_data_1->dnn_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [dnn_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [dnn_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_dnn_configuration_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -191,6 +199,14 @@ cJSON *OpenAPI_session_management_subscription_data_1_convertToJSON(OpenAPI_sess
     if (session_management_subscription_data_1->shared_vn_group_data_ids) {
         OpenAPI_list_for_each(session_management_subscription_data_1->shared_vn_group_data_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [shared_vn_group_data_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [inner]");
                 goto end;
@@ -243,6 +259,14 @@ cJSON *OpenAPI_session_management_subscription_data_1_convertToJSON(OpenAPI_sess
     if (session_management_subscription_data_1->expected_ue_behaviours_list) {
         OpenAPI_list_for_each(session_management_subscription_data_1->expected_ue_behaviours_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [expected_ue_behaviours_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [expected_ue_behaviours_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_expected_ue_behaviour_data_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -265,6 +289,14 @@ cJSON *OpenAPI_session_management_subscription_data_1_convertToJSON(OpenAPI_sess
     if (session_management_subscription_data_1->suggested_packet_num_dl_list) {
         OpenAPI_list_for_each(session_management_subscription_data_1->suggested_packet_num_dl_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [suggested_packet_num_dl_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [suggested_packet_num_dl_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_suggested_packet_num_dl_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/shared_data.c
+++ b/lib/sbi/openapi/model/shared_data.c
@@ -182,6 +182,14 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
     if (shared_data->shared_dnn_configurations) {
         OpenAPI_list_for_each(shared_data->shared_dnn_configurations, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_dnn_configurations]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_dnn_configurations]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_dnn_configuration_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -217,6 +225,14 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
     if (shared_data->shared_snssai_infos) {
         OpenAPI_list_for_each(shared_data->shared_snssai_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_snssai_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_snssai_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_snssai_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -239,6 +255,14 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
     if (shared_data->shared_vn_group_datas) {
         OpenAPI_list_for_each(shared_data->shared_vn_group_datas, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_vn_group_datas]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_vn_group_datas]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_vn_group_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -261,6 +285,14 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
     if (shared_data->treatment_instructions) {
         OpenAPI_list_for_each(shared_data->treatment_instructions, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [treatment_instructions]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_shared_data_convertToJSON() failed [treatment_instructions]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, OpenAPI_shared_data_treatment_instruction_ToString((intptr_t)localKeyValue->value)) == NULL) {
                 ogs_error("OpenAPI_shared_data_convertToJSON() failed [treatment_instructions]");
                 goto end;

--- a/lib/sbi/openapi/model/sm_context_create_data.c
+++ b/lib/sbi/openapi/model/sm_context_create_data.c
@@ -855,7 +855,11 @@ cJSON *OpenAPI_sm_context_create_data_convertToJSON(OpenAPI_sm_context_create_da
         goto end;
     }
     OpenAPI_list_for_each(sm_context_create_data->pdu_sessions_activate_list, node) {
-        if (cJSON_AddNumberToObject(pdu_sessions_activate_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_sm_context_create_data_convertToJSON() failed [pdu_sessions_activate_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(pdu_sessions_activate_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_sm_context_create_data_convertToJSON() failed [pdu_sessions_activate_list]");
             goto end;
         }
@@ -1304,6 +1308,14 @@ cJSON *OpenAPI_sm_context_create_data_convertToJSON(OpenAPI_sm_context_create_da
     if (sm_context_create_data->nrf_oauth2_required) {
         OpenAPI_list_for_each(sm_context_create_data->nrf_oauth2_required, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_context_create_data_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_context_create_data_convertToJSON() failed [nrf_oauth2_required]");
+                goto end;
+            }
             if (cJSON_AddBoolToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_sm_context_create_data_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/sm_context_retrieve_data.c
+++ b/lib/sbi/openapi/model/sm_context_retrieve_data.c
@@ -102,7 +102,11 @@ cJSON *OpenAPI_sm_context_retrieve_data_convertToJSON(OpenAPI_sm_context_retriev
         goto end;
     }
     OpenAPI_list_for_each(sm_context_retrieve_data->not_to_transfer_ebi_list, node) {
-        if (cJSON_AddNumberToObject(not_to_transfer_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_sm_context_retrieve_data_convertToJSON() failed [not_to_transfer_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(not_to_transfer_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_sm_context_retrieve_data_convertToJSON() failed [not_to_transfer_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/sm_context_update_data.c
+++ b/lib/sbi/openapi/model/sm_context_update_data.c
@@ -642,7 +642,11 @@ cJSON *OpenAPI_sm_context_update_data_convertToJSON(OpenAPI_sm_context_update_da
         goto end;
     }
     OpenAPI_list_for_each(sm_context_update_data->revoke_ebi_list, node) {
-        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [revoke_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [revoke_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/sm_context_updated_data.c
+++ b/lib/sbi/openapi/model/sm_context_updated_data.c
@@ -189,7 +189,11 @@ cJSON *OpenAPI_sm_context_updated_data_convertToJSON(OpenAPI_sm_context_updated_
         goto end;
     }
     OpenAPI_list_for_each(sm_context_updated_data->release_ebi_list, node) {
-        if (cJSON_AddNumberToObject(release_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_sm_context_updated_data_convertToJSON() failed [release_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(release_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_sm_context_updated_data_convertToJSON() failed [release_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/sm_policy_data.c
+++ b/lib/sbi/openapi/model/sm_policy_data.c
@@ -99,6 +99,14 @@ cJSON *OpenAPI_sm_policy_data_convertToJSON(OpenAPI_sm_policy_data_t *sm_policy_
     if (sm_policy_data->sm_policy_snssai_data) {
         OpenAPI_list_for_each(sm_policy_data->sm_policy_snssai_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [sm_policy_snssai_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [sm_policy_snssai_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_sm_policy_snssai_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -120,6 +128,14 @@ cJSON *OpenAPI_sm_policy_data_convertToJSON(OpenAPI_sm_policy_data_t *sm_policy_
     if (sm_policy_data->um_data_limits) {
         OpenAPI_list_for_each(sm_policy_data->um_data_limits, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [um_data_limits]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [um_data_limits]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_limit_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -142,6 +158,14 @@ cJSON *OpenAPI_sm_policy_data_convertToJSON(OpenAPI_sm_policy_data_t *sm_policy_
     if (sm_policy_data->um_data) {
         OpenAPI_list_for_each(sm_policy_data->um_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [um_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_convertToJSON() failed [um_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sm_policy_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_data_patch.c
@@ -69,6 +69,14 @@ cJSON *OpenAPI_sm_policy_data_patch_convertToJSON(OpenAPI_sm_policy_data_patch_t
     if (sm_policy_data_patch->um_data) {
         OpenAPI_list_for_each(sm_policy_data_patch->um_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_patch_convertToJSON() failed [um_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_patch_convertToJSON() failed [um_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -91,6 +99,14 @@ cJSON *OpenAPI_sm_policy_data_patch_convertToJSON(OpenAPI_sm_policy_data_patch_t
     if (sm_policy_data_patch->sm_policy_snssai_data) {
         OpenAPI_list_for_each(sm_policy_data_patch->sm_policy_snssai_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_patch_convertToJSON() failed [sm_policy_snssai_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_data_patch_convertToJSON() failed [sm_policy_snssai_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_sm_policy_snssai_data_patch_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -261,6 +261,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->sess_rules) {
         OpenAPI_list_for_each(sm_policy_decision->sess_rules, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [sess_rules]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [sess_rules]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_session_rule_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -283,6 +291,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->pcc_rules) {
         OpenAPI_list_for_each(sm_policy_decision->pcc_rules, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pcc_rules]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pcc_rules]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_pcc_rule_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -312,6 +328,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->qos_decs) {
         OpenAPI_list_for_each(sm_policy_decision->qos_decs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_decs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_decs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_qos_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -334,6 +358,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->chg_decs) {
         OpenAPI_list_for_each(sm_policy_decision->chg_decs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [chg_decs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [chg_decs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_charging_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -369,6 +401,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->traff_cont_decs) {
         OpenAPI_list_for_each(sm_policy_decision->traff_cont_decs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [traff_cont_decs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [traff_cont_decs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_traffic_control_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -391,6 +431,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->um_decs) {
         OpenAPI_list_for_each(sm_policy_decision->um_decs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [um_decs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [um_decs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_monitoring_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -413,6 +461,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->qos_chars) {
         OpenAPI_list_for_each(sm_policy_decision->qos_chars, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_chars]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_chars]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_qos_characteristics_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -435,6 +491,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->qos_mon_decs) {
         OpenAPI_list_for_each(sm_policy_decision->qos_mon_decs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_mon_decs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_mon_decs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_qos_monitoring_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -464,6 +528,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->conds) {
         OpenAPI_list_for_each(sm_policy_decision->conds, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [conds]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [conds]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_condition_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -557,6 +629,14 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
     if (sm_policy_decision->pra_infos) {
         OpenAPI_list_for_each(sm_policy_decision->pra_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_rm_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sm_policy_dnn_data.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data.c
@@ -277,6 +277,14 @@ cJSON *OpenAPI_sm_policy_dnn_data_convertToJSON(OpenAPI_sm_policy_dnn_data_t *sm
     if (sm_policy_dnn_data->ref_um_data_limit_ids) {
         OpenAPI_list_for_each(sm_policy_dnn_data->ref_um_data_limit_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [ref_um_data_limit_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [ref_um_data_limit_ids]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_limit_id_to_monitoring_key_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -334,6 +342,14 @@ cJSON *OpenAPI_sm_policy_dnn_data_convertToJSON(OpenAPI_sm_policy_dnn_data_t *sm
     if (sm_policy_dnn_data->pra_infos) {
         OpenAPI_list_for_each(sm_policy_dnn_data->pra_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -356,6 +372,14 @@ cJSON *OpenAPI_sm_policy_dnn_data_convertToJSON(OpenAPI_sm_policy_dnn_data_t *sm
     if (sm_policy_dnn_data->bdt_ref_ids) {
         OpenAPI_list_for_each(sm_policy_dnn_data->bdt_ref_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [bdt_ref_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [bdt_ref_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
@@ -72,6 +72,14 @@ cJSON *OpenAPI_sm_policy_dnn_data_patch_convertToJSON(OpenAPI_sm_policy_dnn_data
     if (sm_policy_dnn_data_patch->bdt_ref_ids) {
         OpenAPI_list_for_each(sm_policy_dnn_data_patch->bdt_ref_ids, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_patch_convertToJSON() failed [bdt_ref_ids]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_dnn_data_patch_convertToJSON() failed [bdt_ref_ids]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_sm_policy_dnn_data_patch_convertToJSON() failed [inner]");
                 goto end;

--- a/lib/sbi/openapi/model/sm_policy_snssai_data.c
+++ b/lib/sbi/openapi/model/sm_policy_snssai_data.c
@@ -84,6 +84,14 @@ cJSON *OpenAPI_sm_policy_snssai_data_convertToJSON(OpenAPI_sm_policy_snssai_data
     if (sm_policy_snssai_data->sm_policy_dnn_data) {
         OpenAPI_list_for_each(sm_policy_snssai_data->sm_policy_dnn_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_snssai_data_convertToJSON() failed [sm_policy_dnn_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_snssai_data_convertToJSON() failed [sm_policy_dnn_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_sm_policy_dnn_data_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sm_policy_snssai_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_snssai_data_patch.c
@@ -78,6 +78,14 @@ cJSON *OpenAPI_sm_policy_snssai_data_patch_convertToJSON(OpenAPI_sm_policy_snssa
     if (sm_policy_snssai_data_patch->sm_policy_dnn_data) {
         OpenAPI_list_for_each(sm_policy_snssai_data_patch->sm_policy_dnn_data, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_snssai_data_patch_convertToJSON() failed [sm_policy_dnn_data]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_snssai_data_patch_convertToJSON() failed [sm_policy_dnn_data]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_sm_policy_dnn_data_patch_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -724,6 +724,14 @@ cJSON *OpenAPI_sm_policy_update_context_data_convertToJSON(OpenAPI_sm_policy_upd
     if (sm_policy_update_context_data->rep_pra_infos) {
         OpenAPI_list_for_each(sm_policy_update_context_data->rep_pra_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [rep_pra_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [rep_pra_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/smf_change_info.c
+++ b/lib/sbi/openapi/model/smf_change_info.c
@@ -56,7 +56,11 @@ cJSON *OpenAPI_smf_change_info_convertToJSON(OpenAPI_smf_change_info_t *smf_chan
         goto end;
     }
     OpenAPI_list_for_each(smf_change_info->pdu_session_id_list, node) {
-        if (cJSON_AddNumberToObject(pdu_session_id_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_smf_change_info_convertToJSON() failed [pdu_session_id_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(pdu_session_id_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_smf_change_info_convertToJSON() failed [pdu_session_id_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/smf_selection_data.c
+++ b/lib/sbi/openapi/model/smf_selection_data.c
@@ -86,6 +86,14 @@ cJSON *OpenAPI_smf_selection_data_convertToJSON(OpenAPI_smf_selection_data_t *sm
     if (smf_selection_data->candidates) {
         OpenAPI_list_for_each(smf_selection_data->candidates, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_smf_selection_data_convertToJSON() failed [candidates]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_smf_selection_data_convertToJSON() failed [candidates]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_candidate_for_replacement_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/smf_selection_subscription_data.c
+++ b/lib/sbi/openapi/model/smf_selection_subscription_data.c
@@ -82,6 +82,14 @@ cJSON *OpenAPI_smf_selection_subscription_data_convertToJSON(OpenAPI_smf_selecti
     if (smf_selection_subscription_data->subscribed_snssai_infos) {
         OpenAPI_list_for_each(smf_selection_subscription_data->subscribed_snssai_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_smf_selection_subscription_data_convertToJSON() failed [subscribed_snssai_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_smf_selection_subscription_data_convertToJSON() failed [subscribed_snssai_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_snssai_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/spatial_validity.c
+++ b/lib/sbi/openapi/model/spatial_validity.c
@@ -60,6 +60,14 @@ cJSON *OpenAPI_spatial_validity_convertToJSON(OpenAPI_spatial_validity_t *spatia
     if (spatial_validity->presence_info_list) {
         OpenAPI_list_for_each(spatial_validity->presence_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_spatial_validity_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_spatial_validity_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/spatial_validity_rm.c
+++ b/lib/sbi/openapi/model/spatial_validity_rm.c
@@ -60,6 +60,14 @@ cJSON *OpenAPI_spatial_validity_rm_convertToJSON(OpenAPI_spatial_validity_rm_t *
     if (spatial_validity_rm->presence_info_list) {
         OpenAPI_list_for_each(spatial_validity_rm->presence_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_spatial_validity_rm_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_spatial_validity_rm_convertToJSON() failed [presence_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/suci_info.c
+++ b/lib/sbi/openapi/model/suci_info.c
@@ -74,7 +74,11 @@ cJSON *OpenAPI_suci_info_convertToJSON(OpenAPI_suci_info_t *suci_info)
         goto end;
     }
     OpenAPI_list_for_each(suci_info->h_nw_pub_key_ids, node) {
-        if (cJSON_AddNumberToObject(h_nw_pub_key_idsList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_suci_info_convertToJSON() failed [h_nw_pub_key_ids]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(h_nw_pub_key_idsList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_suci_info_convertToJSON() failed [h_nw_pub_key_ids]");
             goto end;
         }

--- a/lib/sbi/openapi/model/traffic_descriptor_components.c
+++ b/lib/sbi/openapi/model/traffic_descriptor_components.c
@@ -102,6 +102,14 @@ cJSON *OpenAPI_traffic_descriptor_components_convertToJSON(OpenAPI_traffic_descr
     if (traffic_descriptor_components->app_descs) {
         OpenAPI_list_for_each(traffic_descriptor_components->app_descs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_traffic_descriptor_components_convertToJSON() failed [app_descs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_traffic_descriptor_components_convertToJSON() failed [app_descs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_app_descriptor_1_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/tsctsf_info.c
+++ b/lib/sbi/openapi/model/tsctsf_info.c
@@ -93,6 +93,14 @@ cJSON *OpenAPI_tsctsf_info_convertToJSON(OpenAPI_tsctsf_info_t *tsctsf_info)
     if (tsctsf_info->s_nssai_info_list) {
         OpenAPI_list_for_each(tsctsf_info->s_nssai_info_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_tsctsf_info_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_tsctsf_info_convertToJSON() failed [s_nssai_info_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_snssai_tsctsf_info_item_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/uc_subscription_data.c
+++ b/lib/sbi/openapi/model/uc_subscription_data.c
@@ -56,6 +56,14 @@ cJSON *OpenAPI_uc_subscription_data_convertToJSON(OpenAPI_uc_subscription_data_t
     if (uc_subscription_data->user_consent_per_purpose_list) {
         OpenAPI_list_for_each(uc_subscription_data->user_consent_per_purpose_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_uc_subscription_data_convertToJSON() failed [user_consent_per_purpose_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_uc_subscription_data_convertToJSON() failed [user_consent_per_purpose_list]");
+                goto end;
+            }
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, OpenAPI_user_consent_ToString((intptr_t)localKeyValue->value)) == NULL) {
                 ogs_error("OpenAPI_uc_subscription_data_convertToJSON() failed [user_consent_per_purpose_list]");
                 goto end;

--- a/lib/sbi/openapi/model/udsf_info.c
+++ b/lib/sbi/openapi/model/udsf_info.c
@@ -95,6 +95,14 @@ cJSON *OpenAPI_udsf_info_convertToJSON(OpenAPI_udsf_info_t *udsf_info)
     if (udsf_info->storage_id_ranges) {
         OpenAPI_list_for_each(udsf_info->storage_id_ranges, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_udsf_info_convertToJSON() failed [storage_id_ranges]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_udsf_info_convertToJSON() failed [storage_id_ranges]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_identity_range_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_authentication_ctx.c
+++ b/lib/sbi/openapi/model/ue_authentication_ctx.c
@@ -98,6 +98,14 @@ cJSON *OpenAPI_ue_authentication_ctx_convertToJSON(OpenAPI_ue_authentication_ctx
     if (ue_authentication_ctx->_links) {
         OpenAPI_list_for_each(ue_authentication_ctx->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_authentication_ctx_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_authentication_ctx_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -649,6 +649,14 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
     if (ue_context->sub_ue_slice_mbr_list) {
         OpenAPI_list_for_each(ue_context->sub_ue_slice_mbr_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [sub_ue_slice_mbr_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [sub_ue_slice_mbr_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_slice_mbr_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1162,6 +1170,14 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
     if (ue_context->pra_in_am_policy) {
         OpenAPI_list_for_each(ue_context->pra_in_am_policy, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pra_in_am_policy]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pra_in_am_policy]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1184,6 +1200,14 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
     if (ue_context->pra_in_ue_policy) {
         OpenAPI_list_for_each(ue_context->pra_in_ue_policy, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pra_in_ue_policy]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pra_in_ue_policy]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -1289,6 +1313,14 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
     if (ue_context->pcf_ue_slice_mbr_list) {
         OpenAPI_list_for_each(ue_context->pcf_ue_slice_mbr_list, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pcf_ue_slice_mbr_list]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_context_convertToJSON() failed [pcf_ue_slice_mbr_list]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_slice_mbr_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_context_in_smf_data.c
+++ b/lib/sbi/openapi/model/ue_context_in_smf_data.c
@@ -72,6 +72,14 @@ cJSON *OpenAPI_ue_context_in_smf_data_convertToJSON(OpenAPI_ue_context_in_smf_da
     if (ue_context_in_smf_data->pdu_sessions) {
         OpenAPI_list_for_each(ue_context_in_smf_data->pdu_sessions, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_context_in_smf_data_convertToJSON() failed [pdu_sessions]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_context_in_smf_data_convertToJSON() failed [pdu_sessions]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_pdu_session_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_policy_set.c
+++ b/lib/sbi/openapi/model/ue_policy_set.c
@@ -133,6 +133,14 @@ cJSON *OpenAPI_ue_policy_set_convertToJSON(OpenAPI_ue_policy_set_t *ue_policy_se
     if (ue_policy_set->pra_infos) {
         OpenAPI_list_for_each(ue_policy_set->pra_infos, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [pra_infos]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_presence_info_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -169,6 +177,14 @@ cJSON *OpenAPI_ue_policy_set_convertToJSON(OpenAPI_ue_policy_set_t *ue_policy_se
     if (ue_policy_set->ue_policy_sections) {
         OpenAPI_list_for_each(ue_policy_set->ue_policy_sections, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [ue_policy_sections]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [ue_policy_sections]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_ue_policy_section_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();
@@ -205,6 +221,14 @@ cJSON *OpenAPI_ue_policy_set_convertToJSON(OpenAPI_ue_policy_set_t *ue_policy_se
     if (ue_policy_set->allowed_route_sel_descs) {
         OpenAPI_list_for_each(ue_policy_set->allowed_route_sel_descs, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [allowed_route_sel_descs]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_convertToJSON() failed [allowed_route_sel_descs]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_plmn_route_selection_descriptor_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_policy_set_patch.c
+++ b/lib/sbi/openapi/model/ue_policy_set_patch.c
@@ -85,6 +85,14 @@ cJSON *OpenAPI_ue_policy_set_patch_convertToJSON(OpenAPI_ue_policy_set_patch_t *
     if (ue_policy_set_patch->ue_policy_sections) {
         OpenAPI_list_for_each(ue_policy_set_patch->ue_policy_sections, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_patch_convertToJSON() failed [ue_policy_sections]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_policy_set_patch_convertToJSON() failed [ue_policy_sections]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_ue_policy_section_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/ue_reg_status_update_req_data.c
+++ b/lib/sbi/openapi/model/ue_reg_status_update_req_data.c
@@ -93,7 +93,11 @@ cJSON *OpenAPI_ue_reg_status_update_req_data_convertToJSON(OpenAPI_ue_reg_status
         goto end;
     }
     OpenAPI_list_for_each(ue_reg_status_update_req_data->to_release_session_list, node) {
-        if (cJSON_AddNumberToObject(to_release_session_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_ue_reg_status_update_req_data_convertToJSON() failed [to_release_session_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(to_release_session_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_ue_reg_status_update_req_data_convertToJSON() failed [to_release_session_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/ue_slice_mbr.c
+++ b/lib/sbi/openapi/model/ue_slice_mbr.c
@@ -72,6 +72,14 @@ cJSON *OpenAPI_ue_slice_mbr_convertToJSON(OpenAPI_ue_slice_mbr_t *ue_slice_mbr)
     if (ue_slice_mbr->slice_mbr) {
         OpenAPI_list_for_each(ue_slice_mbr->slice_mbr, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_ue_slice_mbr_convertToJSON() failed [slice_mbr]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_ue_slice_mbr_convertToJSON() failed [slice_mbr]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_slice_mbr_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/uri_list.c
+++ b/lib/sbi/openapi/model/uri_list.c
@@ -61,6 +61,14 @@ cJSON *OpenAPI_uri_list_convertToJSON(OpenAPI_uri_list_t *uri_list)
     if (uri_list->_links) {
         OpenAPI_list_for_each(uri_list->_links, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_uri_list_convertToJSON() failed [_links]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_uri_list_convertToJSON() failed [_links]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_links_value_schema_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/usage_mon_data.c
+++ b/lib/sbi/openapi/model/usage_mon_data.c
@@ -105,6 +105,14 @@ cJSON *OpenAPI_usage_mon_data_convertToJSON(OpenAPI_usage_mon_data_t *usage_mon_
     if (usage_mon_data->scopes) {
         OpenAPI_list_for_each(usage_mon_data->scopes, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_usage_mon_data_convertToJSON() failed [scopes]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_usage_mon_data_convertToJSON() failed [scopes]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_scope_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/usage_mon_data_limit.c
+++ b/lib/sbi/openapi/model/usage_mon_data_limit.c
@@ -102,6 +102,14 @@ cJSON *OpenAPI_usage_mon_data_limit_convertToJSON(OpenAPI_usage_mon_data_limit_t
     if (usage_mon_data_limit->scopes) {
         OpenAPI_list_for_each(usage_mon_data_limit->scopes, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_usage_mon_data_limit_convertToJSON() failed [scopes]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_usage_mon_data_limit_convertToJSON() failed [scopes]");
+                goto end;
+            }
             cJSON *itemLocal = localKeyValue->value ?
                 OpenAPI_usage_mon_data_scope_convertToJSON(localKeyValue->value) :
                 cJSON_CreateNull();

--- a/lib/sbi/openapi/model/vsmf_update_data.c
+++ b/lib/sbi/openapi/model/vsmf_update_data.c
@@ -309,7 +309,11 @@ cJSON *OpenAPI_vsmf_update_data_convertToJSON(OpenAPI_vsmf_update_data_t *vsmf_u
         goto end;
     }
     OpenAPI_list_for_each(vsmf_update_data->revoke_ebi_list, node) {
-        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_vsmf_update_data_convertToJSON() failed [revoke_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(revoke_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_vsmf_update_data_convertToJSON() failed [revoke_ebi_list]");
             goto end;
         }

--- a/lib/sbi/openapi/model/vsmf_updated_data.c
+++ b/lib/sbi/openapi/model/vsmf_updated_data.c
@@ -332,7 +332,11 @@ cJSON *OpenAPI_vsmf_updated_data_convertToJSON(OpenAPI_vsmf_updated_data_t *vsmf
         goto end;
     }
     OpenAPI_list_for_each(vsmf_updated_data->released_ebi_list, node) {
-        if (cJSON_AddNumberToObject(released_ebi_listList, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_vsmf_updated_data_convertToJSON() failed [released_ebi_list]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject(released_ebi_listList, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_vsmf_updated_data_convertToJSON() failed [released_ebi_list]");
             goto end;
         }

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
@@ -487,7 +487,11 @@ cJSON *OpenAPI_{{classname}}_convertToJSON(OpenAPI_{{classname}}_t *{{classname}
         }
                         {{/isByteArray}}
                         {{#isNumeric}}
-        if (cJSON_AddNumberToObject({{{name}}}List, "", (uintptr_t)node->data) == NULL) {
+        if (node->data == NULL) {
+            ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+            goto end;
+        }
+        if (cJSON_AddNumberToObject({{{name}}}List, "", *(double *)node->data) == NULL) {
             ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
             goto end;
         }
@@ -521,6 +525,14 @@ cJSON *OpenAPI_{{classname}}_convertToJSON(OpenAPI_{{classname}}_t *{{classname}
     if ({{{classname}}}->{{{name}}}) {
         OpenAPI_list_for_each({{{classname}}}->{{{name}}}, node) {
             OpenAPI_map_t *localKeyValue = (OpenAPI_map_t*)node->data;
+            if (localKeyValue == NULL) {
+                ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+                goto end;
+            }
+            if (localKeyValue->key == NULL) {
+                ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+                goto end;
+            }
             {{#isEnum}}
             if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, OpenAPI_{{{complexType}}}_ToString((intptr_t)localKeyValue->value)) == NULL) {
                 ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
@@ -543,7 +555,11 @@ cJSON *OpenAPI_{{classname}}_convertToJSON(OpenAPI_{{classname}}_t *{{classname}
             }
                         {{/isByteArray}}
                         {{#isNumeric}}
-            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, (uintptr_t)localKeyValue->value) == NULL) {
+            if (localKeyValue->value == NULL) {
+                ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+                goto end;
+            }
+            if (cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
                 goto end;
             }


### PR DESCRIPTION
Started NRF on open5gs and tried NRF Registration procedure from SCP. As part of registration response NRF includes invalid number. Expectation is to include SCP's port as included in the request.

Refer to #2103, #2274, #2310