### PR TITLE
[MME] rework sgsn default route config in mme.yaml

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -475,9 +475,9 @@ smf:
         - ::1
 
 #
-# <GTP-C Client>
+# <GTPv1C Client>
 #
-#  o Specify SGSN addresses the GTP-C must connect to
+#  o Specify SGSN addresses the GTPv1C must connect to
 #
 #  o One SGSN is defined.
 #    If prefer_ipv4 is not true, [fd69:f21d:873c:fa::2] is selected.
@@ -513,15 +513,13 @@ smf:
 #          rac: 187
 #        ci: 1223
 #    - name: sgsn3.open5gs.org
-#      routes:
-#       - default: true
+#      default_route: true
 #
-#sgsn:
-#  - gtpc:
-#      addr:
-#        - 127.0.0.3
-#    routes:
-#      - default: true
+sgsn:
+  - gtpc:
+      addr:
+        - 127.0.0.3
+    default_route: true
 
 #
 #  o Disable use of IPv4 addresses (only IPv6)

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1651,7 +1651,6 @@ int mme_context_parse_config(void)
                             ogs_nas_rai_t rai;
                             uint16_t cell_id = 0;
                             bool rai_parsed = false, cell_id_parsed = false;
-                            bool default_route = false;
                             mme_sgsn_route_t *sgsn_rt = NULL;
 
                             if (ogs_yaml_iter_type(&routes_array) == YAML_MAPPING_NODE) {
@@ -1697,8 +1696,6 @@ int mme_context_parse_config(void)
                                     } while (
                                         ogs_yaml_iter_type(&cell_id_iter) ==
                                             YAML_SEQUENCE_NODE);
-                                } else if (!strcmp(routes_key, "default")) {
-                                    default_route = true;
                                 } else
                                     ogs_warn("unknown key `%s`", routes_key);
                             }
@@ -1709,10 +1706,10 @@ int mme_context_parse_config(void)
                             memcpy(&sgsn_rt->rai, &rai, sizeof(rai));
                             sgsn_rt->cell_id = cell_id;
                             ogs_list_add(&sgsn->route_list, sgsn_rt);
-                            if (default_route)
-                                sgsn->default_route = true;
 
                         } while (ogs_yaml_iter_type(&routes_array) == YAML_SEQUENCE_NODE);
+                    } else if (!strcmp(sgsn_key, "default_route")) {
+                        sgsn->default_route = true;
                     }
                 }
             } while (ogs_yaml_iter_type(&sgsn_array) == YAML_SEQUENCE_NODE);


### PR DESCRIPTION
Move the config to the sgsn node instead of having a specific route with specific format "default: route", since anyway internally it's already applied to the sgsn object.

Should fix the problem reported in https://github.com/open5gs/open5gs/pull/2441#issuecomment-1642034949