### PR TITLE
[SBI] crash when enum is unknown (#2622)

### DIFF
--- a/lib/sbi/openapi/model/access_and_mobility_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_data.c
@@ -579,11 +579,17 @@ OpenAPI_access_and_mobility_data_t *OpenAPI_access_and_mobility_data_parseFromJS
         rat_typeList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_type_local, rat_type) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_type_local)) {
                 ogs_error("OpenAPI_access_and_mobility_data_parseFromJSON() failed [rat_type]");
                 goto end;
             }
-            OpenAPI_list_add(rat_typeList, (void *)OpenAPI_rat_type_FromString(rat_type_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_type_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_type_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -1142,11 +1142,17 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_restrictions_local, rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1194,11 +1200,17 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         core_network_type_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(core_network_type_restrictions_local, core_network_type_restrictions) {
+            OpenAPI_core_network_type_e localEnum = OpenAPI_core_network_type_NULL;
             if (!cJSON_IsString(core_network_type_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [core_network_type_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring));
+            localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1286,11 +1298,17 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         sor_update_indicator_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(sor_update_indicator_list_local, sor_update_indicator_list) {
+            OpenAPI_sor_update_indicator_e localEnum = OpenAPI_sor_update_indicator_NULL;
             if (!cJSON_IsString(sor_update_indicator_list_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [sor_update_indicator_list]");
                 goto end;
             }
-            OpenAPI_list_add(sor_update_indicator_listList, (void *)OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring));
+            localEnum = OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
         }
     }
 
@@ -1491,11 +1509,17 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         primary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(primary_rat_restrictions_local, primary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(primary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [primary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1510,11 +1534,17 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         secondary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(secondary_rat_restrictions_local, secondary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(secondary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [secondary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -1142,11 +1142,17 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_restrictions_local, rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1194,11 +1200,17 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         core_network_type_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(core_network_type_restrictions_local, core_network_type_restrictions) {
+            OpenAPI_core_network_type_e localEnum = OpenAPI_core_network_type_NULL;
             if (!cJSON_IsString(core_network_type_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [core_network_type_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring));
+            localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1286,11 +1298,17 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         sor_update_indicator_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(sor_update_indicator_list_local, sor_update_indicator_list) {
+            OpenAPI_sor_update_indicator_e localEnum = OpenAPI_sor_update_indicator_NULL;
             if (!cJSON_IsString(sor_update_indicator_list_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [sor_update_indicator_list]");
                 goto end;
             }
-            OpenAPI_list_add(sor_update_indicator_listList, (void *)OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring));
+            localEnum = OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
         }
     }
 
@@ -1491,11 +1509,17 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         primary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(primary_rat_restrictions_local, primary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(primary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [primary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1510,11 +1534,17 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         secondary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(secondary_rat_restrictions_local, secondary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(secondary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [secondary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/af_event_exposure_data.c
+++ b/lib/sbi/openapi/model/af_event_exposure_data.c
@@ -131,11 +131,17 @@ OpenAPI_af_event_exposure_data_t *OpenAPI_af_event_exposure_data_parseFromJSON(c
         af_eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(af_events_local, af_events) {
+            OpenAPI_af_event_e localEnum = OpenAPI_af_event_NULL;
             if (!cJSON_IsString(af_events_local)) {
                 ogs_error("OpenAPI_af_event_exposure_data_parseFromJSON() failed [af_events]");
                 goto end;
             }
-            OpenAPI_list_add(af_eventsList, (void *)OpenAPI_af_event_FromString(af_events_local->valuestring));
+            localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
 
     af_ids = cJSON_GetObjectItemCaseSensitive(af_event_exposure_dataJSON, "afIds");

--- a/lib/sbi/openapi/model/am_requested_value_rep.c
+++ b/lib/sbi/openapi/model/am_requested_value_rep.c
@@ -252,11 +252,17 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
         access_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_types_local, access_types) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_types_local)) {
                 ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [access_types]");
                 goto end;
             }
-            OpenAPI_list_add(access_typesList, (void *)OpenAPI_access_type_FromString(access_types_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -271,11 +277,17 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
         rat_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_types_local, rat_types) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_types_local)) {
                 ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [rat_types]");
                 goto end;
             }
-            OpenAPI_list_add(rat_typesList, (void *)OpenAPI_rat_type_FromString(rat_types_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/amf_event_mode.c
+++ b/lib/sbi/openapi/model/amf_event_mode.c
@@ -203,11 +203,17 @@ OpenAPI_amf_event_mode_t *OpenAPI_amf_event_mode_parseFromJSON(cJSON *amf_event_
         partitioning_criteriaList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(partitioning_criteria_local, partitioning_criteria) {
+            OpenAPI_partitioning_criteria_e localEnum = OpenAPI_partitioning_criteria_NULL;
             if (!cJSON_IsString(partitioning_criteria_local)) {
                 ogs_error("OpenAPI_amf_event_mode_parseFromJSON() failed [partitioning_criteria]");
                 goto end;
             }
-            OpenAPI_list_add(partitioning_criteriaList, (void *)OpenAPI_partitioning_criteria_FromString(partitioning_criteria_local->valuestring));
+            localEnum = OpenAPI_partitioning_criteria_FromString(partitioning_criteria_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_partitioning_criteria_FromString(partitioning_criteria_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(partitioning_criteriaList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/bsf_subscription.c
+++ b/lib/sbi/openapi/model/bsf_subscription.c
@@ -205,11 +205,17 @@ OpenAPI_bsf_subscription_t *OpenAPI_bsf_subscription_parseFromJSON(cJSON *bsf_su
         eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(events_local, events) {
+            OpenAPI_bsf_event_e localEnum = OpenAPI_bsf_event_NULL;
             if (!cJSON_IsString(events_local)) {
                 ogs_error("OpenAPI_bsf_subscription_parseFromJSON() failed [events]");
                 goto end;
             }
-            OpenAPI_list_add(eventsList, (void *)OpenAPI_bsf_event_FromString(events_local->valuestring));
+            localEnum = OpenAPI_bsf_event_FromString(events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_bsf_event_FromString(events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(eventsList, (void *)localEnum);
         }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscriptionJSON, "notifUri");

--- a/lib/sbi/openapi/model/bsf_subscription_resp.c
+++ b/lib/sbi/openapi/model/bsf_subscription_resp.c
@@ -273,11 +273,17 @@ OpenAPI_bsf_subscription_resp_t *OpenAPI_bsf_subscription_resp_parseFromJSON(cJS
         eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(events_local, events) {
+            OpenAPI_bsf_event_e localEnum = OpenAPI_bsf_event_NULL;
             if (!cJSON_IsString(events_local)) {
                 ogs_error("OpenAPI_bsf_subscription_resp_parseFromJSON() failed [events]");
                 goto end;
             }
-            OpenAPI_list_add(eventsList, (void *)OpenAPI_bsf_event_FromString(events_local->valuestring));
+            localEnum = OpenAPI_bsf_event_FromString(events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_bsf_event_FromString(events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(eventsList, (void *)localEnum);
         }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscription_respJSON, "notifUri");

--- a/lib/sbi/openapi/model/datalink_reporting_configuration.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration.c
@@ -179,11 +179,17 @@ OpenAPI_datalink_reporting_configuration_t *OpenAPI_datalink_reporting_configura
         ddd_status_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(ddd_status_list_local, ddd_status_list) {
+            OpenAPI_dl_data_delivery_status_e localEnum = OpenAPI_dl_data_delivery_status_NULL;
             if (!cJSON_IsString(ddd_status_list_local)) {
                 ogs_error("OpenAPI_datalink_reporting_configuration_parseFromJSON() failed [ddd_status_list]");
                 goto end;
             }
-            OpenAPI_list_add(ddd_status_listList, (void *)OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring));
+            localEnum = OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
@@ -179,11 +179,17 @@ OpenAPI_datalink_reporting_configuration_1_t *OpenAPI_datalink_reporting_configu
         ddd_status_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(ddd_status_list_local, ddd_status_list) {
+            OpenAPI_dl_data_delivery_status_e localEnum = OpenAPI_dl_data_delivery_status_NULL;
             if (!cJSON_IsString(ddd_status_list_local)) {
                 ogs_error("OpenAPI_datalink_reporting_configuration_1_parseFromJSON() failed [ddd_status_list]");
                 goto end;
             }
-            OpenAPI_list_add(ddd_status_listList, (void *)OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring));
+            localEnum = OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dccf_cond.c
+++ b/lib/sbi/openapi/model/dccf_cond.c
@@ -250,11 +250,17 @@ OpenAPI_dccf_cond_t *OpenAPI_dccf_cond_parseFromJSON(cJSON *dccf_condJSON)
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_dccf_cond_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dccf_info.c
+++ b/lib/sbi/openapi/model/dccf_info.c
@@ -155,11 +155,17 @@ OpenAPI_dccf_info_t *OpenAPI_dccf_info_parseFromJSON(cJSON *dccf_infoJSON)
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_dccf_info_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
+++ b/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
@@ -136,11 +136,17 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
         ssc_modesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(ssc_modes_local, ssc_modes) {
+            OpenAPI_ssc_mode_e localEnum = OpenAPI_ssc_mode_NULL;
             if (!cJSON_IsString(ssc_modes_local)) {
                 ogs_error("OpenAPI_dnn_route_selection_descriptor_parseFromJSON() failed [ssc_modes]");
                 goto end;
             }
-            OpenAPI_list_add(ssc_modesList, (void *)OpenAPI_ssc_mode_FromString(ssc_modes_local->valuestring));
+            localEnum = OpenAPI_ssc_mode_FromString(ssc_modes_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_ssc_mode_FromString(ssc_modes_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(ssc_modesList, (void *)localEnum);
         }
     }
 
@@ -155,11 +161,17 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
         pdu_sess_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pdu_sess_types_local, pdu_sess_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(pdu_sess_types_local)) {
                 ogs_error("OpenAPI_dnn_route_selection_descriptor_parseFromJSON() failed [pdu_sess_types]");
                 goto end;
             }
-            OpenAPI_list_add(pdu_sess_typesList, (void *)OpenAPI_pdu_session_type_FromString(pdu_sess_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(pdu_sess_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_sess_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pdu_sess_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_upf_info_item.c
+++ b/lib/sbi/openapi/model/dnn_upf_info_item.c
@@ -296,11 +296,17 @@ OpenAPI_dnn_upf_info_item_t *OpenAPI_dnn_upf_info_item_parseFromJSON(cJSON *dnn_
         pdu_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pdu_session_types_local, pdu_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(pdu_session_types_local)) {
                 ogs_error("OpenAPI_dnn_upf_info_item_parseFromJSON() failed [pdu_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control.c
@@ -98,11 +98,17 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
         notif_ctrl_indsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(notif_ctrl_inds_local, notif_ctrl_inds) {
+            OpenAPI_notification_control_indication_e localEnum = OpenAPI_notification_control_indication_NULL;
             if (!cJSON_IsString(notif_ctrl_inds_local)) {
                 ogs_error("OpenAPI_downlink_data_notification_control_parseFromJSON() failed [notif_ctrl_inds]");
                 goto end;
             }
-            OpenAPI_list_add(notif_ctrl_indsList, (void *)OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring));
+            localEnum = OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
         }
     }
 
@@ -117,11 +123,17 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
         types_of_notifList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(types_of_notif_local, types_of_notif) {
+            OpenAPI_dl_data_delivery_status_e localEnum = OpenAPI_dl_data_delivery_status_NULL;
             if (!cJSON_IsString(types_of_notif_local)) {
                 ogs_error("OpenAPI_downlink_data_notification_control_parseFromJSON() failed [types_of_notif]");
                 goto end;
             }
-            OpenAPI_list_add(types_of_notifList, (void *)OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring));
+            localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
@@ -98,11 +98,17 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
         notif_ctrl_indsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(notif_ctrl_inds_local, notif_ctrl_inds) {
+            OpenAPI_notification_control_indication_e localEnum = OpenAPI_notification_control_indication_NULL;
             if (!cJSON_IsString(notif_ctrl_inds_local)) {
                 ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed [notif_ctrl_inds]");
                 goto end;
             }
-            OpenAPI_list_add(notif_ctrl_indsList, (void *)OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring));
+            localEnum = OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
         }
     }
 
@@ -117,11 +123,17 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
         types_of_notifList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(types_of_notif_local, types_of_notif) {
+            OpenAPI_dl_data_delivery_status_e localEnum = OpenAPI_dl_data_delivery_status_NULL;
             if (!cJSON_IsString(types_of_notif_local)) {
                 ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed [types_of_notif]");
                 goto end;
             }
-            OpenAPI_list_add(types_of_notifList, (void *)OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring));
+            localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/error_report.c
+++ b/lib/sbi/openapi/model/error_report.c
@@ -235,11 +235,17 @@ OpenAPI_error_report_t *OpenAPI_error_report_parseFromJSON(cJSON *error_reportJS
         pol_dec_failure_reportsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pol_dec_failure_reports_local, pol_dec_failure_reports) {
+            OpenAPI_policy_decision_failure_code_e localEnum = OpenAPI_policy_decision_failure_code_NULL;
             if (!cJSON_IsString(pol_dec_failure_reports_local)) {
                 ogs_error("OpenAPI_error_report_parseFromJSON() failed [pol_dec_failure_reports]");
                 goto end;
             }
-            OpenAPI_list_add(pol_dec_failure_reportsList, (void *)OpenAPI_policy_decision_failure_code_FromString(pol_dec_failure_reports_local->valuestring));
+            localEnum = OpenAPI_policy_decision_failure_code_FromString(pol_dec_failure_reports_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_decision_failure_code_FromString(pol_dec_failure_reports_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pol_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/event_subscription.c
+++ b/lib/sbi/openapi/model/event_subscription.c
@@ -1188,11 +1188,17 @@ OpenAPI_event_subscription_t *OpenAPI_event_subscription_parseFromJSON(cJSON *ev
         nf_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(nf_types_local, nf_types) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(nf_types_local)) {
                 ogs_error("OpenAPI_event_subscription_parseFromJSON() failed [nf_types]");
                 goto end;
             }
-            OpenAPI_list_add(nf_typesList, (void *)OpenAPI_nf_type_FromString(nf_types_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(nf_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(nf_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_put_data.c
+++ b/lib/sbi/openapi/model/events_subsc_put_data.c
@@ -817,11 +817,17 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
         req_qos_mon_paramsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_qos_mon_params_local, req_qos_mon_params) {
+            OpenAPI_requested_qos_monitoring_parameter_e localEnum = OpenAPI_requested_qos_monitoring_parameter_NULL;
             if (!cJSON_IsString(req_qos_mon_params_local)) {
                 ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed [req_qos_mon_params]");
                 goto end;
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring));
+            localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -845,11 +851,17 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
         req_anisList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_anis_local, req_anis) {
+            OpenAPI_required_access_info_e localEnum = OpenAPI_required_access_info_NULL;
             if (!cJSON_IsString(req_anis_local)) {
                 ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed [req_anis]");
                 goto end;
             }
-            OpenAPI_list_add(req_anisList, (void *)OpenAPI_required_access_info_FromString(req_anis_local->valuestring));
+            localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data.c
@@ -268,11 +268,17 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
         req_qos_mon_paramsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_qos_mon_params_local, req_qos_mon_params) {
+            OpenAPI_requested_qos_monitoring_parameter_e localEnum = OpenAPI_requested_qos_monitoring_parameter_NULL;
             if (!cJSON_IsString(req_qos_mon_params_local)) {
                 ogs_error("OpenAPI_events_subsc_req_data_parseFromJSON() failed [req_qos_mon_params]");
                 goto end;
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring));
+            localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -296,11 +302,17 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
         req_anisList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_anis_local, req_anis) {
+            OpenAPI_required_access_info_e localEnum = OpenAPI_required_access_info_NULL;
             if (!cJSON_IsString(req_anis_local)) {
                 ogs_error("OpenAPI_events_subsc_req_data_parseFromJSON() failed [req_anis]");
                 goto end;
             }
-            OpenAPI_list_add(req_anisList, (void *)OpenAPI_required_access_info_FromString(req_anis_local->valuestring));
+            localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data_rm.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data_rm.c
@@ -243,11 +243,17 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
         req_qos_mon_paramsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_qos_mon_params_local, req_qos_mon_params) {
+            OpenAPI_requested_qos_monitoring_parameter_e localEnum = OpenAPI_requested_qos_monitoring_parameter_NULL;
             if (!cJSON_IsString(req_qos_mon_params_local)) {
                 ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON() failed [req_qos_mon_params]");
                 goto end;
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring));
+            localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -271,11 +277,17 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
         req_anisList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_anis_local, req_anis) {
+            OpenAPI_required_access_info_e localEnum = OpenAPI_required_access_info_NULL;
             if (!cJSON_IsString(req_anis_local)) {
                 ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON() failed [req_anis]");
                 goto end;
             }
-            OpenAPI_list_add(req_anisList, (void *)OpenAPI_required_access_info_FromString(req_anis_local->valuestring));
+            localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/immediate_mdt_conf.c
+++ b/lib/sbi/openapi/model/immediate_mdt_conf.c
@@ -361,11 +361,17 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
         measurement_lte_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_lte_list_local, measurement_lte_list) {
+            OpenAPI_measurement_lte_for_mdt_e localEnum = OpenAPI_measurement_lte_for_mdt_NULL;
             if (!cJSON_IsString(measurement_lte_list_local)) {
                 ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed [measurement_lte_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring));
+            localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -380,11 +386,17 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
         measurement_nr_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_nr_list_local, measurement_nr_list) {
+            OpenAPI_measurement_nr_for_mdt_e localEnum = OpenAPI_measurement_nr_for_mdt_NULL;
             if (!cJSON_IsString(measurement_nr_list_local)) {
                 ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed [measurement_nr_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring));
+            localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -399,11 +411,17 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
         reporting_trigger_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(reporting_trigger_list_local, reporting_trigger_list) {
+            OpenAPI_reporting_trigger_e localEnum = OpenAPI_reporting_trigger_NULL;
             if (!cJSON_IsString(reporting_trigger_list_local)) {
                 ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed [reporting_trigger_list]");
                 goto end;
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring));
+            localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -522,11 +540,17 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
         add_positioning_method_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(add_positioning_method_list_local, add_positioning_method_list) {
+            OpenAPI_positioning_method_mdt_e localEnum = OpenAPI_positioning_method_mdt_NULL;
             if (!cJSON_IsString(add_positioning_method_list_local)) {
                 ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed [add_positioning_method_list]");
                 goto end;
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring));
+            localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 
@@ -565,11 +589,17 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
         sensor_measurement_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(sensor_measurement_list_local, sensor_measurement_list) {
+            OpenAPI_sensor_measurement_e localEnum = OpenAPI_sensor_measurement_NULL;
             if (!cJSON_IsString(sensor_measurement_list_local)) {
                 ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed [sensor_measurement_list]");
                 goto end;
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring));
+            localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/lcs_mo_data.c
+++ b/lib/sbi/openapi/model/lcs_mo_data.c
@@ -102,11 +102,17 @@ OpenAPI_lcs_mo_data_t *OpenAPI_lcs_mo_data_parseFromJSON(cJSON *lcs_mo_dataJSON)
         allowed_service_classesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_service_classes_local, allowed_service_classes) {
+            OpenAPI_lcs_mo_service_class_e localEnum = OpenAPI_lcs_mo_service_class_NULL;
             if (!cJSON_IsString(allowed_service_classes_local)) {
                 ogs_error("OpenAPI_lcs_mo_data_parseFromJSON() failed [allowed_service_classes]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_service_classesList, (void *)OpenAPI_lcs_mo_service_class_FromString(allowed_service_classes_local->valuestring));
+            localEnum = OpenAPI_lcs_mo_service_class_FromString(allowed_service_classes_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_lcs_mo_service_class_FromString(allowed_service_classes_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_service_classesList, (void *)localEnum);
         }
 
     mo_assistance_data_types = cJSON_GetObjectItemCaseSensitive(lcs_mo_dataJSON, "moAssistanceDataTypes");

--- a/lib/sbi/openapi/model/lmf_info.c
+++ b/lib/sbi/openapi/model/lmf_info.c
@@ -274,11 +274,17 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
         serving_access_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_access_types_local, serving_access_types) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(serving_access_types_local)) {
                 ogs_error("OpenAPI_lmf_info_parseFromJSON() failed [serving_access_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_access_typesList, (void *)OpenAPI_access_type_FromString(serving_access_types_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(serving_access_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(serving_access_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
         }
     }
 
@@ -293,11 +299,17 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
         serving_an_node_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_an_node_types_local, serving_an_node_types) {
+            OpenAPI_an_node_type_e localEnum = OpenAPI_an_node_type_NULL;
             if (!cJSON_IsString(serving_an_node_types_local)) {
                 ogs_error("OpenAPI_lmf_info_parseFromJSON() failed [serving_an_node_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_an_node_typesList, (void *)OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring));
+            localEnum = OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
         }
     }
 
@@ -312,11 +324,17 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
         serving_rat_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_rat_types_local, serving_rat_types) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(serving_rat_types_local)) {
                 ogs_error("OpenAPI_lmf_info_parseFromJSON() failed [serving_rat_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_rat_typesList, (void *)OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration.c
+++ b/lib/sbi/openapi/model/mdt_configuration.c
@@ -510,11 +510,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         measurement_lte_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_lte_list_local, measurement_lte_list) {
+            OpenAPI_measurement_lte_for_mdt_e localEnum = OpenAPI_measurement_lte_for_mdt_NULL;
             if (!cJSON_IsString(measurement_lte_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [measurement_lte_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring));
+            localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -529,11 +535,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         measurement_nr_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_nr_list_local, measurement_nr_list) {
+            OpenAPI_measurement_nr_for_mdt_e localEnum = OpenAPI_measurement_nr_for_mdt_NULL;
             if (!cJSON_IsString(measurement_nr_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [measurement_nr_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring));
+            localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -548,11 +560,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         sensor_measurement_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(sensor_measurement_list_local, sensor_measurement_list) {
+            OpenAPI_sensor_measurement_e localEnum = OpenAPI_sensor_measurement_NULL;
             if (!cJSON_IsString(sensor_measurement_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [sensor_measurement_list]");
                 goto end;
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring));
+            localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 
@@ -567,11 +585,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         reporting_trigger_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(reporting_trigger_list_local, reporting_trigger_list) {
+            OpenAPI_reporting_trigger_e localEnum = OpenAPI_reporting_trigger_NULL;
             if (!cJSON_IsString(reporting_trigger_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [reporting_trigger_list]");
                 goto end;
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring));
+            localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -645,11 +669,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         event_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(event_list_local, event_list) {
+            OpenAPI_event_for_mdt_e localEnum = OpenAPI_event_for_mdt_NULL;
             if (!cJSON_IsString(event_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [event_list]");
                 goto end;
             }
-            OpenAPI_list_add(event_listList, (void *)OpenAPI_event_for_mdt_FromString(event_list_local->valuestring));
+            localEnum = OpenAPI_event_for_mdt_FromString(event_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_event_for_mdt_FromString(event_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(event_listList, (void *)localEnum);
         }
     }
 
@@ -709,11 +739,17 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
         add_positioning_method_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(add_positioning_method_list_local, add_positioning_method_list) {
+            OpenAPI_positioning_method_mdt_e localEnum = OpenAPI_positioning_method_mdt_NULL;
             if (!cJSON_IsString(add_positioning_method_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [add_positioning_method_list]");
                 goto end;
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring));
+            localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration_1.c
+++ b/lib/sbi/openapi/model/mdt_configuration_1.c
@@ -510,11 +510,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         measurement_lte_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_lte_list_local, measurement_lte_list) {
+            OpenAPI_measurement_lte_for_mdt_e localEnum = OpenAPI_measurement_lte_for_mdt_NULL;
             if (!cJSON_IsString(measurement_lte_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [measurement_lte_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring));
+            localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -529,11 +535,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         measurement_nr_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(measurement_nr_list_local, measurement_nr_list) {
+            OpenAPI_measurement_nr_for_mdt_e localEnum = OpenAPI_measurement_nr_for_mdt_NULL;
             if (!cJSON_IsString(measurement_nr_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [measurement_nr_list]");
                 goto end;
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring));
+            localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -548,11 +560,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         sensor_measurement_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(sensor_measurement_list_local, sensor_measurement_list) {
+            OpenAPI_sensor_measurement_e localEnum = OpenAPI_sensor_measurement_NULL;
             if (!cJSON_IsString(sensor_measurement_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [sensor_measurement_list]");
                 goto end;
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring));
+            localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 
@@ -567,11 +585,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         reporting_trigger_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(reporting_trigger_list_local, reporting_trigger_list) {
+            OpenAPI_reporting_trigger_e localEnum = OpenAPI_reporting_trigger_NULL;
             if (!cJSON_IsString(reporting_trigger_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [reporting_trigger_list]");
                 goto end;
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring));
+            localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -645,11 +669,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         event_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(event_list_local, event_list) {
+            OpenAPI_event_for_mdt_e localEnum = OpenAPI_event_for_mdt_NULL;
             if (!cJSON_IsString(event_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [event_list]");
                 goto end;
             }
-            OpenAPI_list_add(event_listList, (void *)OpenAPI_event_for_mdt_FromString(event_list_local->valuestring));
+            localEnum = OpenAPI_event_for_mdt_FromString(event_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_event_for_mdt_FromString(event_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(event_listList, (void *)localEnum);
         }
     }
 
@@ -709,11 +739,17 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
         add_positioning_method_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(add_positioning_method_list_local, add_positioning_method_list) {
+            OpenAPI_positioning_method_mdt_e localEnum = OpenAPI_positioning_method_mdt_NULL;
             if (!cJSON_IsString(add_positioning_method_list_local)) {
                 ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [add_positioning_method_list]");
                 goto end;
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring));
+            localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mfaf_info.c
+++ b/lib/sbi/openapi/model/mfaf_info.c
@@ -155,11 +155,17 @@ OpenAPI_mfaf_info_t *OpenAPI_mfaf_info_parseFromJSON(cJSON *mfaf_infoJSON)
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_mfaf_info_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/model_5_gvn_group_data.c
+++ b/lib/sbi/openapi/model/model_5_gvn_group_data.c
@@ -249,11 +249,17 @@ OpenAPI_model_5_gvn_group_data_t *OpenAPI_model_5_gvn_group_data_parseFromJSON(c
         pdu_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pdu_session_types_local, pdu_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(pdu_session_types_local)) {
                 ogs_error("OpenAPI_model_5_gvn_group_data_parseFromJSON() failed [pdu_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nef_cond.c
+++ b/lib/sbi/openapi/model/nef_cond.c
@@ -250,11 +250,17 @@ OpenAPI_nef_cond_t *OpenAPI_nef_cond_parseFromJSON(cJSON *nef_condJSON)
         af_eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(af_events_local, af_events) {
+            OpenAPI_af_event_e localEnum = OpenAPI_af_event_NULL;
             if (!cJSON_IsString(af_events_local)) {
                 ogs_error("OpenAPI_nef_cond_parseFromJSON() failed [af_events]");
                 goto end;
             }
-            OpenAPI_list_add(af_eventsList, (void *)OpenAPI_af_event_FromString(af_events_local->valuestring));
+            localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nf_profile.c
+++ b/lib/sbi/openapi/model/nf_profile.c
@@ -2610,11 +2610,17 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
         allowed_nf_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_nf_types_local, allowed_nf_types) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(allowed_nf_types_local)) {
                 ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [allowed_nf_types]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_nf_typesList, (void *)OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nf_service.c
+++ b/lib/sbi/openapi/model/nf_service.c
@@ -873,11 +873,17 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
         allowed_nf_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_nf_types_local, allowed_nf_types) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(allowed_nf_types_local)) {
                 ogs_error("OpenAPI_nf_service_parseFromJSON() failed [allowed_nf_types]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_nf_typesList, (void *)OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
+++ b/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
@@ -184,11 +184,17 @@ OpenAPI_non_ue_n2_info_subscription_create_data_t *OpenAPI_non_ue_n2_info_subscr
         an_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(an_type_list_local, an_type_list) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(an_type_list_local)) {
                 ogs_error("OpenAPI_non_ue_n2_info_subscription_create_data_parseFromJSON() failed [an_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(an_type_listList, (void *)OpenAPI_access_type_FromString(an_type_list_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(an_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(an_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(an_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
@@ -274,11 +274,17 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
         serving_access_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_access_types_local, serving_access_types) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(serving_access_types_local)) {
                 ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed [serving_access_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_access_typesList, (void *)OpenAPI_access_type_FromString(serving_access_types_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(serving_access_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(serving_access_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
         }
     }
 
@@ -293,11 +299,17 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
         serving_an_node_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_an_node_types_local, serving_an_node_types) {
+            OpenAPI_an_node_type_e localEnum = OpenAPI_an_node_type_NULL;
             if (!cJSON_IsString(serving_an_node_types_local)) {
                 ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed [serving_an_node_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_an_node_typesList, (void *)OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring));
+            localEnum = OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
         }
     }
 
@@ -312,11 +324,17 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
         serving_rat_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_rat_types_local, serving_rat_types) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(serving_rat_types_local)) {
                 ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed [serving_rat_types]");
                 goto end;
             }
-            OpenAPI_list_add(serving_rat_typesList, (void *)OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
@@ -403,11 +403,17 @@ OpenAPI_nrf_info_served_nwdaf_info_value_t *OpenAPI_nrf_info_served_nwdaf_info_v
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_nrf_info_served_nwdaf_info_value_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
@@ -283,11 +283,17 @@ OpenAPI_nrf_info_served_pcscf_info_list_value_value_t *OpenAPI_nrf_info_served_p
         access_typeList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_type_local, access_type) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_type_local)) {
                 ogs_error("OpenAPI_nrf_info_served_pcscf_info_list_value_value_parseFromJSON() failed [access_type]");
                 goto end;
             }
-            OpenAPI_list_add(access_typeList, (void *)OpenAPI_access_type_FromString(access_type_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
@@ -650,11 +650,17 @@ OpenAPI_nrf_info_served_scp_info_list_value_t *OpenAPI_nrf_info_served_scp_info_
         scp_capabilitiesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(scp_capabilities_local, scp_capabilities) {
+            OpenAPI_scp_capability_e localEnum = OpenAPI_scp_capability_NULL;
             if (!cJSON_IsString(scp_capabilities_local)) {
                 ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_parseFromJSON() failed [scp_capabilities]");
                 goto end;
             }
-            OpenAPI_list_add(scp_capabilitiesList, (void *)OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring));
+            localEnum = OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
@@ -391,11 +391,17 @@ OpenAPI_nrf_info_served_smf_info_value_t *OpenAPI_nrf_info_served_smf_info_value
         access_typeList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_type_local, access_type) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_type_local)) {
                 ogs_error("OpenAPI_nrf_info_served_smf_info_value_parseFromJSON() failed [access_type]");
                 goto end;
             }
-            OpenAPI_list_add(access_typeList, (void *)OpenAPI_access_type_FromString(access_type_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
@@ -278,11 +278,17 @@ OpenAPI_nrf_info_served_udr_info_value_t *OpenAPI_nrf_info_served_udr_info_value
         supported_data_setsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(supported_data_sets_local, supported_data_sets) {
+            OpenAPI_data_set_id_e localEnum = OpenAPI_data_set_id_NULL;
             if (!cJSON_IsString(supported_data_sets_local)) {
                 ogs_error("OpenAPI_nrf_info_served_udr_info_value_parseFromJSON() failed [supported_data_sets]");
                 goto end;
             }
-            OpenAPI_list_add(supported_data_setsList, (void *)OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring));
+            localEnum = OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
@@ -460,11 +460,17 @@ OpenAPI_nrf_info_served_upf_info_value_t *OpenAPI_nrf_info_served_upf_info_value
         pdu_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pdu_session_types_local, pdu_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(pdu_session_types_local)) {
                 ogs_error("OpenAPI_nrf_info_served_upf_info_value_parseFromJSON() failed [pdu_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nwdaf_cond.c
+++ b/lib/sbi/openapi/model/nwdaf_cond.c
@@ -374,11 +374,17 @@ OpenAPI_nwdaf_cond_t *OpenAPI_nwdaf_cond_parseFromJSON(cJSON *nwdaf_condJSON)
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_nwdaf_cond_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nwdaf_info.c
+++ b/lib/sbi/openapi/model/nwdaf_info.c
@@ -403,11 +403,17 @@ OpenAPI_nwdaf_info_t *OpenAPI_nwdaf_info_parseFromJSON(cJSON *nwdaf_infoJSON)
         serving_nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(serving_nf_type_list_local, serving_nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(serving_nf_type_list_local)) {
                 ogs_error("OpenAPI_nwdaf_info_parseFromJSON() failed [serving_nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/partial_success_report.c
+++ b/lib/sbi/openapi/model/partial_success_report.c
@@ -259,11 +259,17 @@ OpenAPI_partial_success_report_t *OpenAPI_partial_success_report_parseFromJSON(c
         policy_dec_failure_reportsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(policy_dec_failure_reports_local, policy_dec_failure_reports) {
+            OpenAPI_policy_decision_failure_code_e localEnum = OpenAPI_policy_decision_failure_code_NULL;
             if (!cJSON_IsString(policy_dec_failure_reports_local)) {
                 ogs_error("OpenAPI_partial_success_report_parseFromJSON() failed [policy_dec_failure_reports]");
                 goto end;
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring));
+            localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pcscf_info.c
+++ b/lib/sbi/openapi/model/pcscf_info.c
@@ -283,11 +283,17 @@ OpenAPI_pcscf_info_t *OpenAPI_pcscf_info_parseFromJSON(cJSON *pcscf_infoJSON)
         access_typeList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_type_local, access_type) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_type_local)) {
                 ogs_error("OpenAPI_pcscf_info_parseFromJSON() failed [access_type]");
                 goto end;
             }
-            OpenAPI_list_add(access_typeList, (void *)OpenAPI_access_type_FromString(access_type_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pdu_session_types.c
+++ b/lib/sbi/openapi/model/pdu_session_types.c
@@ -96,11 +96,17 @@ OpenAPI_pdu_session_types_t *OpenAPI_pdu_session_types_parseFromJSON(cJSON *pdu_
         allowed_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_session_types_local, allowed_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(allowed_session_types_local)) {
                 ogs_error("OpenAPI_pdu_session_types_parseFromJSON() failed [allowed_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pdu_session_types_1.c
+++ b/lib/sbi/openapi/model/pdu_session_types_1.c
@@ -96,11 +96,17 @@ OpenAPI_pdu_session_types_1_t *OpenAPI_pdu_session_types_1_parseFromJSON(cJSON *
         allowed_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_session_types_local, allowed_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(allowed_session_types_local)) {
                 ogs_error("OpenAPI_pdu_session_types_1_parseFromJSON() failed [allowed_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction.c
+++ b/lib/sbi/openapi/model/plmn_restriction.c
@@ -190,11 +190,17 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
         rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_restrictions_local, rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed [rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -242,11 +248,17 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
         core_network_type_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(core_network_type_restrictions_local, core_network_type_restrictions) {
+            OpenAPI_core_network_type_e localEnum = OpenAPI_core_network_type_NULL;
             if (!cJSON_IsString(core_network_type_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed [core_network_type_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring));
+            localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -261,11 +273,17 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
         primary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(primary_rat_restrictions_local, primary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(primary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed [primary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -280,11 +298,17 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
         secondary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(secondary_rat_restrictions_local, secondary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(secondary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed [secondary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction_1.c
+++ b/lib/sbi/openapi/model/plmn_restriction_1.c
@@ -190,11 +190,17 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
         rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_restrictions_local, rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed [rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -242,11 +248,17 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
         core_network_type_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(core_network_type_restrictions_local, core_network_type_restrictions) {
+            OpenAPI_core_network_type_e localEnum = OpenAPI_core_network_type_NULL;
             if (!cJSON_IsString(core_network_type_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed [core_network_type_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring));
+            localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -261,11 +273,17 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
         primary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(primary_rat_restrictions_local, primary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(primary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed [primary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -280,11 +298,17 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
         secondary_rat_restrictionsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(secondary_rat_restrictions_local, secondary_rat_restrictions) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(secondary_rat_restrictions_local)) {
                 ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed [secondary_rat_restrictions]");
                 goto end;
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -370,11 +370,17 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
         triggersList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(triggers_local, triggers) {
+            OpenAPI_request_trigger_e localEnum = OpenAPI_request_trigger_NULL;
             if (!cJSON_IsString(triggers_local)) {
                 ogs_error("OpenAPI_policy_association_parseFromJSON() failed [triggers]");
                 goto end;
             }
-            OpenAPI_list_add(triggersList, (void *)OpenAPI_request_trigger_FromString(triggers_local->valuestring));
+            localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_request.c
+++ b/lib/sbi/openapi/model/policy_association_request.c
@@ -745,11 +745,17 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
         access_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_types_local, access_types) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_types_local)) {
                 ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [access_types]");
                 goto end;
             }
-            OpenAPI_list_add(access_typesList, (void *)OpenAPI_access_type_FromString(access_types_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -807,11 +813,17 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
         rat_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_types_local, rat_types) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_types_local)) {
                 ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [rat_types]");
                 goto end;
             }
-            OpenAPI_list_add(rat_typesList, (void *)OpenAPI_rat_type_FromString(rat_types_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -645,11 +645,17 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
         triggersList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(triggers_local, triggers) {
+            OpenAPI_request_trigger_e localEnum = OpenAPI_request_trigger_NULL;
             if (!cJSON_IsString(triggers_local)) {
                 ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [triggers]");
                 goto end;
             }
-            OpenAPI_list_add(triggersList, (void *)OpenAPI_request_trigger_FromString(triggers_local->valuestring));
+            localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 
@@ -839,11 +845,17 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
         access_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_types_local, access_types) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_types_local)) {
                 ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [access_types]");
                 goto end;
             }
-            OpenAPI_list_add(access_typesList, (void *)OpenAPI_access_type_FromString(access_types_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -858,11 +870,17 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
         rat_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rat_types_local, rat_types) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(rat_types_local)) {
                 ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [rat_types]");
                 goto end;
             }
-            OpenAPI_list_add(rat_typesList, (void *)OpenAPI_rat_type_FromString(rat_types_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -350,11 +350,17 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
         triggersList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(triggers_local, triggers) {
+            OpenAPI_request_trigger_e localEnum = OpenAPI_request_trigger_NULL;
             if (!cJSON_IsString(triggers_local)) {
                 ogs_error("OpenAPI_policy_update_parseFromJSON() failed [triggers]");
                 goto end;
             }
-            OpenAPI_list_add(triggersList, (void *)OpenAPI_request_trigger_FromString(triggers_local->valuestring));
+            localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pro_se_allowed_plmn.c
+++ b/lib/sbi/openapi/model/pro_se_allowed_plmn.c
@@ -110,11 +110,17 @@ OpenAPI_pro_se_allowed_plmn_t *OpenAPI_pro_se_allowed_plmn_parseFromJSON(cJSON *
         prose_direct_allowedList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(prose_direct_allowed_local, prose_direct_allowed) {
+            OpenAPI_prose_direct_allowed_e localEnum = OpenAPI_prose_direct_allowed_NULL;
             if (!cJSON_IsString(prose_direct_allowed_local)) {
                 ogs_error("OpenAPI_pro_se_allowed_plmn_parseFromJSON() failed [prose_direct_allowed]");
                 goto end;
             }
-            OpenAPI_list_add(prose_direct_allowedList, (void *)OpenAPI_prose_direct_allowed_FromString(prose_direct_allowed_local->valuestring));
+            localEnum = OpenAPI_prose_direct_allowed_FromString(prose_direct_allowed_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_prose_direct_allowed_FromString(prose_direct_allowed_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(prose_direct_allowedList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/protection_policy.c
+++ b/lib/sbi/openapi/model/protection_policy.c
@@ -131,11 +131,17 @@ OpenAPI_protection_policy_t *OpenAPI_protection_policy_parseFromJSON(cJSON *prot
         data_type_enc_policyList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(data_type_enc_policy_local, data_type_enc_policy) {
+            OpenAPI_ie_type_e localEnum = OpenAPI_ie_type_NULL;
             if (!cJSON_IsString(data_type_enc_policy_local)) {
                 ogs_error("OpenAPI_protection_policy_parseFromJSON() failed [data_type_enc_policy]");
                 goto end;
             }
-            OpenAPI_list_add(data_type_enc_policyList, (void *)OpenAPI_ie_type_FromString(data_type_enc_policy_local->valuestring));
+            localEnum = OpenAPI_ie_type_FromString(data_type_enc_policy_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_ie_type_FromString(data_type_enc_policy_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(data_type_enc_policyList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/qos_monitoring_data.c
+++ b/lib/sbi/openapi/model/qos_monitoring_data.c
@@ -231,11 +231,17 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
         req_qos_mon_paramsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_qos_mon_params_local, req_qos_mon_params) {
+            OpenAPI_requested_qos_monitoring_parameter_e localEnum = OpenAPI_requested_qos_monitoring_parameter_NULL;
             if (!cJSON_IsString(req_qos_mon_params_local)) {
                 ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [req_qos_mon_params]");
                 goto end;
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring));
+            localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
 
     rep_freqs = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repFreqs");
@@ -252,11 +258,17 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
         rep_freqsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rep_freqs_local, rep_freqs) {
+            OpenAPI_reporting_frequency_e localEnum = OpenAPI_reporting_frequency_NULL;
             if (!cJSON_IsString(rep_freqs_local)) {
                 ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [rep_freqs]");
                 goto end;
             }
-            OpenAPI_list_add(rep_freqsList, (void *)OpenAPI_reporting_frequency_FromString(rep_freqs_local->valuestring));
+            localEnum = OpenAPI_reporting_frequency_FromString(rep_freqs_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_reporting_frequency_FromString(rep_freqs_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rep_freqsList, (void *)localEnum);
         }
 
     rep_thresh_dl = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshDl");

--- a/lib/sbi/openapi/model/registration_location_info.c
+++ b/lib/sbi/openapi/model/registration_location_info.c
@@ -197,11 +197,17 @@ OpenAPI_registration_location_info_t *OpenAPI_registration_location_info_parseFr
         access_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_type_list_local, access_type_list) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_type_list_local)) {
                 ogs_error("OpenAPI_registration_location_info_parseFromJSON() failed [access_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(access_type_listList, (void *)OpenAPI_access_type_FromString(access_type_list_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_type_listList, (void *)localEnum);
         }
 
     registration_location_info_local_var = OpenAPI_registration_location_info_create (

--- a/lib/sbi/openapi/model/reporting_information.c
+++ b/lib/sbi/openapi/model/reporting_information.c
@@ -231,11 +231,17 @@ OpenAPI_reporting_information_t *OpenAPI_reporting_information_parseFromJSON(cJS
         partition_criteriaList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(partition_criteria_local, partition_criteria) {
+            OpenAPI_partitioning_criteria_e localEnum = OpenAPI_partitioning_criteria_NULL;
             if (!cJSON_IsString(partition_criteria_local)) {
                 ogs_error("OpenAPI_reporting_information_parseFromJSON() failed [partition_criteria]");
                 goto end;
             }
-            OpenAPI_list_add(partition_criteriaList, (void *)OpenAPI_partitioning_criteria_FromString(partition_criteria_local->valuestring));
+            localEnum = OpenAPI_partitioning_criteria_FromString(partition_criteria_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_partitioning_criteria_FromString(partition_criteria_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(partition_criteriaList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/requested_rule_data.c
+++ b/lib/sbi/openapi/model/requested_rule_data.c
@@ -131,11 +131,17 @@ OpenAPI_requested_rule_data_t *OpenAPI_requested_rule_data_parseFromJSON(cJSON *
         req_dataList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_data_local, req_data) {
+            OpenAPI_requested_rule_data_type_e localEnum = OpenAPI_requested_rule_data_type_NULL;
             if (!cJSON_IsString(req_data_local)) {
                 ogs_error("OpenAPI_requested_rule_data_parseFromJSON() failed [req_data]");
                 goto end;
             }
-            OpenAPI_list_add(req_dataList, (void *)OpenAPI_requested_rule_data_type_FromString(req_data_local->valuestring));
+            localEnum = OpenAPI_requested_rule_data_type_FromString(req_data_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_requested_rule_data_type_FromString(req_data_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_dataList, (void *)localEnum);
         }
 
     requested_rule_data_local_var = OpenAPI_requested_rule_data_create (

--- a/lib/sbi/openapi/model/scp_domain_cond.c
+++ b/lib/sbi/openapi/model/scp_domain_cond.c
@@ -126,11 +126,17 @@ OpenAPI_scp_domain_cond_t *OpenAPI_scp_domain_cond_parseFromJSON(cJSON *scp_doma
         nf_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(nf_type_list_local, nf_type_list) {
+            OpenAPI_nf_type_e localEnum = OpenAPI_nf_type_NULL;
             if (!cJSON_IsString(nf_type_list_local)) {
                 ogs_error("OpenAPI_scp_domain_cond_parseFromJSON() failed [nf_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(nf_type_listList, (void *)OpenAPI_nf_type_FromString(nf_type_list_local->valuestring));
+            localEnum = OpenAPI_nf_type_FromString(nf_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_nf_type_FromString(nf_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/scp_info.c
+++ b/lib/sbi/openapi/model/scp_info.c
@@ -650,11 +650,17 @@ OpenAPI_scp_info_t *OpenAPI_scp_info_parseFromJSON(cJSON *scp_infoJSON)
         scp_capabilitiesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(scp_capabilities_local, scp_capabilities) {
+            OpenAPI_scp_capability_e localEnum = OpenAPI_scp_capability_NULL;
             if (!cJSON_IsString(scp_capabilities_local)) {
                 ogs_error("OpenAPI_scp_info_parseFromJSON() failed [scp_capabilities]");
                 goto end;
             }
-            OpenAPI_list_add(scp_capabilitiesList, (void *)OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring));
+            localEnum = OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/sec_negotiate_req_data.c
+++ b/lib/sbi/openapi/model/sec_negotiate_req_data.c
@@ -256,11 +256,17 @@ OpenAPI_sec_negotiate_req_data_t *OpenAPI_sec_negotiate_req_data_parseFromJSON(c
         supported_sec_capability_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(supported_sec_capability_list_local, supported_sec_capability_list) {
+            OpenAPI_security_capability_e localEnum = OpenAPI_security_capability_NULL;
             if (!cJSON_IsString(supported_sec_capability_list_local)) {
                 ogs_error("OpenAPI_sec_negotiate_req_data_parseFromJSON() failed [supported_sec_capability_list]");
                 goto end;
             }
-            OpenAPI_list_add(supported_sec_capability_listList, (void *)OpenAPI_security_capability_FromString(supported_sec_capability_list_local->valuestring));
+            localEnum = OpenAPI_security_capability_FromString(supported_sec_capability_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_security_capability_FromString(supported_sec_capability_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(supported_sec_capability_listList, (void *)localEnum);
         }
 
     _3_gpp_sbi_target_api_root_supported = cJSON_GetObjectItemCaseSensitive(sec_negotiate_req_dataJSON, "3GppSbiTargetApiRootSupported");

--- a/lib/sbi/openapi/model/session_rule_report.c
+++ b/lib/sbi/openapi/model/session_rule_report.c
@@ -170,11 +170,17 @@ OpenAPI_session_rule_report_t *OpenAPI_session_rule_report_parseFromJSON(cJSON *
         policy_dec_failure_reportsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(policy_dec_failure_reports_local, policy_dec_failure_reports) {
+            OpenAPI_policy_decision_failure_code_e localEnum = OpenAPI_policy_decision_failure_code_NULL;
             if (!cJSON_IsString(policy_dec_failure_reports_local)) {
                 ogs_error("OpenAPI_session_rule_report_parseFromJSON() failed [policy_dec_failure_reports]");
                 goto end;
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring));
+            localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -1091,11 +1091,17 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
         policy_ctrl_req_triggersList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(policy_ctrl_req_triggers_local, policy_ctrl_req_triggers) {
+            OpenAPI_policy_control_request_trigger_e localEnum = OpenAPI_policy_control_request_trigger_NULL;
             if (!cJSON_IsString(policy_ctrl_req_triggers_local)) {
                 ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [policy_ctrl_req_triggers]");
                 goto end;
             }
-            OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)OpenAPI_policy_control_request_trigger_FromString(policy_ctrl_req_triggers_local->valuestring));
+            localEnum = OpenAPI_policy_control_request_trigger_FromString(policy_ctrl_req_triggers_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_control_request_trigger_FromString(policy_ctrl_req_triggers_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -1126,11 +1126,17 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
         rep_policy_ctrl_req_triggersList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(rep_policy_ctrl_req_triggers_local, rep_policy_ctrl_req_triggers) {
+            OpenAPI_policy_control_request_trigger_e localEnum = OpenAPI_policy_control_request_trigger_NULL;
             if (!cJSON_IsString(rep_policy_ctrl_req_triggers_local)) {
                 ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [rep_policy_ctrl_req_triggers]");
                 goto end;
             }
-            OpenAPI_list_add(rep_policy_ctrl_req_triggersList, (void *)OpenAPI_policy_control_request_trigger_FromString(rep_policy_ctrl_req_triggers_local->valuestring));
+            localEnum = OpenAPI_policy_control_request_trigger_FromString(rep_policy_ctrl_req_triggers_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_control_request_trigger_FromString(rep_policy_ctrl_req_triggers_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(rep_policy_ctrl_req_triggersList, (void *)localEnum);
         }
     }
 
@@ -1686,11 +1692,17 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
         policy_dec_failure_reportsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(policy_dec_failure_reports_local, policy_dec_failure_reports) {
+            OpenAPI_policy_decision_failure_code_e localEnum = OpenAPI_policy_decision_failure_code_NULL;
             if (!cJSON_IsString(policy_dec_failure_reports_local)) {
                 ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [policy_dec_failure_reports]");
                 goto end;
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring));
+            localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 
@@ -1761,11 +1773,17 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
         types_of_notifList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(types_of_notif_local, types_of_notif) {
+            OpenAPI_dl_data_delivery_status_e localEnum = OpenAPI_dl_data_delivery_status_NULL;
             if (!cJSON_IsString(types_of_notif_local)) {
                 ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [types_of_notif]");
                 goto end;
             }
-            OpenAPI_list_add(types_of_notifList, (void *)OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring));
+            localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/smf_info.c
+++ b/lib/sbi/openapi/model/smf_info.c
@@ -391,11 +391,17 @@ OpenAPI_smf_info_t *OpenAPI_smf_info_parseFromJSON(cJSON *smf_infoJSON)
         access_typeList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(access_type_local, access_type) {
+            OpenAPI_access_type_e localEnum = OpenAPI_access_type_NULL;
             if (!cJSON_IsString(access_type_local)) {
                 ogs_error("OpenAPI_smf_info_parseFromJSON() failed [access_type]");
                 goto end;
             }
-            OpenAPI_list_add(access_typeList, (void *)OpenAPI_access_type_FromString(access_type_local->valuestring));
+            localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ssc_modes.c
+++ b/lib/sbi/openapi/model/ssc_modes.c
@@ -100,11 +100,17 @@ OpenAPI_ssc_modes_t *OpenAPI_ssc_modes_parseFromJSON(cJSON *ssc_modesJSON)
         allowed_ssc_modesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_ssc_modes_local, allowed_ssc_modes) {
+            OpenAPI_ssc_mode_e localEnum = OpenAPI_ssc_mode_NULL;
             if (!cJSON_IsString(allowed_ssc_modes_local)) {
                 ogs_error("OpenAPI_ssc_modes_parseFromJSON() failed [allowed_ssc_modes]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_ssc_modesList, (void *)OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring));
+            localEnum = OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ssc_modes_1.c
+++ b/lib/sbi/openapi/model/ssc_modes_1.c
@@ -100,11 +100,17 @@ OpenAPI_ssc_modes_1_t *OpenAPI_ssc_modes_1_parseFromJSON(cJSON *ssc_modes_1JSON)
         allowed_ssc_modesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(allowed_ssc_modes_local, allowed_ssc_modes) {
+            OpenAPI_ssc_mode_e localEnum = OpenAPI_ssc_mode_NULL;
             if (!cJSON_IsString(allowed_ssc_modes_local)) {
                 ogs_error("OpenAPI_ssc_modes_1_parseFromJSON() failed [allowed_ssc_modes]");
                 goto end;
             }
-            OpenAPI_list_add(allowed_ssc_modesList, (void *)OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring));
+            localEnum = OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/subscription_data.c
+++ b/lib/sbi/openapi/model/subscription_data.c
@@ -494,11 +494,17 @@ OpenAPI_subscription_data_t *OpenAPI_subscription_data_parseFromJSON(cJSON *subs
         req_notif_eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(req_notif_events_local, req_notif_events) {
+            OpenAPI_notification_event_type_e localEnum = OpenAPI_notification_event_type_NULL;
             if (!cJSON_IsString(req_notif_events_local)) {
                 ogs_error("OpenAPI_subscription_data_parseFromJSON() failed [req_notif_events]");
                 goto end;
             }
-            OpenAPI_list_add(req_notif_eventsList, (void *)OpenAPI_notification_event_type_FromString(req_notif_events_local->valuestring));
+            localEnum = OpenAPI_notification_event_type_FromString(req_notif_events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_notification_event_type_FromString(req_notif_events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(req_notif_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/trust_af_info.c
+++ b/lib/sbi/openapi/model/trust_af_info.c
@@ -189,11 +189,17 @@ OpenAPI_trust_af_info_t *OpenAPI_trust_af_info_parseFromJSON(cJSON *trust_af_inf
         af_eventsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(af_events_local, af_events) {
+            OpenAPI_af_event_e localEnum = OpenAPI_af_event_NULL;
             if (!cJSON_IsString(af_events_local)) {
                 ogs_error("OpenAPI_trust_af_info_parseFromJSON() failed [af_events]");
                 goto end;
             }
-            OpenAPI_list_add(af_eventsList, (void *)OpenAPI_af_event_FromString(af_events_local->valuestring));
+            localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/udr_info.c
+++ b/lib/sbi/openapi/model/udr_info.c
@@ -278,11 +278,17 @@ OpenAPI_udr_info_t *OpenAPI_udr_info_parseFromJSON(cJSON *udr_infoJSON)
         supported_data_setsList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(supported_data_sets_local, supported_data_sets) {
+            OpenAPI_data_set_id_e localEnum = OpenAPI_data_set_id_NULL;
             if (!cJSON_IsString(supported_data_sets_local)) {
                 ogs_error("OpenAPI_udr_info_parseFromJSON() failed [supported_data_sets]");
                 goto end;
             }
-            OpenAPI_list_add(supported_data_setsList, (void *)OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring));
+            localEnum = OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -1746,11 +1746,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         am_policy_req_trigger_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(am_policy_req_trigger_list_local, am_policy_req_trigger_list) {
+            OpenAPI_policy_req_trigger_e localEnum = OpenAPI_policy_req_trigger_NULL;
             if (!cJSON_IsString(am_policy_req_trigger_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [am_policy_req_trigger_list]");
                 goto end;
             }
-            OpenAPI_list_add(am_policy_req_trigger_listList, (void *)OpenAPI_policy_req_trigger_FromString(am_policy_req_trigger_list_local->valuestring));
+            localEnum = OpenAPI_policy_req_trigger_FromString(am_policy_req_trigger_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_req_trigger_FromString(am_policy_req_trigger_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(am_policy_req_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -1773,11 +1779,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         ue_policy_req_trigger_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(ue_policy_req_trigger_list_local, ue_policy_req_trigger_list) {
+            OpenAPI_policy_req_trigger_e localEnum = OpenAPI_policy_req_trigger_NULL;
             if (!cJSON_IsString(ue_policy_req_trigger_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [ue_policy_req_trigger_list]");
                 goto end;
             }
-            OpenAPI_list_add(ue_policy_req_trigger_listList, (void *)OpenAPI_policy_req_trigger_FromString(ue_policy_req_trigger_list_local->valuestring));
+            localEnum = OpenAPI_policy_req_trigger_FromString(ue_policy_req_trigger_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_policy_req_trigger_FromString(ue_policy_req_trigger_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(ue_policy_req_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -1808,11 +1820,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         restricted_rat_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(restricted_rat_list_local, restricted_rat_list) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(restricted_rat_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [restricted_rat_list]");
                 goto end;
             }
-            OpenAPI_list_add(restricted_rat_listList, (void *)OpenAPI_rat_type_FromString(restricted_rat_list_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(restricted_rat_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(restricted_rat_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(restricted_rat_listList, (void *)localEnum);
         }
     }
 
@@ -1860,11 +1878,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         restricted_core_nw_type_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(restricted_core_nw_type_list_local, restricted_core_nw_type_list) {
+            OpenAPI_core_network_type_e localEnum = OpenAPI_core_network_type_NULL;
             if (!cJSON_IsString(restricted_core_nw_type_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [restricted_core_nw_type_list]");
                 goto end;
             }
-            OpenAPI_list_add(restricted_core_nw_type_listList, (void *)OpenAPI_core_network_type_FromString(restricted_core_nw_type_list_local->valuestring));
+            localEnum = OpenAPI_core_network_type_FromString(restricted_core_nw_type_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_core_network_type_FromString(restricted_core_nw_type_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(restricted_core_nw_type_listList, (void *)localEnum);
         }
     }
 
@@ -2046,11 +2070,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         restricted_primary_rat_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(restricted_primary_rat_list_local, restricted_primary_rat_list) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(restricted_primary_rat_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [restricted_primary_rat_list]");
                 goto end;
             }
-            OpenAPI_list_add(restricted_primary_rat_listList, (void *)OpenAPI_rat_type_FromString(restricted_primary_rat_list_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(restricted_primary_rat_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(restricted_primary_rat_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(restricted_primary_rat_listList, (void *)localEnum);
         }
     }
 
@@ -2065,11 +2095,17 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         restricted_secondary_rat_listList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(restricted_secondary_rat_list_local, restricted_secondary_rat_list) {
+            OpenAPI_rat_type_e localEnum = OpenAPI_rat_type_NULL;
             if (!cJSON_IsString(restricted_secondary_rat_list_local)) {
                 ogs_error("OpenAPI_ue_context_parseFromJSON() failed [restricted_secondary_rat_list]");
                 goto end;
             }
-            OpenAPI_list_add(restricted_secondary_rat_listList, (void *)OpenAPI_rat_type_FromString(restricted_secondary_rat_list_local->valuestring));
+            localEnum = OpenAPI_rat_type_FromString(restricted_secondary_rat_list_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_rat_type_FromString(restricted_secondary_rat_list_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(restricted_secondary_rat_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/upf_info.c
+++ b/lib/sbi/openapi/model/upf_info.c
@@ -460,11 +460,17 @@ OpenAPI_upf_info_t *OpenAPI_upf_info_parseFromJSON(cJSON *upf_infoJSON)
         pdu_session_typesList = OpenAPI_list_create();
 
         cJSON_ArrayForEach(pdu_session_types_local, pdu_session_types) {
+            OpenAPI_pdu_session_type_e localEnum = OpenAPI_pdu_session_type_NULL;
             if (!cJSON_IsString(pdu_session_types_local)) {
                 ogs_error("OpenAPI_upf_info_parseFromJSON() failed [pdu_session_types]");
                 goto end;
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring));
+            localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
@@ -766,11 +766,17 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
 
         cJSON_ArrayForEach({{{name}}}_local, {{{name}}}) {
             {{#isEnum}}
+            OpenAPI_{{{complexType}}}_e localEnum = OpenAPI_{{{complexType}}}_NULL;
             if (!cJSON_IsString({{{name}}}_local)) {
                 ogs_error("OpenAPI_{{classname}}_parseFromJSON() failed [{{{name}}}]");
                 goto end;
             }
-            OpenAPI_list_add({{{name}}}List, (void *)OpenAPI_{{{complexType}}}_FromString({{{name}}}_local->valuestring));
+            localEnum = OpenAPI_{{{complexType}}}_FromString({{{name}}}_local->valuestring);
+            if (!localEnum) {
+                ogs_error("OpenAPI_{{{complexType}}}_FromString({{{name}}}_local->valuestring) failed");
+                goto end;
+            }
+            OpenAPI_list_add({{{name}}}List, (void *)localEnum);
             {{/isEnum}}
             {{^isEnum}}
                 {{#isPrimitiveType}}


### PR DESCRIPTION
The crash is caused by ogs_assert(data) in listEntry_create(void *data). Reason for the failing assertion is that in

OpenAPI_subscription_data_t *OpenAPI_subscription_data_parseFromJSON(
        cJSON *subscription_dataJSON)

in line 501 of file subscription_data.c the event string is transformed into an integer/enum value, which in case of an unknown event is 0.

Steps to reproduce:

1. Deploy NRF
2. Run curl --http2-prior-knowledge --header "Content-Type: application/json" --data '{"nfStatusNotificationUri": "test@example.com", "reqNotifEvents": ["unknown"], "subscriptionId": "12345"}' "http://<NRF_IP>:<NRF_PORT>/nnrf-nfm/v1/subscriptions"