### PR TITLE
[UPF] fix tap mode arp table poisoning

### DIFF
--- a/src/upf/arp-nd.cpp
+++ b/src/upf/arp-nd.cpp
@@ -52,6 +52,16 @@ bool is_arp_req(uint8_t *data, uint len)
     return _parse_arp(pdu);
 }
 
+uint32_t arp_parse_target_addr(uint8_t *data, uint len)
+{
+    EthernetII pdu(data, len);
+    if (pdu.payload_type() == ETHERTYPE_ARP) {
+        const ARP& arp = pdu.rfind_pdu<ARP>();
+        return arp.target_ip_addr();
+    }
+    return 0x0;
+}
+
 uint8_t arp_reply(uint8_t *reply_data, uint8_t *request_data, uint len,
         const uint8_t *mac)
 {

--- a/src/upf/arp-nd.h
+++ b/src/upf/arp-nd.h
@@ -39,6 +39,7 @@ extern "C" {
 
 void set_source_mac(uint8_t *data);
 bool is_arp_req(uint8_t *data, uint len);
+uint32_t arp_parse_target_addr(uint8_t *data, uint len);
 uint8_t arp_reply(uint8_t *reply_data, uint8_t *request_data, uint len,
         const uint8_t *mac);
 bool is_nd_req(uint8_t *data, uint len);

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -123,7 +123,9 @@ static void _gtpv1_tun_recv_common_cb(
         uint8_t size;
 
         if (eth_type == ETHERTYPE_ARP) {
-            if (is_arp_req(recvbuf->data, recvbuf->len)) {
+            if (is_arp_req(recvbuf->data, recvbuf->len) &&
+                    upf_sess_find_by_ipv4(
+                        arp_parse_target_addr(recvbuf->data, recvbuf->len))) {
                 replybuf = ogs_pkbuf_alloc(packet_pool, OGS_MAX_PKT_LEN);
                 ogs_assert(replybuf);
                 ogs_pkbuf_reserve(replybuf, OGS_TUN_MAX_HEADROOM);


### PR DESCRIPTION
Checks if the target IP address of an ARP message is associated with a session before replying to it.  Fixes an issue I ran into where the UPF will ARP-poison every other device on the network by replying to every ARP request as if it holds that IP.

Didn't notice this was happening at first until it commandeered my gateway's IP...

It is possible the same (or similar) is happening with IPv6 ND messages, but I do not have the hardware or network configuration to test that correctly.

All changed code-paths are isolated to TAP interface mode, and these changes are working reliably on my test network.