### PR TITLE
Use x1000 multiplier for Kbps, Mbps, ... etc.

### DIFF
--- a/docs/_docs/troubleshoot/02-now-in-github-issues.md
+++ b/docs/_docs/troubleshoot/02-now-in-github-issues.md
@@ -168,8 +168,8 @@ $ mongosh
     "__v" : 0,
     "access_restriction_data" : 32,
     "ambr" : {
-        "downlink" : NumberLong(1024000),
-        "uplink" : NumberLong(1024000)
+        "downlink" : NumberLong(1000000),
+        "uplink" : NumberLong(1000000)
     },
     "network_access_mode" : 2,
     "pdn" : [
@@ -178,8 +178,8 @@ $ mongosh
             "_id" : ObjectId("609715fd455bcd38c884ce85"),
             "pcc_rule" : [ ],
             "ambr" : {
-                "downlink" : NumberLong(1024000),
-                "uplink" : NumberLong(1024000)
+                "downlink" : NumberLong(1000000),
+                "uplink" : NumberLong(1000000)
             },
             "qos" : {
                 "qci" : 9,

--- a/lib/dbi/session.c
+++ b/lib/dbi/session.c
@@ -226,7 +226,7 @@ done:
                     }
 
                     for (n = 0; n < unit; n++)
-                        session->ambr.downlink *= 1024;
+                        session->ambr.downlink *= 1000;
                 } else if (!strcmp(child5_key, "uplink") &&
                         BSON_ITER_HOLDS_DOCUMENT(&child5_iter)) {
                     uint8_t unit = 0;
@@ -246,7 +246,7 @@ done:
                     }
 
                     for (n = 0; n < unit; n++)
-                        session->ambr.uplink *= 1024;
+                        session->ambr.uplink *= 1000;
                 }
 
             }
@@ -332,7 +332,7 @@ done:
                                         }
 
                                         for (n = 0; n < unit; n++)
-                                            pcc_rule->qos.mbr.downlink *= 1024;
+                                            pcc_rule->qos.mbr.downlink *= 1000;
 
                                     } else if (!strcmp(child8_key, "uplink") &&
                                         BSON_ITER_HOLDS_DOCUMENT(
@@ -361,7 +361,7 @@ done:
                                         }
 
                                         for (n = 0; n < unit; n++)
-                                            pcc_rule->qos.mbr.uplink *= 1024;
+                                            pcc_rule->qos.mbr.uplink *= 1000;
                                     }
                                 }
                             } else if (!strcmp(child7_key, "gbr") &&
@@ -397,7 +397,7 @@ done:
                                         }
 
                                         for (n = 0; n < unit; n++)
-                                            pcc_rule->qos.gbr.downlink *= 1024;
+                                            pcc_rule->qos.gbr.downlink *= 1000;
 
                                     } else if (!strcmp(child8_key, "uplink") &&
                                         BSON_ITER_HOLDS_DOCUMENT(
@@ -426,7 +426,7 @@ done:
                                         }
 
                                         for (n = 0; n < unit; n++)
-                                            pcc_rule->qos.gbr.uplink *= 1024;
+                                            pcc_rule->qos.gbr.uplink *= 1000;
                                     }
                                 }
                             }

--- a/lib/dbi/subscription.c
+++ b/lib/dbi/subscription.c
@@ -424,7 +424,7 @@ int ogs_dbi_subscription_data(char *supi,
                     }
 
                     for (n = 0; n < unit; n++)
-                        subscription_data->ambr.downlink *= 1024;
+                        subscription_data->ambr.downlink *= 1000;
                 } else if (!strcmp(child1_key, "uplink") &&
                         BSON_ITER_HOLDS_DOCUMENT(&child1_iter)) {
                     uint8_t unit = 0;
@@ -444,7 +444,7 @@ int ogs_dbi_subscription_data(char *supi,
                     }
 
                     for (n = 0; n < unit; n++)
-                        subscription_data->ambr.uplink *= 1024;
+                        subscription_data->ambr.uplink *= 1000;
                 }
 
             }
@@ -593,7 +593,7 @@ int ogs_dbi_subscription_data(char *supi,
                                             }
 
                                             for (n = 0; n < unit; n++)
-                                                session->ambr.downlink *= 1024;
+                                                session->ambr.downlink *= 1000;
                                         } else if (!strcmp(child5_key,
                                                     "uplink") &&
                                                 BSON_ITER_HOLDS_DOCUMENT(
@@ -624,7 +624,7 @@ int ogs_dbi_subscription_data(char *supi,
                                             }
 
                                             for (n = 0; n < unit; n++)
-                                                session->ambr.uplink *= 1024;
+                                                session->ambr.uplink *= 1000;
                                         }
                                     }
                                 } else if (!strcmp(child4_key, "smf") &&

--- a/lib/gtp/v2/types.c
+++ b/lib/gtp/v2/types.c
@@ -127,14 +127,14 @@ uint64_t ogs_gtp2_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2)
      * giving a range of 1600 Mbps to 10 Gbps Mbps in 100 Mbps increaments.
      */
     if (extended2 >= 0b00000001 && extended2 <= 0b00111101) {
-        return 256*1024 + extended2 * 4*1024;
+        return 256*1000 + extended2 * 4*1000;
     } else if (extended2 >= 0b00111110 && extended2 <= 0b10100001) {
-        return 500*1024 + (extended2 - 0b00111101) * 10*1024;
+        return 500*1000 + (extended2 - 0b00111101) * 10*1000;
     } else if (extended2 >= 0b10100010 && extended2 <= 0b11110110) {
-        return 1500*1024 + (extended2 - 0b10100001) * 100*1024;
+        return 1500*1000 + (extended2 - 0b10100001) * 100*1000;
     } else if (extended2 > 0b11110110) {
         ogs_error("Protocol Error : extended2[%x]", extended2);
-        return 10*1000*1024; /* 10*1000 Mbps */
+        return 10*1000*1000; /* 10*1000 Mbps */
 
     /*
      * Octet 8
@@ -155,12 +155,12 @@ uint64_t ogs_gtp2_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2)
     } else if (extended >= 0b00000001 && extended <= 0b01001010) {
         return 8600 + extended * 100;
     } else if (extended >= 0b01001011 && extended <= 0b10111010) {
-        return 16*1024 + (extended - 0b01001010) * 1*1024;
+        return 16*1000 + (extended - 0b01001010) * 1*1000;
     } else if (extended >= 0b10111011 && extended <= 0b11111010) {
-        return 128*1024 + (extended - 0b10111010) * 2*1024;
+        return 128*1000 + (extended - 0b10111010) * 2*1000;
     } else if (extended > 0b11111010) {
         ogs_error("Protocol Error : extended[%x]", extended);
-        return 256*1024; /* 256 Mbps */
+        return 256*1000; /* 256 Mbps */
 
     /*
      * Octet 4

--- a/lib/gtp/v2/types.h
+++ b/lib/gtp/v2/types.h
@@ -302,7 +302,7 @@ typedef struct ogs_gtp2_flow_qos_s {
 } __attribute__ ((packed)) ogs_gtp2_flow_qos_t;
 
 #define ogs_gtp2_qos_to_bps(br, extended, extended2) \
-    ogs_gtp2_qos_to_kbps(br, extended, extended2) * 1024;
+    ogs_gtp2_qos_to_kbps(br, extended, extended2) * 1000;
 
 uint64_t ogs_gtp2_qos_to_kbps(uint8_t br, uint8_t extended, uint8_t extended2);
 

--- a/lib/nas/common/types.c
+++ b/lib/nas/common/types.c
@@ -114,31 +114,31 @@ static uint8_t nas_ambr_from_kbps(
         length = ogs_max(length, 2);
     }
     /* Set to 16000 Kbps */
-    else if (input > 16000 && input < (17*1024)) {
+    else if (input > 16000 && input < (17*1000)) {
         *br = 0b11111110;
         *extended = 0b01001010;
         length = ogs_max(length, 2);
     }
     /* giving a range of 17 Mbps to 128 Mbps in 1 Mbps increments. */
-    else if (input >= (17*1024) && input <= (128*1024)) {
+    else if (input >= (17*1000) && input <= (128*1000)) {
         *br = 0b11111110;
-        *extended = ((input - (16*1024)) / (1*1024)) + 0b01001010;
+        *extended = ((input - (16*1000)) / (1*1000)) + 0b01001010;
         length = ogs_max(length, 2);
     }
     /* Set to 128 Mbps */
-    else if (input > (128*1024) && input < (130*1024)) {
+    else if (input > (128*1000) && input < (130*1000)) {
         *br = 0b11111110;
         *extended = 0b10111010;
         length = ogs_max(length, 2);
     }
     /* giving a range of 130 Mbps to 256 Mbps in 2 Mbps increments. */
-    else if (input >= (130*1024) && input <= (256*1024)) {
+    else if (input >= (130*1000) && input <= (256*1000)) {
         *br = 0b11111110;
-        *extended = ((input - (128*1024)) / (2*1024)) + 0b10111010;
+        *extended = ((input - (128*1000)) / (2*1000)) + 0b10111010;
         length = ogs_max(length, 2);
     }
     /* Set to 256 Mbps */
-    else if (input > (1*256*1024) && input < (2*256*1024)) {
+    else if (input > (1*256*1000) && input < (2*256*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         length = ogs_max(length, 2);
@@ -157,14 +157,14 @@ static uint8_t nas_ambr_from_kbps(
      */
 
     /* giving a range of values from 260M to 500M in 4M increments */
-    else if (input >= (2*256*1024) && input <= (255*256*1024)) {
+    else if (input >= (2*256*1000) && input <= (255*256*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
-        *extended2 = (input - (1*256*1024)) / (256*1024);
+        *extended2 = (input - (1*256*1000)) / (256*1000);
         length = ogs_max(length, 3);
     }
     /* if the sending entity want to indicate BR higher than 65280M */
-    else if (input > (255*256*1024)) {
+    else if (input > (255*256*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         *extended2 = 0b11111110;
@@ -262,31 +262,31 @@ static uint8_t nas_qos_from_kbps(
         length = ogs_max(length, 2);
     }
     /* Set to 16000 Kbps */
-    else if (input > 16000 && input < (17*1024)) {
+    else if (input > 16000 && input < (17*1000)) {
         *br = 0b11111110;
         *extended = 0b01001010;
         length = ogs_max(length, 2);
     }
     /* giving a range of 17 Mbps to 128 Mbps in 1 Mbps increments. */
-    else if (input >= (17*1024) && input <= (128*1024)) {
+    else if (input >= (17*1000) && input <= (128*1000)) {
         *br = 0b11111110;
-        *extended = ((input - (16*1024)) / (1*1024)) + 0b01001010;
+        *extended = ((input - (16*1000)) / (1*1000)) + 0b01001010;
         length = ogs_max(length, 2);
     }
     /* Set to 128 Mbps */
-    else if (input > (128*1024) && input < (130*1024)) {
+    else if (input > (128*1000) && input < (130*1000)) {
         *br = 0b11111110;
         *extended = 0b10111010;
         length = ogs_max(length, 2);
     }
     /* giving a range of 130 Mbps to 256 Mbps in 2 Mbps increments. */
-    else if (input >= (130*1024) && input <= (256*1024)) {
+    else if (input >= (130*1000) && input <= (256*1000)) {
         *br = 0b11111110;
-        *extended = ((input - (128*1024)) / (2*1024)) + 0b10111010;
+        *extended = ((input - (128*1000)) / (2*1000)) + 0b10111010;
         length = ogs_max(length, 2);
     }
     /* Set to 256 Mbps */
-    else if (input > (256*1024) && input < (260*1024)) {
+    else if (input > (256*1000) && input < (260*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         length = ogs_max(length, 2);
@@ -310,42 +310,42 @@ static uint8_t nas_qos_from_kbps(
      */
 
     /* giving a range of values from 260M to 500M in 4M increments */
-    else if (input >= (260*1024) && input <= (500*1024)) {
+    else if (input >= (260*1000) && input <= (500*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
-        *extended2 = (input - (256*1024)) / (4*1024);
+        *extended2 = (input - (256*1000)) / (4*1000);
         length = ogs_max(length, 3);
     }
     /* if a range of values from 500M to 510M */
-    else if (input > (500*1024) && input < (510*1024)) {
+    else if (input > (500*1000) && input < (510*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         *extended2 = 0b00111101;
         length = ogs_max(length, 3);
     }
     /* giving a range of values from 510M to 1500M in 10M increments */
-    else if (input >= (510*1024) && input <= (1500*1024)) {
+    else if (input >= (510*1000) && input <= (1500*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
-        *extended2 = (input - (500*1024)) / (10*1024) + 0b00111101;
+        *extended2 = (input - (500*1000)) / (10*1000) + 0b00111101;
         length = ogs_max(length, 3);
     }
     /* if a range of values from 1500M to 1600M */
-    else if (input > (1500*1024) && input < (1600*1024)) {
+    else if (input > (1500*1000) && input < (1600*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         *extended2 = 0b10100001;
         length = ogs_max(length, 3);
     }
     /* giving a range of values from 1600M to 10000M in 100M increments */
-    else if (input >= (1600*1024) && input <= (10*1000*1024)) {
+    else if (input >= (1600*1000) && input <= (10*1000*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
-        *extended2 = (input - (1500*1024)) / (100*1024) + 0b10100001;
+        *extended2 = (input - (1500*1000)) / (100*1000) + 0b10100001;
         length = ogs_max(length, 3);
     }
     /* if the sending entity want to indicate BR higher than 10000Mbps */
-    else if (input > (10*1000*1024)) {
+    else if (input > (10*1000*1000)) {
         *br = 0b11111110;
         *extended = 0b11111010;
         *extended2 = 0b11110110;
@@ -361,8 +361,8 @@ void apn_ambr_build(
 {
     uint8_t length = 0;
 
-    dl_apn_ambr = dl_apn_ambr / 1024; /* Kbps */
-    ul_apn_ambr = ul_apn_ambr / 1024; /* Kbps */
+    dl_apn_ambr = dl_apn_ambr / 1000; /* Kbps */
+    ul_apn_ambr = ul_apn_ambr / 1000; /* Kbps */
 
     memset(apn_aggregate_maximum_bit_rate, 0,
         sizeof(ogs_nas_apn_aggregate_maximum_bit_rate_t));
@@ -387,10 +387,10 @@ void eps_qos_build(ogs_nas_eps_quality_of_service_t *eps_qos, uint8_t qci,
 {
     uint8_t length = 0;
 
-    dl_mbr = dl_mbr / 1024; /* Kbps */
-    ul_mbr = ul_mbr / 1024; /* Kbps */
-    dl_gbr = dl_gbr / 1024; /* Kbps */
-    ul_gbr = ul_gbr / 1024; /* Kbps */
+    dl_mbr = dl_mbr / 1000; /* Kbps */
+    ul_mbr = ul_mbr / 1000; /* Kbps */
+    dl_gbr = dl_gbr / 1000; /* Kbps */
+    ul_gbr = ul_gbr / 1000; /* Kbps */
 
     memset(eps_qos, 0, sizeof(ogs_nas_eps_quality_of_service_t));
 

--- a/src/pcf/nbsf-handler.c
+++ b/src/pcf/nbsf-handler.c
@@ -178,10 +178,10 @@ bool pcf_nbsf_management_handle_register(
                     sess->subscribed_sess_ambr->uplink);
             subscribed_sess_ambr.downlink = ogs_sbi_bitrate_from_string(
                     sess->subscribed_sess_ambr->downlink);
-            if (((subscribed_sess_ambr.uplink / 1024) !=
-                 (session->ambr.uplink / 1024)) ||
-                ((subscribed_sess_ambr.downlink / 1024) !=
-                 (session->ambr.downlink / 1024))) {
+            if (((subscribed_sess_ambr.uplink / 1000) !=
+                 (session->ambr.uplink / 1000)) ||
+                ((subscribed_sess_ambr.downlink / 1000) !=
+                 (session->ambr.downlink / 1000))) {
 
                 OpenAPI_list_add(PolicyCtrlReqTriggers,
                     (void *)OpenAPI_policy_control_request_trigger_SE_AMBR_CH);

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -98,10 +98,10 @@ bool pcf_nudr_dr_handle_query_am_data(
                 subscribed_ue_ambr.downlink = ogs_sbi_bitrate_from_string(
                         pcf_ue->subscribed_ue_ambr->downlink);
 
-                if (((subscribed_ue_ambr.uplink / 1024) !=
-                     (subscription_data.ambr.uplink / 1024)) ||
-                    ((subscribed_ue_ambr.downlink / 1024) !=
-                     (subscription_data.ambr.downlink / 1024))) {
+                if (((subscribed_ue_ambr.uplink / 1000) !=
+                     (subscription_data.ambr.uplink / 1000)) ||
+                    ((subscribed_ue_ambr.downlink / 1000) !=
+                     (subscription_data.ambr.downlink / 1000))) {
 
                     OpenAPI_list_add(TriggerList,
                             (void *)OpenAPI_request_trigger_UE_AMBR_CH);

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -184,8 +184,8 @@ uint8_t smf_gn_handle_create_pdp_context_request(
     }
 
     /* Set some sane default if information not present in QoS Profile or APN-AMBR: */
-    sess->session.ambr.downlink = 102400000;
-    sess->session.ambr.uplink = 102400000;
+    sess->session.ambr.downlink = 100000000;
+    sess->session.ambr.uplink = 100000000;
 
     /* Set Bearer QoS */
     OGS_TLV_STORE_DATA(&sess->gtp.v1.qos, &req->quality_of_service_profile);

--- a/tests/common/gsm-build.c
+++ b/tests/common/gsm-build.c
@@ -242,7 +242,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
                 sizeof(qos_flow_description[0].param[num_of_param].br);
             ogs_nas_bitrate_from_uint64(
                     &qos_flow_description[0].param[num_of_param].br,
-                    32*1024);
+                    32*1000);
             num_of_param++;
             qos_flow_description[0].param[num_of_param].identifier =
                 OGS_NAX_QOS_FLOW_PARAMETER_ID_GFBR_DOWNLINK;
@@ -250,7 +250,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
                 sizeof(qos_flow_description[0].param[num_of_param].br);
             ogs_nas_bitrate_from_uint64(
                     &qos_flow_description[0].param[num_of_param].br,
-                    48*1024);
+                    48*1000);
             num_of_param++;
             qos_flow_description[0].param[num_of_param].identifier =
                 OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_UPLINK;
@@ -258,7 +258,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
                 sizeof(qos_flow_description[0].param[num_of_param].br);
             ogs_nas_bitrate_from_uint64(
                     &qos_flow_description[0].param[num_of_param].br,
-                    16*1024);
+                    16*1000);
             num_of_param++;
             qos_flow_description[0].param[num_of_param].identifier =
                 OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_DOWNLINK;
@@ -266,7 +266,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
                 sizeof(qos_flow_description[0].param[num_of_param].br);
             ogs_nas_bitrate_from_uint64(
                     &qos_flow_description[0].param[num_of_param].br,
-                    64*1024);
+                    64*1000);
             num_of_param++;
         }
 


### PR DESCRIPTION
NAS, GTP, PFCP, SBI, all except S1AP/NGAP use x1000 multiplier for Kbps, Mbps, Gbps ... etc.

From now on in WebUI all units also use a multiplier of x1000.