### PR TITLE
[NRF] Fix crash due to failing assertion on OPTIONS request

### DIFF
--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -99,9 +99,22 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                     }
                     break;
 
+                CASE(OGS_SBI_HTTP_METHOD_OPTIONS)
+                    ogs_assert(
+                        true ==
+                        ogs_sbi_server_send_error(
+                            stream,
+                            OGS_SBI_HTTP_STATUS_NOT_IMPLEMENTED,
+                            &message, "OPTIONS method is not implemented yet",
+                            NULL));
+                    break;
+
                 DEFAULT
-                    nf_instance = ogs_sbi_nf_instance_find(
-                            message.h.resource.component[1]);
+                    if (message.h.resource.component[1]) {
+                        nf_instance = ogs_sbi_nf_instance_find(
+                                message.h.resource.component[1]);
+                    }
+
                     if (!nf_instance) {
                         SWITCH(message.h.method)
                         CASE(OGS_SBI_HTTP_METHOD_PUT)


### PR DESCRIPTION
This is a fix for bug #2417 by adding:

1. A check whether the NRF ID is null, before searching an NRF instance based on the ID which led to the bug in the first place
2. A separate switch case for OPTIONS requests to `/nnrf-nfm/v1/nf-instances` which will be replied to with a 501 `Not Implemented`

fixes #2417 