### PR TITLE
mac: fix mongodb config path for Apple Silicon

### DIFF
--- a/docs/_docs/platform/05-macosx-apple-silicon.md
+++ b/docs/_docs/platform/05-macosx-apple-silicon.md
@@ -33,7 +33,7 @@ $ brew install mongodb-community
 
 Run MongoDB server.
 ```bash
-$ mongod --config /usr/local/etc/mongod.conf
+$ mongod --config /opt/homebrew/etc/mongod.conf
 ```
 
 **Tip:** MongoDB is persistent after rebooting with the following commands:


### PR DESCRIPTION
Trying to build Open5GS from sources on an M1 Mac, I noticed that the documentation specifies an incorrect config path for running MongoDB (c.f. the respective page in the [MongoDB documentation](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/#install-mongodb-community-edition)). This PR simply updates the docs with the correct path, resolving the issue.