### PR TITLE
[PCF metrics] Always expose SNSSAI label

### DIFF
--- a/src/pcf/metrics.h
+++ b/src/pcf/metrics.h
@@ -24,19 +24,11 @@ static inline void pcf_metrics_inst_global_inc(pcf_metric_type_global_t t)
 static inline void pcf_metrics_inst_global_dec(pcf_metric_type_global_t t)
 { ogs_metrics_inst_dec(pcf_metrics_inst_global[t]); }
 
-/* BY_PLMN */
-typedef enum pcf_metric_type_by_plmn_s {
-    PCF_METR_CTR_PA_POLICYAMASSOREQ = 0,
-    PCF_METR_CTR_PA_POLICYAMASSOSUCC,
-    _PCF_METR_BY_PLMN_MAX,
-} pcf_metric_type_by_plmn_t;
-
-void pcf_metrics_inst_by_plmn_add(
-    ogs_plmn_id_t *plmn, pcf_metric_type_by_plmn_t t, int val);
-
 /* BY_SLICE */
 typedef enum pcf_metric_type_by_slice_s {
-    PCF_METR_CTR_PA_POLICYSMASSOREQ = 0,
+    PCF_METR_CTR_PA_POLICYAMASSOREQ = 0,
+    PCF_METR_CTR_PA_POLICYAMASSOSUCC,
+    PCF_METR_CTR_PA_POLICYSMASSOREQ,
     PCF_METR_CTR_PA_POLICYSMASSOSUCC,
     PCF_METR_GAUGE_PA_SESSIONNBR,
     _PCF_METR_BY_SLICE_MAX,

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -147,8 +147,20 @@ bool pcf_nudr_dr_handle_query_am_data(
 
         ogs_subscription_data_free(&subscription_data);
 
-        pcf_metrics_inst_by_plmn_add(&pcf_ue->guami.plmn_id,
-                PCF_METR_CTR_PA_POLICYAMASSOSUCC, 1);
+        OpenAPI_lnode_t *node = NULL;
+        OpenAPI_list_for_each(PolicyAssociation.request->allowed_snssais, node) {
+            struct OpenAPI_snssai_s *Snssai = node->data;
+            if (Snssai) {
+                ogs_s_nssai_t s_nssai;
+                s_nssai.sst = Snssai->sst;
+                s_nssai.sd = ogs_s_nssai_sd_from_string(Snssai->sd);
+
+                pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+                        &s_nssai, PCF_METR_CTR_PA_POLICYAMASSOSUCC, 1);
+            } else {
+                ogs_error("[%s] No Snssai", pcf_ue->supi);
+            }
+        }
 
         return true;
 


### PR DESCRIPTION
AM policy:
AMF requests AM policy association for array of slices in a single POST request.
So slices have to be defined immediately after receiving request to expose proper number of AM policy associations. Therefore:
- slice is exposed as label,
- the basic metric with empty label is abandoned.

SM policy:
snssai can be defined immediately after receiving request too. So the basic metric with empty labels is abandoned.

Exposed metrics example:
fivegs_pcffunction_pa_policyamassoreq{plmnid="99970",snssai="1000009"} 3 fivegs_pcffunction_pa_policyamassosucc{plmnid="99970,snssai="1000009""} 3 fivegs_pcffunction_pa_policysmassoreq{plmnid="99970",snssai="1000009"} 3 fivegs_pcffunction_pa_policysmassosucc{plmnid="99970",snssai="1000009"} 3