### PR TITLE
[SBI] Ignore unknown enum values and continue parsing (#2622)

### DIFF
--- a/lib/sbi/openapi/model/access_and_mobility_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_data.c
@@ -586,10 +586,11 @@ OpenAPI_access_and_mobility_data_t *OpenAPI_access_and_mobility_data_parseFromJS
             }
             localEnum = OpenAPI_rat_type_FromString(rat_type_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_type_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_type\" is not supported. Ignoring it ...",
+                         rat_type_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_typeList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_data.c
@@ -592,6 +592,10 @@ OpenAPI_access_and_mobility_data_t *OpenAPI_access_and_mobility_data_parseFromJS
                 OpenAPI_list_add(rat_typeList, (void *)localEnum);
             }
         }
+        if (rat_typeList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_data_parseFromJSON() failed: Expected rat_typeList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     rat_types_ts = cJSON_GetObjectItemCaseSensitive(access_and_mobility_dataJSON, "ratTypesTs");

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -1155,6 +1155,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                 OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed: Expected rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     forbidden_areas = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "forbiddenAreas");
@@ -1213,6 +1217,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             } else {
                 OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
+        }
+        if (core_network_type_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed: Expected core_network_type_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1312,6 +1320,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             } else {
                 OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
             }
+        }
+        if (sor_update_indicator_listList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed: Expected sor_update_indicator_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1525,6 +1537,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                 OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (primary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed: Expected primary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     secondary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "secondaryRatRestrictions");
@@ -1550,6 +1566,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             } else {
                 OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
+        }
+        if (secondary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed: Expected secondary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -1149,10 +1149,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             }
             localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_restrictions\" is not supported. Ignoring it ...",
+                         rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1207,10 +1208,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             }
             localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"core_network_type_restrictions\" is not supported. Ignoring it ...",
+                         core_network_type_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1305,10 +1307,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             }
             localEnum = OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"sor_update_indicator_list\" is not supported. Ignoring it ...",
+                         sor_update_indicator_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
         }
     }
 
@@ -1516,10 +1519,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             }
             localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"primary_rat_restrictions\" is not supported. Ignoring it ...",
+                         primary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1541,10 +1545,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
             }
             localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"secondary_rat_restrictions\" is not supported. Ignoring it ...",
+                         secondary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -1155,6 +1155,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                 OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed: Expected rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     forbidden_areas = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "forbiddenAreas");
@@ -1213,6 +1217,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             } else {
                 OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
+        }
+        if (core_network_type_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed: Expected core_network_type_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1312,6 +1320,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             } else {
                 OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
             }
+        }
+        if (sor_update_indicator_listList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed: Expected sor_update_indicator_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1525,6 +1537,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                 OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (primary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed: Expected primary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     secondary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "secondaryRatRestrictions");
@@ -1550,6 +1566,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             } else {
                 OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
+        }
+        if (secondary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed: Expected secondary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -1149,10 +1149,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             }
             localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_restrictions\" is not supported. Ignoring it ...",
+                         rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1207,10 +1208,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             }
             localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"core_network_type_restrictions\" is not supported. Ignoring it ...",
+                         core_network_type_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1305,10 +1307,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             }
             localEnum = OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_sor_update_indicator_FromString(sor_update_indicator_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"sor_update_indicator_list\" is not supported. Ignoring it ...",
+                         sor_update_indicator_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(sor_update_indicator_listList, (void *)localEnum);
         }
     }
 
@@ -1516,10 +1519,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             }
             localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"primary_rat_restrictions\" is not supported. Ignoring it ...",
+                         primary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -1541,10 +1545,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
             }
             localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"secondary_rat_restrictions\" is not supported. Ignoring it ...",
+                         secondary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/af_event_exposure_data.c
+++ b/lib/sbi/openapi/model/af_event_exposure_data.c
@@ -138,10 +138,11 @@ OpenAPI_af_event_exposure_data_t *OpenAPI_af_event_exposure_data_parseFromJSON(c
             }
             localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"af_events\" is not supported. Ignoring it ...",
+                         af_events_local->valuestring);
+            } else {
+                OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
 
     af_ids = cJSON_GetObjectItemCaseSensitive(af_event_exposure_dataJSON, "afIds");

--- a/lib/sbi/openapi/model/af_event_exposure_data.c
+++ b/lib/sbi/openapi/model/af_event_exposure_data.c
@@ -144,6 +144,10 @@ OpenAPI_af_event_exposure_data_t *OpenAPI_af_event_exposure_data_parseFromJSON(c
                 OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
         }
+        if (af_eventsList->count == 0) {
+            ogs_error("OpenAPI_af_event_exposure_data_parseFromJSON() failed: Expected af_eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     af_ids = cJSON_GetObjectItemCaseSensitive(af_event_exposure_dataJSON, "afIds");
     if (af_ids) {

--- a/lib/sbi/openapi/model/am_requested_value_rep.c
+++ b/lib/sbi/openapi/model/am_requested_value_rep.c
@@ -259,10 +259,11 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
             }
             localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_types\" is not supported. Ignoring it ...",
+                         access_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -284,10 +285,11 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
             }
             localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_types\" is not supported. Ignoring it ...",
+                         rat_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/am_requested_value_rep.c
+++ b/lib/sbi/openapi/model/am_requested_value_rep.c
@@ -265,6 +265,10 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
                 OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
         }
+        if (access_typesList->count == 0) {
+            ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed: Expected access_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     rat_types = cJSON_GetObjectItemCaseSensitive(am_requested_value_repJSON, "ratTypes");
@@ -290,6 +294,10 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
             } else {
                 OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
+        }
+        if (rat_typesList->count == 0) {
+            ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed: Expected rat_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/amf_event_mode.c
+++ b/lib/sbi/openapi/model/amf_event_mode.c
@@ -210,10 +210,11 @@ OpenAPI_amf_event_mode_t *OpenAPI_amf_event_mode_parseFromJSON(cJSON *amf_event_
             }
             localEnum = OpenAPI_partitioning_criteria_FromString(partitioning_criteria_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_partitioning_criteria_FromString(partitioning_criteria_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"partitioning_criteria\" is not supported. Ignoring it ...",
+                         partitioning_criteria_local->valuestring);
+            } else {
+                OpenAPI_list_add(partitioning_criteriaList, (void *)localEnum);
             }
-            OpenAPI_list_add(partitioning_criteriaList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/amf_event_mode.c
+++ b/lib/sbi/openapi/model/amf_event_mode.c
@@ -216,6 +216,10 @@ OpenAPI_amf_event_mode_t *OpenAPI_amf_event_mode_parseFromJSON(cJSON *amf_event_
                 OpenAPI_list_add(partitioning_criteriaList, (void *)localEnum);
             }
         }
+        if (partitioning_criteriaList->count == 0) {
+            ogs_error("OpenAPI_amf_event_mode_parseFromJSON() failed: Expected partitioning_criteriaList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     notif_flag = cJSON_GetObjectItemCaseSensitive(amf_event_modeJSON, "notifFlag");

--- a/lib/sbi/openapi/model/bsf_subscription.c
+++ b/lib/sbi/openapi/model/bsf_subscription.c
@@ -218,6 +218,10 @@ OpenAPI_bsf_subscription_t *OpenAPI_bsf_subscription_parseFromJSON(cJSON *bsf_su
                 OpenAPI_list_add(eventsList, (void *)localEnum);
             }
         }
+        if (eventsList->count == 0) {
+            ogs_error("OpenAPI_bsf_subscription_parseFromJSON() failed: Expected eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscriptionJSON, "notifUri");
     if (!notif_uri) {

--- a/lib/sbi/openapi/model/bsf_subscription.c
+++ b/lib/sbi/openapi/model/bsf_subscription.c
@@ -212,10 +212,11 @@ OpenAPI_bsf_subscription_t *OpenAPI_bsf_subscription_parseFromJSON(cJSON *bsf_su
             }
             localEnum = OpenAPI_bsf_event_FromString(events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_bsf_event_FromString(events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"events\" is not supported. Ignoring it ...",
+                         events_local->valuestring);
+            } else {
+                OpenAPI_list_add(eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(eventsList, (void *)localEnum);
         }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscriptionJSON, "notifUri");

--- a/lib/sbi/openapi/model/bsf_subscription_resp.c
+++ b/lib/sbi/openapi/model/bsf_subscription_resp.c
@@ -286,6 +286,10 @@ OpenAPI_bsf_subscription_resp_t *OpenAPI_bsf_subscription_resp_parseFromJSON(cJS
                 OpenAPI_list_add(eventsList, (void *)localEnum);
             }
         }
+        if (eventsList->count == 0) {
+            ogs_error("OpenAPI_bsf_subscription_resp_parseFromJSON() failed: Expected eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscription_respJSON, "notifUri");
     if (!notif_uri) {

--- a/lib/sbi/openapi/model/bsf_subscription_resp.c
+++ b/lib/sbi/openapi/model/bsf_subscription_resp.c
@@ -280,10 +280,11 @@ OpenAPI_bsf_subscription_resp_t *OpenAPI_bsf_subscription_resp_parseFromJSON(cJS
             }
             localEnum = OpenAPI_bsf_event_FromString(events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_bsf_event_FromString(events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"events\" is not supported. Ignoring it ...",
+                         events_local->valuestring);
+            } else {
+                OpenAPI_list_add(eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(eventsList, (void *)localEnum);
         }
 
     notif_uri = cJSON_GetObjectItemCaseSensitive(bsf_subscription_respJSON, "notifUri");

--- a/lib/sbi/openapi/model/datalink_reporting_configuration.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration.c
@@ -186,10 +186,11 @@ OpenAPI_datalink_reporting_configuration_t *OpenAPI_datalink_reporting_configura
             }
             localEnum = OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"ddd_status_list\" is not supported. Ignoring it ...",
+                         ddd_status_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/datalink_reporting_configuration.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration.c
@@ -192,6 +192,10 @@ OpenAPI_datalink_reporting_configuration_t *OpenAPI_datalink_reporting_configura
                 OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
             }
         }
+        if (ddd_status_listList->count == 0) {
+            ogs_error("OpenAPI_datalink_reporting_configuration_parseFromJSON() failed: Expected ddd_status_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     datalink_reporting_configuration_local_var = OpenAPI_datalink_reporting_configuration_create (

--- a/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
@@ -192,6 +192,10 @@ OpenAPI_datalink_reporting_configuration_1_t *OpenAPI_datalink_reporting_configu
                 OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
             }
         }
+        if (ddd_status_listList->count == 0) {
+            ogs_error("OpenAPI_datalink_reporting_configuration_1_parseFromJSON() failed: Expected ddd_status_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     datalink_reporting_configuration_1_local_var = OpenAPI_datalink_reporting_configuration_1_create (

--- a/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
+++ b/lib/sbi/openapi/model/datalink_reporting_configuration_1.c
@@ -186,10 +186,11 @@ OpenAPI_datalink_reporting_configuration_1_t *OpenAPI_datalink_reporting_configu
             }
             localEnum = OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_dl_data_delivery_status_FromString(ddd_status_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"ddd_status_list\" is not supported. Ignoring it ...",
+                         ddd_status_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(ddd_status_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dccf_cond.c
+++ b/lib/sbi/openapi/model/dccf_cond.c
@@ -257,10 +257,11 @@ OpenAPI_dccf_cond_t *OpenAPI_dccf_cond_parseFromJSON(cJSON *dccf_condJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dccf_cond.c
+++ b/lib/sbi/openapi/model/dccf_cond.c
@@ -263,6 +263,10 @@ OpenAPI_dccf_cond_t *OpenAPI_dccf_cond_parseFromJSON(cJSON *dccf_condJSON)
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_dccf_cond_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_nf_set_id_list = cJSON_GetObjectItemCaseSensitive(dccf_condJSON, "servingNfSetIdList");

--- a/lib/sbi/openapi/model/dccf_info.c
+++ b/lib/sbi/openapi/model/dccf_info.c
@@ -168,6 +168,10 @@ OpenAPI_dccf_info_t *OpenAPI_dccf_info_parseFromJSON(cJSON *dccf_infoJSON)
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_dccf_info_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_nf_set_id_list = cJSON_GetObjectItemCaseSensitive(dccf_infoJSON, "servingNfSetIdList");

--- a/lib/sbi/openapi/model/dccf_info.c
+++ b/lib/sbi/openapi/model/dccf_info.c
@@ -162,10 +162,11 @@ OpenAPI_dccf_info_t *OpenAPI_dccf_info_parseFromJSON(cJSON *dccf_infoJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
+++ b/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
@@ -149,6 +149,10 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
                 OpenAPI_list_add(ssc_modesList, (void *)localEnum);
             }
         }
+        if (ssc_modesList->count == 0) {
+            ogs_error("OpenAPI_dnn_route_selection_descriptor_parseFromJSON() failed: Expected ssc_modesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pdu_sess_types = cJSON_GetObjectItemCaseSensitive(dnn_route_selection_descriptorJSON, "pduSessTypes");
@@ -174,6 +178,10 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
             } else {
                 OpenAPI_list_add(pdu_sess_typesList, (void *)localEnum);
             }
+        }
+        if (pdu_sess_typesList->count == 0) {
+            ogs_error("OpenAPI_dnn_route_selection_descriptor_parseFromJSON() failed: Expected pdu_sess_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
+++ b/lib/sbi/openapi/model/dnn_route_selection_descriptor.c
@@ -143,10 +143,11 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
             }
             localEnum = OpenAPI_ssc_mode_FromString(ssc_modes_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_ssc_mode_FromString(ssc_modes_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"ssc_modes\" is not supported. Ignoring it ...",
+                         ssc_modes_local->valuestring);
+            } else {
+                OpenAPI_list_add(ssc_modesList, (void *)localEnum);
             }
-            OpenAPI_list_add(ssc_modesList, (void *)localEnum);
         }
     }
 
@@ -168,10 +169,11 @@ OpenAPI_dnn_route_selection_descriptor_t *OpenAPI_dnn_route_selection_descriptor
             }
             localEnum = OpenAPI_pdu_session_type_FromString(pdu_sess_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_sess_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pdu_sess_types\" is not supported. Ignoring it ...",
+                         pdu_sess_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(pdu_sess_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(pdu_sess_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_upf_info_item.c
+++ b/lib/sbi/openapi/model/dnn_upf_info_item.c
@@ -303,10 +303,11 @@ OpenAPI_dnn_upf_info_item_t *OpenAPI_dnn_upf_info_item_parseFromJSON(cJSON *dnn_
             }
             localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pdu_session_types\" is not supported. Ignoring it ...",
+                         pdu_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/dnn_upf_info_item.c
+++ b/lib/sbi/openapi/model/dnn_upf_info_item.c
@@ -309,6 +309,10 @@ OpenAPI_dnn_upf_info_item_t *OpenAPI_dnn_upf_info_item_parseFromJSON(cJSON *dnn_
                 OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
         }
+        if (pdu_session_typesList->count == 0) {
+            ogs_error("OpenAPI_dnn_upf_info_item_parseFromJSON() failed: Expected pdu_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     ipv4_address_ranges = cJSON_GetObjectItemCaseSensitive(dnn_upf_info_itemJSON, "ipv4AddressRanges");

--- a/lib/sbi/openapi/model/downlink_data_notification_control.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control.c
@@ -105,10 +105,11 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
             }
             localEnum = OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"notif_ctrl_inds\" is not supported. Ignoring it ...",
+                         notif_ctrl_inds_local->valuestring);
+            } else {
+                OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
             }
-            OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
         }
     }
 
@@ -130,10 +131,11 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
             }
             localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"types_of_notif\" is not supported. Ignoring it ...",
+                         types_of_notif_local->valuestring);
+            } else {
+                OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
-            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control.c
@@ -111,6 +111,10 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
                 OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
             }
         }
+        if (notif_ctrl_indsList->count == 0) {
+            ogs_error("OpenAPI_downlink_data_notification_control_parseFromJSON() failed: Expected notif_ctrl_indsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     types_of_notif = cJSON_GetObjectItemCaseSensitive(downlink_data_notification_controlJSON, "typesOfNotif");
@@ -136,6 +140,10 @@ OpenAPI_downlink_data_notification_control_t *OpenAPI_downlink_data_notification
             } else {
                 OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
+        }
+        if (types_of_notifList->count == 0) {
+            ogs_error("OpenAPI_downlink_data_notification_control_parseFromJSON() failed: Expected types_of_notifList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
@@ -111,6 +111,10 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
                 OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
             }
         }
+        if (notif_ctrl_indsList->count == 0) {
+            ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed: Expected notif_ctrl_indsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     types_of_notif = cJSON_GetObjectItemCaseSensitive(downlink_data_notification_control_rmJSON, "typesOfNotif");
@@ -136,6 +140,10 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
             } else {
                 OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
+        }
+        if (types_of_notifList->count == 0) {
+            ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed: Expected types_of_notifList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
@@ -105,10 +105,11 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
             }
             localEnum = OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_notification_control_indication_FromString(notif_ctrl_inds_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"notif_ctrl_inds\" is not supported. Ignoring it ...",
+                         notif_ctrl_inds_local->valuestring);
+            } else {
+                OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
             }
-            OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
         }
     }
 
@@ -130,10 +131,11 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
             }
             localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"types_of_notif\" is not supported. Ignoring it ...",
+                         types_of_notif_local->valuestring);
+            } else {
+                OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
-            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/error_report.c
+++ b/lib/sbi/openapi/model/error_report.c
@@ -248,6 +248,10 @@ OpenAPI_error_report_t *OpenAPI_error_report_parseFromJSON(cJSON *error_reportJS
                 OpenAPI_list_add(pol_dec_failure_reportsList, (void *)localEnum);
             }
         }
+        if (pol_dec_failure_reportsList->count == 0) {
+            ogs_error("OpenAPI_error_report_parseFromJSON() failed: Expected pol_dec_failure_reportsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     invalid_policy_decs = cJSON_GetObjectItemCaseSensitive(error_reportJSON, "invalidPolicyDecs");

--- a/lib/sbi/openapi/model/error_report.c
+++ b/lib/sbi/openapi/model/error_report.c
@@ -242,10 +242,11 @@ OpenAPI_error_report_t *OpenAPI_error_report_parseFromJSON(cJSON *error_reportJS
             }
             localEnum = OpenAPI_policy_decision_failure_code_FromString(pol_dec_failure_reports_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_decision_failure_code_FromString(pol_dec_failure_reports_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pol_dec_failure_reports\" is not supported. Ignoring it ...",
+                         pol_dec_failure_reports_local->valuestring);
+            } else {
+                OpenAPI_list_add(pol_dec_failure_reportsList, (void *)localEnum);
             }
-            OpenAPI_list_add(pol_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/event_subscription.c
+++ b/lib/sbi/openapi/model/event_subscription.c
@@ -1201,6 +1201,10 @@ OpenAPI_event_subscription_t *OpenAPI_event_subscription_parseFromJSON(cJSON *ev
                 OpenAPI_list_add(nf_typesList, (void *)localEnum);
             }
         }
+        if (nf_typesList->count == 0) {
+            ogs_error("OpenAPI_event_subscription_parseFromJSON() failed: Expected nf_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     network_area = cJSON_GetObjectItemCaseSensitive(event_subscriptionJSON, "networkArea");

--- a/lib/sbi/openapi/model/event_subscription.c
+++ b/lib/sbi/openapi/model/event_subscription.c
@@ -1195,10 +1195,11 @@ OpenAPI_event_subscription_t *OpenAPI_event_subscription_parseFromJSON(cJSON *ev
             }
             localEnum = OpenAPI_nf_type_FromString(nf_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(nf_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"nf_types\" is not supported. Ignoring it ...",
+                         nf_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(nf_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_put_data.c
+++ b/lib/sbi/openapi/model/events_subsc_put_data.c
@@ -830,6 +830,10 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
                 OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
         }
+        if (req_qos_mon_paramsList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed: Expected req_qos_mon_paramsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     qos_mon = cJSON_GetObjectItemCaseSensitive(events_subsc_put_dataJSON, "qosMon");
@@ -864,6 +868,10 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
             } else {
                 OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
+        }
+        if (req_anisList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed: Expected req_anisList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_put_data.c
+++ b/lib/sbi/openapi/model/events_subsc_put_data.c
@@ -824,10 +824,11 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
             }
             localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_qos_mon_params\" is not supported. Ignoring it ...",
+                         req_qos_mon_params_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -858,10 +859,11 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
             }
             localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_anis\" is not supported. Ignoring it ...",
+                         req_anis_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data.c
@@ -275,10 +275,11 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
             }
             localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_qos_mon_params\" is not supported. Ignoring it ...",
+                         req_qos_mon_params_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -309,10 +310,11 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
             }
             localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_anis\" is not supported. Ignoring it ...",
+                         req_anis_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data.c
@@ -281,6 +281,10 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
                 OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
         }
+        if (req_qos_mon_paramsList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_req_data_parseFromJSON() failed: Expected req_qos_mon_paramsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     qos_mon = cJSON_GetObjectItemCaseSensitive(events_subsc_req_dataJSON, "qosMon");
@@ -315,6 +319,10 @@ OpenAPI_events_subsc_req_data_t *OpenAPI_events_subsc_req_data_parseFromJSON(cJS
             } else {
                 OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
+        }
+        if (req_anisList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_req_data_parseFromJSON() failed: Expected req_anisList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data_rm.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data_rm.c
@@ -250,10 +250,11 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
             }
             localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_qos_mon_params\" is not supported. Ignoring it ...",
+                         req_qos_mon_params_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
     }
 
@@ -284,10 +285,11 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
             }
             localEnum = OpenAPI_required_access_info_FromString(req_anis_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_required_access_info_FromString(req_anis_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_anis\" is not supported. Ignoring it ...",
+                         req_anis_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_anisList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/events_subsc_req_data_rm.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data_rm.c
@@ -256,6 +256,10 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
                 OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
         }
+        if (req_qos_mon_paramsList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON() failed: Expected req_qos_mon_paramsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     qos_mon = cJSON_GetObjectItemCaseSensitive(events_subsc_req_data_rmJSON, "qosMon");
@@ -290,6 +294,10 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
             } else {
                 OpenAPI_list_add(req_anisList, (void *)localEnum);
             }
+        }
+        if (req_anisList->count == 0) {
+            ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON() failed: Expected req_anisList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/immediate_mdt_conf.c
+++ b/lib/sbi/openapi/model/immediate_mdt_conf.c
@@ -374,6 +374,10 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
                 OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
         }
+        if (measurement_lte_listList->count == 0) {
+            ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed: Expected measurement_lte_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     measurement_nr_list = cJSON_GetObjectItemCaseSensitive(immediate_mdt_confJSON, "measurementNrList");
@@ -400,6 +404,10 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
                 OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
         }
+        if (measurement_nr_listList->count == 0) {
+            ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed: Expected measurement_nr_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     reporting_trigger_list = cJSON_GetObjectItemCaseSensitive(immediate_mdt_confJSON, "reportingTriggerList");
@@ -425,6 +433,10 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             } else {
                 OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
+        }
+        if (reporting_trigger_listList->count == 0) {
+            ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed: Expected reporting_trigger_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -556,6 +568,10 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
                 OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
         }
+        if (add_positioning_method_listList->count == 0) {
+            ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed: Expected add_positioning_method_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     mdt_allowed_plmn_id_list = cJSON_GetObjectItemCaseSensitive(immediate_mdt_confJSON, "mdtAllowedPlmnIdList");
@@ -605,6 +621,10 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             } else {
                 OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
+        }
+        if (sensor_measurement_listList->count == 0) {
+            ogs_error("OpenAPI_immediate_mdt_conf_parseFromJSON() failed: Expected sensor_measurement_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/immediate_mdt_conf.c
+++ b/lib/sbi/openapi/model/immediate_mdt_conf.c
@@ -368,10 +368,11 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             }
             localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_lte_list\" is not supported. Ignoring it ...",
+                         measurement_lte_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -393,10 +394,11 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             }
             localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_nr_list\" is not supported. Ignoring it ...",
+                         measurement_nr_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -418,10 +420,11 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             }
             localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"reporting_trigger_list\" is not supported. Ignoring it ...",
+                         reporting_trigger_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -547,10 +550,11 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             }
             localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"add_positioning_method_list\" is not supported. Ignoring it ...",
+                         add_positioning_method_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 
@@ -596,10 +600,11 @@ OpenAPI_immediate_mdt_conf_t *OpenAPI_immediate_mdt_conf_parseFromJSON(cJSON *im
             }
             localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"sensor_measurement_list\" is not supported. Ignoring it ...",
+                         sensor_measurement_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/lcs_mo_data.c
+++ b/lib/sbi/openapi/model/lcs_mo_data.c
@@ -109,10 +109,11 @@ OpenAPI_lcs_mo_data_t *OpenAPI_lcs_mo_data_parseFromJSON(cJSON *lcs_mo_dataJSON)
             }
             localEnum = OpenAPI_lcs_mo_service_class_FromString(allowed_service_classes_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_lcs_mo_service_class_FromString(allowed_service_classes_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_service_classes\" is not supported. Ignoring it ...",
+                         allowed_service_classes_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_service_classesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_service_classesList, (void *)localEnum);
         }
 
     mo_assistance_data_types = cJSON_GetObjectItemCaseSensitive(lcs_mo_dataJSON, "moAssistanceDataTypes");

--- a/lib/sbi/openapi/model/lcs_mo_data.c
+++ b/lib/sbi/openapi/model/lcs_mo_data.c
@@ -115,6 +115,10 @@ OpenAPI_lcs_mo_data_t *OpenAPI_lcs_mo_data_parseFromJSON(cJSON *lcs_mo_dataJSON)
                 OpenAPI_list_add(allowed_service_classesList, (void *)localEnum);
             }
         }
+        if (allowed_service_classesList->count == 0) {
+            ogs_error("OpenAPI_lcs_mo_data_parseFromJSON() failed: Expected allowed_service_classesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     mo_assistance_data_types = cJSON_GetObjectItemCaseSensitive(lcs_mo_dataJSON, "moAssistanceDataTypes");
     if (mo_assistance_data_types) {

--- a/lib/sbi/openapi/model/lmf_info.c
+++ b/lib/sbi/openapi/model/lmf_info.c
@@ -281,10 +281,11 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
             }
             localEnum = OpenAPI_access_type_FromString(serving_access_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(serving_access_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_access_types\" is not supported. Ignoring it ...",
+                         serving_access_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
         }
     }
 
@@ -306,10 +307,11 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
             }
             localEnum = OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_an_node_types\" is not supported. Ignoring it ...",
+                         serving_an_node_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
         }
     }
 
@@ -331,10 +333,11 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
             }
             localEnum = OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_rat_types\" is not supported. Ignoring it ...",
+                         serving_rat_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/lmf_info.c
+++ b/lib/sbi/openapi/model/lmf_info.c
@@ -287,6 +287,10 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
                 OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
             }
         }
+        if (serving_access_typesList->count == 0) {
+            ogs_error("OpenAPI_lmf_info_parseFromJSON() failed: Expected serving_access_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_an_node_types = cJSON_GetObjectItemCaseSensitive(lmf_infoJSON, "servingAnNodeTypes");
@@ -313,6 +317,10 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
                 OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
             }
         }
+        if (serving_an_node_typesList->count == 0) {
+            ogs_error("OpenAPI_lmf_info_parseFromJSON() failed: Expected serving_an_node_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_rat_types = cJSON_GetObjectItemCaseSensitive(lmf_infoJSON, "servingRatTypes");
@@ -338,6 +346,10 @@ OpenAPI_lmf_info_t *OpenAPI_lmf_info_parseFromJSON(cJSON *lmf_infoJSON)
             } else {
                 OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
             }
+        }
+        if (serving_rat_typesList->count == 0) {
+            ogs_error("OpenAPI_lmf_info_parseFromJSON() failed: Expected serving_rat_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration.c
+++ b/lib/sbi/openapi/model/mdt_configuration.c
@@ -523,6 +523,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
                 OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
         }
+        if (measurement_lte_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected measurement_lte_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     measurement_nr_list = cJSON_GetObjectItemCaseSensitive(mdt_configurationJSON, "measurementNrList");
@@ -548,6 +552,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             } else {
                 OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
+        }
+        if (measurement_nr_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected measurement_nr_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -575,6 +583,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
                 OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
         }
+        if (sensor_measurement_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected sensor_measurement_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     reporting_trigger_list = cJSON_GetObjectItemCaseSensitive(mdt_configurationJSON, "reportingTriggerList");
@@ -600,6 +612,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             } else {
                 OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
+        }
+        if (reporting_trigger_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected reporting_trigger_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -686,6 +702,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
                 OpenAPI_list_add(event_listList, (void *)localEnum);
             }
         }
+        if (event_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected event_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     logging_interval = cJSON_GetObjectItemCaseSensitive(mdt_configurationJSON, "loggingInterval");
@@ -756,6 +776,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             } else {
                 OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
+        }
+        if (add_positioning_method_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed: Expected add_positioning_method_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration.c
+++ b/lib/sbi/openapi/model/mdt_configuration.c
@@ -517,10 +517,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_lte_list\" is not supported. Ignoring it ...",
+                         measurement_lte_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -542,10 +543,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_nr_list\" is not supported. Ignoring it ...",
+                         measurement_nr_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -567,10 +569,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"sensor_measurement_list\" is not supported. Ignoring it ...",
+                         sensor_measurement_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 
@@ -592,10 +595,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"reporting_trigger_list\" is not supported. Ignoring it ...",
+                         reporting_trigger_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -676,10 +680,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_event_for_mdt_FromString(event_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_event_for_mdt_FromString(event_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"event_list\" is not supported. Ignoring it ...",
+                         event_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(event_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(event_listList, (void *)localEnum);
         }
     }
 
@@ -746,10 +751,11 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
             }
             localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"add_positioning_method_list\" is not supported. Ignoring it ...",
+                         add_positioning_method_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration_1.c
+++ b/lib/sbi/openapi/model/mdt_configuration_1.c
@@ -517,10 +517,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_lte_for_mdt_FromString(measurement_lte_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_lte_list\" is not supported. Ignoring it ...",
+                         measurement_lte_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
         }
     }
 
@@ -542,10 +543,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_measurement_nr_for_mdt_FromString(measurement_nr_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"measurement_nr_list\" is not supported. Ignoring it ...",
+                         measurement_nr_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
         }
     }
 
@@ -567,10 +569,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_sensor_measurement_FromString(sensor_measurement_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"sensor_measurement_list\" is not supported. Ignoring it ...",
+                         sensor_measurement_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
         }
     }
 
@@ -592,10 +595,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_reporting_trigger_FromString(reporting_trigger_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"reporting_trigger_list\" is not supported. Ignoring it ...",
+                         reporting_trigger_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -676,10 +680,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_event_for_mdt_FromString(event_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_event_for_mdt_FromString(event_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"event_list\" is not supported. Ignoring it ...",
+                         event_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(event_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(event_listList, (void *)localEnum);
         }
     }
 
@@ -746,10 +751,11 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_positioning_method_mdt_FromString(add_positioning_method_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"add_positioning_method_list\" is not supported. Ignoring it ...",
+                         add_positioning_method_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mdt_configuration_1.c
+++ b/lib/sbi/openapi/model/mdt_configuration_1.c
@@ -523,6 +523,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
                 OpenAPI_list_add(measurement_lte_listList, (void *)localEnum);
             }
         }
+        if (measurement_lte_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected measurement_lte_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     measurement_nr_list = cJSON_GetObjectItemCaseSensitive(mdt_configuration_1JSON, "measurementNrList");
@@ -548,6 +552,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             } else {
                 OpenAPI_list_add(measurement_nr_listList, (void *)localEnum);
             }
+        }
+        if (measurement_nr_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected measurement_nr_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -575,6 +583,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
                 OpenAPI_list_add(sensor_measurement_listList, (void *)localEnum);
             }
         }
+        if (sensor_measurement_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected sensor_measurement_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     reporting_trigger_list = cJSON_GetObjectItemCaseSensitive(mdt_configuration_1JSON, "reportingTriggerList");
@@ -600,6 +612,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             } else {
                 OpenAPI_list_add(reporting_trigger_listList, (void *)localEnum);
             }
+        }
+        if (reporting_trigger_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected reporting_trigger_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -686,6 +702,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
                 OpenAPI_list_add(event_listList, (void *)localEnum);
             }
         }
+        if (event_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected event_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     logging_interval = cJSON_GetObjectItemCaseSensitive(mdt_configuration_1JSON, "loggingInterval");
@@ -756,6 +776,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
             } else {
                 OpenAPI_list_add(add_positioning_method_listList, (void *)localEnum);
             }
+        }
+        if (add_positioning_method_listList->count == 0) {
+            ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed: Expected add_positioning_method_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/mfaf_info.c
+++ b/lib/sbi/openapi/model/mfaf_info.c
@@ -162,10 +162,11 @@ OpenAPI_mfaf_info_t *OpenAPI_mfaf_info_parseFromJSON(cJSON *mfaf_infoJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/mfaf_info.c
+++ b/lib/sbi/openapi/model/mfaf_info.c
@@ -168,6 +168,10 @@ OpenAPI_mfaf_info_t *OpenAPI_mfaf_info_parseFromJSON(cJSON *mfaf_infoJSON)
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_mfaf_info_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_nf_set_id_list = cJSON_GetObjectItemCaseSensitive(mfaf_infoJSON, "servingNfSetIdList");

--- a/lib/sbi/openapi/model/model_5_gvn_group_data.c
+++ b/lib/sbi/openapi/model/model_5_gvn_group_data.c
@@ -256,10 +256,11 @@ OpenAPI_model_5_gvn_group_data_t *OpenAPI_model_5_gvn_group_data_parseFromJSON(c
             }
             localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pdu_session_types\" is not supported. Ignoring it ...",
+                         pdu_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/model_5_gvn_group_data.c
+++ b/lib/sbi/openapi/model/model_5_gvn_group_data.c
@@ -262,6 +262,10 @@ OpenAPI_model_5_gvn_group_data_t *OpenAPI_model_5_gvn_group_data_parseFromJSON(c
                 OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
         }
+        if (pdu_session_typesList->count == 0) {
+            ogs_error("OpenAPI_model_5_gvn_group_data_parseFromJSON() failed: Expected pdu_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     app_descriptors = cJSON_GetObjectItemCaseSensitive(model_5_gvn_group_dataJSON, "appDescriptors");

--- a/lib/sbi/openapi/model/nef_cond.c
+++ b/lib/sbi/openapi/model/nef_cond.c
@@ -263,6 +263,10 @@ OpenAPI_nef_cond_t *OpenAPI_nef_cond_parseFromJSON(cJSON *nef_condJSON)
                 OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
         }
+        if (af_eventsList->count == 0) {
+            ogs_error("OpenAPI_nef_cond_parseFromJSON() failed: Expected af_eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     snssai_list = cJSON_GetObjectItemCaseSensitive(nef_condJSON, "snssaiList");

--- a/lib/sbi/openapi/model/nef_cond.c
+++ b/lib/sbi/openapi/model/nef_cond.c
@@ -257,10 +257,11 @@ OpenAPI_nef_cond_t *OpenAPI_nef_cond_parseFromJSON(cJSON *nef_condJSON)
             }
             localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"af_events\" is not supported. Ignoring it ...",
+                         af_events_local->valuestring);
+            } else {
+                OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nf_profile.c
+++ b/lib/sbi/openapi/model/nf_profile.c
@@ -2623,6 +2623,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                 OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
             }
         }
+        if (allowed_nf_typesList->count == 0) {
+            ogs_error("OpenAPI_nf_profile_parseFromJSON() failed: Expected allowed_nf_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     allowed_nf_domains = cJSON_GetObjectItemCaseSensitive(nf_profileJSON, "allowedNfDomains");

--- a/lib/sbi/openapi/model/nf_profile.c
+++ b/lib/sbi/openapi/model/nf_profile.c
@@ -2617,10 +2617,11 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_nf_types\" is not supported. Ignoring it ...",
+                         allowed_nf_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nf_service.c
+++ b/lib/sbi/openapi/model/nf_service.c
@@ -886,6 +886,10 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
                 OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
             }
         }
+        if (allowed_nf_typesList->count == 0) {
+            ogs_error("OpenAPI_nf_service_parseFromJSON() failed: Expected allowed_nf_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     allowed_nf_domains = cJSON_GetObjectItemCaseSensitive(nf_serviceJSON, "allowedNfDomains");

--- a/lib/sbi/openapi/model/nf_service.c
+++ b/lib/sbi/openapi/model/nf_service.c
@@ -880,10 +880,11 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(allowed_nf_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_nf_types\" is not supported. Ignoring it ...",
+                         allowed_nf_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_nf_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
+++ b/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
@@ -197,6 +197,10 @@ OpenAPI_non_ue_n2_info_subscription_create_data_t *OpenAPI_non_ue_n2_info_subscr
                 OpenAPI_list_add(an_type_listList, (void *)localEnum);
             }
         }
+        if (an_type_listList->count == 0) {
+            ogs_error("OpenAPI_non_ue_n2_info_subscription_create_data_parseFromJSON() failed: Expected an_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     n2_information_class = cJSON_GetObjectItemCaseSensitive(non_ue_n2_info_subscription_create_dataJSON, "n2InformationClass");

--- a/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
+++ b/lib/sbi/openapi/model/non_ue_n2_info_subscription_create_data.c
@@ -191,10 +191,11 @@ OpenAPI_non_ue_n2_info_subscription_create_data_t *OpenAPI_non_ue_n2_info_subscr
             }
             localEnum = OpenAPI_access_type_FromString(an_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(an_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"an_type_list\" is not supported. Ignoring it ...",
+                         an_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(an_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(an_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
@@ -287,6 +287,10 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
                 OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
             }
         }
+        if (serving_access_typesList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed: Expected serving_access_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_an_node_types = cJSON_GetObjectItemCaseSensitive(nrf_info_served_lmf_info_valueJSON, "servingAnNodeTypes");
@@ -313,6 +317,10 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
                 OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
             }
         }
+        if (serving_an_node_typesList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed: Expected serving_an_node_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_rat_types = cJSON_GetObjectItemCaseSensitive(nrf_info_served_lmf_info_valueJSON, "servingRatTypes");
@@ -338,6 +346,10 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
             } else {
                 OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
             }
+        }
+        if (serving_rat_typesList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_lmf_info_value_parseFromJSON() failed: Expected serving_rat_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_lmf_info_value.c
@@ -281,10 +281,11 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
             }
             localEnum = OpenAPI_access_type_FromString(serving_access_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(serving_access_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_access_types\" is not supported. Ignoring it ...",
+                         serving_access_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_access_typesList, (void *)localEnum);
         }
     }
 
@@ -306,10 +307,11 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
             }
             localEnum = OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_an_node_type_FromString(serving_an_node_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_an_node_types\" is not supported. Ignoring it ...",
+                         serving_an_node_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_an_node_typesList, (void *)localEnum);
         }
     }
 
@@ -331,10 +333,11 @@ OpenAPI_nrf_info_served_lmf_info_value_t *OpenAPI_nrf_info_served_lmf_info_value
             }
             localEnum = OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(serving_rat_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_rat_types\" is not supported. Ignoring it ...",
+                         serving_rat_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
@@ -416,6 +416,10 @@ OpenAPI_nrf_info_served_nwdaf_info_value_t *OpenAPI_nrf_info_served_nwdaf_info_v
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_nwdaf_info_value_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     ml_analytics_list = cJSON_GetObjectItemCaseSensitive(nrf_info_served_nwdaf_info_valueJSON, "mlAnalyticsList");

--- a/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_nwdaf_info_value.c
@@ -410,10 +410,11 @@ OpenAPI_nrf_info_served_nwdaf_info_value_t *OpenAPI_nrf_info_served_nwdaf_info_v
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
@@ -296,6 +296,10 @@ OpenAPI_nrf_info_served_pcscf_info_list_value_value_t *OpenAPI_nrf_info_served_p
                 OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
         }
+        if (access_typeList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_pcscf_info_list_value_value_parseFromJSON() failed: Expected access_typeList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     dnn_list = cJSON_GetObjectItemCaseSensitive(nrf_info_served_pcscf_info_list_value_valueJSON, "dnnList");

--- a/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_pcscf_info_list_value_value.c
@@ -290,10 +290,11 @@ OpenAPI_nrf_info_served_pcscf_info_list_value_value_t *OpenAPI_nrf_info_served_p
             }
             localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_type\" is not supported. Ignoring it ...",
+                         access_type_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
@@ -663,6 +663,10 @@ OpenAPI_nrf_info_served_scp_info_list_value_t *OpenAPI_nrf_info_served_scp_info_
                 OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
             }
         }
+        if (scp_capabilitiesList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_parseFromJSON() failed: Expected scp_capabilitiesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     nrf_info_served_scp_info_list_value_local_var = OpenAPI_nrf_info_served_scp_info_list_value_create (

--- a/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
@@ -657,10 +657,11 @@ OpenAPI_nrf_info_served_scp_info_list_value_t *OpenAPI_nrf_info_served_scp_info_
             }
             localEnum = OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"scp_capabilities\" is not supported. Ignoring it ...",
+                         scp_capabilities_local->valuestring);
+            } else {
+                OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
             }
-            OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
@@ -398,10 +398,11 @@ OpenAPI_nrf_info_served_smf_info_value_t *OpenAPI_nrf_info_served_smf_info_value
             }
             localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_type\" is not supported. Ignoring it ...",
+                         access_type_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_smf_info_value.c
@@ -404,6 +404,10 @@ OpenAPI_nrf_info_served_smf_info_value_t *OpenAPI_nrf_info_served_smf_info_value
                 OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
         }
+        if (access_typeList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_smf_info_value_parseFromJSON() failed: Expected access_typeList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     priority = cJSON_GetObjectItemCaseSensitive(nrf_info_served_smf_info_valueJSON, "priority");

--- a/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
@@ -285,10 +285,11 @@ OpenAPI_nrf_info_served_udr_info_value_t *OpenAPI_nrf_info_served_udr_info_value
             }
             localEnum = OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"supported_data_sets\" is not supported. Ignoring it ...",
+                         supported_data_sets_local->valuestring);
+            } else {
+                OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
             }
-            OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_udr_info_value.c
@@ -291,6 +291,10 @@ OpenAPI_nrf_info_served_udr_info_value_t *OpenAPI_nrf_info_served_udr_info_value
                 OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
             }
         }
+        if (supported_data_setsList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_udr_info_value_parseFromJSON() failed: Expected supported_data_setsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     shared_data_id_ranges = cJSON_GetObjectItemCaseSensitive(nrf_info_served_udr_info_valueJSON, "sharedDataIdRanges");

--- a/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
@@ -467,10 +467,11 @@ OpenAPI_nrf_info_served_upf_info_value_t *OpenAPI_nrf_info_served_upf_info_value
             }
             localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pdu_session_types\" is not supported. Ignoring it ...",
+                         pdu_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
@@ -473,6 +473,10 @@ OpenAPI_nrf_info_served_upf_info_value_t *OpenAPI_nrf_info_served_upf_info_value
                 OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
         }
+        if (pdu_session_typesList->count == 0) {
+            ogs_error("OpenAPI_nrf_info_served_upf_info_value_parseFromJSON() failed: Expected pdu_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     atsss_capability = cJSON_GetObjectItemCaseSensitive(nrf_info_served_upf_info_valueJSON, "atsssCapability");

--- a/lib/sbi/openapi/model/nwdaf_cond.c
+++ b/lib/sbi/openapi/model/nwdaf_cond.c
@@ -381,10 +381,11 @@ OpenAPI_nwdaf_cond_t *OpenAPI_nwdaf_cond_parseFromJSON(cJSON *nwdaf_condJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/nwdaf_cond.c
+++ b/lib/sbi/openapi/model/nwdaf_cond.c
@@ -387,6 +387,10 @@ OpenAPI_nwdaf_cond_t *OpenAPI_nwdaf_cond_parseFromJSON(cJSON *nwdaf_condJSON)
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_nwdaf_cond_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serving_nf_set_id_list = cJSON_GetObjectItemCaseSensitive(nwdaf_condJSON, "servingNfSetIdList");

--- a/lib/sbi/openapi/model/nwdaf_info.c
+++ b/lib/sbi/openapi/model/nwdaf_info.c
@@ -416,6 +416,10 @@ OpenAPI_nwdaf_info_t *OpenAPI_nwdaf_info_parseFromJSON(cJSON *nwdaf_infoJSON)
                 OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
         }
+        if (serving_nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_nwdaf_info_parseFromJSON() failed: Expected serving_nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     ml_analytics_list = cJSON_GetObjectItemCaseSensitive(nwdaf_infoJSON, "mlAnalyticsList");

--- a/lib/sbi/openapi/model/nwdaf_info.c
+++ b/lib/sbi/openapi/model/nwdaf_info.c
@@ -410,10 +410,11 @@ OpenAPI_nwdaf_info_t *OpenAPI_nwdaf_info_parseFromJSON(cJSON *nwdaf_infoJSON)
             }
             localEnum = OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(serving_nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"serving_nf_type_list\" is not supported. Ignoring it ...",
+                         serving_nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(serving_nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/partial_success_report.c
+++ b/lib/sbi/openapi/model/partial_success_report.c
@@ -266,10 +266,11 @@ OpenAPI_partial_success_report_t *OpenAPI_partial_success_report_parseFromJSON(c
             }
             localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"policy_dec_failure_reports\" is not supported. Ignoring it ...",
+                         policy_dec_failure_reports_local->valuestring);
+            } else {
+                OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/partial_success_report.c
+++ b/lib/sbi/openapi/model/partial_success_report.c
@@ -272,6 +272,10 @@ OpenAPI_partial_success_report_t *OpenAPI_partial_success_report_parseFromJSON(c
                 OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
         }
+        if (policy_dec_failure_reportsList->count == 0) {
+            ogs_error("OpenAPI_partial_success_report_parseFromJSON() failed: Expected policy_dec_failure_reportsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     invalid_policy_decs = cJSON_GetObjectItemCaseSensitive(partial_success_reportJSON, "invalidPolicyDecs");

--- a/lib/sbi/openapi/model/pcscf_info.c
+++ b/lib/sbi/openapi/model/pcscf_info.c
@@ -290,10 +290,11 @@ OpenAPI_pcscf_info_t *OpenAPI_pcscf_info_parseFromJSON(cJSON *pcscf_infoJSON)
             }
             localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_type\" is not supported. Ignoring it ...",
+                         access_type_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pcscf_info.c
+++ b/lib/sbi/openapi/model/pcscf_info.c
@@ -296,6 +296,10 @@ OpenAPI_pcscf_info_t *OpenAPI_pcscf_info_parseFromJSON(cJSON *pcscf_infoJSON)
                 OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
         }
+        if (access_typeList->count == 0) {
+            ogs_error("OpenAPI_pcscf_info_parseFromJSON() failed: Expected access_typeList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     dnn_list = cJSON_GetObjectItemCaseSensitive(pcscf_infoJSON, "dnnList");

--- a/lib/sbi/openapi/model/pdu_session_types.c
+++ b/lib/sbi/openapi/model/pdu_session_types.c
@@ -109,6 +109,10 @@ OpenAPI_pdu_session_types_t *OpenAPI_pdu_session_types_parseFromJSON(cJSON *pdu_
                 OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
             }
         }
+        if (allowed_session_typesList->count == 0) {
+            ogs_error("OpenAPI_pdu_session_types_parseFromJSON() failed: Expected allowed_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pdu_session_types_local_var = OpenAPI_pdu_session_types_create (

--- a/lib/sbi/openapi/model/pdu_session_types.c
+++ b/lib/sbi/openapi/model/pdu_session_types.c
@@ -103,10 +103,11 @@ OpenAPI_pdu_session_types_t *OpenAPI_pdu_session_types_parseFromJSON(cJSON *pdu_
             }
             localEnum = OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_session_types\" is not supported. Ignoring it ...",
+                         allowed_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pdu_session_types_1.c
+++ b/lib/sbi/openapi/model/pdu_session_types_1.c
@@ -109,6 +109,10 @@ OpenAPI_pdu_session_types_1_t *OpenAPI_pdu_session_types_1_parseFromJSON(cJSON *
                 OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
             }
         }
+        if (allowed_session_typesList->count == 0) {
+            ogs_error("OpenAPI_pdu_session_types_1_parseFromJSON() failed: Expected allowed_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pdu_session_types_1_local_var = OpenAPI_pdu_session_types_1_create (

--- a/lib/sbi/openapi/model/pdu_session_types_1.c
+++ b/lib/sbi/openapi/model/pdu_session_types_1.c
@@ -103,10 +103,11 @@ OpenAPI_pdu_session_types_1_t *OpenAPI_pdu_session_types_1_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(allowed_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_session_types\" is not supported. Ignoring it ...",
+                         allowed_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction.c
+++ b/lib/sbi/openapi/model/plmn_restriction.c
@@ -203,6 +203,10 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
                 OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed: Expected rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     forbidden_areas = cJSON_GetObjectItemCaseSensitive(plmn_restrictionJSON, "forbiddenAreas");
@@ -262,6 +266,10 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
                 OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
         }
+        if (core_network_type_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed: Expected core_network_type_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     primary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(plmn_restrictionJSON, "primaryRatRestrictions");
@@ -288,6 +296,10 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
                 OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (primary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed: Expected primary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     secondary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(plmn_restrictionJSON, "secondaryRatRestrictions");
@@ -313,6 +325,10 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
             } else {
                 OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
+        }
+        if (secondary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_parseFromJSON() failed: Expected secondary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction.c
+++ b/lib/sbi/openapi/model/plmn_restriction.c
@@ -197,10 +197,11 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
             }
             localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_restrictions\" is not supported. Ignoring it ...",
+                         rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -255,10 +256,11 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
             }
             localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"core_network_type_restrictions\" is not supported. Ignoring it ...",
+                         core_network_type_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -280,10 +282,11 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
             }
             localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"primary_rat_restrictions\" is not supported. Ignoring it ...",
+                         primary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -305,10 +308,11 @@ OpenAPI_plmn_restriction_t *OpenAPI_plmn_restriction_parseFromJSON(cJSON *plmn_r
             }
             localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"secondary_rat_restrictions\" is not supported. Ignoring it ...",
+                         secondary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction_1.c
+++ b/lib/sbi/openapi/model/plmn_restriction_1.c
@@ -203,6 +203,10 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
                 OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed: Expected rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     forbidden_areas = cJSON_GetObjectItemCaseSensitive(plmn_restriction_1JSON, "forbiddenAreas");
@@ -262,6 +266,10 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
                 OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
         }
+        if (core_network_type_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed: Expected core_network_type_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     primary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(plmn_restriction_1JSON, "primaryRatRestrictions");
@@ -288,6 +296,10 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
                 OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
         }
+        if (primary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed: Expected primary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     secondary_rat_restrictions = cJSON_GetObjectItemCaseSensitive(plmn_restriction_1JSON, "secondaryRatRestrictions");
@@ -313,6 +325,10 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
             } else {
                 OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
+        }
+        if (secondary_rat_restrictionsList->count == 0) {
+            ogs_error("OpenAPI_plmn_restriction_1_parseFromJSON() failed: Expected secondary_rat_restrictionsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/plmn_restriction_1.c
+++ b/lib/sbi/openapi/model/plmn_restriction_1.c
@@ -197,10 +197,11 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
             }
             localEnum = OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_restrictions\" is not supported. Ignoring it ...",
+                         rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -255,10 +256,11 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
             }
             localEnum = OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_core_network_type_FromString(core_network_type_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"core_network_type_restrictions\" is not supported. Ignoring it ...",
+                         core_network_type_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(core_network_type_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -280,10 +282,11 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
             }
             localEnum = OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(primary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"primary_rat_restrictions\" is not supported. Ignoring it ...",
+                         primary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(primary_rat_restrictionsList, (void *)localEnum);
         }
     }
 
@@ -305,10 +308,11 @@ OpenAPI_plmn_restriction_1_t *OpenAPI_plmn_restriction_1_parseFromJSON(cJSON *pl
             }
             localEnum = OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(secondary_rat_restrictions_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"secondary_rat_restrictions\" is not supported. Ignoring it ...",
+                         secondary_rat_restrictions_local->valuestring);
+            } else {
+                OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
             }
-            OpenAPI_list_add(secondary_rat_restrictionsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -383,6 +383,10 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
                 OpenAPI_list_add(triggersList, (void *)localEnum);
             }
         }
+        if (triggersList->count == 0) {
+            ogs_error("OpenAPI_policy_association_parseFromJSON() failed: Expected triggersList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serv_area_res = cJSON_GetObjectItemCaseSensitive(policy_associationJSON, "servAreaRes");

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -377,10 +377,11 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
             }
             localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"triggers\" is not supported. Ignoring it ...",
+                         triggers_local->valuestring);
+            } else {
+                OpenAPI_list_add(triggersList, (void *)localEnum);
             }
-            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_request.c
+++ b/lib/sbi/openapi/model/policy_association_request.c
@@ -758,6 +758,10 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
                 OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
         }
+        if (access_typesList->count == 0) {
+            ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed: Expected access_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pei = cJSON_GetObjectItemCaseSensitive(policy_association_requestJSON, "pei");
@@ -826,6 +830,10 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
             } else {
                 OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
+        }
+        if (rat_typesList->count == 0) {
+            ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed: Expected rat_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_request.c
+++ b/lib/sbi/openapi/model/policy_association_request.c
@@ -752,10 +752,11 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
             }
             localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_types\" is not supported. Ignoring it ...",
+                         access_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -820,10 +821,11 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
             }
             localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_types\" is not supported. Ignoring it ...",
+                         rat_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -658,6 +658,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
                 OpenAPI_list_add(triggersList, (void *)localEnum);
             }
         }
+        if (triggersList->count == 0) {
+            ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed: Expected triggersList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serv_area_res = cJSON_GetObjectItemCaseSensitive(policy_association_update_requestJSON, "servAreaRes");
@@ -859,6 +863,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
                 OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
         }
+        if (access_typesList->count == 0) {
+            ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed: Expected access_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     rat_types = cJSON_GetObjectItemCaseSensitive(policy_association_update_requestJSON, "ratTypes");
@@ -884,6 +892,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
             } else {
                 OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
+        }
+        if (rat_typesList->count == 0) {
+            ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed: Expected rat_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -652,10 +652,11 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
             }
             localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"triggers\" is not supported. Ignoring it ...",
+                         triggers_local->valuestring);
+            } else {
+                OpenAPI_list_add(triggersList, (void *)localEnum);
             }
-            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 
@@ -852,10 +853,11 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
             }
             localEnum = OpenAPI_access_type_FromString(access_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_types\" is not supported. Ignoring it ...",
+                         access_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typesList, (void *)localEnum);
         }
     }
 
@@ -877,10 +879,11 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
             }
             localEnum = OpenAPI_rat_type_FromString(rat_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(rat_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rat_types\" is not supported. Ignoring it ...",
+                         rat_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(rat_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(rat_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -363,6 +363,10 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
                 OpenAPI_list_add(triggersList, (void *)localEnum);
             }
         }
+        if (triggersList->count == 0) {
+            ogs_error("OpenAPI_policy_update_parseFromJSON() failed: Expected triggersList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     serv_area_res = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "servAreaRes");

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -357,10 +357,11 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
             }
             localEnum = OpenAPI_request_trigger_FromString(triggers_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_request_trigger_FromString(triggers_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"triggers\" is not supported. Ignoring it ...",
+                         triggers_local->valuestring);
+            } else {
+                OpenAPI_list_add(triggersList, (void *)localEnum);
             }
-            OpenAPI_list_add(triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/pro_se_allowed_plmn.c
+++ b/lib/sbi/openapi/model/pro_se_allowed_plmn.c
@@ -123,6 +123,10 @@ OpenAPI_pro_se_allowed_plmn_t *OpenAPI_pro_se_allowed_plmn_parseFromJSON(cJSON *
                 OpenAPI_list_add(prose_direct_allowedList, (void *)localEnum);
             }
         }
+        if (prose_direct_allowedList->count == 0) {
+            ogs_error("OpenAPI_pro_se_allowed_plmn_parseFromJSON() failed: Expected prose_direct_allowedList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pro_se_allowed_plmn_local_var = OpenAPI_pro_se_allowed_plmn_create (

--- a/lib/sbi/openapi/model/pro_se_allowed_plmn.c
+++ b/lib/sbi/openapi/model/pro_se_allowed_plmn.c
@@ -117,10 +117,11 @@ OpenAPI_pro_se_allowed_plmn_t *OpenAPI_pro_se_allowed_plmn_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_prose_direct_allowed_FromString(prose_direct_allowed_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_prose_direct_allowed_FromString(prose_direct_allowed_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"prose_direct_allowed\" is not supported. Ignoring it ...",
+                         prose_direct_allowed_local->valuestring);
+            } else {
+                OpenAPI_list_add(prose_direct_allowedList, (void *)localEnum);
             }
-            OpenAPI_list_add(prose_direct_allowedList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/protection_policy.c
+++ b/lib/sbi/openapi/model/protection_policy.c
@@ -144,6 +144,10 @@ OpenAPI_protection_policy_t *OpenAPI_protection_policy_parseFromJSON(cJSON *prot
                 OpenAPI_list_add(data_type_enc_policyList, (void *)localEnum);
             }
         }
+        if (data_type_enc_policyList->count == 0) {
+            ogs_error("OpenAPI_protection_policy_parseFromJSON() failed: Expected data_type_enc_policyList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     protection_policy_local_var = OpenAPI_protection_policy_create (

--- a/lib/sbi/openapi/model/protection_policy.c
+++ b/lib/sbi/openapi/model/protection_policy.c
@@ -138,10 +138,11 @@ OpenAPI_protection_policy_t *OpenAPI_protection_policy_parseFromJSON(cJSON *prot
             }
             localEnum = OpenAPI_ie_type_FromString(data_type_enc_policy_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_ie_type_FromString(data_type_enc_policy_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"data_type_enc_policy\" is not supported. Ignoring it ...",
+                         data_type_enc_policy_local->valuestring);
+            } else {
+                OpenAPI_list_add(data_type_enc_policyList, (void *)localEnum);
             }
-            OpenAPI_list_add(data_type_enc_policyList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/qos_monitoring_data.c
+++ b/lib/sbi/openapi/model/qos_monitoring_data.c
@@ -244,6 +244,10 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
                 OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
         }
+        if (req_qos_mon_paramsList->count == 0) {
+            ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed: Expected req_qos_mon_paramsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     rep_freqs = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repFreqs");
     if (!rep_freqs) {
@@ -271,6 +275,10 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
             } else {
                 OpenAPI_list_add(rep_freqsList, (void *)localEnum);
             }
+        }
+        if (rep_freqsList->count == 0) {
+            ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed: Expected rep_freqsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
 
     rep_thresh_dl = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshDl");

--- a/lib/sbi/openapi/model/qos_monitoring_data.c
+++ b/lib/sbi/openapi/model/qos_monitoring_data.c
@@ -238,10 +238,11 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_requested_qos_monitoring_parameter_FromString(req_qos_mon_params_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_qos_mon_params\" is not supported. Ignoring it ...",
+                         req_qos_mon_params_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_qos_mon_paramsList, (void *)localEnum);
         }
 
     rep_freqs = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repFreqs");
@@ -265,10 +266,11 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_reporting_frequency_FromString(rep_freqs_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_reporting_frequency_FromString(rep_freqs_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rep_freqs\" is not supported. Ignoring it ...",
+                         rep_freqs_local->valuestring);
+            } else {
+                OpenAPI_list_add(rep_freqsList, (void *)localEnum);
             }
-            OpenAPI_list_add(rep_freqsList, (void *)localEnum);
         }
 
     rep_thresh_dl = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshDl");

--- a/lib/sbi/openapi/model/registration_location_info.c
+++ b/lib/sbi/openapi/model/registration_location_info.c
@@ -210,6 +210,10 @@ OpenAPI_registration_location_info_t *OpenAPI_registration_location_info_parseFr
                 OpenAPI_list_add(access_type_listList, (void *)localEnum);
             }
         }
+        if (access_type_listList->count == 0) {
+            ogs_error("OpenAPI_registration_location_info_parseFromJSON() failed: Expected access_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     registration_location_info_local_var = OpenAPI_registration_location_info_create (
         ogs_strdup(amf_instance_id->valuestring),

--- a/lib/sbi/openapi/model/registration_location_info.c
+++ b/lib/sbi/openapi/model/registration_location_info.c
@@ -204,10 +204,11 @@ OpenAPI_registration_location_info_t *OpenAPI_registration_location_info_parseFr
             }
             localEnum = OpenAPI_access_type_FromString(access_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_type_list\" is not supported. Ignoring it ...",
+                         access_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_type_listList, (void *)localEnum);
         }
 
     registration_location_info_local_var = OpenAPI_registration_location_info_create (

--- a/lib/sbi/openapi/model/reporting_information.c
+++ b/lib/sbi/openapi/model/reporting_information.c
@@ -244,6 +244,10 @@ OpenAPI_reporting_information_t *OpenAPI_reporting_information_parseFromJSON(cJS
                 OpenAPI_list_add(partition_criteriaList, (void *)localEnum);
             }
         }
+        if (partition_criteriaList->count == 0) {
+            ogs_error("OpenAPI_reporting_information_parseFromJSON() failed: Expected partition_criteriaList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     grp_rep_time = cJSON_GetObjectItemCaseSensitive(reporting_informationJSON, "grpRepTime");

--- a/lib/sbi/openapi/model/reporting_information.c
+++ b/lib/sbi/openapi/model/reporting_information.c
@@ -238,10 +238,11 @@ OpenAPI_reporting_information_t *OpenAPI_reporting_information_parseFromJSON(cJS
             }
             localEnum = OpenAPI_partitioning_criteria_FromString(partition_criteria_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_partitioning_criteria_FromString(partition_criteria_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"partition_criteria\" is not supported. Ignoring it ...",
+                         partition_criteria_local->valuestring);
+            } else {
+                OpenAPI_list_add(partition_criteriaList, (void *)localEnum);
             }
-            OpenAPI_list_add(partition_criteriaList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/requested_rule_data.c
+++ b/lib/sbi/openapi/model/requested_rule_data.c
@@ -138,10 +138,11 @@ OpenAPI_requested_rule_data_t *OpenAPI_requested_rule_data_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_requested_rule_data_type_FromString(req_data_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_requested_rule_data_type_FromString(req_data_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_data\" is not supported. Ignoring it ...",
+                         req_data_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_dataList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_dataList, (void *)localEnum);
         }
 
     requested_rule_data_local_var = OpenAPI_requested_rule_data_create (

--- a/lib/sbi/openapi/model/requested_rule_data.c
+++ b/lib/sbi/openapi/model/requested_rule_data.c
@@ -144,6 +144,10 @@ OpenAPI_requested_rule_data_t *OpenAPI_requested_rule_data_parseFromJSON(cJSON *
                 OpenAPI_list_add(req_dataList, (void *)localEnum);
             }
         }
+        if (req_dataList->count == 0) {
+            ogs_error("OpenAPI_requested_rule_data_parseFromJSON() failed: Expected req_dataList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     requested_rule_data_local_var = OpenAPI_requested_rule_data_create (
         ref_pcc_rule_idsList,

--- a/lib/sbi/openapi/model/scp_domain_cond.c
+++ b/lib/sbi/openapi/model/scp_domain_cond.c
@@ -139,6 +139,10 @@ OpenAPI_scp_domain_cond_t *OpenAPI_scp_domain_cond_parseFromJSON(cJSON *scp_doma
                 OpenAPI_list_add(nf_type_listList, (void *)localEnum);
             }
         }
+        if (nf_type_listList->count == 0) {
+            ogs_error("OpenAPI_scp_domain_cond_parseFromJSON() failed: Expected nf_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     scp_domain_cond_local_var = OpenAPI_scp_domain_cond_create (

--- a/lib/sbi/openapi/model/scp_domain_cond.c
+++ b/lib/sbi/openapi/model/scp_domain_cond.c
@@ -133,10 +133,11 @@ OpenAPI_scp_domain_cond_t *OpenAPI_scp_domain_cond_parseFromJSON(cJSON *scp_doma
             }
             localEnum = OpenAPI_nf_type_FromString(nf_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_nf_type_FromString(nf_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"nf_type_list\" is not supported. Ignoring it ...",
+                         nf_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(nf_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(nf_type_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/scp_info.c
+++ b/lib/sbi/openapi/model/scp_info.c
@@ -657,10 +657,11 @@ OpenAPI_scp_info_t *OpenAPI_scp_info_parseFromJSON(cJSON *scp_infoJSON)
             }
             localEnum = OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_scp_capability_FromString(scp_capabilities_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"scp_capabilities\" is not supported. Ignoring it ...",
+                         scp_capabilities_local->valuestring);
+            } else {
+                OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
             }
-            OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/scp_info.c
+++ b/lib/sbi/openapi/model/scp_info.c
@@ -663,6 +663,10 @@ OpenAPI_scp_info_t *OpenAPI_scp_info_parseFromJSON(cJSON *scp_infoJSON)
                 OpenAPI_list_add(scp_capabilitiesList, (void *)localEnum);
             }
         }
+        if (scp_capabilitiesList->count == 0) {
+            ogs_error("OpenAPI_scp_info_parseFromJSON() failed: Expected scp_capabilitiesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     scp_info_local_var = OpenAPI_scp_info_create (

--- a/lib/sbi/openapi/model/sec_negotiate_req_data.c
+++ b/lib/sbi/openapi/model/sec_negotiate_req_data.c
@@ -269,6 +269,10 @@ OpenAPI_sec_negotiate_req_data_t *OpenAPI_sec_negotiate_req_data_parseFromJSON(c
                 OpenAPI_list_add(supported_sec_capability_listList, (void *)localEnum);
             }
         }
+        if (supported_sec_capability_listList->count == 0) {
+            ogs_error("OpenAPI_sec_negotiate_req_data_parseFromJSON() failed: Expected supported_sec_capability_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
 
     _3_gpp_sbi_target_api_root_supported = cJSON_GetObjectItemCaseSensitive(sec_negotiate_req_dataJSON, "3GppSbiTargetApiRootSupported");
     if (_3_gpp_sbi_target_api_root_supported) {

--- a/lib/sbi/openapi/model/sec_negotiate_req_data.c
+++ b/lib/sbi/openapi/model/sec_negotiate_req_data.c
@@ -263,10 +263,11 @@ OpenAPI_sec_negotiate_req_data_t *OpenAPI_sec_negotiate_req_data_parseFromJSON(c
             }
             localEnum = OpenAPI_security_capability_FromString(supported_sec_capability_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_security_capability_FromString(supported_sec_capability_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"supported_sec_capability_list\" is not supported. Ignoring it ...",
+                         supported_sec_capability_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(supported_sec_capability_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(supported_sec_capability_listList, (void *)localEnum);
         }
 
     _3_gpp_sbi_target_api_root_supported = cJSON_GetObjectItemCaseSensitive(sec_negotiate_req_dataJSON, "3GppSbiTargetApiRootSupported");

--- a/lib/sbi/openapi/model/session_rule_report.c
+++ b/lib/sbi/openapi/model/session_rule_report.c
@@ -177,10 +177,11 @@ OpenAPI_session_rule_report_t *OpenAPI_session_rule_report_parseFromJSON(cJSON *
             }
             localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"policy_dec_failure_reports\" is not supported. Ignoring it ...",
+                         policy_dec_failure_reports_local->valuestring);
+            } else {
+                OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/session_rule_report.c
+++ b/lib/sbi/openapi/model/session_rule_report.c
@@ -183,6 +183,10 @@ OpenAPI_session_rule_report_t *OpenAPI_session_rule_report_parseFromJSON(cJSON *
                 OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
         }
+        if (policy_dec_failure_reportsList->count == 0) {
+            ogs_error("OpenAPI_session_rule_report_parseFromJSON() failed: Expected policy_dec_failure_reportsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     session_rule_report_local_var = OpenAPI_session_rule_report_create (

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -1098,10 +1098,11 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
             }
             localEnum = OpenAPI_policy_control_request_trigger_FromString(policy_ctrl_req_triggers_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_control_request_trigger_FromString(policy_ctrl_req_triggers_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"policy_ctrl_req_triggers\" is not supported. Ignoring it ...",
+                         policy_ctrl_req_triggers_local->valuestring);
+            } else {
+                OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)localEnum);
             }
-            OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -1104,6 +1104,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)localEnum);
             }
         }
+        if (policy_ctrl_req_triggersList->count == 0) {
+            ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed: Expected policy_ctrl_req_triggersList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     last_req_rule_data = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "lastReqRuleData");

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -1133,10 +1133,11 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
             }
             localEnum = OpenAPI_policy_control_request_trigger_FromString(rep_policy_ctrl_req_triggers_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_control_request_trigger_FromString(rep_policy_ctrl_req_triggers_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"rep_policy_ctrl_req_triggers\" is not supported. Ignoring it ...",
+                         rep_policy_ctrl_req_triggers_local->valuestring);
+            } else {
+                OpenAPI_list_add(rep_policy_ctrl_req_triggersList, (void *)localEnum);
             }
-            OpenAPI_list_add(rep_policy_ctrl_req_triggersList, (void *)localEnum);
         }
     }
 
@@ -1699,10 +1700,11 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
             }
             localEnum = OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_decision_failure_code_FromString(policy_dec_failure_reports_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"policy_dec_failure_reports\" is not supported. Ignoring it ...",
+                         policy_dec_failure_reports_local->valuestring);
+            } else {
+                OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
-            OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
         }
     }
 
@@ -1780,10 +1782,11 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
             }
             localEnum = OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_dl_data_delivery_status_FromString(types_of_notif_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"types_of_notif\" is not supported. Ignoring it ...",
+                         types_of_notif_local->valuestring);
+            } else {
+                OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
-            OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -1139,6 +1139,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
                 OpenAPI_list_add(rep_policy_ctrl_req_triggersList, (void *)localEnum);
             }
         }
+        if (rep_policy_ctrl_req_triggersList->count == 0) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed: Expected rep_policy_ctrl_req_triggersList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     acc_net_ch_ids = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "accNetChIds");
@@ -1706,6 +1710,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
                 OpenAPI_list_add(policy_dec_failure_reportsList, (void *)localEnum);
             }
         }
+        if (policy_dec_failure_reportsList->count == 0) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed: Expected policy_dec_failure_reportsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     invalid_policy_decs = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "invalidPolicyDecs");
@@ -1787,6 +1795,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
             } else {
                 OpenAPI_list_add(types_of_notifList, (void *)localEnum);
             }
+        }
+        if (types_of_notifList->count == 0) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed: Expected types_of_notifList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/smf_info.c
+++ b/lib/sbi/openapi/model/smf_info.c
@@ -404,6 +404,10 @@ OpenAPI_smf_info_t *OpenAPI_smf_info_parseFromJSON(cJSON *smf_infoJSON)
                 OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
         }
+        if (access_typeList->count == 0) {
+            ogs_error("OpenAPI_smf_info_parseFromJSON() failed: Expected access_typeList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     priority = cJSON_GetObjectItemCaseSensitive(smf_infoJSON, "priority");

--- a/lib/sbi/openapi/model/smf_info.c
+++ b/lib/sbi/openapi/model/smf_info.c
@@ -398,10 +398,11 @@ OpenAPI_smf_info_t *OpenAPI_smf_info_parseFromJSON(cJSON *smf_infoJSON)
             }
             localEnum = OpenAPI_access_type_FromString(access_type_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_access_type_FromString(access_type_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"access_type\" is not supported. Ignoring it ...",
+                         access_type_local->valuestring);
+            } else {
+                OpenAPI_list_add(access_typeList, (void *)localEnum);
             }
-            OpenAPI_list_add(access_typeList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ssc_modes.c
+++ b/lib/sbi/openapi/model/ssc_modes.c
@@ -107,10 +107,11 @@ OpenAPI_ssc_modes_t *OpenAPI_ssc_modes_parseFromJSON(cJSON *ssc_modesJSON)
             }
             localEnum = OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_ssc_modes\" is not supported. Ignoring it ...",
+                         allowed_ssc_modes_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ssc_modes.c
+++ b/lib/sbi/openapi/model/ssc_modes.c
@@ -113,6 +113,10 @@ OpenAPI_ssc_modes_t *OpenAPI_ssc_modes_parseFromJSON(cJSON *ssc_modesJSON)
                 OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
             }
         }
+        if (allowed_ssc_modesList->count == 0) {
+            ogs_error("OpenAPI_ssc_modes_parseFromJSON() failed: Expected allowed_ssc_modesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     ssc_modes_local_var = OpenAPI_ssc_modes_create (

--- a/lib/sbi/openapi/model/ssc_modes_1.c
+++ b/lib/sbi/openapi/model/ssc_modes_1.c
@@ -107,10 +107,11 @@ OpenAPI_ssc_modes_1_t *OpenAPI_ssc_modes_1_parseFromJSON(cJSON *ssc_modes_1JSON)
             }
             localEnum = OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_ssc_mode_FromString(allowed_ssc_modes_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"allowed_ssc_modes\" is not supported. Ignoring it ...",
+                         allowed_ssc_modes_local->valuestring);
+            } else {
+                OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
             }
-            OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/ssc_modes_1.c
+++ b/lib/sbi/openapi/model/ssc_modes_1.c
@@ -113,6 +113,10 @@ OpenAPI_ssc_modes_1_t *OpenAPI_ssc_modes_1_parseFromJSON(cJSON *ssc_modes_1JSON)
                 OpenAPI_list_add(allowed_ssc_modesList, (void *)localEnum);
             }
         }
+        if (allowed_ssc_modesList->count == 0) {
+            ogs_error("OpenAPI_ssc_modes_1_parseFromJSON() failed: Expected allowed_ssc_modesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     ssc_modes_1_local_var = OpenAPI_ssc_modes_1_create (

--- a/lib/sbi/openapi/model/subscription_data.c
+++ b/lib/sbi/openapi/model/subscription_data.c
@@ -501,10 +501,11 @@ OpenAPI_subscription_data_t *OpenAPI_subscription_data_parseFromJSON(cJSON *subs
             }
             localEnum = OpenAPI_notification_event_type_FromString(req_notif_events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_notification_event_type_FromString(req_notif_events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"req_notif_events\" is not supported. Ignoring it ...",
+                         req_notif_events_local->valuestring);
+            } else {
+                OpenAPI_list_add(req_notif_eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(req_notif_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/subscription_data.c
+++ b/lib/sbi/openapi/model/subscription_data.c
@@ -507,6 +507,10 @@ OpenAPI_subscription_data_t *OpenAPI_subscription_data_parseFromJSON(cJSON *subs
                 OpenAPI_list_add(req_notif_eventsList, (void *)localEnum);
             }
         }
+        if (req_notif_eventsList->count == 0) {
+            ogs_error("OpenAPI_subscription_data_parseFromJSON() failed: Expected req_notif_eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     plmn_id = cJSON_GetObjectItemCaseSensitive(subscription_dataJSON, "plmnId");

--- a/lib/sbi/openapi/model/trust_af_info.c
+++ b/lib/sbi/openapi/model/trust_af_info.c
@@ -196,10 +196,11 @@ OpenAPI_trust_af_info_t *OpenAPI_trust_af_info_parseFromJSON(cJSON *trust_af_inf
             }
             localEnum = OpenAPI_af_event_FromString(af_events_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_af_event_FromString(af_events_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"af_events\" is not supported. Ignoring it ...",
+                         af_events_local->valuestring);
+            } else {
+                OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
-            OpenAPI_list_add(af_eventsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/trust_af_info.c
+++ b/lib/sbi/openapi/model/trust_af_info.c
@@ -202,6 +202,10 @@ OpenAPI_trust_af_info_t *OpenAPI_trust_af_info_parseFromJSON(cJSON *trust_af_inf
                 OpenAPI_list_add(af_eventsList, (void *)localEnum);
             }
         }
+        if (af_eventsList->count == 0) {
+            ogs_error("OpenAPI_trust_af_info_parseFromJSON() failed: Expected af_eventsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     app_ids = cJSON_GetObjectItemCaseSensitive(trust_af_infoJSON, "appIds");

--- a/lib/sbi/openapi/model/udr_info.c
+++ b/lib/sbi/openapi/model/udr_info.c
@@ -285,10 +285,11 @@ OpenAPI_udr_info_t *OpenAPI_udr_info_parseFromJSON(cJSON *udr_infoJSON)
             }
             localEnum = OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_data_set_id_FromString(supported_data_sets_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"supported_data_sets\" is not supported. Ignoring it ...",
+                         supported_data_sets_local->valuestring);
+            } else {
+                OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
             }
-            OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/udr_info.c
+++ b/lib/sbi/openapi/model/udr_info.c
@@ -291,6 +291,10 @@ OpenAPI_udr_info_t *OpenAPI_udr_info_parseFromJSON(cJSON *udr_infoJSON)
                 OpenAPI_list_add(supported_data_setsList, (void *)localEnum);
             }
         }
+        if (supported_data_setsList->count == 0) {
+            ogs_error("OpenAPI_udr_info_parseFromJSON() failed: Expected supported_data_setsList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     shared_data_id_ranges = cJSON_GetObjectItemCaseSensitive(udr_infoJSON, "sharedDataIdRanges");

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -1759,6 +1759,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                 OpenAPI_list_add(am_policy_req_trigger_listList, (void *)localEnum);
             }
         }
+        if (am_policy_req_trigger_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected am_policy_req_trigger_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     pcf_ue_policy_uri = cJSON_GetObjectItemCaseSensitive(ue_contextJSON, "pcfUePolicyUri");
@@ -1792,6 +1796,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             } else {
                 OpenAPI_list_add(ue_policy_req_trigger_listList, (void *)localEnum);
             }
+        }
+        if (ue_policy_req_trigger_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected ue_policy_req_trigger_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1834,6 +1842,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             } else {
                 OpenAPI_list_add(restricted_rat_listList, (void *)localEnum);
             }
+        }
+        if (restricted_rat_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected restricted_rat_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -1893,6 +1905,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             } else {
                 OpenAPI_list_add(restricted_core_nw_type_listList, (void *)localEnum);
             }
+        }
+        if (restricted_core_nw_type_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected restricted_core_nw_type_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 
@@ -2087,6 +2103,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                 OpenAPI_list_add(restricted_primary_rat_listList, (void *)localEnum);
             }
         }
+        if (restricted_primary_rat_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected restricted_primary_rat_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     restricted_secondary_rat_list = cJSON_GetObjectItemCaseSensitive(ue_contextJSON, "restrictedSecondaryRatList");
@@ -2112,6 +2132,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             } else {
                 OpenAPI_list_add(restricted_secondary_rat_listList, (void *)localEnum);
             }
+        }
+        if (restricted_secondary_rat_listList->count == 0) {
+            ogs_error("OpenAPI_ue_context_parseFromJSON() failed: Expected restricted_secondary_rat_listList to not be empty (after ignoring unsupported enum values).");
+            goto end;
         }
     }
 

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -1753,10 +1753,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_policy_req_trigger_FromString(am_policy_req_trigger_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_req_trigger_FromString(am_policy_req_trigger_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"am_policy_req_trigger_list\" is not supported. Ignoring it ...",
+                         am_policy_req_trigger_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(am_policy_req_trigger_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(am_policy_req_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -1786,10 +1787,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_policy_req_trigger_FromString(ue_policy_req_trigger_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_policy_req_trigger_FromString(ue_policy_req_trigger_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"ue_policy_req_trigger_list\" is not supported. Ignoring it ...",
+                         ue_policy_req_trigger_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(ue_policy_req_trigger_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(ue_policy_req_trigger_listList, (void *)localEnum);
         }
     }
 
@@ -1827,10 +1829,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_rat_type_FromString(restricted_rat_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(restricted_rat_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"restricted_rat_list\" is not supported. Ignoring it ...",
+                         restricted_rat_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(restricted_rat_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(restricted_rat_listList, (void *)localEnum);
         }
     }
 
@@ -1885,10 +1888,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_core_network_type_FromString(restricted_core_nw_type_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_core_network_type_FromString(restricted_core_nw_type_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"restricted_core_nw_type_list\" is not supported. Ignoring it ...",
+                         restricted_core_nw_type_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(restricted_core_nw_type_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(restricted_core_nw_type_listList, (void *)localEnum);
         }
     }
 
@@ -2077,10 +2081,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_rat_type_FromString(restricted_primary_rat_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(restricted_primary_rat_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"restricted_primary_rat_list\" is not supported. Ignoring it ...",
+                         restricted_primary_rat_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(restricted_primary_rat_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(restricted_primary_rat_listList, (void *)localEnum);
         }
     }
 
@@ -2102,10 +2107,11 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
             }
             localEnum = OpenAPI_rat_type_FromString(restricted_secondary_rat_list_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_rat_type_FromString(restricted_secondary_rat_list_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"restricted_secondary_rat_list\" is not supported. Ignoring it ...",
+                         restricted_secondary_rat_list_local->valuestring);
+            } else {
+                OpenAPI_list_add(restricted_secondary_rat_listList, (void *)localEnum);
             }
-            OpenAPI_list_add(restricted_secondary_rat_listList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/upf_info.c
+++ b/lib/sbi/openapi/model/upf_info.c
@@ -467,10 +467,11 @@ OpenAPI_upf_info_t *OpenAPI_upf_info_parseFromJSON(cJSON *upf_infoJSON)
             }
             localEnum = OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_pdu_session_type_FromString(pdu_session_types_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"pdu_session_types\" is not supported. Ignoring it ...",
+                         pdu_session_types_local->valuestring);
+            } else {
+                OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
-            OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
         }
     }
 

--- a/lib/sbi/openapi/model/upf_info.c
+++ b/lib/sbi/openapi/model/upf_info.c
@@ -473,6 +473,10 @@ OpenAPI_upf_info_t *OpenAPI_upf_info_parseFromJSON(cJSON *upf_infoJSON)
                 OpenAPI_list_add(pdu_session_typesList, (void *)localEnum);
             }
         }
+        if (pdu_session_typesList->count == 0) {
+            ogs_error("OpenAPI_upf_info_parseFromJSON() failed: Expected pdu_session_typesList to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
     }
 
     atsss_capability = cJSON_GetObjectItemCaseSensitive(upf_infoJSON, "atsssCapability");

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/generator.sh
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/generator.sh
@@ -4,7 +4,7 @@
 #export C_POST_PROCESS_FILE="/usr/bin/uncrustify --no-backup"
 #export UNCRUSTIFY_CONFIG="./openapi-generator/uncrustify-rules.cfg"
 
-openapi_generator_cli="java -jar openapi-generator-cli.jar"
+openapi_generator_cli="openapi-generator-cli"
 
 $openapi_generator_cli generate -i ./modified/TS29573_N32_Handshake.yaml -c ./openapi-generator/config.yaml -g c -o ../../openapi || exit 1
 $openapi_generator_cli generate -i ./modified/TS29504_Nudr_DR.yaml -c ./openapi-generator/config.yaml -g c -o ../../openapi || exit 1

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/generator.sh
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/generator.sh
@@ -4,7 +4,7 @@
 #export C_POST_PROCESS_FILE="/usr/bin/uncrustify --no-backup"
 #export UNCRUSTIFY_CONFIG="./openapi-generator/uncrustify-rules.cfg"
 
-openapi_generator_cli="openapi-generator-cli"
+openapi_generator_cli="java -jar openapi-generator-cli.jar"
 
 $openapi_generator_cli generate -i ./modified/TS29573_N32_Handshake.yaml -c ./openapi-generator/config.yaml -g c -o ../../openapi || exit 1
 $openapi_generator_cli generate -i ./modified/TS29504_Nudr_DR.yaml -c ./openapi-generator/config.yaml -g c -o ../../openapi || exit 1

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
@@ -842,6 +842,12 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
                 {{/items}}
             {{/isEnum}}
         }
+        {{#isEnum}}
+        if ({{{name}}}List->count == 0) {
+            ogs_error("OpenAPI_{{classname}}_parseFromJSON() failed: Expected {{{name}}}List to not be empty (after ignoring unsupported enum values).");
+            goto end;
+        }
+        {{/isEnum}}
         {{/isArray}}
         {{#isMap}}
         cJSON *{{{name}}}_local_map = NULL;

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
@@ -773,10 +773,11 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
             }
             localEnum = OpenAPI_{{{complexType}}}_FromString({{{name}}}_local->valuestring);
             if (!localEnum) {
-                ogs_error("OpenAPI_{{{complexType}}}_FromString({{{name}}}_local->valuestring) failed");
-                goto end;
+                ogs_info("Enum value \"%s\" for field \"{{{name}}}\" is not supported. Ignoring it ...",
+                         {{{name}}}_local->valuestring);
+            } else {
+                OpenAPI_list_add({{{name}}}List, (void *)localEnum);
             }
-            OpenAPI_list_add({{{name}}}List, (void *)localEnum);
             {{/isEnum}}
             {{^isEnum}}
                 {{#isPrimitiveType}}


### PR DESCRIPTION
This is a fix for bug https://github.com/open5gs/open5gs/issues/2622 by adding:

A check whether an enum value to be parsed is unknown and ignoring it, while logging a warning. This may result in an empty list if the request contains only unknown events.

fixes https://github.com/open5gs/open5gs/issues/2622

Edit: An HTTP request containing an empty enum list -- either because it was received empty or it resulted in an empty list due to ignoring unsupported enum values -- is rejected with a `400 Bad Request` error.