### PR TITLE
[SMF] Expose metrics for nr. of PDU session creations

### DIFF
--- a/src/smf/metrics.c
+++ b/src/smf/metrics.c
@@ -202,6 +202,14 @@ const char *labels_slice[] = {
         .num_labels = OGS_ARRAY_SIZE(labels_slice), \
         .labels = labels_slice, \
     },
+#define SMF_METR_BY_SLICE_CTR_ENTRY(_id, _name, _desc) \
+    [_id] = { \
+        .type = OGS_METRICS_METRIC_TYPE_COUNTER, \
+        .name = _name, \
+        .description = _desc, \
+        .num_labels = OGS_ARRAY_SIZE(labels_slice), \
+        .labels = labels_slice, \
+    },
 ogs_metrics_spec_t *smf_metrics_spec_by_slice[_SMF_METR_BY_SLICE_MAX];
 ogs_hash_t *metrics_hash_by_slice = NULL;   /* hash table for SLICE labels */
 smf_metrics_spec_def_t smf_metrics_spec_def_by_slice[_SMF_METR_BY_SLICE_MAX] = {
@@ -210,6 +218,14 @@ SMF_METR_BY_SLICE_GAUGE_ENTRY(
     SMF_METR_GAUGE_SM_SESSIONNBR,
     "fivegs_smffunction_sm_sessionnbr",
     "Active Sessions")
+SMF_METR_BY_SLICE_CTR_ENTRY(
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ,
+    "fivegs_smffunction_sm_pdusessioncreationreq",
+    "Number of PDU sessions requested to be created by the SMF")
+SMF_METR_BY_SLICE_CTR_ENTRY(
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONSUCC,
+    "fivegs_smffunction_sm_pdusessioncreationsucc",
+    "Number of PDU sessions successfully created by the SMF")
 };
 void smf_metrics_init_by_slice(void);
 int smf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst);
@@ -411,11 +427,15 @@ SMF_METR_BY_CAUSE_CTR_ENTRY(
     SMF_METR_CTR_SM_N4SESSIONESTABFAIL,
     "fivegs_smffunction_sm_n4sessionestabfail",
     "Number of failed N4 session establishments evidented by SMF")
+SMF_METR_BY_CAUSE_CTR_ENTRY(
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONFAIL,
+    "fivegs_smffunction_sm_pdusessioncreationfail",
+    "Number of PDU sessions failed to be created by the SMF")
 };
 void smf_metrics_init_by_cause(void);
 int smf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst);
 typedef struct smf_metric_key_by_cause_s {
-    uint8_t                     cause;
+    int                         cause;
     smf_metric_type_by_cause_t  t;
 } smf_metric_key_by_cause_t;
 
@@ -425,7 +445,7 @@ void smf_metrics_init_by_cause(void)
     ogs_assert(metrics_hash_by_cause);
 }
 
-void smf_metrics_inst_by_cause_add(uint8_t cause,
+void smf_metrics_inst_by_cause_add(int cause,
         smf_metric_type_by_cause_t t, int val)
 {
     ogs_metrics_inst_t *metrics = NULL;

--- a/src/smf/metrics.h
+++ b/src/smf/metrics.h
@@ -68,6 +68,8 @@ static inline void smf_metrics_inst_gtp_node_dec(
 /* BY SLICE */
 typedef enum smf_metric_type_by_slice_s {
     SMF_METR_GAUGE_SM_SESSIONNBR = 0,
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ,
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONSUCC,
     _SMF_METR_BY_SLICE_MAX,
 } smf_metric_type_by_slice_t;
 
@@ -88,11 +90,12 @@ void smf_metrics_inst_by_5qi_add(
 /* BY CAUSE */
 typedef enum smf_metric_type_by_cause_s {
     SMF_METR_CTR_SM_N4SESSIONESTABFAIL = 0,
+    SMF_METR_CTR_SM_PDUSESSIONCREATIONFAIL,
     _SMF_METR_BY_CAUSE_MAX,
 } smf_metric_type_by_cause_t;
 
 void smf_metrics_inst_by_cause_add(
-    uint8_t cause, smf_metric_type_by_cause_t t, int val);
+    int cause, smf_metric_type_by_cause_t t, int val);
 void smf_metrics_init(void);
 void smf_metrics_final(void);
 

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -238,6 +238,8 @@ bool smf_nsmf_handle_create_sm_context(
 
     smf_metrics_inst_by_slice_add(&sess->plmn_id, &sess->s_nssai,
             SMF_METR_GAUGE_SM_SESSIONNBR, 1);
+    smf_metrics_inst_by_slice_add(&sess->plmn_id, &sess->s_nssai,
+            SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ, 1);
 
     if (sess->sm_context_status_uri)
         ogs_free(sess->sm_context_status_uri);

--- a/src/smf/nudm-handler.c
+++ b/src/smf/nudm-handler.c
@@ -332,6 +332,9 @@ bool smf_nudm_sdm_handle_get(smf_sess_t *sess, ogs_sbi_stream_t *stream,
     ogs_assert(response);
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 
+    smf_metrics_inst_by_slice_add(&sess->plmn_id, &sess->s_nssai,
+            SMF_METR_CTR_SM_PDUSESSIONCREATIONSUCC, 1);
+
     ogs_free(sendmsg.http.location);
 
     r = smf_sbi_discover_and_send(

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -216,6 +216,9 @@ void smf_sbi_send_sm_context_create_error(
     ogs_assert(response);
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 
+    smf_metrics_inst_by_cause_add(problem.status,
+            SMF_METR_CTR_SM_PDUSESSIONCREATIONFAIL, 1);
+
     if (n1smbuf)
         ogs_pkbuf_free(n1smbuf);
 }

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -530,6 +530,9 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                     DEFAULT
                         sess = smf_sess_add_by_sbi_message(&sbi_message);
                         ogs_assert(sess);
+
+                        smf_metrics_inst_by_slice_add(NULL, NULL,
+                                SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ, 1);
                     END
                     break;
 


### PR DESCRIPTION
[ETSI TS 128 552 V16.9.0](https://www.etsi.org/deliver/etsi_ts/128500_128599/128552/16.09.00_60/ts_128552v160900p.pdf):

Registration type label is not provided.
A nonstandard PLMNID label is added to achieve uniqueness.

- 5.3.1.3 Number of PDU sessions requested to be created by the SMF

PLMNID and SNSSAI are defined during PDU session creation processing. Some requests can be rejected during processing before label values are known. Those requests are not counted under particular labels. To count also such requests, the basic metric with empty labels is exposed too.

```
fivegs_smffunction_sm_pdusessioncreationreq{plmnid="",snssai=""} 1
fivegs_smffunction_sm_pdusessioncreationreq{plmnid="00101",snssai="1000009"} 1
```

- 5.3.1.4 Number of PDU sessions successfully created by the SMF
```
fivegs_smffunction_sm_pdusessioncreationsucc{plmnid="00101",snssai="1000009"} 1
```

- 5.3.1.5 Number of PDU sessions failed to be created by the SMF
```
fivegs_smffunction_sm_pdusessioncreationfail{cause="400"} 1
```

Example for one successful and one failed (during creation processing) PDU session creation:

```
fivegs_smffunction_sm_pdusessioncreationreq{plmnid="",snssai=""} 2
fivegs_smffunction_sm_pdusessioncreationreq{plmnid="00101",snssai="1000009"} 1

fivegs_smffunction_sm_pdusessioncreationsucc{plmnid="00101",snssai="1000009"} 1

fivegs_smffunction_sm_pdusessioncreationfail{cause="400"} 1
```