### PR TITLE
UPF HA - release/establish new PDU session in CM_IDLE

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -230,10 +230,11 @@ struct amf_ue_s {
         ogs_nas_de_registration_type_t de_registration;
 
         struct {
-        ED4(uint8_t uplink_data_status:1;,
+        ED5(uint8_t uplink_data_status:1;,
             uint8_t pdu_session_status:1;,
             uint8_t allowed_pdu_session_status:1;,
-            uint8_t reserved:5;)
+            uint8_t pdu_session_reactivation_result_error_cause:1;,
+            uint8_t reserved:4;)
         } present;
 
     } __attribute__ ((packed)) nas;

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -718,6 +718,13 @@ ogs_nas_5gmm_cause_t gmm_handle_service_update(amf_ue_t *amf_ue,
                 if (SESSION_CONTEXT_IN_SMF(sess))
                     amf_sbi_send_release_session(
                         sess, AMF_RELEASE_SM_CONTEXT_SERVICE_ACCEPT);
+            } else {
+                if (SESSION_CONTEXT_IN_SMF(sess) &&
+                        (service_request->presencemask &
+                        OGS_NAS_5GS_SERVICE_REQUEST_UPLINK_DATA_STATUS_PRESENT)
+                        == 0 && sess->paging.ongoing)
+                    amf_sbi_send_activating_session(
+                            sess, AMF_UPDATE_SM_CONTEXT_SERVICE_REQUEST);
             }
         }
     }

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -661,19 +661,19 @@ bool smf_nsmf_handle_update_sm_context(
         }
     } else if (SmContextUpdateData->is_release == true &&
                 SmContextUpdateData->release == true) {
-        if (sess->policy_association_id) {
-            if (sess->ngap_state.pdu_session_resource_release ==
-                    SMF_NGAP_STATE_DELETE_TRIGGER_UE_REQUESTED) {
+        if (sess->ngap_state.pdu_session_resource_release ==
+                SMF_NGAP_STATE_DELETE_TRIGGER_UE_REQUESTED) {
 
-                /* PCF session context has already been removed */
-                memset(&sendmsg, 0, sizeof(sendmsg));
+            /* PCF session context has already been removed */
+            memset(&sendmsg, 0, sizeof(sendmsg));
 
-                response = ogs_sbi_build_response(
-                    &sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
-                ogs_assert(response);
-                ogs_assert(true ==
-                        ogs_sbi_server_send_response(stream, response));
-            } else {
+            response = ogs_sbi_build_response(
+                &sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+            ogs_assert(response);
+            ogs_assert(true ==
+                    ogs_sbi_server_send_response(stream, response));
+        } else {
+            if (sess->policy_association_id) {
                 smf_npcf_smpolicycontrol_param_t param;
 
                 memset(&param, 0, sizeof(param));
@@ -689,12 +689,12 @@ bool smf_nsmf_handle_update_sm_context(
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
 
+            } else {
+                ogs_error("No PolicyAssociationId");
+                smf_sbi_send_sm_context_update_error(
+                        stream, OGS_SBI_HTTP_STATUS_NOT_FOUND,
+                        "No PolicyAssociationId", NULL, NULL, NULL);
             }
-        } else {
-            ogs_error("No PolicyAssociationId");
-            smf_sbi_send_sm_context_update_error(
-                    stream, OGS_SBI_HTTP_STATUS_NOT_FOUND,
-                    "No PolicyAssociationId", NULL, NULL, NULL);
         }
     } else if (SmContextUpdateData->serving_nf_id) {
         ogs_debug("Old serving_nf_id: %s, new serving_nf_id: %s",

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -336,6 +336,9 @@ void smf_sbi_send_sm_context_update_error(
     }
 
     if (n2smbuf) {
+        SmContextUpdateError.up_cnx_state = OpenAPI_up_cnx_state_DEACTIVATED;
+        SmContextUpdateError.n2_sm_info_type =
+            OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD;
         SmContextUpdateError.n2_sm_info = &n2SmInfo;
         n2SmInfo.content_id = (char *)OGS_SBI_CONTENT_NGAP_SM_ID;
         sendmsg.part[sendmsg.num_of_part].content_id =


### PR DESCRIPTION
When UPF crash is detected In CM_Idle, PDU Session Release Command (Reactivation requested)
is transferred to the UE and PDU session is reestablished using UPF2.
This scenario is achieved by the following changes:
- [SMF] No Rel in IDLE on DELETE_TRIGGER_SMF_INITIATED
- [AMF] Send ACTIVATING for paged act. PSIs in PDU session status
   (solving UERANSIM)
- [SMF] Reject ACTIVATING with 403 if no policy association
   Initialization of policy_association_id on NPCF_SMPOLICYCONTROL,
   DELETE.
   Rejecting with 403 if no policy_association_id on NSMF_PDUSESSION,
   MODIFY.
- [AMF] Send ServiceAccept with result error cause on 403
   On 403 answer from SMF on ServiceRequest send one
   ServiceAccept with PDU session reactivation result error cause
   (with multiple PSIs for multiple sessions).
- [AMF] Send PDUSessionResourceReleaseCommand on InitialContextSetupResponse
   Send PDUSessionResourceReleaseCommand (PDU Session Release
   with PTI unassigned) instead of
   Update and ConfigurationUpdateCommand on InitialContextSetupResponse.

Additional commit [[SMF] Do not check policy in case of DELETE_TRIGGER_UE_REQUESTED](https://github.com/open5gs/open5gs/commit/396f400bd418467f2e91649d39c916ee936dcba2) solves test failure.

Solves: [#2396](https://github.com/open5gs/open5gs/issues/2396)