### PR TITLE
[SMF] Invalid Message(SmContextCreateData) (#2590)

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1018,8 +1018,10 @@ smf_ue_t *smf_ue_add_by_supi(char *supi)
 
     ogs_assert(supi);
 
-    if ((smf_ue = smf_ue_add()) == NULL)
+    if ((smf_ue = smf_ue_add()) == NULL) {
+        ogs_error("smf_ue_add_by_supi() failed");
         return NULL;
+    }
 
     smf_ue->supi = ogs_strdup(supi);
     ogs_assert(smf_ue->supi);
@@ -1467,7 +1469,10 @@ smf_sess_t *smf_sess_add_by_sbi_message(ogs_sbi_message_t *message)
 
     ogs_assert(message);
     SmContextCreateData = message->SmContextCreateData;
-    ogs_assert(SmContextCreateData);
+    if (!SmContextCreateData) {
+        ogs_error("No SmContextCreateData");
+        return NULL;
+    }
 
     if (!SmContextCreateData->supi) {
         ogs_error("No SUPI");
@@ -1482,8 +1487,10 @@ smf_sess_t *smf_sess_add_by_sbi_message(ogs_sbi_message_t *message)
     smf_ue = smf_ue_find_by_supi(SmContextCreateData->supi);
     if (!smf_ue) {
         smf_ue = smf_ue_add_by_supi(SmContextCreateData->supi);
-        if (!smf_ue)
+        if (!smf_ue) {
+            ogs_error("smf_ue_add_by_supi() failed");
             return NULL;
+        }
     }
 
     sess = smf_sess_find_by_psi(smf_ue, SmContextCreateData->pdu_session_id);

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -528,7 +528,15 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
                     DEFAULT
                         sess = smf_sess_add_by_sbi_message(&sbi_message);
-                        ogs_assert(sess);
+                        if (!sess) {
+                            ogs_error("smf_sess_add_by_sbi_message() failed");
+                            smf_sbi_send_sm_context_create_error(stream,
+                                    OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                    OGS_SBI_APP_ERRNO_NULL,
+                                    "smf_sess_add_by_sbi_message() failed",
+                                    NULL, NULL);
+                            break;
+                        }
 
                         smf_metrics_inst_by_slice_add(NULL, NULL,
                                 SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ, 1);


### PR DESCRIPTION
curl --noproxy '*' --http2-prior-knowledge -X POST --header "Content-Type: multipart/related" --data-binary @pdu http:/192.168.29.231:7777/nsmf-pdusession/v1/sm-contexts Attaching file 'pdu'

SMF crashes as not able to decode the message properly. SmContextCreateData is not accessible.