### PR TITLE
[SMF] Decrease sessions metric on OLD Session Release

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1490,6 +1490,8 @@ smf_sess_t *smf_sess_add_by_sbi_message(ogs_sbi_message_t *message)
     if (sess) {
         ogs_warn("OLD Session Will Release [SUPI:%s,PDU Session identity:%d]",
                 SmContextCreateData->supi, SmContextCreateData->pdu_session_id);
+        smf_metrics_inst_by_slice_add(&sess->plmn_id, &sess->s_nssai,
+                SMF_METR_GAUGE_SM_SESSIONNBR, -1);
         smf_sess_remove(sess);
     }
 


### PR DESCRIPTION
Since [redesign](https://github.com/open5gs/open5gs/commit/8553c77733f50f82bfa6a9a4ee57f7ca0133a815) of fivegs_smffunction_sm_sessionnbr gauge, the metric doesn't expose some decrements. The decreasing of gauge had been moved out of function stats_remove_smf_session.

It should be decreased every time stats_remove_smf_session is called, but this particular case is easily reproducible by killing UPF while the session is established.