### PR TITLE
[SBI] Add support for encoding/decoding Base64 binary data in OpenAPI…

### DIFF
--- a/lib/sbi/openapi/meson.build
+++ b/lib/sbi/openapi/meson.build
@@ -1371,6 +1371,9 @@ libsbi_openapi_sources = files('''
 
 libsbi_openapi_inc = include_directories('.')
 
+libssl_dep = dependency('libssl', required : true)
+libcrypto_dep = dependency('libcrypto', required : true)
+
 sbi_openapi_cc_flags = ['-DOGS_SBI_COMPILATION']
 
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
@@ -1389,10 +1392,15 @@ libsbi_openapi = library('ogssbi-openapi',
     version : libogslib_version,
     c_args : sbi_openapi_cc_flags,
     include_directories : [libsbi_openapi_inc, libinc],
-    dependencies : libcore_dep,
+    dependencies : [libcore_dep,
+                    libssl_dep,
+                    libcrypto_dep],
     install : true)
 
 libsbi_openapi_dep = declare_dependency(
     link_with : libsbi_openapi,
     include_directories : [libsbi_openapi_inc, libinc],
-    dependencies : libcore_dep)
+    dependencies : [libcore_dep,
+                    libssl_dep,
+                    libcrypto_dep]
+    )

--- a/lib/sbi/openapi/src/binary.c
+++ b/lib/sbi/openapi/src/binary.c
@@ -1,9 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../include/binary.h"
-#ifdef OPENSSL
 #include "openssl/pem.h"
-#endif
 
 OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 {
@@ -19,7 +17,6 @@ OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 char *OpenAPI_base64encode(const void *b64_encode_this,
     int encode_this_many_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -34,16 +31,11 @@ char *OpenAPI_base64encode(const void *b64_encode_this,
     BUF_MEM_grow(mem_bio_mem_ptr, (*mem_bio_mem_ptr).length + 1);   //Makes space for end null.
     (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';  //Adds null-terminator to tail.
     return (*mem_bio_mem_ptr).data; //Returns base-64 encoded data. (See: "buf_mem_st" struct).
-#else // OPENSSL
-//#warning Data will not be encoded. If you want to use function "base64encode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }
 
 char *OpenAPI_base64decode(const void *b64_decode_this,
     int decode_this_many_bytes, int *decoded_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -58,8 +50,4 @@ char *OpenAPI_base64decode(const void *b64_decode_this,
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
     *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
-#else // OPENSSL
-//#warning Data will not be decoded. If you want to use function "base64decode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }

--- a/lib/sbi/support/r16-20210629-openapitools-5.2.0/openapi-generator/templates/binary.c.mustache
+++ b/lib/sbi/support/r16-20210629-openapitools-5.2.0/openapi-generator/templates/binary.c.mustache
@@ -1,9 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../include/binary.h"
-#ifdef OPENSSL
-#include "openssl/pem.h"
-#endif
 
 OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 {
@@ -19,7 +16,6 @@ OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 char *OpenAPI_base64encode(const void *b64_encode_this,
     int encode_this_many_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -34,16 +30,11 @@ char *OpenAPI_base64encode(const void *b64_encode_this,
     BUF_MEM_grow(mem_bio_mem_ptr, (*mem_bio_mem_ptr).length + 1);   //Makes space for end null.
     (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';  //Adds null-terminator to tail.
     return (*mem_bio_mem_ptr).data; //Returns base-64 encoded data. (See: "buf_mem_st" struct).
-#else // OPENSSL
-//#warning Data will not be encoded. If you want to use function "base64encode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }
 
 char *OpenAPI_base64decode(const void *b64_decode_this,
     int decode_this_many_bytes, int *decoded_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -58,8 +49,4 @@ char *OpenAPI_base64decode(const void *b64_decode_this,
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
     *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
-#else // OPENSSL
-//#warning Data will not be decoded. If you want to use function "base64decode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }

--- a/lib/sbi/support/r16-20230226-openapitools-6.4.0/openapi-generator/templates/binary.c.mustache
+++ b/lib/sbi/support/r16-20230226-openapitools-6.4.0/openapi-generator/templates/binary.c.mustache
@@ -1,9 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../include/binary.h"
-#ifdef OPENSSL
 #include "openssl/pem.h"
-#endif
 
 OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 {
@@ -19,7 +17,6 @@ OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 char *OpenAPI_base64encode(const void *b64_encode_this,
     int encode_this_many_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -34,16 +31,11 @@ char *OpenAPI_base64encode(const void *b64_encode_this,
     BUF_MEM_grow(mem_bio_mem_ptr, (*mem_bio_mem_ptr).length + 1);   //Makes space for end null.
     (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';  //Adds null-terminator to tail.
     return (*mem_bio_mem_ptr).data; //Returns base-64 encoded data. (See: "buf_mem_st" struct).
-#else // OPENSSL
-//#warning Data will not be encoded. If you want to use function "base64encode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }
 
 char *OpenAPI_base64decode(const void *b64_decode_this,
     int decode_this_many_bytes, int *decoded_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -58,8 +50,4 @@ char *OpenAPI_base64decode(const void *b64_decode_this,
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
     *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
-#else // OPENSSL
-//#warning Data will not be decoded. If you want to use function "base64decode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/binary.c.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/binary.c.mustache
@@ -1,9 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../include/binary.h"
-#ifdef OPENSSL
 #include "openssl/pem.h"
-#endif
 
 OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 {
@@ -19,7 +17,6 @@ OpenAPI_binary_t *OpenAPI_instantiate_binary_t(char *data, int len)
 char *OpenAPI_base64encode(const void *b64_encode_this,
     int encode_this_many_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -34,16 +31,11 @@ char *OpenAPI_base64encode(const void *b64_encode_this,
     BUF_MEM_grow(mem_bio_mem_ptr, (*mem_bio_mem_ptr).length + 1);   //Makes space for end null.
     (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';  //Adds null-terminator to tail.
     return (*mem_bio_mem_ptr).data; //Returns base-64 encoded data. (See: "buf_mem_st" struct).
-#else // OPENSSL
-//#warning Data will not be encoded. If you want to use function "base64encode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }
 
 char *OpenAPI_base64decode(const void *b64_decode_this,
     int decode_this_many_bytes, int *decoded_bytes)
 {
-#ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
     b64_bio = BIO_new(BIO_f_base64());                      //Initialize our base64 filter BIO.
@@ -58,8 +50,4 @@ char *OpenAPI_base64decode(const void *b64_decode_this,
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
     *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
-#else // OPENSSL
-//#warning Data will not be decoded. If you want to use function "base64decode", please define "-DOPENSSL" when building the library.
-    return NULL;
-#endif // OPENSSL
 }


### PR DESCRIPTION
… documents

Include the OpenSSL libraries as a dependency.


Is there a particular reason we don't want to include OpenSSL as a dependency to lib/sbi/openapi? Since we already require OpenSSL for SBI server there is no harm requiring it for OpenAPI. Agree?