### PR TITLE
[CORE] Rollback ogs_pool_init/final (#2339)

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -2084,11 +2084,11 @@ void ogs_pfcp_pool_init(ogs_pfcp_sess_t *sess)
 
     sess->obj.type = OGS_PFCP_OBJ_SESS_TYPE;
 
-    ogs_pool_init(&sess->pdr_id_pool, OGS_MAX_NUM_OF_PDR);
-    ogs_pool_init(&sess->far_id_pool, OGS_MAX_NUM_OF_FAR);
-    ogs_pool_init(&sess->urr_id_pool, OGS_MAX_NUM_OF_URR);
-    ogs_pool_init(&sess->qer_id_pool, OGS_MAX_NUM_OF_QER);
-    ogs_pool_init(&sess->bar_id_pool, OGS_MAX_NUM_OF_BAR);
+    ogs_pool_create(&sess->pdr_id_pool, OGS_MAX_NUM_OF_PDR);
+    ogs_pool_create(&sess->far_id_pool, OGS_MAX_NUM_OF_FAR);
+    ogs_pool_create(&sess->urr_id_pool, OGS_MAX_NUM_OF_URR);
+    ogs_pool_create(&sess->qer_id_pool, OGS_MAX_NUM_OF_QER);
+    ogs_pool_create(&sess->bar_id_pool, OGS_MAX_NUM_OF_BAR);
 
     ogs_pool_sequence_id_generate(&sess->pdr_id_pool);
     ogs_pool_sequence_id_generate(&sess->far_id_pool);
@@ -2100,9 +2100,9 @@ void ogs_pfcp_pool_final(ogs_pfcp_sess_t *sess)
 {
     ogs_assert(sess);
 
-    ogs_pool_final(&sess->pdr_id_pool);
-    ogs_pool_final(&sess->far_id_pool);
-    ogs_pool_final(&sess->urr_id_pool);
-    ogs_pool_final(&sess->qer_id_pool);
-    ogs_pool_final(&sess->bar_id_pool);
+    ogs_pool_destroy(&sess->pdr_id_pool);
+    ogs_pool_destroy(&sess->far_id_pool);
+    ogs_pool_destroy(&sess->urr_id_pool);
+    ogs_pool_destroy(&sess->qer_id_pool);
+    ogs_pool_destroy(&sess->bar_id_pool);
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3970,7 +3970,7 @@ void mme_ebi_pool_init(mme_ue_t *mme_ue)
 
     ogs_assert(mme_ue);
 
-    ogs_pool_init(&mme_ue->ebi_pool, MAX_EPS_BEARER_ID-MIN_EPS_BEARER_ID+1);
+    ogs_pool_create(&mme_ue->ebi_pool, MAX_EPS_BEARER_ID-MIN_EPS_BEARER_ID+1);
 
     for (i = MIN_EPS_BEARER_ID, index = 0;
             i <= MAX_EPS_BEARER_ID; i++, index++) {
@@ -3982,7 +3982,7 @@ void mme_ebi_pool_final(mme_ue_t *mme_ue)
 {
     ogs_assert(mme_ue);
 
-    ogs_pool_final(&mme_ue->ebi_pool);
+    ogs_pool_destroy(&mme_ue->ebi_pool);
 }
 
 void mme_ebi_pool_clear(mme_ue_t *mme_ue)

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3003,7 +3003,7 @@ void smf_qfi_pool_init(smf_sess_t *sess)
 {
     ogs_assert(sess);
 
-    ogs_pool_init(&sess->qfi_pool, OGS_MAX_QOS_FLOW_ID);
+    ogs_pool_create(&sess->qfi_pool, OGS_MAX_QOS_FLOW_ID);
     ogs_pool_sequence_id_generate(&sess->qfi_pool);
 }
 
@@ -3011,14 +3011,14 @@ void smf_qfi_pool_final(smf_sess_t *sess)
 {
     ogs_assert(sess);
 
-    ogs_pool_final(&sess->qfi_pool);
+    ogs_pool_destroy(&sess->qfi_pool);
 }
 
 void smf_pf_identifier_pool_init(smf_bearer_t *bearer)
 {
     ogs_assert(bearer);
 
-    ogs_pool_init(&bearer->pf_identifier_pool, OGS_MAX_NUM_OF_FLOW_IN_BEARER);
+    ogs_pool_create(&bearer->pf_identifier_pool, OGS_MAX_NUM_OF_FLOW_IN_BEARER);
     ogs_pool_sequence_id_generate(&bearer->pf_identifier_pool);
 }
 
@@ -3026,14 +3026,14 @@ void smf_pf_identifier_pool_final(smf_bearer_t *bearer)
 {
     ogs_assert(bearer);
 
-    ogs_pool_final(&bearer->pf_identifier_pool);
+    ogs_pool_destroy(&bearer->pf_identifier_pool);
 }
 
 void smf_pf_precedence_pool_init(smf_sess_t *sess)
 {
     ogs_assert(sess);
 
-    ogs_pool_init(&sess->pf_precedence_pool,
+    ogs_pool_create(&sess->pf_precedence_pool,
             OGS_MAX_NUM_OF_BEARER * OGS_MAX_NUM_OF_FLOW_IN_BEARER);
     ogs_pool_sequence_id_generate(&sess->pf_precedence_pool);
 }
@@ -3042,7 +3042,7 @@ void smf_pf_precedence_pool_final(smf_sess_t *sess)
 {
     ogs_assert(sess);
 
-    ogs_pool_final(&sess->pf_precedence_pool);
+    ogs_pool_destroy(&sess->pf_precedence_pool);
 }
 
 static void stats_add_smf_session(void)


### PR DESCRIPTION
ogs_pool_init() shall be used in the initialization routine. Otherwise, memory will be fragment since this function uses system malloc()

Compared with ogs_pool_init()

ogs_pool_create() could be called while the process is running, so this function should use ogs_malloc() instead of system malloc()