### PR TITLE
[HSS] fix mongodb stream option parsing

### DIFF
--- a/lib/app/meson.build
+++ b/lib/app/meson.build
@@ -30,6 +30,7 @@ libapp_sources = files('''
 '''.split())
 
 yaml_dep = dependency('yaml-0.1')
+libmongoc_dep = dependency('libmongoc-1.0')
 
 libapp_inc = include_directories('.')
 
@@ -38,11 +39,11 @@ libapp = library('ogsapp',
     version : libogslib_version,
     c_args : '-DOGS_APP_COMPILATION',
     include_directories : [libapp_inc, libinc],
-    dependencies : [libcore_dep, yaml_dep],
+    dependencies : [libcore_dep, yaml_dep, libmongoc_dep],
     install : true)
 
 libapp_dep = declare_dependency(
     link_with : libapp,
     include_directories : [libapp_inc, libinc],
-    dependencies : [libcore_dep, yaml_dep],
+    dependencies : [libcore_dep, yaml_dep, libmongoc_dep],
 )

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -18,6 +18,7 @@
  */
 
 #include "ogs-app.h"
+#include <mongoc/mongoc.h>
 
 static ogs_app_context_t self;
 


### PR DESCRIPTION
the code in the YAML parser was checking for the version of mongodb, but there was no dependency on the library, so that branch was ignored and the value in the YAML file was always set to false.