### PR TITLE
[UDM] Fixed crash for invalid SUCI (#2571)

### DIFF
--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -163,7 +163,15 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                         message.h.resource.component[0]);
                 if (!udm_ue) {
                     udm_ue = udm_ue_add(message.h.resource.component[0]);
-                    ogs_assert(udm_ue);
+                    if (!udm_ue) {
+                        ogs_error("Invalid Request [%s]",
+                                message.h.resource.component[0]);
+                        ogs_assert(true ==
+                            ogs_sbi_server_send_error(stream,
+                                OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                &message, NULL, NULL));
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Modifications were made to resolve the following assertion..

Invalid HNET PKI Value [0] (../lib/sbi/conv.c:135) ogs_supi_from_supi_or_suci: Expectation `supi' failed. (../lib/sbi/conv.c:262) udm_ue_add: Assertion `udm_ue->supi' failed. (../src/udm/context.c:144) backtrace() returned 8 addresses (../lib/core/ogs-abort.c:37)