### PR TITLE
[AMF] Implicit Deregistration (Reset, ConnRefused)

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -161,6 +161,80 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
             }
             break;
 
+        case AMF_TIMER_MOBILE_REACHABLE:
+
+            /*
+             * TS 24.501
+             * 5.3.7 Handling of the periodic registration update timer and
+             *
+             * Upon expiry of the mobile reachable timer the network shall
+             * start the implicit de-registration timer over 3GPP access.
+             * The default value of the implicit de-registration timer over
+             * 3GPP access is 4 minutes greater than the value of timer T3512.
+             */
+
+            ogs_warn("[%s] Mobile Reachable Timer Expired", amf_ue->supi);
+
+            ogs_list_for_each(&amf_ue->sess_list, sess) {
+                if (sess->paging.ongoing == true &&
+                    sess->paging.n1n2_failure_txf_notif_uri != NULL) {
+                    ogs_assert(true ==
+                        amf_sbi_send_n1_n2_failure_notify(
+                            sess,
+                            OpenAPI_n1_n2_message_transfer_cause_UE_NOT_REACHABLE_FOR_SESSION));
+                }
+            }
+
+            /* Stop Paging */
+            AMF_UE_CLEAR_PAGING_INFO(amf_ue);
+            AMF_UE_CLEAR_N2_TRANSFER(
+                    amf_ue, pdu_session_resource_setup_request);
+            AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
+            CLEAR_AMF_UE_TIMER(amf_ue->t3513);
+
+            ogs_timer_start(amf_ue->implicit_deregistration.timer,
+                    ogs_time_from_sec(amf_self()->time.t3512.value + 240));
+            break;
+
+        case AMF_TIMER_IMPLICIT_DEREGISTRATION:
+
+            /*
+             * TS 24.501
+             * 5.3.7 Handling of the periodic registration update timer and
+             *
+             * If the implicit de-registration timer expires before the UE
+             * contacts the network, the network shall implicitly de-register
+             * the UE.
+             *
+             * TS 23.502
+             * 4.2.2.3.3 Network-initiated Deregistration
+             *
+             * The AMF does not send the Deregistration Request message
+             * to the UE for Implicit Deregistration.
+             */
+
+            ogs_info("[%s] Do Network-initiated De-register UE", amf_ue->supi);
+
+            state = AMF_NETWORK_INITIATED_IMPLICIT_DE_REGISTERED;
+
+            if (UDM_SDM_SUBSCRIBED(amf_ue)) {
+                r = amf_ue_sbi_discover_and_send(
+                        OGS_SBI_SERVICE_TYPE_NUDM_SDM, NULL,
+                        amf_nudm_sdm_build_subscription_delete,
+                        amf_ue, state, NULL);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+            } else if (PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
+                    r = amf_ue_sbi_discover_and_send(
+                        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
+                        NULL,
+                        amf_npcf_am_policy_control_build_delete,
+                        amf_ue, state, NULL);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+            }
+            break;
+
         default:
             ogs_error("Unknown timer[%s:%d]",
                     amf_timer_get_name(e->h.timer_id), e->h.timer_id);
@@ -600,6 +674,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
             ogs_timer_start(amf_ue->implicit_deregistration.timer,
                     ogs_time_from_sec(amf_self()->time.t3512.value + 240));
             break;
+
         case AMF_TIMER_IMPLICIT_DEREGISTRATION:
 
             /*
@@ -638,6 +713,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
                     ogs_assert(r != OGS_ERROR);
             }
             break;
+
         default:
             ogs_error("Unknown timer[%s:%d]",
                     amf_timer_get_name(e->h.timer_id), e->h.timer_id);

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -1644,8 +1644,31 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
          * to prevent retransmission of NAS messages.
          */
         CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
+    }
+
+    switch (ran_ue->ue_ctx_rel_action) {
+    case NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE:
+        ogs_debug("    Action: NG context remove");
+        ran_ue_remove(ran_ue);
+        break;
+    case NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK:
+        ogs_debug("    Action: NG normal release");
+        ran_ue_remove(ran_ue);
+        if (!amf_ue) {
+            ogs_error("No UE(amf-ue) Context");
+            return;
+        }
+        amf_ue_deassociate(amf_ue);
 
         /*
+         * When AMF release the NAS signalling connection,
+         * ran_ue context is removed by ran_ue_remove() and
+         * amf_ue/ran_ue is de-associated by amf_ue_deassociate().
+         *
+         * In this case, implicit deregistration is attempted
+         * by the mobile reachable timer according to the standard document,
+         * and amf_ue will be removed by amf_ue_remove().
+         *
          * TS 24.501
          * 5.3.7 Handling of the periodic registration update timer and
          *
@@ -1664,28 +1687,11 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
          * TODO: If the UE is registered for emergency services, the AMF shall
          * set the mobile reachable timer with a value equal to timer T3512.
          */
-        if (OGS_FSM_CHECK(&amf_ue->sm, gmm_state_registered) &&
-            ran_ue->ue_ctx_rel_action == NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK) {
+        ogs_timer_start(amf_ue->mobile_reachable.timer,
+                ogs_time_from_sec(amf_self()->time.t3512.value + 240));
 
-            ogs_timer_start(amf_ue->mobile_reachable.timer,
-                    ogs_time_from_sec(amf_self()->time.t3512.value + 240));
-        }
-    }
+        break;
 
-    switch (ran_ue->ue_ctx_rel_action) {
-    case NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE:
-        ogs_debug("    Action: NG context remove");
-        ran_ue_remove(ran_ue);
-        break;
-    case NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK:
-        ogs_debug("    Action: NG normal release");
-        ran_ue_remove(ran_ue);
-        if (!amf_ue) {
-            ogs_error("No UE(amf-ue) Context");
-            return;
-        }
-        amf_ue_deassociate(amf_ue);
-        break;
     case NGAP_UE_CTX_REL_UE_CONTEXT_REMOVE:
         ogs_debug("    Action: UE context remove");
         ran_ue_remove(ran_ue);

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -664,6 +664,37 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_warn("[%s] RAN-NG Context has already been removed",
                                 amf_ue->supi);
                     }
+
+        /*
+         * When AMF release the NAS signalling connection,
+         * ran_ue context is removed by ran_ue_remove() and
+         * amf_ue/ran_ue is de-associated by amf_ue_deassociate().
+         *
+         * In this case, implicit deregistration is attempted
+         * by the mobile reachable timer according to the standard document,
+         * and amf_ue will be removed by amf_ue_remove().
+         *
+         * TS 24.501
+         * 5.3.7 Handling of the periodic registration update timer and
+         *
+         * Start AMF_TIMER_MOBILE_REACHABLE
+         * mobile reachable timer
+         * The network supervises the periodic registration update procedure
+         * of the UE by means of the mobile reachable timer.
+         * If the UE is not registered for emergency services,
+         * the mobile reachable timer shall be longer than the value of timer
+         * T3512. In this case, by default, the mobile reachable timer is
+         * 4 minutes greater than the value of timer T3512.
+         * The mobile reachable timer shall be reset and started with the
+         * value as indicated above, when the AMF releases the NAS signalling
+         * connection for the UE.
+         *
+         * TODO: If the UE is registered for emergency services, the AMF shall
+         * set the mobile reachable timer with a value equal to timer T3512.
+         */
+                    ogs_timer_start(amf_ue->mobile_reachable.timer,
+                            ogs_time_from_sec(
+                                amf_self()->time.t3512.value + 240));
                 }
 
             } else if (state == AMF_REMOVE_S1_CONTEXT_BY_RESET_ALL) {
@@ -689,6 +720,37 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_warn("[%s] RAN-NG Context has already been removed",
                                 amf_ue->supi);
                     }
+
+        /*
+         * When AMF release the NAS signalling connection,
+         * ran_ue context is removed by ran_ue_remove() and
+         * amf_ue/ran_ue is de-associated by amf_ue_deassociate().
+         *
+         * In this case, implicit deregistration is attempted
+         * by the mobile reachable timer according to the standard document,
+         * and amf_ue will be removed by amf_ue_remove().
+         *
+         * TS 24.501
+         * 5.3.7 Handling of the periodic registration update timer and
+         *
+         * Start AMF_TIMER_MOBILE_REACHABLE
+         * mobile reachable timer
+         * The network supervises the periodic registration update procedure
+         * of the UE by means of the mobile reachable timer.
+         * If the UE is not registered for emergency services,
+         * the mobile reachable timer shall be longer than the value of timer
+         * T3512. In this case, by default, the mobile reachable timer is
+         * 4 minutes greater than the value of timer T3512.
+         * The mobile reachable timer shall be reset and started with the
+         * value as indicated above, when the AMF releases the NAS signalling
+         * connection for the UE.
+         *
+         * TODO: If the UE is registered for emergency services, the AMF shall
+         * set the mobile reachable timer with a value equal to timer T3512.
+         */
+                    ogs_timer_start(amf_ue->mobile_reachable.timer,
+                            ogs_time_from_sec(
+                                amf_self()->time.t3512.value + 240));
                 }
 
             } else if (state == AMF_REMOVE_S1_CONTEXT_BY_RESET_PARTIAL) {
@@ -730,6 +792,36 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                         ogs_warn("[%s] RAN-NG Context has already been removed",
                                 amf_ue->supi);
                     }
+        /*
+         * When AMF release the NAS signalling connection,
+         * ran_ue context is removed by ran_ue_remove() and
+         * amf_ue/ran_ue is de-associated by amf_ue_deassociate().
+         *
+         * In this case, implicit deregistration is attempted
+         * by the mobile reachable timer according to the standard document,
+         * and amf_ue will be removed by amf_ue_remove().
+         *
+         * TS 24.501
+         * 5.3.7 Handling of the periodic registration update timer and
+         *
+         * Start AMF_TIMER_MOBILE_REACHABLE
+         * mobile reachable timer
+         * The network supervises the periodic registration update procedure
+         * of the UE by means of the mobile reachable timer.
+         * If the UE is not registered for emergency services,
+         * the mobile reachable timer shall be longer than the value of timer
+         * T3512. In this case, by default, the mobile reachable timer is
+         * 4 minutes greater than the value of timer T3512.
+         * The mobile reachable timer shall be reset and started with the
+         * value as indicated above, when the AMF releases the NAS signalling
+         * connection for the UE.
+         *
+         * TODO: If the UE is registered for emergency services, the AMF shall
+         * set the mobile reachable timer with a value equal to timer T3512.
+         */
+                    ogs_timer_start(amf_ue->mobile_reachable.timer,
+                            ogs_time_from_sec(
+                                amf_self()->time.t3512.value + 240));
                 }
             } else {
                 ogs_error("Invalid STATE[%d]", state);


### PR DESCRIPTION
When AMF release the NAS signalling connection,
ran_ue context is removed by ran_ue_remove() and
amf_ue/ran_ue is de-associated by amf_ue_deassociate().

In this case, implicit deregistration is attempted by the mobile reachable timer according to the standard document, and amf_ue will be removed by amf_ue_remove().

TS 24.501
5.3.7 Handling of the periodic registration update timer and

Start AMF_TIMER_MOBILE_REACHABLE
mobile reachable timer
The network supervises the periodic registration update procedure of the UE by means of the mobile reachable timer.
If the UE is not registered for emergency services, the mobile reachable timer shall be longer than the value of timer T3512. In this case, by default, the mobile reachable timer is 4 minutes greater than the value of timer T3512.
The mobile reachable timer shall be reset and started with the value as indicated above, when the AMF releases the NAS signalling connection for the UE.