### PR TITLE
[SBI] Fixed Invalid S-NSSAI format (#2337)

### DIFF
--- a/lib/sbi/conv.h
+++ b/lib/sbi/conv.h
@@ -63,6 +63,9 @@ bool ogs_sbi_time_from_string(ogs_time_t *time, char *str);
 #define OGS_SBI_RFC7231_DATE_LEN (34)
 int ogs_sbi_rfc7231_string(char *date_str, ogs_time_t time);
 
+char *ogs_sbi_s_nssai_to_json(ogs_s_nssai_t *s_nssai);
+bool ogs_sbi_s_nssai_from_json(ogs_s_nssai_t *s_nssai, char *str);
+
 char *ogs_sbi_s_nssai_to_string(ogs_s_nssai_t *s_nssai);
 bool ogs_sbi_s_nssai_from_string(ogs_s_nssai_t *s_nssai, char *str);
 
@@ -91,7 +94,6 @@ OpenAPI_pcc_rule_t *ogs_sbi_build_pcc_rule(
 void ogs_sbi_free_pcc_rule(OpenAPI_pcc_rule_t *PccRule);
 OpenAPI_qos_data_t *ogs_sbi_build_qos_data(ogs_pcc_rule_t *pcc_rule);
 void ogs_sbi_free_qos_data(OpenAPI_qos_data_t *QosData);
-char *ogs_sbi_s_nssai_to_string_plain(ogs_s_nssai_t *s_nssai);
 
 #ifdef __cplusplus
 }

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -475,9 +475,9 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
         }
     }
     if (message->param.single_nssai_presence) {
-        char *v = ogs_sbi_s_nssai_to_string(&message->param.s_nssai);
+        char *v = ogs_sbi_s_nssai_to_json(&message->param.s_nssai);
         if (!v) {
-            ogs_error("ogs_sbi_s_nssai_to_string() failed");
+            ogs_error("ogs_sbi_s_nssai_to_json() failed");
             ogs_sbi_request_free(request);
             return NULL;
         }
@@ -485,9 +485,9 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
         ogs_free(v);
     }
     if (message->param.snssai_presence) {
-        char *v = ogs_sbi_s_nssai_to_string(&message->param.s_nssai);
+        char *v = ogs_sbi_s_nssai_to_json(&message->param.s_nssai);
         if (!v) {
-            ogs_error("ogs_sbi_s_nssai_to_string() failed");
+            ogs_error("ogs_sbi_s_nssai_to_json() failed");
             ogs_sbi_request_free(request);
             return NULL;
         }
@@ -748,16 +748,14 @@ int ogs_sbi_parse_request(
         } else if (!strcmp(ogs_hash_this_key(hi), OGS_SBI_PARAM_SINGLE_NSSAI)) {
             char *v = ogs_hash_this_val(hi);
             if (v) {
-                bool rc = ogs_sbi_s_nssai_from_string(
-                        &message->param.s_nssai, v);
+                bool rc = ogs_sbi_s_nssai_from_json(&message->param.s_nssai, v);
                 if (rc == true)
                     message->param.single_nssai_presence = true;
             }
         } else if (!strcmp(ogs_hash_this_key(hi), OGS_SBI_PARAM_SNSSAI)) {
             char *v = ogs_hash_this_val(hi);
             if (v) {
-                bool rc = ogs_sbi_s_nssai_from_string(
-                        &message->param.s_nssai, v);
+                bool rc = ogs_sbi_s_nssai_from_json(&message->param.s_nssai, v);
                 if (rc == true)
                     message->param.snssai_presence = true;
             }

--- a/src/amf/metrics.c
+++ b/src/amf/metrics.c
@@ -232,7 +232,7 @@ void amf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
         }
 
         if (snssai) {
-            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+            s_nssai = ogs_sbi_s_nssai_to_string(snssai);
         } else {
             s_nssai = ogs_strdup("");
         }

--- a/src/pcf/metrics.c
+++ b/src/pcf/metrics.c
@@ -159,7 +159,7 @@ void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
         }
 
         if (snssai) {
-            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+            s_nssai = ogs_sbi_s_nssai_to_string(snssai);
         } else {
             s_nssai = ogs_strdup("");
         }

--- a/src/smf/metrics.c
+++ b/src/smf/metrics.c
@@ -275,7 +275,7 @@ void smf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
         }
 
         if (snssai) {
-            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+            s_nssai = ogs_sbi_s_nssai_to_string(snssai);
         } else {
             s_nssai = ogs_strdup("");
         }
@@ -377,7 +377,7 @@ void smf_metrics_inst_by_5qi_add(ogs_plmn_id_t *plmn,
         }
 
         if (snssai) {
-            s_nssai = ogs_sbi_s_nssai_to_string_plain(snssai);
+            s_nssai = ogs_sbi_s_nssai_to_string(snssai);
         } else {
             s_nssai = ogs_strdup("");
         }

--- a/tests/unit/sbi-message-test.c
+++ b/tests/unit/sbi-message-test.c
@@ -506,6 +506,43 @@ static void sbi_message_test5(abts_case *tc, void *data)
 
 static void sbi_message_test6(abts_case *tc, void *data)
 {
+    ogs_s_nssai_t s_nssai1, s_nssai2;
+    char *string = NULL;
+    bool rc = false;
+
+    memset(&s_nssai1, 0, sizeof(ogs_s_nssai_t));
+
+    s_nssai1.sst = 255;
+    s_nssai1.sd.v = 0x19cde0;
+
+    string = ogs_sbi_s_nssai_to_string(&s_nssai1);
+    ABTS_PTR_NOTNULL(tc, string);
+
+    rc = ogs_sbi_s_nssai_from_string(&s_nssai2, string);
+    ABTS_TRUE(tc, rc == true);
+
+    ogs_free(string);
+
+    ABTS_INT_EQUAL(tc, s_nssai1.sst, s_nssai2.sst);
+    ABTS_INT_EQUAL(tc, s_nssai1.sd.v, s_nssai2.sd.v);
+
+    s_nssai1.sst = 1;
+    s_nssai1.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+
+    string = ogs_sbi_s_nssai_to_string(&s_nssai1);
+    ABTS_PTR_NOTNULL(tc, string);
+
+    rc = ogs_sbi_s_nssai_from_string(&s_nssai2, string);
+    ABTS_TRUE(tc, rc == true);
+
+    ogs_free(string);
+
+    ABTS_INT_EQUAL(tc, s_nssai1.sst, s_nssai2.sst);
+    ABTS_INT_EQUAL(tc, s_nssai1.sd.v, s_nssai2.sd.v);
+}
+
+static void sbi_message_test7(abts_case *tc, void *data)
+{
     cJSON *item = NULL, *item2 = NULL;
     char *content = NULL;
     OpenAPI_smf_selection_subscription_data_t SmfSelectionSubscriptionData;
@@ -553,12 +590,11 @@ static void sbi_message_test6(abts_case *tc, void *data)
             OpenAPI_list_free(DnnInfoList);
 
         memset(&s_nssai, 0, sizeof(s_nssai));
-        s_nssai.sst = 1;
-        s_nssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+        s_nssai.sst = 255;
+        s_nssai.sd.v = 0x19cde0;
 
         SubscribedSnssaiInfoMap = OpenAPI_map_create(
-                ogs_sbi_s_nssai_to_string(&s_nssai),
-                SubscribedSnssaiInfo);
+                ogs_sbi_s_nssai_to_string(&s_nssai), SubscribedSnssaiInfo);
         ogs_assert(SubscribedSnssaiInfoMap);
         ogs_assert(SubscribedSnssaiInfoMap->key);
 
@@ -611,8 +647,8 @@ static void sbi_message_test6(abts_case *tc, void *data)
         if (SubscribedSnssaiInfoMap) {
             memset(&s_nssai, 0, sizeof(s_nssai));
             ogs_sbi_s_nssai_from_string(&s_nssai, SubscribedSnssaiInfoMap->key);
-            ABTS_INT_EQUAL(tc, 1, s_nssai.sst);
-            ABTS_INT_EQUAL(tc, OGS_S_NSSAI_NO_SD_VALUE, s_nssai.sd.v);
+            ABTS_INT_EQUAL(tc, 255, s_nssai.sst);
+            ABTS_INT_EQUAL(tc, 0x19cde0, s_nssai.sd.v);
         }
     }
 
@@ -621,11 +657,11 @@ static void sbi_message_test6(abts_case *tc, void *data)
     content = cJSON_Print(item);
     cJSON_Delete(item);
     ogs_assert(content);
-    ABTS_INT_EQUAL(tc, 148, (int)strlen(content));
+    ABTS_INT_EQUAL(tc, 139, (int)strlen(content));
     ogs_free(content);
 }
 
-static void sbi_message_test7(abts_case *tc, void *data)
+static void sbi_message_test8(abts_case *tc, void *data)
 {
     ABTS_INT_EQUAL(tc, OpenAPI_nf_type_NRF,
         ogs_sbi_service_type_to_nf_type(OGS_SBI_SERVICE_TYPE_NNRF_NFM));
@@ -795,6 +831,7 @@ abts_suite *test_sbi_message(abts_suite *suite)
     abts_run_test(suite, sbi_message_test5, NULL);
     abts_run_test(suite, sbi_message_test6, NULL);
     abts_run_test(suite, sbi_message_test7, NULL);
+    abts_run_test(suite, sbi_message_test8, NULL);
 
     return suite;
 }


### PR DESCRIPTION
As discussed in #2337, Open5GS has a bug when S-NSSAI is used as a MAP-key.

So, I've fixed it as below.

- OLD format
```
        "subscribedSnssaiInfos": {
            "{\n\t\"sst\":\t1,\n\t\"sd\":\t\"000001\"\n}":  {
     
           "dnnInfos":     
```

- NEW format
```
		 "subscribedSnssaiInfos": {
			"1-000001": {
				"dnnInfos": [
```
