### PR TITLE
[SBI] Fix finding NF service by it's ID

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1195,10 +1195,10 @@ ogs_sbi_nf_service_t *ogs_sbi_nf_service_find_by_id(
     ogs_list_for_each(&nf_instance->nf_service_list, nf_service) {
         ogs_assert(nf_service->id);
         if (strcmp(nf_service->id, id) == 0)
-            break;
+            return nf_service;
     }
 
-    return nf_service;
+    return NULL;
 }
 
 ogs_sbi_nf_service_t *ogs_sbi_nf_service_find_by_name(


### PR DESCRIPTION
The issue was that the function returned the last NF service of the list, even if the ID was not found in the list.
The fixed version is in-line with the function
ogs_sbi_nf_service_find_by_name().

The function is used in parsing the response from NRF, compiling an internal list of NF's and it's services. The bug could cause that some services of NF would not be represented.