### PR TITLE
[AMF] Start implicit de-reg. timer on every NAS conn. release

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -822,6 +822,7 @@ void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 bool amf_update_allowed_nssai(amf_ue_t *amf_ue);
 bool amf_ue_is_rat_restricted(amf_ue_t *amf_ue);
 int amf_instance_get_load(void);
+void amf_ue_enter_idle(amf_ue_t *amf_ue);
 
 #ifdef __cplusplus
 }

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -1644,41 +1644,17 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
          * to prevent retransmission of NAS messages.
          */
         CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
-
-        /*
-         * TS 24.501
-         * 5.3.7 Handling of the periodic registration update timer and
-         *
-         * Start AMF_TIMER_MOBILE_REACHABLE
-         * mobile reachable timer
-         * The network supervises the periodic registration update procedure
-         * of the UE by means of the mobile reachable timer.
-         * If the UE is not registered for emergency services,
-         * the mobile reachable timer shall be longer than the value of timer
-         * T3512. In this case, by default, the mobile reachable timer is
-         * 4 minutes greater than the value of timer T3512.
-         * The mobile reachable timer shall be reset and started with the
-         * value as indicated above, when the AMF releases the NAS signalling
-         * connection for the UE.
-         *
-         * TODO: If the UE is registered for emergency services, the AMF shall
-         * set the mobile reachable timer with a value equal to timer T3512.
-         */
-        if (OGS_FSM_CHECK(&amf_ue->sm, gmm_state_registered) &&
-            ran_ue->ue_ctx_rel_action == NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK) {
-
-            ogs_timer_start(amf_ue->mobile_reachable.timer,
-                    ogs_time_from_sec(amf_self()->time.t3512.value + 240));
-        }
     }
 
     switch (ran_ue->ue_ctx_rel_action) {
     case NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE:
         ogs_debug("    Action: NG context remove");
+        amf_ue_enter_idle(amf_ue);
         ran_ue_remove(ran_ue);
         break;
     case NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK:
         ogs_debug("    Action: NG normal release");
+        amf_ue_enter_idle(amf_ue);
         ran_ue_remove(ran_ue);
         if (!amf_ue) {
             ogs_error("No UE(amf-ue) Context");
@@ -1688,6 +1664,7 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
         break;
     case NGAP_UE_CTX_REL_UE_CONTEXT_REMOVE:
         ogs_debug("    Action: UE context remove");
+        amf_ue_enter_idle(amf_ue);
         ran_ue_remove(ran_ue);
         if (!amf_ue) {
             ogs_error("No UE(amf-ue) context");
@@ -4454,7 +4431,10 @@ void ngap_handle_ng_reset(
                             ran_ue->ran_ue_ngap_id);
             }
 
-            if (old_xact_count == new_xact_count) ran_ue_remove(ran_ue);
+            if (old_xact_count == new_xact_count) {
+                amf_ue_enter_idle(amf_ue);
+                ran_ue_remove(ran_ue);
+            }
         }
 
         ogs_list_for_each(&gnb->ran_ue_list, iter) {

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -658,6 +658,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
                     if (ran_ue) {
                         ogs_debug("    SUPI[%s]", amf_ue->supi);
+                        amf_ue_enter_idle(amf_ue);
                         ran_ue_remove(ran_ue);
                     } else {
                         ogs_warn("[%s] RAN-NG Context has already been removed",
@@ -676,6 +677,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_assert(gnb);
 
                         ogs_debug("    SUPI[%s]", amf_ue->supi);
+                        amf_ue_enter_idle(amf_ue);
                         ran_ue_remove(ran_ue);
 
                         if (ogs_list_count(&gnb->ran_ue_list) == 0) {
@@ -702,6 +704,7 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_assert(gnb);
 
                         ogs_debug("    SUPI[%s]", amf_ue->supi);
+                        amf_ue_enter_idle(amf_ue);
                         ran_ue_remove(ran_ue);
 
                         ogs_list_for_each(&gnb->ran_ue_list, iter) {

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -404,6 +404,7 @@ void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state)
             new_xact_count = amf_sess_xact_count(amf_ue);
 
             if (old_xact_count == new_xact_count) {
+                amf_ue_enter_idle(amf_ue);
                 ran_ue_remove(ran_ue);
                 amf_ue_deassociate(amf_ue);
             }
@@ -415,6 +416,7 @@ void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state)
 
             if (state == AMF_REMOVE_S1_CONTEXT_BY_LO_CONNREFUSED ||
                 state == AMF_REMOVE_S1_CONTEXT_BY_RESET_ALL) {
+                amf_ue_enter_idle(amf_ue);
                 ran_ue_remove(ran_ue);
             } else {
                 /* At this point, it does not support other action */


### PR DESCRIPTION
Scenario:
1. UE is registered
2. GNB is switched off, GNB closed the connection with AMF (sctp):
```
[amf] INFO: gNB-N2[172.19.242.44] connection refused!!! (../src/amf/amf-sm.c:816)
[amf] INFO: [Removed] Number of gNBs is now 0 (../src/amf/context.c:1210)
[amf] INFO: [Removed] Number of gNB-UEs is now 0 (../src/amf/context.c:2617)
```

Bug:

After GNB is switched off, UE remains registered forever. AMF supervises the periodic registration update procedure of the UE with mobile reachable timer, which is started on context release only.

Fix:

Start mobile reachable timer on every NAS signalling connection release (not just on context release).

Abstract from standard:

[ETSI TS 124 501 V16.5.1](https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/16.05.01_60/ts_124501v160501p.pdf), 5.3.7 Handling of the periodic registration update timer and mobile reachable timer

When a UE is not registered for emergency services, and timer T3512 expires when the UE is in 5GMM-IDLE mode, the periodic registration update procedure shall be started.

The network supervises the periodic registration update procedure of the UE by means of the mobile reachable timer.

If the UE is not registered for emergency services, the mobile reachable timer shall be longer than the value of timer T3512. In this case, by default, the mobile reachable timer is 4 minutes greater than the value of timer T3512.

The **mobile reachable timer shall be reset and started** with the value as indicated above, **when the AMF releases the NAS signalling connection for the UE**.
The mobile reachable timer shall be stopped when a NAS signalling connection is established for the UE.