### PR TITLE
[NRF] Fixed NRF crash when Custom nfType (#2576)

### DIFF
--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -40,6 +40,33 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
         return false;
     }
 
+    if (!NFProfile->nf_instance_id) {
+        ogs_error("No NFProfile.NFInstanceId");
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "No NFProfile.NFInstanceId", NULL));
+        return false;
+    }
+
+    if (!NFProfile->nf_type) {
+        ogs_error("No NFProfile.NFType");
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "No NFProfile.NFType", NULL));
+        return false;
+    }
+
+    if (!NFProfile->nf_status) {
+        ogs_error("No NFProfile.NFStatus");
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "No NFProfile.NFStatus", NULL));
+        return false;
+    }
+
     ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
 
     if (OGS_FSM_CHECK(&nf_instance->sm, nrf_nf_state_will_register)) {

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -164,7 +164,6 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                                     nrf_nf_state_exception)) {
                             ogs_error("[%s] State machine exception",
                                     nf_instance->id);
-                            ogs_sbi_message_free(&message);
 
                             nrf_nf_fsm_fini(nf_instance);
                             ogs_sbi_nf_instance_remove(nf_instance);


### PR DESCRIPTION
NF Instance Registration to reproduce crash:

curl -v -X PUT -d '{"nfInstanceId":"0b8a8d59-af80-4fb7-8645-b832fd69d94a","nfType":"CUSTOM_INF","nfStatus":"REGISTERED","ipv4Addresses":["127.0.13.37"]}' --http2-prior-knowledge http://127.0.0.10:7777/nnrf-nfm/v1/nf-instances/0b8a8d59-af80-4fb7-8645-b832fd69d94a