### PR TITLE
Rename NF instance load functions

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -587,7 +587,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
-            ogs_sbi_self()->nf_instance->load = get_ran_ue_load();
+            ogs_sbi_self()->nf_instance->load = amf_instance_get_load();
 
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2509,7 +2509,7 @@ static void stats_remove_ran_ue(void)
     ogs_info("[Removed] Number of gNB-UEs is now %d", num_of_ran_ue);
 }
 
-int get_ran_ue_load(void)
+int amf_instance_get_load(void)
 {
     return (((ogs_pool_size(&ran_ue_pool) -
             ogs_pool_avail(&ran_ue_pool)) * 100) /

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -821,7 +821,7 @@ void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 
 bool amf_update_allowed_nssai(amf_ue_t *amf_ue);
 bool amf_ue_is_rat_restricted(amf_ue_t *amf_ue);
-int get_ran_ue_load(void);
+int amf_instance_get_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -595,7 +595,7 @@ pcf_app_t *pcf_app_find_by_app_session_id(char *app_session_id)
     return pcf_app_find(atoll(app_session_id));
 }
 
-int get_pcf_load(void)
+int pcf_instance_get_load(void)
 {
     return (((ogs_pool_size(&pcf_ue_pool) -
             ogs_pool_avail(&pcf_ue_pool)) * 100) /

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -174,7 +174,7 @@ int pcf_app_remove(pcf_app_t *app);
 void pcf_app_remove_all(pcf_sess_t *sess);
 pcf_app_t *pcf_app_find(uint32_t index);
 pcf_app_t *pcf_app_find_by_app_session_id(char *app_session_id);
-int get_pcf_load(void);
+int pcf_instance_get_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -577,7 +577,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
-            ogs_sbi_self()->nf_instance->load = get_pcf_load();
+            ogs_sbi_self()->nf_instance->load = pcf_instance_get_load();
 
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3059,7 +3059,7 @@ static void stats_remove_smf_session(smf_sess_t *sess)
     ogs_info("[Removed] Number of SMF-Sessions is now %d", num_of_smf_sess);
 }
 
-int get_sess_load(void)
+int smf_instance_get_load(void)
 {
     return (((ogs_pool_size(&smf_sess_pool) -
             ogs_pool_avail(&smf_sess_pool)) * 100) /

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -526,7 +526,7 @@ int smf_maximum_integrity_protected_data_rate_uplink_value2enum(
         const char *value);
 int smf_maximum_integrity_protected_data_rate_downlink_value2enum(
         const char *value);
-int get_sess_load(void);
+int smf_instance_get_load(void);
 
 #ifdef __cplusplus
 }

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -825,7 +825,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_assert(nf_instance);
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
-            ogs_sbi_self()->nf_instance->load = get_sess_load();
+            ogs_sbi_self()->nf_instance->load = smf_instance_get_load();
 
             ogs_fsm_dispatch(&nf_instance->sm, e);
             if (OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_exception))


### PR DESCRIPTION
- Fix calculation of NF Instance load information for PCF
- Rename the function for calculating NF Instance load