### PR TITLE
[AMF] Start implicit de-reg. timer on every NAS conn. release

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1313,6 +1313,32 @@ void ran_ue_remove(ran_ue_t *ran_ue)
     ogs_assert(ran_ue);
     ogs_assert(ran_ue->gnb);
 
+    /*
+     * TS 24.501
+     * 5.3.7 Handling of the periodic registration update timer and
+     *
+     * Start AMF_TIMER_MOBILE_REACHABLE
+     * mobile reachable timer
+     * The network supervises the periodic registration update procedure
+     * of the UE by means of the mobile reachable timer.
+     * If the UE is not registered for emergency services,
+     * the mobile reachable timer shall be longer than the value of timer
+     * T3512. In this case, by default, the mobile reachable timer is
+     * 4 minutes greater than the value of timer T3512.
+     * The mobile reachable timer shall be reset and started with the
+     * value as indicated above, when the AMF releases the NAS signalling
+     * connection for the UE.
+     *
+     * TODO: If the UE is registered for emergency services, the AMF shall
+     * set the mobile reachable timer with a value equal to timer T3512.
+     */
+    if (ran_ue->amf_ue &&
+            OGS_FSM_CHECK(&ran_ue->amf_ue->sm, gmm_state_registered) &&
+            ran_ue->ue_ctx_rel_action < NGAP_UE_CTX_REL_NG_HANDOVER_COMPLETE) {
+        ogs_timer_start(ran_ue->amf_ue->mobile_reachable.timer,
+                ogs_time_from_sec(amf_self()->time.t3512.value + 240));
+    }
+
     ogs_list_remove(&ran_ue->gnb->ran_ue_list, ran_ue);
 
     ogs_assert(ran_ue->t_ng_holding);

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -1644,32 +1644,6 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
          * to prevent retransmission of NAS messages.
          */
         CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
-
-        /*
-         * TS 24.501
-         * 5.3.7 Handling of the periodic registration update timer and
-         *
-         * Start AMF_TIMER_MOBILE_REACHABLE
-         * mobile reachable timer
-         * The network supervises the periodic registration update procedure
-         * of the UE by means of the mobile reachable timer.
-         * If the UE is not registered for emergency services,
-         * the mobile reachable timer shall be longer than the value of timer
-         * T3512. In this case, by default, the mobile reachable timer is
-         * 4 minutes greater than the value of timer T3512.
-         * The mobile reachable timer shall be reset and started with the
-         * value as indicated above, when the AMF releases the NAS signalling
-         * connection for the UE.
-         *
-         * TODO: If the UE is registered for emergency services, the AMF shall
-         * set the mobile reachable timer with a value equal to timer T3512.
-         */
-        if (OGS_FSM_CHECK(&amf_ue->sm, gmm_state_registered) &&
-            ran_ue->ue_ctx_rel_action == NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK) {
-
-            ogs_timer_start(amf_ue->mobile_reachable.timer,
-                    ogs_time_from_sec(amf_self()->time.t3512.value + 240));
-        }
     }
 
     switch (ran_ue->ue_ctx_rel_action) {


### PR DESCRIPTION
Scenario:
1. UE is registered
2. GNB is switched off, GNB closed the connection with AMF (sctp):
```
[amf] INFO: gNB-N2[172.19.242.44] connection refused!!! (../src/amf/amf-sm.c:816)
[amf] INFO: [Removed] Number of gNBs is now 0 (../src/amf/context.c:1210)
[amf] INFO: [Removed] Number of gNB-UEs is now 0 (../src/amf/context.c:2617)
```

Bug:


After GNB is switched off, UE remains registered forever.
AMF supervises the periodic registration update procedure
of the UE with mobile reachable timer, which is started
on context release only.

Fix:

Start mobile reachable timer on every NAS signalling
connection release (not just on context release).

Abstract from standard:

[ETSI TS 124 501 V16.5.1](https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/16.05.01_60/ts_124501v160501p.pdf), 5.3.7 Handling of the periodic
registration update timer and mobile reachable timer

When a UE is not registered for emergency services,
and timer T3512 expires when the UE is in 5GMM-IDLE mode,
the periodic registration update procedure shall be started.

The network supervises the periodic registration update
procedure of the UE by means of the mobile reachable timer.

If the UE is not registered for emergency services,
the mobile reachable timer shall be longer than the value
of timer T3512. In this case, by default, the mobile
reachable timer is 4 minutes greater than the value of
timer T3512.

The **mobile reachable timer shall be reset and started**
with the value as indicated above, **when the AMF releases
the NAS signalling connection for the UE**.
The mobile reachable timer shall be stopped when a
NAS signalling connection is established for the UE.