### PR TITLE
[SMF] relocation of user-location-info on top level for Gx,Gy

### DIFF
--- a/src/smf/fd-path.c
+++ b/src/smf/fd-path.c
@@ -69,7 +69,7 @@ void smf_fd_final(void)
 }
 
 /* Append 3GPP-User-Location-Info, 3GPP TS 29.061 16.4.7.2 22 */
-void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct avp *avp)
+void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct msg *req)
 {
     struct avp *avpch1;
     union avp_value val;
@@ -92,7 +92,7 @@ void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct avp *avp)
         val.os.len = sess->gtp.user_location_information.len;
         ret = fd_msg_avp_setvalue(avpch1, &val);
         ogs_assert(ret == 0);
-        ret = fd_msg_avp_add(avp, MSG_BRW_LAST_CHILD, avpch1);
+        ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avpch1);
         ogs_assert(ret == 0);
         return;
     }
@@ -149,7 +149,7 @@ void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct avp *avp)
     val.os.len = uli_len;
     ret = fd_msg_avp_setvalue(avpch1, &val);
     ogs_assert(ret == 0);
-    ret = fd_msg_avp_add(avp, MSG_BRW_LAST_CHILD, avpch1);
+    ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avpch1);
     ogs_assert(ret == 0);
 
 }

--- a/src/smf/fd-path.h
+++ b/src/smf/fd-path.h
@@ -46,7 +46,7 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
 void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact);
 void smf_s6b_send_str(smf_sess_t *sess, ogs_gtp_xact_t *xact, uint32_t cause);
 
-void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct avp *avp);
+void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct msg *req);
 
 #ifdef __cplusplus
 }

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -499,7 +499,7 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_assert(ret == 0);
 
         /* 3GPP-User-Location-Info, 3GPP TS 29.061 16.4.7.2 22 */
-        smf_fd_msg_avp_add_3gpp_uli(sess, avpch1);
+        smf_fd_msg_avp_add_3gpp_uli(sess, req);
 
         /* Set 3GPP-MS-Timezone */
         if (sess->gtp.ue_timezone.presence &&

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -512,7 +512,7 @@ static void fill_service_information_ccr(smf_sess_t *sess,
     }
 
     /* 3GPP-User-Location-Info, 3GPP TS 29.061 16.4.7.2 22 */
-    smf_fd_msg_avp_add_3gpp_uli(sess, avpch1);
+    smf_fd_msg_avp_add_3gpp_uli(sess, req);
 
     if (sess->smf_ue->imeisv_len > 0) {
         /* User-Equipment-Info, 3GPP TS 32.299 7.1.17 */


### PR DESCRIPTION
Now "3GPP-User-Location-Info" located in the wrong place.

![image](https://github.com/open5gs/open5gs/assets/1798186/d23973de-101c-4614-85ea-662ebd4b347b)

at according 3GPP TS 32.299 "3GPP-User-Location-Info" is 3GPP specific AVP, which used in CCR,
and must locate on top level, as below:

![image](https://github.com/open5gs/open5gs/assets/1798186/e1826eb9-61fa-4082-bda8-489eda43d180)

