### PR TITLE
[ipfw] Fix memory leak when parsing ipv6

### DIFF
--- a/lib/ipfw/ipv6.c
+++ b/lib/ipfw/ipv6.c
@@ -338,6 +338,7 @@ fill_ip6(ipfw_insn_ip6 *cmd, char *av, int cblen)
 {
 	int len = 0;
 	struct in6_addr *d = &(cmd->addr6);
+	char *av1;
 	/*
 	 * Needed for multiple address.
 	 * Note d[1] points to struct in6_add r mask6 of cmd
@@ -375,7 +376,7 @@ fill_ip6(ipfw_insn_ip6 *cmd, char *av, int cblen)
 		return (1);
 	}
 
-	av = strdup(av);
+	av1 = av = strdup(av);
 	while (av) {
 		/*
 		 * After the address we can have '/' indicating a mask,
@@ -451,7 +452,7 @@ fill_ip6(ipfw_insn_ip6 *cmd, char *av, int cblen)
 	if (len + 1 > F_LEN_MASK)
 		errx(EX_DATAERR, "address list too long");
 	cmd->o.len |= len+1;
-	free(av);
+	free(av1);
 	return (1);
 }
 


### PR DESCRIPTION
```sh
valgrind --leak-check=full --show-leak-kinds=all src/upf/open5gs-upfd -c ./configs/open5gs/upf.yaml

# Perform registration and deregistration
# Ctrl-c

09/27 12:36:43.704: [app] INFO: UPF terminate...done (../src/upf/app.c:39)
==2320446== 
==2320446== HEAP SUMMARY:
==2320446==     in use at exit: 120 bytes in 3 blocks
==2320446==   total heap usage: 2,984 allocs, 2,981 frees, 505,391,902 bytes allocated
==2320446== 
==2320446== Thread 1:
==2320446== 24 bytes in 2 blocks are definitely lost in loss record 1 of 2
==2320446==    at 0x4841848: malloc (vg_replace_malloc.c:431)
==2320446==    by 0x4E863EE: strdup (strdup.c:42)
==2320446==    by 0x50A33ED: fill_ip6 (ipv6.c:378)
==2320446==    by 0x50A37F5: add_srcip6 (ipv6.c:498)
==2320446==    by 0x5099A5D: add_src (ipfw2.c:3421)
==2320446==    by 0x509B54D: compile_rule (ipfw2.c:4011)
==2320446==    by 0x50A9B19: ogs_ipfw_compile_rule (ogs-ipfw.c:100)
==2320446==    by 0x48BEC75: ogs_pfcp_handle_create_pdr (handler.c:472)
==2320446==    by 0x11FFDF: upf_n4_handle_session_establishment_request (n4-handler.c:85)
==2320446==    by 0x118C69: upf_pfcp_state_associated (pfcp-sm.c:287)
==2320446==    by 0x488781B: ogs_fsm_dispatch (ogs-fsm.c:127)
==2320446==    by 0x117330: upf_state_operational (upf-sm.c:91)
==2320446== 
==2320446== 96 bytes in 1 blocks are definitely lost in loss record 2 of 2
==2320446==    at 0x4841848: malloc (vg_replace_malloc.c:431)
==2320446==    by 0x4B3AA76: __talloc_with_prefix (talloc.c:783)
==2320446==    by 0x4B3C745: UnknownInlinedFun (talloc.c:825)
==2320446==    by 0x4B3C745: UnknownInlinedFun (talloc.c:982)
==2320446==    by 0x4B3C745: UnknownInlinedFun (talloc.c:2353)
==2320446==    by 0x4B3C745: talloc_enable_null_tracking (talloc.c:2350)
==2320446==    by 0x487554C: ogs_mem_init (ogs-memory.c:37)
==2320446==    by 0x4889D26: ogs_core_initialize (ogs-core.c:41)
==2320446==    by 0x48638C2: ogs_app_initialize (ogs-init.c:38)
==2320446==    by 0x1105FD: main (main.c:206)
==2320446== 
==2320446== LEAK SUMMARY:
==2320446==    definitely lost: 120 bytes in 3 blocks
==2320446==    indirectly lost: 0 bytes in 0 blocks
==2320446==      possibly lost: 0 bytes in 0 blocks
==2320446==    still reachable: 0 bytes in 0 blocks
==2320446==         suppressed: 0 bytes in 0 blocks
==2320446== 
==2320446== Use --track-origins=yes to see where uninitialised values come from
==2320446== For lists of detected and suppressed errors, rerun with: -s
==2320446== ERROR SUMMARY: 6 errors from 5 contexts (suppressed: 0 from 0)
```