### PR TITLE
[SMF] Fix crash on double policy deletion

### DIFF
--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -701,8 +701,6 @@ bool smf_npcf_smpolicycontrol_handle_terminate_notify(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {
     smf_ue_t *smf_ue = NULL;
-    smf_npcf_smpolicycontrol_param_t param;
-    int r;
 
     ogs_assert(sess);
     ogs_assert(stream);
@@ -713,13 +711,18 @@ bool smf_npcf_smpolicycontrol_handle_terminate_notify(
 
     ogs_assert(true == ogs_sbi_send_http_status_no_content(stream));
 
-    memset(&param, 0, sizeof(param));
-    r = smf_sbi_discover_and_send(
-            OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL, NULL,
-            smf_npcf_smpolicycontrol_build_delete,
-            sess, NULL, OGS_PFCP_DELETE_TRIGGER_PCF_INITIATED, &param);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
+    if (sess->policy_association_id) {
+        smf_npcf_smpolicycontrol_param_t param;
+        int r;
+
+        memset(&param, 0, sizeof(param));
+        r = smf_sbi_discover_and_send(
+                OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL, NULL,
+                smf_npcf_smpolicycontrol_build_delete,
+                sess, NULL, OGS_PFCP_DELETE_TRIGGER_PCF_INITIATED, &param);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    }
 
     return true;
 }

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -510,6 +510,8 @@ static void reselect_upf(ogs_pfcp_node_t *node)
                     ogs_error("[%s:%s] EPC restoration is not implemented",
                             smf_ue->imsi_bcd, sess->session.name);
                 } else {
+                    if (!sess->policy_association_id) return;
+
                     smf_npcf_smpolicycontrol_param_t param;
 
                     ogs_info("[%s:%d] SMF-initiated Deletion",


### PR DESCRIPTION
Follow-up on [#2428](https://github.com/open5gs/open5gs/pull/2428)

Since [Follow-up on #2428](https://github.com/open5gs/open5gs/commit/9ba20f6e22b10777346b5d3f15ed35fe6387c3c9) the policy_association_id is freed and initialized after deletion.

Bug:

Now SMF crashes in `smf_npcf_smpolicycontrol_build_delete` on `ogs_assert(sess->policy_association_id)`:
```
smf  | 08/02 10:41:49.528: [smf] DEBUG: Session Deletion Request (../src/smf/n4-build.c:545)
smf  | 08/02 10:41:49.877: [pfcp] DEBUG: [22] LOCAL  Response Timeout for step 1 type 1 peer [10.15.199.102]:8805 (../lib/pfcp/xact.c:579)
smf  | 08/02 10:41:49.877: [pfcp] WARNING: [22] LOCAL  No Reponse. Give up! for step 1 type 1 peer [10.15.199.102]:8805 (../lib/pfcp/xact.c:599)
smf  | 08/02 10:41:49.877: [smf] INFO: [imsi-001010000000000:1] SMF-initiated Deletion (../src/smf/pfcp-sm.c:515)
smf  | 08/02 10:41:49.877: [smf] FATAL: smf_npcf_smpolicycontrol_build_delete: Assertion `sess->policy_association_id' failed. (../src/smf/npcf-build.c:244)
smf  | 08/02 10:41:49.898: [core] FATAL: backtrace() returned 11 addresses (../lib/core/ogs-abort.c:37)
```

Fix:

policy_association_id is checked before every call of `smf_npcf_smpolicycontrol_build_delete`.