### PR TITLE
[GTPU] Fixed PDCP SN handling (#2584, #2477)

### DIFF
--- a/lib/gtp/util.c
+++ b/lib/gtp/util.c
@@ -19,16 +19,27 @@
 
 #include "ogs-gtp.h"
 
-int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf)
+int ogs_gtpu_parse_header(
+        ogs_gtp2_header_desc_t *header_desc, ogs_pkbuf_t *pkbuf)
 {
     ogs_gtp2_header_t *gtp_h = NULL;
+    ogs_gtp2_extension_header_t ext_hdesc;
     uint8_t *ext_h = NULL;
     uint16_t len = 0;
+    int i;
 
     ogs_assert(pkbuf);
     ogs_assert(pkbuf->data);
 
     gtp_h = (ogs_gtp2_header_t *)pkbuf->data;
+
+    if (header_desc) {
+        memset(header_desc, 0, sizeof(*header_desc));
+
+        header_desc->flags = gtp_h->flags;
+        header_desc->type = gtp_h->type;
+        header_desc->teid = be32toh(gtp_h->teid);
+    }
 
     len = OGS_GTPV1U_HEADER_LEN;
     if (pkbuf->len < len) {
@@ -52,6 +63,8 @@ int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf)
          *
          * If no such Header follows,
          * then the value of the Next Extension Header Type shall be 0. */
+
+        i = 0;
         while (*(ext_h = (((uint8_t *)gtp_h) + len - 1))) {
         /*
          * The length of the Extension header shall be defined
@@ -68,6 +81,42 @@ int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf)
                         pkbuf->len, len);
                 return -1;
             }
+
+            if (!header_desc) /* Skip to extract header content */
+                continue;
+
+            /* Copy Header Content */
+            memcpy(&ext_hdesc.array[i], ext_h-1, (*ext_h) * 4);
+
+            switch (ext_hdesc.array[i].type) {
+            case OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER:
+                header_desc->pdu_type = ext_hdesc.array[i].pdu_type;
+                if (ext_hdesc.array[i].pdu_type ==
+                    OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
+                        header_desc->qos_flow_identifier =
+                            ext_hdesc.array[i].qos_flow_identifier;
+                        ogs_trace("   QFI [0x%x]",
+                                header_desc->qos_flow_identifier);
+                }
+                break;
+            case OGS_GTP2_EXTENSION_HEADER_TYPE_UDP_PORT:
+                header_desc->udp.presence = true;
+                header_desc->udp.port = be16toh(ext_hdesc.array[i].udp_port);
+
+                ogs_trace("   UDP Port [%d]", header_desc->udp.port);
+                break;
+            case OGS_GTP2_EXTENSION_HEADER_TYPE_PDCP_NUMBER:
+                header_desc->pdcp_number_presence = true;
+                header_desc->pdcp_number =
+                    be16toh(ext_hdesc.array[i].pdcp_number);
+
+                ogs_trace("   PDCP Number [%d]", header_desc->pdcp_number);
+                break;
+            default:
+                break;
+            }
+
+            i++;
         }
 
     } else if (gtp_h->flags & (OGS_GTPU_FLAGS_S|OGS_GTPU_FLAGS_PN)) {
@@ -92,7 +141,6 @@ int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf)
 
     return len;
 }
-
 
 uint16_t ogs_in_cksum(uint16_t *addr, int len)
 {

--- a/lib/gtp/util.h
+++ b/lib/gtp/util.h
@@ -28,7 +28,8 @@
 extern "C" {
 #endif
 
-int ogs_gtpu_header_len(ogs_pkbuf_t *pkbuf);
+int ogs_gtpu_parse_header(
+        ogs_gtp2_header_desc_t *header_desc, ogs_pkbuf_t *pkbuf);
 uint16_t ogs_in_cksum(uint16_t *addr, int len);
 
 #ifdef __cplusplus

--- a/lib/gtp/v2/path.h
+++ b/lib/gtp/v2/path.h
@@ -32,7 +32,7 @@ typedef struct ogs_gtp_xact_s ogs_gtp_xact_t;
 
 int ogs_gtp2_send_user_plane(
         ogs_gtp_node_t *gnode,
-        ogs_gtp2_header_t *gtp_hdesc, ogs_gtp2_extension_header_t *ext_hdesc,
+        ogs_gtp2_header_desc_t *hdesc,
         ogs_pkbuf_t *pkbuf);
 
 ogs_pkbuf_t *ogs_gtp2_handle_echo_req(ogs_pkbuf_t *pkb);

--- a/lib/gtp/v2/types.h
+++ b/lib/gtp/v2/types.h
@@ -53,20 +53,43 @@ extern "C" {
 typedef struct ogs_gtp2_extension_header_s {
 #define OGS_GTP2_EXTENSION_HEADER_TYPE_UDP_PORT 0x40
 #define OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER 0x85
+#define OGS_GTP2_EXTENSION_HEADER_TYPE_PDCP_NUMBER 0xc0
 #define OGS_GTP2_EXTENSION_HEADER_TYPE_NO_MORE_EXTENSION_HEADERS 0x0
     uint16_t sequence_number;
     uint8_t n_pdu_number;
-    uint8_t type;
-    uint8_t len;
+    struct {
+        uint8_t type;
+        uint8_t len;
+        union {
+            struct {
 #define OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_DL_PDU_SESSION_INFORMATION 0
 #define OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION 1
-    ED2(uint8_t pdu_type:4;,
-        uint8_t spare1:4;);
-    ED3(uint8_t paging_policy_presence:1;,
-        uint8_t reflective_qos_indicator:1;,
-        uint8_t qos_flow_identifier:6;);
-    uint8_t next_type;
+            ED2(uint8_t pdu_type:4;,
+                uint8_t spare1:4;);
+            ED3(uint8_t paging_policy_presence:1;,
+                uint8_t reflective_qos_indicator:1;,
+                uint8_t qos_flow_identifier:6;);
+            };
+            uint16_t udp_port;
+            uint16_t pdcp_number;
+        };
+#define OGS_GTP2_NUM_OF_EXTENSION_HEADER 8
+    } __attribute__ ((packed)) array[OGS_GTP2_NUM_OF_EXTENSION_HEADER];
 } __attribute__ ((packed)) ogs_gtp2_extension_header_t;
+
+typedef struct ogs_gtp2_header_desc_s {
+    /* GTP Header */
+    uint8_t type;
+    uint8_t flags;
+    uint32_t teid;
+
+    /* GTP Extension Header */
+    uint8_t qos_flow_identifier;
+    uint8_t pdu_type;
+    ogs_port_t udp;
+    bool pdcp_number_presence;
+    uint16_t pdcp_number;
+} ogs_gtp2_header_desc_t;
 
 /* 8.4 Cause */
 #define OGS_GTP2_CAUSE_UNDEFINED_VALUE 0

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -218,7 +218,8 @@ bool ogs_pfcp_up_handle_association_setup_response(
 }
 
 bool ogs_pfcp_up_handle_pdr(
-        ogs_pfcp_pdr_t *pdr, uint8_t type, ogs_pkbuf_t *recvbuf,
+        ogs_pfcp_pdr_t *pdr, uint8_t type,
+        ogs_gtp2_header_desc_t *recvhdr, ogs_pkbuf_t *recvbuf,
         ogs_pfcp_user_plane_report_t *report)
 {
     ogs_pfcp_far_t *far = NULL;
@@ -248,9 +249,27 @@ bool ogs_pfcp_up_handle_pdr(
 
     } else {
         if (far->apply_action & OGS_PFCP_APPLY_ACTION_FORW) {
+            ogs_gtp2_header_desc_t sendhdr;
 
             /* Forward packet */
-            ogs_pfcp_send_g_pdu(pdr, type, sendbuf);
+            memset(&sendhdr, 0, sizeof(sendhdr));
+            sendhdr.type = type;
+
+            if (recvhdr) {
+                /*
+                 * Issue #2584
+                 * Discussion #2477
+                 *
+                 * Forward PDCP Number via Indirect Tunnel during Handover
+                 */
+                if (recvhdr->pdcp_number_presence == true) {
+                    sendhdr.pdcp_number_presence =
+                        recvhdr->pdcp_number_presence;
+                    sendhdr.pdcp_number = recvhdr->pdcp_number;
+                }
+            }
+
+            ogs_pfcp_send_g_pdu(pdr, &sendhdr, sendbuf);
 
         } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_BUFF) {
 

--- a/lib/pfcp/handler.h
+++ b/lib/pfcp/handler.h
@@ -46,7 +46,8 @@ bool ogs_pfcp_up_handle_association_setup_response(
         ogs_pfcp_association_setup_response_t *req);
 
 bool ogs_pfcp_up_handle_pdr(
-        ogs_pfcp_pdr_t *pdr, uint8_t type, ogs_pkbuf_t *recvbuf,
+        ogs_pfcp_pdr_t *pdr, uint8_t type,
+        ogs_gtp2_header_desc_t *recvhdr, ogs_pkbuf_t *recvbuf,
         ogs_pfcp_user_plane_report_t *report);
 bool ogs_pfcp_up_handle_error_indication(
         ogs_pfcp_far_t *far, ogs_pfcp_user_plane_report_t *report);

--- a/lib/pfcp/path.h
+++ b/lib/pfcp/path.h
@@ -79,7 +79,8 @@ int ogs_pfcp_up_send_association_setup_response(ogs_pfcp_xact_t *xact,
         uint8_t cause);
 
 void ogs_pfcp_send_g_pdu(
-        ogs_pfcp_pdr_t *pdr, uint8_t type, ogs_pkbuf_t *sendbuf);
+        ogs_pfcp_pdr_t *pdr,
+        ogs_gtp2_header_desc_t *sendhdr, ogs_pkbuf_t *sendbuf);
 int ogs_pfcp_send_end_marker(ogs_pfcp_pdr_t *pdr);
 
 void ogs_pfcp_send_buffered_packet(ogs_pfcp_pdr_t *pdr);

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -214,7 +214,7 @@ static void _gtpv1_tun_recv_common_cb(
         upf_sess_urr_acc_add(sess, pdr->urr[i], recvbuf->len, false);
 
     ogs_assert(true == ogs_pfcp_up_handle_pdr(
-                pdr, OGS_GTPU_MSGTYPE_GPDU, recvbuf, &report));
+                pdr, OGS_GTPU_MSGTYPE_GPDU, NULL, recvbuf, &report));
 
     /*
      * Issue #2210, Discussion #2208, #2209
@@ -270,10 +270,8 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_sockaddr_t from;
 
     ogs_gtp2_header_t *gtp_h = NULL;
+    ogs_gtp2_header_desc_t header_desc;
     ogs_pfcp_user_plane_report_t report;
-
-    uint32_t teid;
-    uint8_t qfi;
 
     ogs_assert(fd != INVALID_SOCKET);
     sock = data;
@@ -303,7 +301,13 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
         goto cleanup;
     }
 
-    if (gtp_h->type == OGS_GTPU_MSGTYPE_ECHO_REQ) {
+    len = ogs_gtpu_parse_header(&header_desc, pkbuf);
+    if (len < 0) {
+        ogs_error("[DROP] Cannot decode GTPU packet");
+        ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
+        goto cleanup;
+    }
+    if (header_desc.type == OGS_GTPU_MSGTYPE_ECHO_REQ) {
         ogs_pkbuf_t *echo_rsp;
 
         ogs_debug("[RECV] Echo Request from [%s]", OGS_ADDR(&from, buf1));
@@ -324,55 +328,24 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
         }
         goto cleanup;
     }
-
-    teid = be32toh(gtp_h->teid);
+    if (header_desc.type != OGS_GTPU_MSGTYPE_END_MARKER &&
+        pkbuf->len <= len) {
+        ogs_error("[DROP] Small GTPU packet(type:%d len:%d)",
+                header_desc.type, len);
+        ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
+        goto cleanup;
+    }
 
     ogs_trace("[RECV] GPU-U Type [%d] from [%s] : TEID[0x%x]",
-            gtp_h->type, OGS_ADDR(&from, buf1), teid);
-
-    qfi = 0;
-    if (gtp_h->flags & OGS_GTPU_FLAGS_E) {
-        /*
-         * TS29.281
-         * 5.2.1 General format of the GTP-U Extension Header
-         * Figure 5.2.1-3: Definition of Extension Header Type
-         *
-         * Note 4 : For a GTP-PDU with several Extension Headers, the PDU
-         *          Session Container should be the first Extension Header
-         */
-        ogs_gtp2_extension_header_t *extension_header =
-            (ogs_gtp2_extension_header_t *)(pkbuf->data+OGS_GTPV1U_HEADER_LEN);
-        ogs_assert(extension_header);
-        if (extension_header->type ==
-                OGS_GTP2_EXTENSION_HEADER_TYPE_PDU_SESSION_CONTAINER) {
-            if (extension_header->pdu_type ==
-                OGS_GTP2_EXTENSION_HEADER_PDU_TYPE_UL_PDU_SESSION_INFORMATION) {
-                    ogs_trace("   QFI [0x%x]",
-                            extension_header->qos_flow_identifier);
-                    qfi = extension_header->qos_flow_identifier;
-            }
-        }
-    }
+            header_desc.type, OGS_ADDR(&from, buf1), header_desc.teid);
 
     /* Remove GTP header and send packets to TUN interface */
-    len = ogs_gtpu_header_len(pkbuf);
-    if (len < 0) {
-        ogs_error("[DROP] Cannot decode GTPU packet");
-        ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
-        goto cleanup;
-    }
-    if (gtp_h->type != OGS_GTPU_MSGTYPE_END_MARKER &&
-        pkbuf->len <= len) {
-        ogs_error("[DROP] Small GTPU packet(type:%d len:%d)", gtp_h->type, len);
-        ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
-        goto cleanup;
-    }
     ogs_assert(ogs_pkbuf_pull(pkbuf, len));
 
-    if (gtp_h->type == OGS_GTPU_MSGTYPE_END_MARKER) {
+    if (header_desc.type == OGS_GTPU_MSGTYPE_END_MARKER) {
         /* Nothing */
 
-    } else if (gtp_h->type == OGS_GTPU_MSGTYPE_ERR_IND) {
+    } else if (header_desc.type == OGS_GTPU_MSGTYPE_ERR_IND) {
         ogs_pfcp_far_t *far = NULL;
 
         far = ogs_pfcp_far_find_by_gtpu_error_indication(pkbuf);
@@ -394,7 +367,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
             ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
         }
 
-    } else if (gtp_h->type == OGS_GTPU_MSGTYPE_GPDU) {
+    } else if (header_desc.type == OGS_GTPU_MSGTYPE_GPDU) {
         uint16_t eth_type = 0;
         struct ip *ip_h = NULL;
         uint32_t *src_addr = NULL;
@@ -419,11 +392,11 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
          */
 #if 0
         upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF);
-        upf_metrics_inst_by_qfi_add(qfi,
+        upf_metrics_inst_by_qfi_add(header_desc.qos_flow_identifier,
                 UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF, pkbuf->len);
 #endif
 
-        pfcp_object = ogs_pfcp_object_find_by_teid(teid);
+        pfcp_object = ogs_pfcp_object_find_by_teid(header_desc.teid);
         if (!pfcp_object) {
             /*
              * TS23.527 Restoration procedures
@@ -440,9 +413,11 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                         ogs_app()->time.message.pfcp.association_interval))) {
                 ogs_error("[%s] Send Error Indication [TEID:0x%x] to [%s]",
                         OGS_ADDR(&sock->local_addr, buf1),
-                        teid,
+                        header_desc.teid,
                         OGS_ADDR(&from, buf2));
-                ogs_gtp1_send_error_indication(sock, teid, qfi, &from);
+                ogs_gtp1_send_error_indication(
+                        sock, header_desc.teid,
+                        header_desc.qos_flow_identifier, &from);
             }
             goto cleanup;
         }
@@ -466,11 +441,12 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                     continue;
 
                 /* Check if TEID */
-                if (teid != pdr->f_teid.teid)
+                if (header_desc.teid != pdr->f_teid.teid)
                     continue;
 
                 /* Check if QFI */
-                if (qfi && pdr->qfi != qfi)
+                if (header_desc.qos_flow_identifier &&
+                    pdr->qfi != header_desc.qos_flow_identifier)
                     continue;
 
                 /* Check if Rule List in PDR */
@@ -493,14 +469,16 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                  */
                 if (ogs_time_ntp32_now() >
                        (ogs_pfcp_self()->local_recovery +
-                        ogs_time_sec(
-                            ogs_app()->time.message.pfcp.association_interval))) {
+                        ogs_time_sec(ogs_app()->time.message.pfcp.
+                            association_interval))) {
                     ogs_error(
                             "[%s] Send Error Indication [TEID:0x%x] to [%s]",
                             OGS_ADDR(&sock->local_addr, buf1),
-                            teid,
+                            header_desc.teid,
                             OGS_ADDR(&from, buf2));
-                    ogs_gtp1_send_error_indication(sock, teid, qfi, &from);
+                    ogs_gtp1_send_error_indication(
+                            sock, header_desc.teid,
+                            header_desc.qos_flow_identifier, &from);
                 }
                 goto cleanup;
             }
@@ -540,7 +518,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                     /* Or source IP address should match a framed route */
                 } else {
                     ogs_error("[DROP] Source IP-%d Spoofing APN:%s SrcIf:%d DstIf:%d TEID:0x%x",
-                                ip_h->ip_v, pdr->dnn, pdr->src_if, far->dst_if, teid);
+                                ip_h->ip_v, pdr->dnn, pdr->src_if, far->dst_if, header_desc.teid);
                     ogs_error("       SRC:%08X, UE:%08X",
                         be32toh(src_addr[0]), be32toh(sess->ipv4->addr[0]));
                     ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
@@ -618,7 +596,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                     /* Or source IP address should match a framed route */
                 } else {
                     ogs_error("[DROP] Source IP-%d Spoofing APN:%s SrcIf:%d DstIf:%d TEID:0x%x",
-                                ip_h->ip_v, pdr->dnn, pdr->src_if, far->dst_if, teid);
+                                ip_h->ip_v, pdr->dnn, pdr->src_if, far->dst_if, header_desc.teid);
                     ogs_error("SRC:%08x %08x %08x %08x",
                             be32toh(src_addr[0]), be32toh(src_addr[1]),
                             be32toh(src_addr[2]), be32toh(src_addr[3]));
@@ -678,7 +656,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
 
         } else if (far->dst_if == OGS_PFCP_INTERFACE_ACCESS) {
             ogs_assert(true == ogs_pfcp_up_handle_pdr(
-                        pdr, gtp_h->type, pkbuf, &report));
+                        pdr, header_desc.type, &header_desc, pkbuf, &report));
 
             if (report.type.downlink_data_report) {
                 ogs_error("Indirect Data Fowarding Buffered");
@@ -705,7 +683,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
             }
 
             ogs_assert(true == ogs_pfcp_up_handle_pdr(
-                        pdr, gtp_h->type, pkbuf, &report));
+                        pdr, header_desc.type, &header_desc, pkbuf, &report));
 
             ogs_assert(report.type.downlink_data_report == 0);
 
@@ -714,7 +692,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
             ogs_assert_if_reached();
         }
     } else {
-        ogs_error("[DROP] Invalid GTPU Type [%d]", gtp_h->type);
+        ogs_error("[DROP] Invalid GTPU Type [%d]", header_desc.type);
         ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
     }
 
@@ -895,8 +873,9 @@ static void upf_gtp_handle_multicast(ogs_pkbuf_t *recvbuf)
                     ogs_list_for_each(&sess->pfcp.pdr_list, pdr) {
                         if (pdr->src_if == OGS_PFCP_INTERFACE_CORE) {
                             ogs_assert(true ==
-                                ogs_pfcp_up_handle_pdr(pdr,
-                                    OGS_GTPU_MSGTYPE_GPDU, recvbuf, &report));
+                                ogs_pfcp_up_handle_pdr(
+                                    pdr, OGS_GTPU_MSGTYPE_GPDU,
+                                    NULL, recvbuf, &report));
                             break;
                         }
                     }

--- a/tests/common/gtpu.h
+++ b/tests/common/gtpu.h
@@ -35,8 +35,7 @@ void testgtpu_recv(test_ue_t *test_ue, ogs_pkbuf_t *pkbuf);
 
 int test_gtpu_send(
         ogs_socknode_t *node, test_bearer_t *bearer,
-        ogs_gtp2_header_t *gtp_hdesc, ogs_gtp2_extension_header_t *ext_hdesc,
-        ogs_pkbuf_t *pkbuf);
+        ogs_gtp2_header_desc_t *header_desc, ogs_pkbuf_t *pkbuf);
 int test_gtpu_send_ping(
         ogs_socknode_t *node, test_bearer_t *bearer, const char *dst_ip);
 int test_gtpu_send_slacc_rs(ogs_socknode_t *node, test_bearer_t *bearer);


### PR DESCRIPTION
Scenario is handover on S1AP, data forwarding is enabled, and the Source ENB is forwarding DL PDCP packets to EPC(SGWU) with PDCP SN included. SGWU is also forwarding these packets to the Target ENB.

However the PDCP SN is not present in the forwarded packets from SGWU to Target ENB.

I modified this part, and there was the same problem in 5GC, fixed it as well.

A lot of code in GTP-U has been modified,
so if you have any problems, please let us know right away.