### PR TITLE
[WebUI] fixed a EDIT bug after 10 minutes (#2615)

### DIFF
--- a/webui/src/components/Account/Edit.js
+++ b/webui/src/components/Account/Edit.js
@@ -145,7 +145,7 @@ class Edit extends Component {
 
     return (
       <Form 
-        visible={visible}
+        visible={isLoading ? false : visible}
         title={(action === 'update') ? 'Edit Account' : 'Create Account'}
         width="480px"
         height="400px"

--- a/webui/src/components/Profile/Edit.js
+++ b/webui/src/components/Profile/Edit.js
@@ -715,7 +715,7 @@ class Edit extends Component {
 
     return (
       <Form 
-        visible={visible}
+        visible={isLoading ? false : visible}
         title={(action === 'update') ? 'Edit Profile' : 'Create Profile'}
         schema={this.state.schema}
         uiSchema={this.state.uiSchema}

--- a/webui/src/components/Subscriber/Edit.js
+++ b/webui/src/components/Subscriber/Edit.js
@@ -808,7 +808,7 @@ class Edit extends Component {
 
     return (
       <Form 
-        visible={visible}
+        visible={isLoading ? false : visible}
         title={(action === 'update') ? 'Edit Subscriber' : 'Create Subscriber'}
         schema={this.state.schema}
         uiSchema={this.state.uiSchema}


### PR DESCRIPTION
After the page remains inactive for 10 minutes,
clicking on the edit page will result in a blank screen

when you click on edit after 10 minutes,
all user data is lost. After capturing the network packets, it can be observed that the frontend sends a fresh request to the backend for data, and the backend responds correctly, but the page does not refresh correctly.

`function recent(fetchedAt) {
if (fetchedAt === null) return false;

const interval = 10 * 60 * 1000; // 10 minutes
return ((Date.now() - interval) < fetchedAt);
}`