### PR TITLE
[AMF/MME] Fixed crashes by M-TMSI (#2307)

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2437,6 +2437,9 @@ amf_m_tmsi_t *amf_m_tmsi_alloc(void)
 int amf_m_tmsi_free(amf_m_tmsi_t *m_tmsi)
 {
     ogs_assert(m_tmsi);
+
+    /* Restore M-TMSI by Issue #2307 */
+    *m_tmsi &= 0x003fffff;
     ogs_pool_free(&m_tmsi_pool, m_tmsi);
 
     return OGS_OK;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3956,6 +3956,9 @@ mme_m_tmsi_t *mme_m_tmsi_alloc(void)
 int mme_m_tmsi_free(mme_m_tmsi_t *m_tmsi)
 {
     ogs_assert(m_tmsi);
+
+    /* Restore M-TMSI by Issue #2307 */
+    *m_tmsi &= 0x003fffff;
     ogs_pool_free(&m_tmsi_pool, m_tmsi);
 
     return OGS_OK;


### PR DESCRIPTION
Add 0xc000000 when assigning M-TMSI. However, this value was not reset on release. So in the next allocation, 0xc000000 was automatically added, causing this problem.