### PR TITLE
[AMF] Fix search for correct SMF based on SmfInfo

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2185,11 +2185,21 @@ void amf_sbi_select_nf(
                         false)
                 continue;
 
-            nf_info = ogs_sbi_nf_info_find(
-                        &nf_instance->nf_info_list, nf_instance->nf_type);
-            if (nf_info) {
-                if (nf_instance->nf_type == OpenAPI_nf_type_SMF &&
-                    check_smf_info(nf_info, sess) == false)
+            if ((nf_instance->nf_type == OpenAPI_nf_type_SMF) &&
+                (ogs_list_count(&nf_instance->nf_info_list) > 0)) {
+                bool match = false;
+
+                ogs_list_for_each(&nf_instance->nf_info_list, nf_info) {
+                    if (nf_info->nf_type != nf_instance->nf_type)
+                        continue;
+                    if (check_smf_info(nf_info, sess) == false)
+                        continue;
+
+                    match = true;
+                    break;
+                }
+
+                if (!match)
                     continue;
             }
 


### PR DESCRIPTION
Each SMF's NfProfile can contain multiple SmfInfo items. The issue was that AMF checked only the first SmfInfo for correct S-NSSAI/NR-TAI information.

In case of a 5G core setup with SMF handling 2 or more slices, and UE trying to establish multiple PDU sessions, AMF would report an error when trying to find the correct serving SMF.

[amf] ERROR: [1:0] (NF discover) No [nsmf-pdusession] (../src/amf/nnrf-handler.c:85)