### PR TITLE
UE slice shall be also available in RAN (#2482)

### DIFF
--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -173,11 +173,16 @@ ogs_pkbuf_t *gmm_build_registration_accept(amf_ue_t *amf_ue)
     return pkbuf;
 }
 
-ogs_pkbuf_t *gmm_build_registration_reject(ogs_nas_5gmm_cause_t gmm_cause)
+ogs_pkbuf_t *gmm_build_registration_reject(
+        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
 {
     ogs_nas_5gs_message_t message;
     ogs_nas_5gs_registration_reject_t *registration_reject =
         &message.gmm.registration_reject;
+    ogs_nas_rejected_nssai_t *rejected_nssai =
+        &registration_reject->rejected_nssai;
+
+    ogs_assert(amf_ue);
 
     memset(&message, 0, sizeof(message));
     message.gmm.h.extended_protocol_discriminator =
@@ -185,6 +190,14 @@ ogs_pkbuf_t *gmm_build_registration_reject(ogs_nas_5gmm_cause_t gmm_cause)
     message.gmm.h.message_type = OGS_NAS_5GS_REGISTRATION_REJECT;
 
     registration_reject->gmm_cause = gmm_cause;
+
+    if (amf_ue->rejected_nssai.num_of_s_nssai) {
+        ogs_nas_build_rejected_nssai(rejected_nssai,
+                amf_ue->rejected_nssai.s_nssai,
+                amf_ue->rejected_nssai.num_of_s_nssai);
+        registration_reject->presencemask |=
+            OGS_NAS_5GS_REGISTRATION_REJECT_REJECTED_NSSAI_PRESENT;
+    }
 
     return ogs_nas_5gs_plain_encode(&message);
 }

--- a/src/amf/gmm-build.h
+++ b/src/amf/gmm-build.h
@@ -27,7 +27,8 @@ extern "C" {
 #endif
 
 ogs_pkbuf_t *gmm_build_registration_accept(amf_ue_t *amf_ue);
-ogs_pkbuf_t *gmm_build_registration_reject(ogs_nas_5gmm_cause_t gmm_cause);
+ogs_pkbuf_t *gmm_build_registration_reject(
+        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 
 ogs_pkbuf_t *gmm_build_service_accept(amf_ue_t *amf_ue);
 ogs_pkbuf_t *gmm_build_service_reject(

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1116,7 +1116,11 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
 
                     if (amf_update_allowed_nssai(amf_ue) == false) {
                         ogs_error("No Allowed-NSSAI");
-
+                        r = nas_5gs_send_gmm_reject(
+                                amf_ue,
+                                OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
+                        ogs_expect(r == OGS_OK);
+                        ogs_assert(r != OGS_ERROR);
                         OGS_FSM_TRAN(s, gmm_state_exception);
                         break;
                     }
@@ -1906,10 +1910,6 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                 if (rv != OGS_OK) {
                     ogs_error("[%s] amf_nudm_sdm_handle_provisioned(%s) failed",
                             amf_ue->supi, sbi_message->h.resource.component[1]);
-                    r = nas_5gs_send_gmm_reject(
-                            amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
-                    ogs_expect(r == OGS_OK);
-                    ogs_assert(r != OGS_ERROR);
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
                     break;
                 }
@@ -2292,6 +2292,12 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
 
                     if (amf_update_allowed_nssai(amf_ue) == false) {
                         ogs_error("No Allowed-NSSAI");
+                        r = nas_5gs_send_gmm_reject(
+                                amf_ue,
+                                OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
+                        ogs_expect(r == OGS_OK);
+                        ogs_assert(r != OGS_ERROR);
+                        OGS_FSM_TRAN(s, gmm_state_exception);
                         break;
                     }
 

--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -218,7 +218,7 @@ int nas_5gs_send_registration_reject(
 
     ogs_warn("[%s] Registration reject [%d]", amf_ue->suci, gmm_cause);
 
-    gmmbuf = gmm_build_registration_reject(gmm_cause);
+    gmmbuf = gmm_build_registration_reject(amf_ue, gmm_cause);
     if (!gmmbuf) {
         ogs_error("gmm_build_registration_reject() failed");
         return OGS_ERROR;

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -35,6 +35,10 @@ int amf_nudm_sdm_handle_provisioned(
     if (!ran_ue) {
         /* ran_ue is required for amf_ue_is_rat_restricted() */
         ogs_error("NG context has already been removed");
+        r = nas_5gs_send_gmm_reject(
+                amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
         return OGS_ERROR;
     }
 
@@ -151,11 +155,19 @@ int amf_nudm_sdm_handle_provisioned(
 
         if (amf_update_allowed_nssai(amf_ue) == false) {
             ogs_error("No Allowed-NSSAI");
+            r = nas_5gs_send_gmm_reject(
+                    amf_ue, OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
             return OGS_ERROR;
         }
 
         if (amf_ue_is_rat_restricted(amf_ue)) {
             ogs_error("Registration rejected due to RAT restrictions");
+            r = nas_5gs_send_gmm_reject(
+                    amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
             return OGS_ERROR;
         }
 


### PR DESCRIPTION
Changed to that registration can be accepted only when the UE slice is available in the RAN slice.


See the following the standard document in TS23.502

```
4.2.2 Registration Management procedures
4.2.2.2 Registration procedures
4.2.2.2.2 General Registration

21. ...
If the Requested NSSAI does not include S-NSSAIs which map to S-NSSAIs
of the HPLMN subject to Network Slice-Specific Authentication and
Authorization and the AMF determines that no S-NSSAI can be provided
in the Allowed NSSAI for the UE in the current UE's Tracking Area and
if no default S-NSSAI(s) not yet involved in the current UE Registration
procedure could be further considered, the AMF shall reject the UE
Registration and shall include in the rejection message the list
of Rejected S-NSSAIs, each of them with the appropriate rejection
cause value.
```
