### PR TITLE
mme: fix missing memset in mme_fd_init

### DIFF
--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -2193,6 +2193,7 @@ int mme_fd_init(void)
     ogs_assert(ret == 0);
 
     /* Specific handler for Cancel-Location-Request */
+    memset(&data, 0, sizeof(data));
     data.command = ogs_diam_s6a_cmd_clr;
     ret = fd_disp_register(mme_ogs_diam_s6a_clr_cb, DISP_HOW_CC, &data, NULL,
                 &hdl_s6a_clr);


### PR DESCRIPTION
The 'data' struct used to specify the diameter dispatch options for the MME callbacks was not being initialized properly, which meant that the App id could contain garbage. This was preventing the callbacks from being invoked when receiving ISD/CLR requests.