### PR TITLE
fix crashing of UPF with interface in TAP mode

### DIFF
--- a/src/upf/arp-nd.cpp
+++ b/src/upf/arp-nd.cpp
@@ -21,6 +21,7 @@
 #include <tins/ethernetII.h>
 #include <tins/hw_address.h>
 #include <tins/icmpv6.h>
+#include <tins/exceptions.h>
 
 #include "arp-nd.h"
 
@@ -69,8 +70,14 @@ uint8_t arp_reply(uint8_t *reply_data, uint8_t *request_data, uint len,
 bool _parse_nd(EthernetII &pdu)
 {
     if (pdu.payload_type() == ETHERTYPE_IPV6) {
-        const ICMPv6& icmp6 = pdu.rfind_pdu<ICMPv6>();
-        return icmp6.type() == ICMPv6::NEIGHBOUR_SOLICIT;
+        try {
+            const ICMPv6& icmp6 = pdu.rfind_pdu<ICMPv6>();
+            return icmp6.type() == ICMPv6::NEIGHBOUR_SOLICIT;
+        }
+        catch (Tins::pdu_not_found& e) {
+            /* If it is not an ICMPv6 message, it can not be a NEIGHBOUR_SOLICIT */
+            return false;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Playing around with using Open5gs on a flat network and discovered that the UPF was restarting frequently when the interface was changed to a TAP device, usually once every few seconds.

Traced the issue back to Tins throwing a Tins::pdu_not_found error.  The is_nd_req() function in upf/arp-nd.cpp runs every IPv6 message reveived on a TAP interface against a Tins rfind_pdu() call to try and detect the type of ND message it might contain, but in the case that the message did not contain any ICMPv6 payload, Tins throws an exception.  
This means that any "normal" IPv6 message can crash the UPF, in my case it was a stray mDNS packet.

Patched to catch the exception and return false, as a packet not containing an ICMPv6 payload cannot ever be an ICMPv6 NEIGHBOUR_SOLICIT request.

Tested working on a couple machines, and fixes the crashing I was experiencing.