### PR TITLE
[PCF,SMF] Fix PCF initiated SM Policy Association termination

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -1335,6 +1335,10 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
 
                     memset(&param, 0, sizeof(param));
                     param.state = SMF_NETWORK_REQUESTED_PDU_SESSION_RELEASE;
+                    sess->pti = OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED;
+                    param.n1smbuf = gsm_build_pdu_session_release_command(
+                            sess, OGS_5GSM_CAUSE_REGULAR_DEACTIVATION);
+                    ogs_assert(param.n1smbuf);
                     param.n2smbuf = ngap_build_pdu_session_resource_release_command_transfer(
                             sess, SMF_NGAP_STATE_DELETE_TRIGGER_PCF_INITIATED,
                             NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release);

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -718,7 +718,7 @@ bool smf_npcf_smpolicycontrol_handle_terminate_notify(
         r = smf_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL, NULL,
                 smf_npcf_smpolicycontrol_build_delete,
-                sess, NULL, OGS_PFCP_DELETE_TRIGGER_PCF_INITIATED, &param);
+                sess, stream, OGS_PFCP_DELETE_TRIGGER_PCF_INITIATED, &param);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
     } else {


### PR DESCRIPTION
- [PCF] TerminationNotification data structure in the body of the HTTP POST request
- [SMF] Stream usage to prevent assertion when trying to request PFCP Deletion
- [SMF] N1 container usage for OGS_PFCP_DELETE_TRIGGER_PCF_INITIATED to trigger PDU session release from UE