### PR TITLE
Add suport for nullable fields in OpenAPI documents

### DIFF
--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -11,13 +11,16 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     OpenAPI_list_t *internal_group_ids,
     OpenAPI_list_t* shared_vn_group_data_ids,
     OpenAPI_ambr_rm_t *subscribed_ue_ambr,
+    bool is_nssai_null,
     OpenAPI_nssai_t *nssai,
     OpenAPI_set_t *rat_restrictions,
     OpenAPI_list_t *forbidden_areas,
     OpenAPI_service_area_restriction_t *service_area_restriction,
     OpenAPI_list_t *core_network_type_restrictions,
+    bool is_rfsp_index_null,
     bool is_rfsp_index,
     int rfsp_index,
+    bool is_subs_reg_timer_null,
     bool is_subs_reg_timer,
     int subs_reg_timer,
     bool is_ue_usage_type,
@@ -26,6 +29,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     int mps_priority,
     bool is_mcs_priority,
     int mcs_priority,
+    bool is_active_time_null,
     bool is_active_time,
     int active_time,
     OpenAPI_sor_info_t *sor_info,
@@ -45,6 +49,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     int service_gap_time,
     OpenAPI_mdt_user_consent_e mdt_user_consent,
     OpenAPI_mdt_configuration_t *mdt_configuration,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_cag_data_t *cag_data,
     char *stn_sr,
@@ -83,13 +88,16 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     access_and_mobility_subscription_data_local_var->internal_group_ids = internal_group_ids;
     access_and_mobility_subscription_data_local_var->shared_vn_group_data_ids = shared_vn_group_data_ids;
     access_and_mobility_subscription_data_local_var->subscribed_ue_ambr = subscribed_ue_ambr;
+    access_and_mobility_subscription_data_local_var->is_nssai_null = is_nssai_null;
     access_and_mobility_subscription_data_local_var->nssai = nssai;
     access_and_mobility_subscription_data_local_var->rat_restrictions = rat_restrictions;
     access_and_mobility_subscription_data_local_var->forbidden_areas = forbidden_areas;
     access_and_mobility_subscription_data_local_var->service_area_restriction = service_area_restriction;
     access_and_mobility_subscription_data_local_var->core_network_type_restrictions = core_network_type_restrictions;
+    access_and_mobility_subscription_data_local_var->is_rfsp_index_null = is_rfsp_index_null;
     access_and_mobility_subscription_data_local_var->is_rfsp_index = is_rfsp_index;
     access_and_mobility_subscription_data_local_var->rfsp_index = rfsp_index;
+    access_and_mobility_subscription_data_local_var->is_subs_reg_timer_null = is_subs_reg_timer_null;
     access_and_mobility_subscription_data_local_var->is_subs_reg_timer = is_subs_reg_timer;
     access_and_mobility_subscription_data_local_var->subs_reg_timer = subs_reg_timer;
     access_and_mobility_subscription_data_local_var->is_ue_usage_type = is_ue_usage_type;
@@ -98,6 +106,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     access_and_mobility_subscription_data_local_var->mps_priority = mps_priority;
     access_and_mobility_subscription_data_local_var->is_mcs_priority = is_mcs_priority;
     access_and_mobility_subscription_data_local_var->mcs_priority = mcs_priority;
+    access_and_mobility_subscription_data_local_var->is_active_time_null = is_active_time_null;
     access_and_mobility_subscription_data_local_var->is_active_time = is_active_time;
     access_and_mobility_subscription_data_local_var->active_time = active_time;
     access_and_mobility_subscription_data_local_var->sor_info = sor_info;
@@ -117,6 +126,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     access_and_mobility_subscription_data_local_var->service_gap_time = service_gap_time;
     access_and_mobility_subscription_data_local_var->mdt_user_consent = mdt_user_consent;
     access_and_mobility_subscription_data_local_var->mdt_configuration = mdt_configuration;
+    access_and_mobility_subscription_data_local_var->is_trace_data_null = is_trace_data_null;
     access_and_mobility_subscription_data_local_var->trace_data = trace_data;
     access_and_mobility_subscription_data_local_var->cag_data = cag_data;
     access_and_mobility_subscription_data_local_var->stn_sr = stn_sr;
@@ -440,6 +450,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
         ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [nssai]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data->is_nssai_null) {
+        if (cJSON_AddNullToObject(item, "nssai") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [nssai]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data->rat_restrictions != OpenAPI_rat_type_NULL) {
@@ -504,6 +519,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
         ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [rfsp_index]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data->is_rfsp_index_null) {
+        if (cJSON_AddNullToObject(item, "rfspIndex") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [rfsp_index]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data->is_subs_reg_timer) {
@@ -511,6 +531,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
         ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [subs_reg_timer]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data->is_subs_reg_timer_null) {
+        if (cJSON_AddNullToObject(item, "subsRegTimer") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [subs_reg_timer]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data->is_ue_usage_type) {
@@ -539,6 +564,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
         ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [active_time]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data->is_active_time_null) {
+        if (cJSON_AddNullToObject(item, "activeTime") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [active_time]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data->sor_info) {
@@ -682,6 +712,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_convertToJSON(OpenAPI_acces
         ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data->cag_data) {
@@ -1124,10 +1159,12 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
 
     nssai = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "nssai");
     if (nssai) {
+    if (!cJSON_IsNull(nssai)) {
     nssai_local_nonprim = OpenAPI_nssai_parseFromJSON(nssai);
     if (!nssai_local_nonprim) {
         ogs_error("OpenAPI_nssai_parseFromJSON failed [nssai]");
         goto end;
+    }
     }
     }
 
@@ -1216,17 +1253,21 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
 
     rfsp_index = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "rfspIndex");
     if (rfsp_index) {
+    if (!cJSON_IsNull(rfsp_index)) {
     if (!cJSON_IsNumber(rfsp_index)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [rfsp_index]");
         goto end;
     }
     }
+    }
 
     subs_reg_timer = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "subsRegTimer");
     if (subs_reg_timer) {
+    if (!cJSON_IsNull(subs_reg_timer)) {
     if (!cJSON_IsNumber(subs_reg_timer)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [subs_reg_timer]");
         goto end;
+    }
     }
     }
 
@@ -1256,9 +1297,11 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
 
     active_time = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "activeTime");
     if (active_time) {
+    if (!cJSON_IsNull(active_time)) {
     if (!cJSON_IsNumber(active_time)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [active_time]");
         goto end;
+    }
     }
     }
 
@@ -1416,10 +1459,12 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
 
     trace_data = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_dataJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -1720,13 +1765,16 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         internal_group_ids ? internal_group_idsList : NULL,
         shared_vn_group_data_ids ? shared_vn_group_data_idsList : NULL,
         subscribed_ue_ambr ? subscribed_ue_ambr_local_nonprim : NULL,
+        nssai && cJSON_IsNull(nssai) ? true : false,
         nssai ? nssai_local_nonprim : NULL,
         rat_restrictions ? rat_restrictionsList : NULL,
         forbidden_areas ? forbidden_areasList : NULL,
         service_area_restriction ? service_area_restriction_local_nonprim : NULL,
         core_network_type_restrictions ? core_network_type_restrictionsList : NULL,
+        rfsp_index && cJSON_IsNull(rfsp_index) ? true : false,
         rfsp_index ? true : false,
         rfsp_index ? rfsp_index->valuedouble : 0,
+        subs_reg_timer && cJSON_IsNull(subs_reg_timer) ? true : false,
         subs_reg_timer ? true : false,
         subs_reg_timer ? subs_reg_timer->valuedouble : 0,
         ue_usage_type ? true : false,
@@ -1735,6 +1783,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         mps_priority ? mps_priority->valueint : 0,
         mcs_priority ? true : false,
         mcs_priority ? mcs_priority->valueint : 0,
+        active_time && cJSON_IsNull(active_time) ? true : false,
         active_time ? true : false,
         active_time ? active_time->valuedouble : 0,
         sor_info ? sor_info_local_nonprim : NULL,
@@ -1754,6 +1803,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
         service_gap_time ? service_gap_time->valuedouble : 0,
         mdt_user_consent ? mdt_user_consentVariable : 0,
         mdt_configuration ? mdt_configuration_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         cag_data ? cag_data_local_nonprim : NULL,
         stn_sr && !cJSON_IsNull(stn_sr) ? ogs_strdup(stn_sr->valuestring) : NULL,

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.h
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.h
@@ -50,13 +50,16 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_s {
     OpenAPI_list_t *internal_group_ids;
     OpenAPI_list_t* shared_vn_group_data_ids;
     struct OpenAPI_ambr_rm_s *subscribed_ue_ambr;
+    bool is_nssai_null;
     struct OpenAPI_nssai_s *nssai;
     OpenAPI_set_t *rat_restrictions;
     OpenAPI_list_t *forbidden_areas;
     struct OpenAPI_service_area_restriction_s *service_area_restriction;
     OpenAPI_list_t *core_network_type_restrictions;
+    bool is_rfsp_index_null;
     bool is_rfsp_index;
     int rfsp_index;
+    bool is_subs_reg_timer_null;
     bool is_subs_reg_timer;
     int subs_reg_timer;
     bool is_ue_usage_type;
@@ -65,6 +68,7 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_s {
     int mps_priority;
     bool is_mcs_priority;
     int mcs_priority;
+    bool is_active_time_null;
     bool is_active_time;
     int active_time;
     struct OpenAPI_sor_info_s *sor_info;
@@ -84,6 +88,7 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_s {
     int service_gap_time;
     OpenAPI_mdt_user_consent_e mdt_user_consent;
     struct OpenAPI_mdt_configuration_s *mdt_configuration;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     struct OpenAPI_cag_data_s *cag_data;
     char *stn_sr;
@@ -120,13 +125,16 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     OpenAPI_list_t *internal_group_ids,
     OpenAPI_list_t* shared_vn_group_data_ids,
     OpenAPI_ambr_rm_t *subscribed_ue_ambr,
+    bool is_nssai_null,
     OpenAPI_nssai_t *nssai,
     OpenAPI_set_t *rat_restrictions,
     OpenAPI_list_t *forbidden_areas,
     OpenAPI_service_area_restriction_t *service_area_restriction,
     OpenAPI_list_t *core_network_type_restrictions,
+    bool is_rfsp_index_null,
     bool is_rfsp_index,
     int rfsp_index,
+    bool is_subs_reg_timer_null,
     bool is_subs_reg_timer,
     int subs_reg_timer,
     bool is_ue_usage_type,
@@ -135,6 +143,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     int mps_priority,
     bool is_mcs_priority,
     int mcs_priority,
+    bool is_active_time_null,
     bool is_active_time,
     int active_time,
     OpenAPI_sor_info_t *sor_info,
@@ -154,6 +163,7 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
     int service_gap_time,
     OpenAPI_mdt_user_consent_e mdt_user_consent,
     OpenAPI_mdt_configuration_t *mdt_configuration,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_cag_data_t *cag_data,
     char *stn_sr,

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -11,13 +11,16 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     OpenAPI_list_t *internal_group_ids,
     OpenAPI_list_t* shared_vn_group_data_ids,
     OpenAPI_ambr_rm_t *subscribed_ue_ambr,
+    bool is_nssai_null,
     OpenAPI_nssai_1_t *nssai,
     OpenAPI_set_t *rat_restrictions,
     OpenAPI_list_t *forbidden_areas,
     OpenAPI_service_area_restriction_1_t *service_area_restriction,
     OpenAPI_list_t *core_network_type_restrictions,
+    bool is_rfsp_index_null,
     bool is_rfsp_index,
     int rfsp_index,
+    bool is_subs_reg_timer_null,
     bool is_subs_reg_timer,
     int subs_reg_timer,
     bool is_ue_usage_type,
@@ -26,6 +29,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     int mps_priority,
     bool is_mcs_priority,
     int mcs_priority,
+    bool is_active_time_null,
     bool is_active_time,
     int active_time,
     OpenAPI_sor_info_1_t *sor_info,
@@ -45,6 +49,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     int service_gap_time,
     OpenAPI_mdt_user_consent_e mdt_user_consent,
     OpenAPI_mdt_configuration_1_t *mdt_configuration,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_cag_data_1_t *cag_data,
     char *stn_sr,
@@ -83,13 +88,16 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     access_and_mobility_subscription_data_1_local_var->internal_group_ids = internal_group_ids;
     access_and_mobility_subscription_data_1_local_var->shared_vn_group_data_ids = shared_vn_group_data_ids;
     access_and_mobility_subscription_data_1_local_var->subscribed_ue_ambr = subscribed_ue_ambr;
+    access_and_mobility_subscription_data_1_local_var->is_nssai_null = is_nssai_null;
     access_and_mobility_subscription_data_1_local_var->nssai = nssai;
     access_and_mobility_subscription_data_1_local_var->rat_restrictions = rat_restrictions;
     access_and_mobility_subscription_data_1_local_var->forbidden_areas = forbidden_areas;
     access_and_mobility_subscription_data_1_local_var->service_area_restriction = service_area_restriction;
     access_and_mobility_subscription_data_1_local_var->core_network_type_restrictions = core_network_type_restrictions;
+    access_and_mobility_subscription_data_1_local_var->is_rfsp_index_null = is_rfsp_index_null;
     access_and_mobility_subscription_data_1_local_var->is_rfsp_index = is_rfsp_index;
     access_and_mobility_subscription_data_1_local_var->rfsp_index = rfsp_index;
+    access_and_mobility_subscription_data_1_local_var->is_subs_reg_timer_null = is_subs_reg_timer_null;
     access_and_mobility_subscription_data_1_local_var->is_subs_reg_timer = is_subs_reg_timer;
     access_and_mobility_subscription_data_1_local_var->subs_reg_timer = subs_reg_timer;
     access_and_mobility_subscription_data_1_local_var->is_ue_usage_type = is_ue_usage_type;
@@ -98,6 +106,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     access_and_mobility_subscription_data_1_local_var->mps_priority = mps_priority;
     access_and_mobility_subscription_data_1_local_var->is_mcs_priority = is_mcs_priority;
     access_and_mobility_subscription_data_1_local_var->mcs_priority = mcs_priority;
+    access_and_mobility_subscription_data_1_local_var->is_active_time_null = is_active_time_null;
     access_and_mobility_subscription_data_1_local_var->is_active_time = is_active_time;
     access_and_mobility_subscription_data_1_local_var->active_time = active_time;
     access_and_mobility_subscription_data_1_local_var->sor_info = sor_info;
@@ -117,6 +126,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     access_and_mobility_subscription_data_1_local_var->service_gap_time = service_gap_time;
     access_and_mobility_subscription_data_1_local_var->mdt_user_consent = mdt_user_consent;
     access_and_mobility_subscription_data_1_local_var->mdt_configuration = mdt_configuration;
+    access_and_mobility_subscription_data_1_local_var->is_trace_data_null = is_trace_data_null;
     access_and_mobility_subscription_data_1_local_var->trace_data = trace_data;
     access_and_mobility_subscription_data_1_local_var->cag_data = cag_data;
     access_and_mobility_subscription_data_1_local_var->stn_sr = stn_sr;
@@ -440,6 +450,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [nssai]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data_1->is_nssai_null) {
+        if (cJSON_AddNullToObject(item, "nssai") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [nssai]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data_1->rat_restrictions != OpenAPI_rat_type_NULL) {
@@ -504,6 +519,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [rfsp_index]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data_1->is_rfsp_index_null) {
+        if (cJSON_AddNullToObject(item, "rfspIndex") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [rfsp_index]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data_1->is_subs_reg_timer) {
@@ -511,6 +531,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [subs_reg_timer]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data_1->is_subs_reg_timer_null) {
+        if (cJSON_AddNullToObject(item, "subsRegTimer") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [subs_reg_timer]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data_1->is_ue_usage_type) {
@@ -539,6 +564,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [active_time]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data_1->is_active_time_null) {
+        if (cJSON_AddNullToObject(item, "activeTime") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [active_time]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data_1->sor_info) {
@@ -682,6 +712,11 @@ cJSON *OpenAPI_access_and_mobility_subscription_data_1_convertToJSON(OpenAPI_acc
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (access_and_mobility_subscription_data_1->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_access_and_mobility_subscription_data_1_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (access_and_mobility_subscription_data_1->cag_data) {
@@ -1124,10 +1159,12 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
 
     nssai = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "nssai");
     if (nssai) {
+    if (!cJSON_IsNull(nssai)) {
     nssai_local_nonprim = OpenAPI_nssai_1_parseFromJSON(nssai);
     if (!nssai_local_nonprim) {
         ogs_error("OpenAPI_nssai_1_parseFromJSON failed [nssai]");
         goto end;
+    }
     }
     }
 
@@ -1216,17 +1253,21 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
 
     rfsp_index = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "rfspIndex");
     if (rfsp_index) {
+    if (!cJSON_IsNull(rfsp_index)) {
     if (!cJSON_IsNumber(rfsp_index)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [rfsp_index]");
         goto end;
     }
     }
+    }
 
     subs_reg_timer = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "subsRegTimer");
     if (subs_reg_timer) {
+    if (!cJSON_IsNull(subs_reg_timer)) {
     if (!cJSON_IsNumber(subs_reg_timer)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [subs_reg_timer]");
         goto end;
+    }
     }
     }
 
@@ -1256,9 +1297,11 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
 
     active_time = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "activeTime");
     if (active_time) {
+    if (!cJSON_IsNull(active_time)) {
     if (!cJSON_IsNumber(active_time)) {
         ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [active_time]");
         goto end;
+    }
     }
     }
 
@@ -1416,10 +1459,12 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
 
     trace_data = cJSON_GetObjectItemCaseSensitive(access_and_mobility_subscription_data_1JSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -1720,13 +1765,16 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         internal_group_ids ? internal_group_idsList : NULL,
         shared_vn_group_data_ids ? shared_vn_group_data_idsList : NULL,
         subscribed_ue_ambr ? subscribed_ue_ambr_local_nonprim : NULL,
+        nssai && cJSON_IsNull(nssai) ? true : false,
         nssai ? nssai_local_nonprim : NULL,
         rat_restrictions ? rat_restrictionsList : NULL,
         forbidden_areas ? forbidden_areasList : NULL,
         service_area_restriction ? service_area_restriction_local_nonprim : NULL,
         core_network_type_restrictions ? core_network_type_restrictionsList : NULL,
+        rfsp_index && cJSON_IsNull(rfsp_index) ? true : false,
         rfsp_index ? true : false,
         rfsp_index ? rfsp_index->valuedouble : 0,
+        subs_reg_timer && cJSON_IsNull(subs_reg_timer) ? true : false,
         subs_reg_timer ? true : false,
         subs_reg_timer ? subs_reg_timer->valuedouble : 0,
         ue_usage_type ? true : false,
@@ -1735,6 +1783,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         mps_priority ? mps_priority->valueint : 0,
         mcs_priority ? true : false,
         mcs_priority ? mcs_priority->valueint : 0,
+        active_time && cJSON_IsNull(active_time) ? true : false,
         active_time ? true : false,
         active_time ? active_time->valuedouble : 0,
         sor_info ? sor_info_local_nonprim : NULL,
@@ -1754,6 +1803,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
         service_gap_time ? service_gap_time->valuedouble : 0,
         mdt_user_consent ? mdt_user_consentVariable : 0,
         mdt_configuration ? mdt_configuration_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         cag_data ? cag_data_local_nonprim : NULL,
         stn_sr && !cJSON_IsNull(stn_sr) ? ogs_strdup(stn_sr->valuestring) : NULL,

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.h
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.h
@@ -50,13 +50,16 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_1_s {
     OpenAPI_list_t *internal_group_ids;
     OpenAPI_list_t* shared_vn_group_data_ids;
     struct OpenAPI_ambr_rm_s *subscribed_ue_ambr;
+    bool is_nssai_null;
     struct OpenAPI_nssai_1_s *nssai;
     OpenAPI_set_t *rat_restrictions;
     OpenAPI_list_t *forbidden_areas;
     struct OpenAPI_service_area_restriction_1_s *service_area_restriction;
     OpenAPI_list_t *core_network_type_restrictions;
+    bool is_rfsp_index_null;
     bool is_rfsp_index;
     int rfsp_index;
+    bool is_subs_reg_timer_null;
     bool is_subs_reg_timer;
     int subs_reg_timer;
     bool is_ue_usage_type;
@@ -65,6 +68,7 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_1_s {
     int mps_priority;
     bool is_mcs_priority;
     int mcs_priority;
+    bool is_active_time_null;
     bool is_active_time;
     int active_time;
     struct OpenAPI_sor_info_1_s *sor_info;
@@ -84,6 +88,7 @@ typedef struct OpenAPI_access_and_mobility_subscription_data_1_s {
     int service_gap_time;
     OpenAPI_mdt_user_consent_e mdt_user_consent;
     struct OpenAPI_mdt_configuration_1_s *mdt_configuration;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     struct OpenAPI_cag_data_1_s *cag_data;
     char *stn_sr;
@@ -120,13 +125,16 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     OpenAPI_list_t *internal_group_ids,
     OpenAPI_list_t* shared_vn_group_data_ids,
     OpenAPI_ambr_rm_t *subscribed_ue_ambr,
+    bool is_nssai_null,
     OpenAPI_nssai_1_t *nssai,
     OpenAPI_set_t *rat_restrictions,
     OpenAPI_list_t *forbidden_areas,
     OpenAPI_service_area_restriction_1_t *service_area_restriction,
     OpenAPI_list_t *core_network_type_restrictions,
+    bool is_rfsp_index_null,
     bool is_rfsp_index,
     int rfsp_index,
+    bool is_subs_reg_timer_null,
     bool is_subs_reg_timer,
     int subs_reg_timer,
     bool is_ue_usage_type,
@@ -135,6 +143,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     int mps_priority,
     bool is_mcs_priority,
     int mcs_priority,
+    bool is_active_time_null,
     bool is_active_time,
     int active_time,
     OpenAPI_sor_info_1_t *sor_info,
@@ -154,6 +163,7 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
     int service_gap_time,
     OpenAPI_mdt_user_consent_e mdt_user_consent,
     OpenAPI_mdt_configuration_1_t *mdt_configuration,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_cag_data_1_t *cag_data,
     char *stn_sr,

--- a/lib/sbi/openapi/model/af_routing_requirement.c
+++ b/lib/sbi/openapi/model/af_routing_requirement.c
@@ -10,6 +10,7 @@ OpenAPI_af_routing_requirement_t *OpenAPI_af_routing_requirement_create(
     OpenAPI_list_t *route_to_locs,
     OpenAPI_spatial_validity_t *sp_val,
     OpenAPI_list_t *temp_vals,
+    bool is_up_path_chg_sub_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_sub,
     bool is_addr_preser_ind,
     int addr_preser_ind,
@@ -32,6 +33,7 @@ OpenAPI_af_routing_requirement_t *OpenAPI_af_routing_requirement_create(
     af_routing_requirement_local_var->route_to_locs = route_to_locs;
     af_routing_requirement_local_var->sp_val = sp_val;
     af_routing_requirement_local_var->temp_vals = temp_vals;
+    af_routing_requirement_local_var->is_up_path_chg_sub_null = is_up_path_chg_sub_null;
     af_routing_requirement_local_var->up_path_chg_sub = up_path_chg_sub;
     af_routing_requirement_local_var->is_addr_preser_ind = is_addr_preser_ind;
     af_routing_requirement_local_var->addr_preser_ind = addr_preser_ind;
@@ -161,6 +163,11 @@ cJSON *OpenAPI_af_routing_requirement_convertToJSON(OpenAPI_af_routing_requireme
         ogs_error("OpenAPI_af_routing_requirement_convertToJSON() failed [up_path_chg_sub]");
         goto end;
     }
+    } else if (af_routing_requirement->is_up_path_chg_sub_null) {
+        if (cJSON_AddNullToObject(item, "upPathChgSub") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_convertToJSON() failed [up_path_chg_sub]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement->is_addr_preser_ind) {
@@ -305,10 +312,12 @@ OpenAPI_af_routing_requirement_t *OpenAPI_af_routing_requirement_parseFromJSON(c
 
     up_path_chg_sub = cJSON_GetObjectItemCaseSensitive(af_routing_requirementJSON, "upPathChgSub");
     if (up_path_chg_sub) {
+    if (!cJSON_IsNull(up_path_chg_sub)) {
     up_path_chg_sub_local_nonprim = OpenAPI_up_path_chg_event_parseFromJSON(up_path_chg_sub);
     if (!up_path_chg_sub_local_nonprim) {
         ogs_error("OpenAPI_up_path_chg_event_parseFromJSON failed [up_path_chg_sub]");
         goto end;
+    }
     }
     }
 
@@ -382,6 +391,7 @@ OpenAPI_af_routing_requirement_t *OpenAPI_af_routing_requirement_parseFromJSON(c
         route_to_locs ? route_to_locsList : NULL,
         sp_val ? sp_val_local_nonprim : NULL,
         temp_vals ? temp_valsList : NULL,
+        up_path_chg_sub && cJSON_IsNull(up_path_chg_sub) ? true : false,
         up_path_chg_sub ? up_path_chg_sub_local_nonprim : NULL,
         addr_preser_ind ? true : false,
         addr_preser_ind ? addr_preser_ind->valueint : 0,

--- a/lib/sbi/openapi/model/af_routing_requirement.h
+++ b/lib/sbi/openapi/model/af_routing_requirement.h
@@ -29,6 +29,7 @@ typedef struct OpenAPI_af_routing_requirement_s {
     OpenAPI_list_t *route_to_locs;
     struct OpenAPI_spatial_validity_s *sp_val;
     OpenAPI_list_t *temp_vals;
+    bool is_up_path_chg_sub_null;
     struct OpenAPI_up_path_chg_event_s *up_path_chg_sub;
     bool is_addr_preser_ind;
     int addr_preser_ind;
@@ -49,6 +50,7 @@ OpenAPI_af_routing_requirement_t *OpenAPI_af_routing_requirement_create(
     OpenAPI_list_t *route_to_locs,
     OpenAPI_spatial_validity_t *sp_val,
     OpenAPI_list_t *temp_vals,
+    bool is_up_path_chg_sub_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_sub,
     bool is_addr_preser_ind,
     int addr_preser_ind,

--- a/lib/sbi/openapi/model/af_routing_requirement_rm.c
+++ b/lib/sbi/openapi/model/af_routing_requirement_rm.c
@@ -7,19 +7,28 @@
 OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_create(
     bool is_app_reloc,
     int app_reloc,
+    bool is_route_to_locs_null,
     OpenAPI_list_t *route_to_locs,
+    bool is_sp_val_null,
     OpenAPI_spatial_validity_rm_t *sp_val,
+    bool is_temp_vals_null,
     OpenAPI_list_t *temp_vals,
+    bool is_up_path_chg_sub_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_sub,
+    bool is_addr_preser_ind_null,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_sim_conn_ind_null,
     bool is_sim_conn_ind,
     int sim_conn_ind,
+    bool is_sim_conn_term_null,
     bool is_sim_conn_term,
     int sim_conn_term,
+    bool is_eas_ip_replace_infos_null,
     OpenAPI_list_t *eas_ip_replace_infos,
     bool is_eas_redis_ind,
     int eas_redis_ind,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat
 )
@@ -29,19 +38,28 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_create(
 
     af_routing_requirement_rm_local_var->is_app_reloc = is_app_reloc;
     af_routing_requirement_rm_local_var->app_reloc = app_reloc;
+    af_routing_requirement_rm_local_var->is_route_to_locs_null = is_route_to_locs_null;
     af_routing_requirement_rm_local_var->route_to_locs = route_to_locs;
+    af_routing_requirement_rm_local_var->is_sp_val_null = is_sp_val_null;
     af_routing_requirement_rm_local_var->sp_val = sp_val;
+    af_routing_requirement_rm_local_var->is_temp_vals_null = is_temp_vals_null;
     af_routing_requirement_rm_local_var->temp_vals = temp_vals;
+    af_routing_requirement_rm_local_var->is_up_path_chg_sub_null = is_up_path_chg_sub_null;
     af_routing_requirement_rm_local_var->up_path_chg_sub = up_path_chg_sub;
+    af_routing_requirement_rm_local_var->is_addr_preser_ind_null = is_addr_preser_ind_null;
     af_routing_requirement_rm_local_var->is_addr_preser_ind = is_addr_preser_ind;
     af_routing_requirement_rm_local_var->addr_preser_ind = addr_preser_ind;
+    af_routing_requirement_rm_local_var->is_sim_conn_ind_null = is_sim_conn_ind_null;
     af_routing_requirement_rm_local_var->is_sim_conn_ind = is_sim_conn_ind;
     af_routing_requirement_rm_local_var->sim_conn_ind = sim_conn_ind;
+    af_routing_requirement_rm_local_var->is_sim_conn_term_null = is_sim_conn_term_null;
     af_routing_requirement_rm_local_var->is_sim_conn_term = is_sim_conn_term;
     af_routing_requirement_rm_local_var->sim_conn_term = sim_conn_term;
+    af_routing_requirement_rm_local_var->is_eas_ip_replace_infos_null = is_eas_ip_replace_infos_null;
     af_routing_requirement_rm_local_var->eas_ip_replace_infos = eas_ip_replace_infos;
     af_routing_requirement_rm_local_var->is_eas_redis_ind = is_eas_redis_ind;
     af_routing_requirement_rm_local_var->eas_redis_ind = eas_redis_ind;
+    af_routing_requirement_rm_local_var->is_max_allowed_up_lat_null = is_max_allowed_up_lat_null;
     af_routing_requirement_rm_local_var->is_max_allowed_up_lat = is_max_allowed_up_lat;
     af_routing_requirement_rm_local_var->max_allowed_up_lat = max_allowed_up_lat;
 
@@ -119,6 +137,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         }
         cJSON_AddItemToArray(route_to_locsList, itemLocal);
     }
+    } else if (af_routing_requirement_rm->is_route_to_locs_null) {
+        if (cJSON_AddNullToObject(item, "routeToLocs") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [route_to_locs]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->sp_val) {
@@ -132,6 +155,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sp_val]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_sp_val_null) {
+        if (cJSON_AddNullToObject(item, "spVal") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sp_val]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->temp_vals) {
@@ -148,6 +176,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         }
         cJSON_AddItemToArray(temp_valsList, itemLocal);
     }
+    } else if (af_routing_requirement_rm->is_temp_vals_null) {
+        if (cJSON_AddNullToObject(item, "tempVals") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [temp_vals]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->up_path_chg_sub) {
@@ -161,6 +194,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [up_path_chg_sub]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_up_path_chg_sub_null) {
+        if (cJSON_AddNullToObject(item, "upPathChgSub") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [up_path_chg_sub]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->is_addr_preser_ind) {
@@ -168,6 +206,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [addr_preser_ind]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_addr_preser_ind_null) {
+        if (cJSON_AddNullToObject(item, "addrPreserInd") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [addr_preser_ind]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->is_sim_conn_ind) {
@@ -175,6 +218,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sim_conn_ind]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_sim_conn_ind_null) {
+        if (cJSON_AddNullToObject(item, "simConnInd") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sim_conn_ind]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->is_sim_conn_term) {
@@ -182,6 +230,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sim_conn_term]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_sim_conn_term_null) {
+        if (cJSON_AddNullToObject(item, "simConnTerm") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [sim_conn_term]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->eas_ip_replace_infos) {
@@ -198,6 +251,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         }
         cJSON_AddItemToArray(eas_ip_replace_infosList, itemLocal);
     }
+    } else if (af_routing_requirement_rm->is_eas_ip_replace_infos_null) {
+        if (cJSON_AddNullToObject(item, "easIpReplaceInfos") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [eas_ip_replace_infos]");
+            goto end;
+        }
     }
 
     if (af_routing_requirement_rm->is_eas_redis_ind) {
@@ -212,6 +270,11 @@ cJSON *OpenAPI_af_routing_requirement_rm_convertToJSON(OpenAPI_af_routing_requir
         ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [max_allowed_up_lat]");
         goto end;
     }
+    } else if (af_routing_requirement_rm->is_max_allowed_up_lat_null) {
+        if (cJSON_AddNullToObject(item, "maxAllowedUpLat") == NULL) {
+            ogs_error("OpenAPI_af_routing_requirement_rm_convertToJSON() failed [max_allowed_up_lat]");
+            goto end;
+        }
     }
 
 end:
@@ -248,6 +311,7 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_parseFrom
 
     route_to_locs = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "routeToLocs");
     if (route_to_locs) {
+    if (!cJSON_IsNull(route_to_locs)) {
         cJSON *route_to_locs_local = NULL;
         if (!cJSON_IsArray(route_to_locs)) {
             ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [route_to_locs]");
@@ -269,18 +333,22 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_parseFrom
             OpenAPI_list_add(route_to_locsList, route_to_locsItem);
         }
     }
+    }
 
     sp_val = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "spVal");
     if (sp_val) {
+    if (!cJSON_IsNull(sp_val)) {
     sp_val_local_nonprim = OpenAPI_spatial_validity_rm_parseFromJSON(sp_val);
     if (!sp_val_local_nonprim) {
         ogs_error("OpenAPI_spatial_validity_rm_parseFromJSON failed [sp_val]");
         goto end;
     }
     }
+    }
 
     temp_vals = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "tempVals");
     if (temp_vals) {
+    if (!cJSON_IsNull(temp_vals)) {
         cJSON *temp_vals_local = NULL;
         if (!cJSON_IsArray(temp_vals)) {
             ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [temp_vals]");
@@ -302,42 +370,52 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_parseFrom
             OpenAPI_list_add(temp_valsList, temp_valsItem);
         }
     }
+    }
 
     up_path_chg_sub = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "upPathChgSub");
     if (up_path_chg_sub) {
+    if (!cJSON_IsNull(up_path_chg_sub)) {
     up_path_chg_sub_local_nonprim = OpenAPI_up_path_chg_event_parseFromJSON(up_path_chg_sub);
     if (!up_path_chg_sub_local_nonprim) {
         ogs_error("OpenAPI_up_path_chg_event_parseFromJSON failed [up_path_chg_sub]");
         goto end;
     }
     }
+    }
 
     addr_preser_ind = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "addrPreserInd");
     if (addr_preser_ind) {
+    if (!cJSON_IsNull(addr_preser_ind)) {
     if (!cJSON_IsBool(addr_preser_ind)) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [addr_preser_ind]");
         goto end;
     }
     }
+    }
 
     sim_conn_ind = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "simConnInd");
     if (sim_conn_ind) {
+    if (!cJSON_IsNull(sim_conn_ind)) {
     if (!cJSON_IsBool(sim_conn_ind)) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [sim_conn_ind]");
         goto end;
     }
     }
+    }
 
     sim_conn_term = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "simConnTerm");
     if (sim_conn_term) {
+    if (!cJSON_IsNull(sim_conn_term)) {
     if (!cJSON_IsNumber(sim_conn_term)) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [sim_conn_term]");
         goto end;
     }
     }
+    }
 
     eas_ip_replace_infos = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "easIpReplaceInfos");
     if (eas_ip_replace_infos) {
+    if (!cJSON_IsNull(eas_ip_replace_infos)) {
         cJSON *eas_ip_replace_infos_local = NULL;
         if (!cJSON_IsArray(eas_ip_replace_infos)) {
             ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [eas_ip_replace_infos]");
@@ -359,6 +437,7 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_parseFrom
             OpenAPI_list_add(eas_ip_replace_infosList, eas_ip_replace_infosItem);
         }
     }
+    }
 
     eas_redis_ind = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "easRedisInd");
     if (eas_redis_ind) {
@@ -370,28 +449,39 @@ OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_parseFrom
 
     max_allowed_up_lat = cJSON_GetObjectItemCaseSensitive(af_routing_requirement_rmJSON, "maxAllowedUpLat");
     if (max_allowed_up_lat) {
+    if (!cJSON_IsNull(max_allowed_up_lat)) {
     if (!cJSON_IsNumber(max_allowed_up_lat)) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON() failed [max_allowed_up_lat]");
         goto end;
+    }
     }
     }
 
     af_routing_requirement_rm_local_var = OpenAPI_af_routing_requirement_rm_create (
         app_reloc ? true : false,
         app_reloc ? app_reloc->valueint : 0,
+        route_to_locs && cJSON_IsNull(route_to_locs) ? true : false,
         route_to_locs ? route_to_locsList : NULL,
+        sp_val && cJSON_IsNull(sp_val) ? true : false,
         sp_val ? sp_val_local_nonprim : NULL,
+        temp_vals && cJSON_IsNull(temp_vals) ? true : false,
         temp_vals ? temp_valsList : NULL,
+        up_path_chg_sub && cJSON_IsNull(up_path_chg_sub) ? true : false,
         up_path_chg_sub ? up_path_chg_sub_local_nonprim : NULL,
+        addr_preser_ind && cJSON_IsNull(addr_preser_ind) ? true : false,
         addr_preser_ind ? true : false,
         addr_preser_ind ? addr_preser_ind->valueint : 0,
+        sim_conn_ind && cJSON_IsNull(sim_conn_ind) ? true : false,
         sim_conn_ind ? true : false,
         sim_conn_ind ? sim_conn_ind->valueint : 0,
+        sim_conn_term && cJSON_IsNull(sim_conn_term) ? true : false,
         sim_conn_term ? true : false,
         sim_conn_term ? sim_conn_term->valuedouble : 0,
+        eas_ip_replace_infos && cJSON_IsNull(eas_ip_replace_infos) ? true : false,
         eas_ip_replace_infos ? eas_ip_replace_infosList : NULL,
         eas_redis_ind ? true : false,
         eas_redis_ind ? eas_redis_ind->valueint : 0,
+        max_allowed_up_lat && cJSON_IsNull(max_allowed_up_lat) ? true : false,
         max_allowed_up_lat ? true : false,
         max_allowed_up_lat ? max_allowed_up_lat->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/af_routing_requirement_rm.h
+++ b/lib/sbi/openapi/model/af_routing_requirement_rm.h
@@ -26,19 +26,28 @@ typedef struct OpenAPI_af_routing_requirement_rm_s OpenAPI_af_routing_requiremen
 typedef struct OpenAPI_af_routing_requirement_rm_s {
     bool is_app_reloc;
     int app_reloc;
+    bool is_route_to_locs_null;
     OpenAPI_list_t *route_to_locs;
+    bool is_sp_val_null;
     struct OpenAPI_spatial_validity_rm_s *sp_val;
+    bool is_temp_vals_null;
     OpenAPI_list_t *temp_vals;
+    bool is_up_path_chg_sub_null;
     struct OpenAPI_up_path_chg_event_s *up_path_chg_sub;
+    bool is_addr_preser_ind_null;
     bool is_addr_preser_ind;
     int addr_preser_ind;
+    bool is_sim_conn_ind_null;
     bool is_sim_conn_ind;
     int sim_conn_ind;
+    bool is_sim_conn_term_null;
     bool is_sim_conn_term;
     int sim_conn_term;
+    bool is_eas_ip_replace_infos_null;
     OpenAPI_list_t *eas_ip_replace_infos;
     bool is_eas_redis_ind;
     int eas_redis_ind;
+    bool is_max_allowed_up_lat_null;
     bool is_max_allowed_up_lat;
     int max_allowed_up_lat;
 } OpenAPI_af_routing_requirement_rm_t;
@@ -46,19 +55,28 @@ typedef struct OpenAPI_af_routing_requirement_rm_s {
 OpenAPI_af_routing_requirement_rm_t *OpenAPI_af_routing_requirement_rm_create(
     bool is_app_reloc,
     int app_reloc,
+    bool is_route_to_locs_null,
     OpenAPI_list_t *route_to_locs,
+    bool is_sp_val_null,
     OpenAPI_spatial_validity_rm_t *sp_val,
+    bool is_temp_vals_null,
     OpenAPI_list_t *temp_vals,
+    bool is_up_path_chg_sub_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_sub,
+    bool is_addr_preser_ind_null,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_sim_conn_ind_null,
     bool is_sim_conn_ind,
     int sim_conn_ind,
+    bool is_sim_conn_term_null,
     bool is_sim_conn_term,
     int sim_conn_term,
+    bool is_eas_ip_replace_infos_null,
     OpenAPI_list_t *eas_ip_replace_infos,
     bool is_eas_redis_ind,
     int eas_redis_ind,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat
 );

--- a/lib/sbi/openapi/model/amf3_gpp_access_registration_modification.c
+++ b/lib/sbi/openapi/model/amf3_gpp_access_registration_modification.c
@@ -12,6 +12,7 @@ OpenAPI_amf3_gpp_access_registration_modification_t *OpenAPI_amf3_gpp_access_reg
     OpenAPI_ims_vo_ps_e ims_vo_ps,
     OpenAPI_list_t *backup_amf_info,
     OpenAPI_eps_interworking_info_t *eps_interworking_info,
+    bool is_ue_srvcc_capability_null,
     bool is_ue_srvcc_capability,
     int ue_srvcc_capability,
     bool is_ue_mint_capability,
@@ -28,6 +29,7 @@ OpenAPI_amf3_gpp_access_registration_modification_t *OpenAPI_amf3_gpp_access_reg
     amf3_gpp_access_registration_modification_local_var->ims_vo_ps = ims_vo_ps;
     amf3_gpp_access_registration_modification_local_var->backup_amf_info = backup_amf_info;
     amf3_gpp_access_registration_modification_local_var->eps_interworking_info = eps_interworking_info;
+    amf3_gpp_access_registration_modification_local_var->is_ue_srvcc_capability_null = is_ue_srvcc_capability_null;
     amf3_gpp_access_registration_modification_local_var->is_ue_srvcc_capability = is_ue_srvcc_capability;
     amf3_gpp_access_registration_modification_local_var->ue_srvcc_capability = ue_srvcc_capability;
     amf3_gpp_access_registration_modification_local_var->is_ue_mint_capability = is_ue_mint_capability;
@@ -146,6 +148,11 @@ cJSON *OpenAPI_amf3_gpp_access_registration_modification_convertToJSON(OpenAPI_a
         ogs_error("OpenAPI_amf3_gpp_access_registration_modification_convertToJSON() failed [ue_srvcc_capability]");
         goto end;
     }
+    } else if (amf3_gpp_access_registration_modification->is_ue_srvcc_capability_null) {
+        if (cJSON_AddNullToObject(item, "ueSrvccCapability") == NULL) {
+            ogs_error("OpenAPI_amf3_gpp_access_registration_modification_convertToJSON() failed [ue_srvcc_capability]");
+            goto end;
+        }
     }
 
     if (amf3_gpp_access_registration_modification->is_ue_mint_capability) {
@@ -246,9 +253,11 @@ OpenAPI_amf3_gpp_access_registration_modification_t *OpenAPI_amf3_gpp_access_reg
 
     ue_srvcc_capability = cJSON_GetObjectItemCaseSensitive(amf3_gpp_access_registration_modificationJSON, "ueSrvccCapability");
     if (ue_srvcc_capability) {
+    if (!cJSON_IsNull(ue_srvcc_capability)) {
     if (!cJSON_IsBool(ue_srvcc_capability)) {
         ogs_error("OpenAPI_amf3_gpp_access_registration_modification_parseFromJSON() failed [ue_srvcc_capability]");
         goto end;
+    }
     }
     }
 
@@ -268,6 +277,7 @@ OpenAPI_amf3_gpp_access_registration_modification_t *OpenAPI_amf3_gpp_access_reg
         ims_vo_ps ? ims_vo_psVariable : 0,
         backup_amf_info ? backup_amf_infoList : NULL,
         eps_interworking_info ? eps_interworking_info_local_nonprim : NULL,
+        ue_srvcc_capability && cJSON_IsNull(ue_srvcc_capability) ? true : false,
         ue_srvcc_capability ? true : false,
         ue_srvcc_capability ? ue_srvcc_capability->valueint : 0,
         ue_mint_capability ? true : false,

--- a/lib/sbi/openapi/model/amf3_gpp_access_registration_modification.h
+++ b/lib/sbi/openapi/model/amf3_gpp_access_registration_modification.h
@@ -30,6 +30,7 @@ typedef struct OpenAPI_amf3_gpp_access_registration_modification_s {
     OpenAPI_ims_vo_ps_e ims_vo_ps;
     OpenAPI_list_t *backup_amf_info;
     struct OpenAPI_eps_interworking_info_s *eps_interworking_info;
+    bool is_ue_srvcc_capability_null;
     bool is_ue_srvcc_capability;
     int ue_srvcc_capability;
     bool is_ue_mint_capability;
@@ -44,6 +45,7 @@ OpenAPI_amf3_gpp_access_registration_modification_t *OpenAPI_amf3_gpp_access_reg
     OpenAPI_ims_vo_ps_e ims_vo_ps,
     OpenAPI_list_t *backup_amf_info,
     OpenAPI_eps_interworking_info_t *eps_interworking_info,
+    bool is_ue_srvcc_capability_null,
     bool is_ue_srvcc_capability,
     int ue_srvcc_capability,
     bool is_ue_mint_capability,

--- a/lib/sbi/openapi/model/app_session_context_update_data.c
+++ b/lib/sbi/openapi/model/app_session_context_update_data.c
@@ -6,9 +6,11 @@
 
 OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_data_create(
     char *af_app_id,
+    bool is_af_rout_req_null,
     OpenAPI_af_routing_requirement_rm_t *af_rout_req,
     char *asp_id,
     char *bdt_ref_id,
+    bool is_ev_subsc_null,
     OpenAPI_events_subsc_req_data_rm_t *ev_subsc,
     char *mcptt_id,
     char *mc_video_id,
@@ -31,9 +33,11 @@ OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_da
     ogs_assert(app_session_context_update_data_local_var);
 
     app_session_context_update_data_local_var->af_app_id = af_app_id;
+    app_session_context_update_data_local_var->is_af_rout_req_null = is_af_rout_req_null;
     app_session_context_update_data_local_var->af_rout_req = af_rout_req;
     app_session_context_update_data_local_var->asp_id = asp_id;
     app_session_context_update_data_local_var->bdt_ref_id = bdt_ref_id;
+    app_session_context_update_data_local_var->is_ev_subsc_null = is_ev_subsc_null;
     app_session_context_update_data_local_var->ev_subsc = ev_subsc;
     app_session_context_update_data_local_var->mcptt_id = mcptt_id;
     app_session_context_update_data_local_var->mc_video_id = mc_video_id;
@@ -162,6 +166,11 @@ cJSON *OpenAPI_app_session_context_update_data_convertToJSON(OpenAPI_app_session
         ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [af_rout_req]");
         goto end;
     }
+    } else if (app_session_context_update_data->is_af_rout_req_null) {
+        if (cJSON_AddNullToObject(item, "afRoutReq") == NULL) {
+            ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [af_rout_req]");
+            goto end;
+        }
     }
 
     if (app_session_context_update_data->asp_id) {
@@ -189,6 +198,11 @@ cJSON *OpenAPI_app_session_context_update_data_convertToJSON(OpenAPI_app_session
         ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [ev_subsc]");
         goto end;
     }
+    } else if (app_session_context_update_data->is_ev_subsc_null) {
+        if (cJSON_AddNullToObject(item, "evSubsc") == NULL) {
+            ogs_error("OpenAPI_app_session_context_update_data_convertToJSON() failed [ev_subsc]");
+            goto end;
+        }
     }
 
     if (app_session_context_update_data->mcptt_id) {
@@ -396,10 +410,12 @@ OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_da
 
     af_rout_req = cJSON_GetObjectItemCaseSensitive(app_session_context_update_dataJSON, "afRoutReq");
     if (af_rout_req) {
+    if (!cJSON_IsNull(af_rout_req)) {
     af_rout_req_local_nonprim = OpenAPI_af_routing_requirement_rm_parseFromJSON(af_rout_req);
     if (!af_rout_req_local_nonprim) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON failed [af_rout_req]");
         goto end;
+    }
     }
     }
 
@@ -421,10 +437,12 @@ OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_da
 
     ev_subsc = cJSON_GetObjectItemCaseSensitive(app_session_context_update_dataJSON, "evSubsc");
     if (ev_subsc) {
+    if (!cJSON_IsNull(ev_subsc)) {
     ev_subsc_local_nonprim = OpenAPI_events_subsc_req_data_rm_parseFromJSON(ev_subsc);
     if (!ev_subsc_local_nonprim) {
         ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON failed [ev_subsc]");
         goto end;
+    }
     }
     }
 
@@ -592,9 +610,11 @@ OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_da
 
     app_session_context_update_data_local_var = OpenAPI_app_session_context_update_data_create (
         af_app_id && !cJSON_IsNull(af_app_id) ? ogs_strdup(af_app_id->valuestring) : NULL,
+        af_rout_req && cJSON_IsNull(af_rout_req) ? true : false,
         af_rout_req ? af_rout_req_local_nonprim : NULL,
         asp_id && !cJSON_IsNull(asp_id) ? ogs_strdup(asp_id->valuestring) : NULL,
         bdt_ref_id && !cJSON_IsNull(bdt_ref_id) ? ogs_strdup(bdt_ref_id->valuestring) : NULL,
+        ev_subsc && cJSON_IsNull(ev_subsc) ? true : false,
         ev_subsc ? ev_subsc_local_nonprim : NULL,
         mcptt_id && !cJSON_IsNull(mcptt_id) ? ogs_strdup(mcptt_id->valuestring) : NULL,
         mc_video_id && !cJSON_IsNull(mc_video_id) ? ogs_strdup(mc_video_id->valuestring) : NULL,

--- a/lib/sbi/openapi/model/app_session_context_update_data.h
+++ b/lib/sbi/openapi/model/app_session_context_update_data.h
@@ -31,9 +31,11 @@ extern "C" {
 typedef struct OpenAPI_app_session_context_update_data_s OpenAPI_app_session_context_update_data_t;
 typedef struct OpenAPI_app_session_context_update_data_s {
     char *af_app_id;
+    bool is_af_rout_req_null;
     struct OpenAPI_af_routing_requirement_rm_s *af_rout_req;
     char *asp_id;
     char *bdt_ref_id;
+    bool is_ev_subsc_null;
     struct OpenAPI_events_subsc_req_data_rm_s *ev_subsc;
     char *mcptt_id;
     char *mc_video_id;
@@ -54,9 +56,11 @@ typedef struct OpenAPI_app_session_context_update_data_s {
 
 OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_data_create(
     char *af_app_id,
+    bool is_af_rout_req_null,
     OpenAPI_af_routing_requirement_rm_t *af_rout_req,
     char *asp_id,
     char *bdt_ref_id,
+    bool is_ev_subsc_null,
     OpenAPI_events_subsc_req_data_rm_t *ev_subsc,
     char *mcptt_id,
     char *mc_video_id,

--- a/lib/sbi/openapi/model/arp.c
+++ b/lib/sbi/openapi/model/arp.c
@@ -5,6 +5,7 @@
 #include "arp.h"
 
 OpenAPI_arp_t *OpenAPI_arp_create(
+    bool is_priority_level_null,
     int priority_level,
     OpenAPI_preemption_capability_e preempt_cap,
     OpenAPI_preemption_vulnerability_e preempt_vuln
@@ -13,6 +14,7 @@ OpenAPI_arp_t *OpenAPI_arp_create(
     OpenAPI_arp_t *arp_local_var = ogs_malloc(sizeof(OpenAPI_arp_t));
     ogs_assert(arp_local_var);
 
+    arp_local_var->is_priority_level_null = is_priority_level_null;
     arp_local_var->priority_level = priority_level;
     arp_local_var->preempt_cap = preempt_cap;
     arp_local_var->preempt_vuln = preempt_vuln;
@@ -110,6 +112,7 @@ OpenAPI_arp_t *OpenAPI_arp_parseFromJSON(cJSON *arpJSON)
     preempt_vulnVariable = OpenAPI_preemption_vulnerability_FromString(preempt_vuln->valuestring);
 
     arp_local_var = OpenAPI_arp_create (
+        priority_level && cJSON_IsNull(priority_level) ? true : false,
         
         priority_level->valuedouble,
         preempt_capVariable,

--- a/lib/sbi/openapi/model/arp.h
+++ b/lib/sbi/openapi/model/arp.h
@@ -21,12 +21,14 @@ extern "C" {
 
 typedef struct OpenAPI_arp_s OpenAPI_arp_t;
 typedef struct OpenAPI_arp_s {
+    bool is_priority_level_null;
     int priority_level;
     OpenAPI_preemption_capability_e preempt_cap;
     OpenAPI_preemption_vulnerability_e preempt_vuln;
 } OpenAPI_arp_t;
 
 OpenAPI_arp_t *OpenAPI_arp_create(
+    bool is_priority_level_null,
     int priority_level,
     OpenAPI_preemption_capability_e preempt_cap,
     OpenAPI_preemption_vulnerability_e preempt_vuln

--- a/lib/sbi/openapi/model/arp_1.c
+++ b/lib/sbi/openapi/model/arp_1.c
@@ -5,6 +5,7 @@
 #include "arp_1.h"
 
 OpenAPI_arp_1_t *OpenAPI_arp_1_create(
+    bool is_priority_level_null,
     int priority_level,
     OpenAPI_preemption_capability_e preempt_cap,
     OpenAPI_preemption_vulnerability_e preempt_vuln
@@ -13,6 +14,7 @@ OpenAPI_arp_1_t *OpenAPI_arp_1_create(
     OpenAPI_arp_1_t *arp_1_local_var = ogs_malloc(sizeof(OpenAPI_arp_1_t));
     ogs_assert(arp_1_local_var);
 
+    arp_1_local_var->is_priority_level_null = is_priority_level_null;
     arp_1_local_var->priority_level = priority_level;
     arp_1_local_var->preempt_cap = preempt_cap;
     arp_1_local_var->preempt_vuln = preempt_vuln;
@@ -110,6 +112,7 @@ OpenAPI_arp_1_t *OpenAPI_arp_1_parseFromJSON(cJSON *arp_1JSON)
     preempt_vulnVariable = OpenAPI_preemption_vulnerability_FromString(preempt_vuln->valuestring);
 
     arp_1_local_var = OpenAPI_arp_1_create (
+        priority_level && cJSON_IsNull(priority_level) ? true : false,
         
         priority_level->valuedouble,
         preempt_capVariable,

--- a/lib/sbi/openapi/model/arp_1.h
+++ b/lib/sbi/openapi/model/arp_1.h
@@ -21,12 +21,14 @@ extern "C" {
 
 typedef struct OpenAPI_arp_1_s OpenAPI_arp_1_t;
 typedef struct OpenAPI_arp_1_s {
+    bool is_priority_level_null;
     int priority_level;
     OpenAPI_preemption_capability_e preempt_cap;
     OpenAPI_preemption_vulnerability_e preempt_vuln;
 } OpenAPI_arp_1_t;
 
 OpenAPI_arp_1_t *OpenAPI_arp_1_create(
+    bool is_priority_level_null,
     int priority_level,
     OpenAPI_preemption_capability_e preempt_cap,
     OpenAPI_preemption_vulnerability_e preempt_vuln

--- a/lib/sbi/openapi/model/as_time_distribution_param.c
+++ b/lib/sbi/openapi/model/as_time_distribution_param.c
@@ -7,6 +7,7 @@
 OpenAPI_as_time_distribution_param_t *OpenAPI_as_time_distribution_param_create(
     bool is_as_time_dist_ind,
     int as_time_dist_ind,
+    bool is_uu_error_budget_null,
     bool is_uu_error_budget,
     int uu_error_budget
 )
@@ -16,6 +17,7 @@ OpenAPI_as_time_distribution_param_t *OpenAPI_as_time_distribution_param_create(
 
     as_time_distribution_param_local_var->is_as_time_dist_ind = is_as_time_dist_ind;
     as_time_distribution_param_local_var->as_time_dist_ind = as_time_dist_ind;
+    as_time_distribution_param_local_var->is_uu_error_budget_null = is_uu_error_budget_null;
     as_time_distribution_param_local_var->is_uu_error_budget = is_uu_error_budget;
     as_time_distribution_param_local_var->uu_error_budget = uu_error_budget;
 
@@ -55,6 +57,11 @@ cJSON *OpenAPI_as_time_distribution_param_convertToJSON(OpenAPI_as_time_distribu
         ogs_error("OpenAPI_as_time_distribution_param_convertToJSON() failed [uu_error_budget]");
         goto end;
     }
+    } else if (as_time_distribution_param->is_uu_error_budget_null) {
+        if (cJSON_AddNullToObject(item, "uuErrorBudget") == NULL) {
+            ogs_error("OpenAPI_as_time_distribution_param_convertToJSON() failed [uu_error_budget]");
+            goto end;
+        }
     }
 
 end:
@@ -77,15 +84,18 @@ OpenAPI_as_time_distribution_param_t *OpenAPI_as_time_distribution_param_parseFr
 
     uu_error_budget = cJSON_GetObjectItemCaseSensitive(as_time_distribution_paramJSON, "uuErrorBudget");
     if (uu_error_budget) {
+    if (!cJSON_IsNull(uu_error_budget)) {
     if (!cJSON_IsNumber(uu_error_budget)) {
         ogs_error("OpenAPI_as_time_distribution_param_parseFromJSON() failed [uu_error_budget]");
         goto end;
+    }
     }
     }
 
     as_time_distribution_param_local_var = OpenAPI_as_time_distribution_param_create (
         as_time_dist_ind ? true : false,
         as_time_dist_ind ? as_time_dist_ind->valueint : 0,
+        uu_error_budget && cJSON_IsNull(uu_error_budget) ? true : false,
         uu_error_budget ? true : false,
         uu_error_budget ? uu_error_budget->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/as_time_distribution_param.h
+++ b/lib/sbi/openapi/model/as_time_distribution_param.h
@@ -21,6 +21,7 @@ typedef struct OpenAPI_as_time_distribution_param_s OpenAPI_as_time_distribution
 typedef struct OpenAPI_as_time_distribution_param_s {
     bool is_as_time_dist_ind;
     int as_time_dist_ind;
+    bool is_uu_error_budget_null;
     bool is_uu_error_budget;
     int uu_error_budget;
 } OpenAPI_as_time_distribution_param_t;
@@ -28,6 +29,7 @@ typedef struct OpenAPI_as_time_distribution_param_s {
 OpenAPI_as_time_distribution_param_t *OpenAPI_as_time_distribution_param_create(
     bool is_as_time_dist_ind,
     int as_time_dist_ind,
+    bool is_uu_error_budget_null,
     bool is_uu_error_budget,
     int uu_error_budget
 );

--- a/lib/sbi/openapi/model/atom.c
+++ b/lib/sbi/openapi/model/atom.c
@@ -6,6 +6,7 @@
 
 OpenAPI_atom_t *OpenAPI_atom_create(
     char *attr,
+    bool is_value_null,
     OpenAPI_any_type_t *value,
     bool is_negative,
     int negative
@@ -15,6 +16,7 @@ OpenAPI_atom_t *OpenAPI_atom_create(
     ogs_assert(atom_local_var);
 
     atom_local_var->attr = attr;
+    atom_local_var->is_value_null = is_value_null;
     atom_local_var->value = value;
     atom_local_var->is_negative = is_negative;
     atom_local_var->negative = negative;
@@ -121,6 +123,7 @@ OpenAPI_atom_t *OpenAPI_atom_parseFromJSON(cJSON *atomJSON)
 
     atom_local_var = OpenAPI_atom_create (
         ogs_strdup(attr->valuestring),
+        value && cJSON_IsNull(value) ? true : false,
         value_local_object,
         negative ? true : false,
         negative ? negative->valueint : 0

--- a/lib/sbi/openapi/model/atom.h
+++ b/lib/sbi/openapi/model/atom.h
@@ -21,6 +21,7 @@ extern "C" {
 typedef struct OpenAPI_atom_s OpenAPI_atom_t;
 typedef struct OpenAPI_atom_s {
     char *attr;
+    bool is_value_null;
     OpenAPI_any_type_t *value;
     bool is_negative;
     int negative;
@@ -28,6 +29,7 @@ typedef struct OpenAPI_atom_s {
 
 OpenAPI_atom_t *OpenAPI_atom_create(
     char *attr,
+    bool is_value_null,
     OpenAPI_any_type_t *value,
     bool is_negative,
     int negative

--- a/lib/sbi/openapi/model/authentication_info.h
+++ b/lib/sbi/openapi/model/authentication_info.h
@@ -25,6 +25,7 @@ typedef struct OpenAPI_authentication_info_s {
     char *serving_network_name;
     struct OpenAPI_resynchronization_info_s *resynchronization_info;
     char *pei;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *udm_group_id;
     char *routing_indicator;
@@ -45,6 +46,7 @@ OpenAPI_authentication_info_t *OpenAPI_authentication_info_create(
     char *serving_network_name,
     OpenAPI_resynchronization_info_t *resynchronization_info,
     char *pei,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *udm_group_id,
     char *routing_indicator,

--- a/lib/sbi/openapi/model/authorized_default_qos.c
+++ b/lib/sbi/openapi/model/authorized_default_qos.c
@@ -8,16 +8,24 @@ OpenAPI_authorized_default_qos_t *OpenAPI_authorized_default_qos_create(
     bool is__5qi,
     int _5qi,
     OpenAPI_arp_t *arp,
+    bool is_priority_level_null,
     bool is_priority_level,
     int priority_level,
+    bool is_aver_window_null,
     bool is_aver_window,
     int aver_window,
+    bool is_max_data_burst_vol_null,
     bool is_max_data_burst_vol,
     int max_data_burst_vol,
+    bool is_maxbr_ul_null,
     char *maxbr_ul,
+    bool is_maxbr_dl_null,
     char *maxbr_dl,
+    bool is_gbr_ul_null,
     char *gbr_ul,
+    bool is_gbr_dl_null,
     char *gbr_dl,
+    bool is_ext_max_data_burst_vol_null,
     bool is_ext_max_data_burst_vol,
     int ext_max_data_burst_vol
 )
@@ -28,16 +36,24 @@ OpenAPI_authorized_default_qos_t *OpenAPI_authorized_default_qos_create(
     authorized_default_qos_local_var->is__5qi = is__5qi;
     authorized_default_qos_local_var->_5qi = _5qi;
     authorized_default_qos_local_var->arp = arp;
+    authorized_default_qos_local_var->is_priority_level_null = is_priority_level_null;
     authorized_default_qos_local_var->is_priority_level = is_priority_level;
     authorized_default_qos_local_var->priority_level = priority_level;
+    authorized_default_qos_local_var->is_aver_window_null = is_aver_window_null;
     authorized_default_qos_local_var->is_aver_window = is_aver_window;
     authorized_default_qos_local_var->aver_window = aver_window;
+    authorized_default_qos_local_var->is_max_data_burst_vol_null = is_max_data_burst_vol_null;
     authorized_default_qos_local_var->is_max_data_burst_vol = is_max_data_burst_vol;
     authorized_default_qos_local_var->max_data_burst_vol = max_data_burst_vol;
+    authorized_default_qos_local_var->is_maxbr_ul_null = is_maxbr_ul_null;
     authorized_default_qos_local_var->maxbr_ul = maxbr_ul;
+    authorized_default_qos_local_var->is_maxbr_dl_null = is_maxbr_dl_null;
     authorized_default_qos_local_var->maxbr_dl = maxbr_dl;
+    authorized_default_qos_local_var->is_gbr_ul_null = is_gbr_ul_null;
     authorized_default_qos_local_var->gbr_ul = gbr_ul;
+    authorized_default_qos_local_var->is_gbr_dl_null = is_gbr_dl_null;
     authorized_default_qos_local_var->gbr_dl = gbr_dl;
+    authorized_default_qos_local_var->is_ext_max_data_burst_vol_null = is_ext_max_data_burst_vol_null;
     authorized_default_qos_local_var->is_ext_max_data_burst_vol = is_ext_max_data_burst_vol;
     authorized_default_qos_local_var->ext_max_data_burst_vol = ext_max_data_burst_vol;
 
@@ -110,6 +126,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [priority_level]");
         goto end;
     }
+    } else if (authorized_default_qos->is_priority_level_null) {
+        if (cJSON_AddNullToObject(item, "priorityLevel") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [priority_level]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->is_aver_window) {
@@ -117,6 +138,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [aver_window]");
         goto end;
     }
+    } else if (authorized_default_qos->is_aver_window_null) {
+        if (cJSON_AddNullToObject(item, "averWindow") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [aver_window]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->is_max_data_burst_vol) {
@@ -124,6 +150,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [max_data_burst_vol]");
         goto end;
     }
+    } else if (authorized_default_qos->is_max_data_burst_vol_null) {
+        if (cJSON_AddNullToObject(item, "maxDataBurstVol") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [max_data_burst_vol]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->maxbr_ul) {
@@ -131,6 +162,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [maxbr_ul]");
         goto end;
     }
+    } else if (authorized_default_qos->is_maxbr_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxbrUl") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [maxbr_ul]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->maxbr_dl) {
@@ -138,6 +174,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [maxbr_dl]");
         goto end;
     }
+    } else if (authorized_default_qos->is_maxbr_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxbrDl") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [maxbr_dl]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->gbr_ul) {
@@ -145,6 +186,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [gbr_ul]");
         goto end;
     }
+    } else if (authorized_default_qos->is_gbr_ul_null) {
+        if (cJSON_AddNullToObject(item, "gbrUl") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [gbr_ul]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->gbr_dl) {
@@ -152,6 +198,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [gbr_dl]");
         goto end;
     }
+    } else if (authorized_default_qos->is_gbr_dl_null) {
+        if (cJSON_AddNullToObject(item, "gbrDl") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [gbr_dl]");
+            goto end;
+        }
     }
 
     if (authorized_default_qos->is_ext_max_data_burst_vol) {
@@ -159,6 +210,11 @@ cJSON *OpenAPI_authorized_default_qos_convertToJSON(OpenAPI_authorized_default_q
         ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [ext_max_data_burst_vol]");
         goto end;
     }
+    } else if (authorized_default_qos->is_ext_max_data_burst_vol_null) {
+        if (cJSON_AddNullToObject(item, "extMaxDataBurstVol") == NULL) {
+            ogs_error("OpenAPI_authorized_default_qos_convertToJSON() failed [ext_max_data_burst_vol]");
+            goto end;
+        }
     }
 
 end:
@@ -199,65 +255,81 @@ OpenAPI_authorized_default_qos_t *OpenAPI_authorized_default_qos_parseFromJSON(c
 
     priority_level = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "priorityLevel");
     if (priority_level) {
+    if (!cJSON_IsNull(priority_level)) {
     if (!cJSON_IsNumber(priority_level)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [priority_level]");
         goto end;
     }
     }
+    }
 
     aver_window = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "averWindow");
     if (aver_window) {
+    if (!cJSON_IsNull(aver_window)) {
     if (!cJSON_IsNumber(aver_window)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [aver_window]");
         goto end;
     }
     }
+    }
 
     max_data_burst_vol = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "maxDataBurstVol");
     if (max_data_burst_vol) {
+    if (!cJSON_IsNull(max_data_burst_vol)) {
     if (!cJSON_IsNumber(max_data_burst_vol)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [max_data_burst_vol]");
         goto end;
     }
     }
+    }
 
     maxbr_ul = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "maxbrUl");
     if (maxbr_ul) {
+    if (!cJSON_IsNull(maxbr_ul)) {
     if (!cJSON_IsString(maxbr_ul) && !cJSON_IsNull(maxbr_ul)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [maxbr_ul]");
         goto end;
     }
     }
+    }
 
     maxbr_dl = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "maxbrDl");
     if (maxbr_dl) {
+    if (!cJSON_IsNull(maxbr_dl)) {
     if (!cJSON_IsString(maxbr_dl) && !cJSON_IsNull(maxbr_dl)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [maxbr_dl]");
         goto end;
     }
     }
+    }
 
     gbr_ul = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "gbrUl");
     if (gbr_ul) {
+    if (!cJSON_IsNull(gbr_ul)) {
     if (!cJSON_IsString(gbr_ul) && !cJSON_IsNull(gbr_ul)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [gbr_ul]");
         goto end;
     }
     }
+    }
 
     gbr_dl = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "gbrDl");
     if (gbr_dl) {
+    if (!cJSON_IsNull(gbr_dl)) {
     if (!cJSON_IsString(gbr_dl) && !cJSON_IsNull(gbr_dl)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [gbr_dl]");
         goto end;
     }
     }
+    }
 
     ext_max_data_burst_vol = cJSON_GetObjectItemCaseSensitive(authorized_default_qosJSON, "extMaxDataBurstVol");
     if (ext_max_data_burst_vol) {
+    if (!cJSON_IsNull(ext_max_data_burst_vol)) {
     if (!cJSON_IsNumber(ext_max_data_burst_vol)) {
         ogs_error("OpenAPI_authorized_default_qos_parseFromJSON() failed [ext_max_data_burst_vol]");
         goto end;
+    }
     }
     }
 
@@ -265,16 +337,24 @@ OpenAPI_authorized_default_qos_t *OpenAPI_authorized_default_qos_parseFromJSON(c
         _5qi ? true : false,
         _5qi ? _5qi->valuedouble : 0,
         arp ? arp_local_nonprim : NULL,
+        priority_level && cJSON_IsNull(priority_level) ? true : false,
         priority_level ? true : false,
         priority_level ? priority_level->valuedouble : 0,
+        aver_window && cJSON_IsNull(aver_window) ? true : false,
         aver_window ? true : false,
         aver_window ? aver_window->valuedouble : 0,
+        max_data_burst_vol && cJSON_IsNull(max_data_burst_vol) ? true : false,
         max_data_burst_vol ? true : false,
         max_data_burst_vol ? max_data_burst_vol->valuedouble : 0,
+        maxbr_ul && cJSON_IsNull(maxbr_ul) ? true : false,
         maxbr_ul && !cJSON_IsNull(maxbr_ul) ? ogs_strdup(maxbr_ul->valuestring) : NULL,
+        maxbr_dl && cJSON_IsNull(maxbr_dl) ? true : false,
         maxbr_dl && !cJSON_IsNull(maxbr_dl) ? ogs_strdup(maxbr_dl->valuestring) : NULL,
+        gbr_ul && cJSON_IsNull(gbr_ul) ? true : false,
         gbr_ul && !cJSON_IsNull(gbr_ul) ? ogs_strdup(gbr_ul->valuestring) : NULL,
+        gbr_dl && cJSON_IsNull(gbr_dl) ? true : false,
         gbr_dl && !cJSON_IsNull(gbr_dl) ? ogs_strdup(gbr_dl->valuestring) : NULL,
+        ext_max_data_burst_vol && cJSON_IsNull(ext_max_data_burst_vol) ? true : false,
         ext_max_data_burst_vol ? true : false,
         ext_max_data_burst_vol ? ext_max_data_burst_vol->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/authorized_default_qos.h
+++ b/lib/sbi/openapi/model/authorized_default_qos.h
@@ -23,16 +23,24 @@ typedef struct OpenAPI_authorized_default_qos_s {
     bool is__5qi;
     int _5qi;
     struct OpenAPI_arp_s *arp;
+    bool is_priority_level_null;
     bool is_priority_level;
     int priority_level;
+    bool is_aver_window_null;
     bool is_aver_window;
     int aver_window;
+    bool is_max_data_burst_vol_null;
     bool is_max_data_burst_vol;
     int max_data_burst_vol;
+    bool is_maxbr_ul_null;
     char *maxbr_ul;
+    bool is_maxbr_dl_null;
     char *maxbr_dl;
+    bool is_gbr_ul_null;
     char *gbr_ul;
+    bool is_gbr_dl_null;
     char *gbr_dl;
+    bool is_ext_max_data_burst_vol_null;
     bool is_ext_max_data_burst_vol;
     int ext_max_data_burst_vol;
 } OpenAPI_authorized_default_qos_t;
@@ -41,16 +49,24 @@ OpenAPI_authorized_default_qos_t *OpenAPI_authorized_default_qos_create(
     bool is__5qi,
     int _5qi,
     OpenAPI_arp_t *arp,
+    bool is_priority_level_null,
     bool is_priority_level,
     int priority_level,
+    bool is_aver_window_null,
     bool is_aver_window,
     int aver_window,
+    bool is_max_data_burst_vol_null,
     bool is_max_data_burst_vol,
     int max_data_burst_vol,
+    bool is_maxbr_ul_null,
     char *maxbr_ul,
+    bool is_maxbr_dl_null,
     char *maxbr_dl,
+    bool is_gbr_ul_null,
     char *gbr_ul,
+    bool is_gbr_dl_null,
     char *gbr_dl,
+    bool is_ext_max_data_burst_vol_null,
     bool is_ext_max_data_burst_vol,
     int ext_max_data_burst_vol
 );

--- a/lib/sbi/openapi/model/candidate_for_replacement.c
+++ b/lib/sbi/openapi/model/candidate_for_replacement.c
@@ -6,6 +6,7 @@
 
 OpenAPI_candidate_for_replacement_t *OpenAPI_candidate_for_replacement_create(
     OpenAPI_snssai_t *snssai,
+    bool is_dnns_null,
     OpenAPI_list_t *dnns
 )
 {
@@ -13,6 +14,7 @@ OpenAPI_candidate_for_replacement_t *OpenAPI_candidate_for_replacement_create(
     ogs_assert(candidate_for_replacement_local_var);
 
     candidate_for_replacement_local_var->snssai = snssai;
+    candidate_for_replacement_local_var->is_dnns_null = is_dnns_null;
     candidate_for_replacement_local_var->dnns = dnns;
 
     return candidate_for_replacement_local_var;
@@ -77,6 +79,11 @@ cJSON *OpenAPI_candidate_for_replacement_convertToJSON(OpenAPI_candidate_for_rep
             goto end;
         }
     }
+    } else if (candidate_for_replacement->is_dnns_null) {
+        if (cJSON_AddNullToObject(item, "dnns") == NULL) {
+            ogs_error("OpenAPI_candidate_for_replacement_convertToJSON() failed [dnns]");
+            goto end;
+        }
     }
 
 end:
@@ -104,6 +111,7 @@ OpenAPI_candidate_for_replacement_t *OpenAPI_candidate_for_replacement_parseFrom
 
     dnns = cJSON_GetObjectItemCaseSensitive(candidate_for_replacementJSON, "dnns");
     if (dnns) {
+    if (!cJSON_IsNull(dnns)) {
         cJSON *dnns_local = NULL;
         if (!cJSON_IsArray(dnns)) {
             ogs_error("OpenAPI_candidate_for_replacement_parseFromJSON() failed [dnns]");
@@ -122,9 +130,11 @@ OpenAPI_candidate_for_replacement_t *OpenAPI_candidate_for_replacement_parseFrom
             OpenAPI_list_add(dnnsList, ogs_strdup(dnns_local->valuestring));
         }
     }
+    }
 
     candidate_for_replacement_local_var = OpenAPI_candidate_for_replacement_create (
         snssai_local_nonprim,
+        dnns && cJSON_IsNull(dnns) ? true : false,
         dnns ? dnnsList : NULL
     );
 

--- a/lib/sbi/openapi/model/candidate_for_replacement.h
+++ b/lib/sbi/openapi/model/candidate_for_replacement.h
@@ -21,11 +21,13 @@ extern "C" {
 typedef struct OpenAPI_candidate_for_replacement_s OpenAPI_candidate_for_replacement_t;
 typedef struct OpenAPI_candidate_for_replacement_s {
     struct OpenAPI_snssai_s *snssai;
+    bool is_dnns_null;
     OpenAPI_list_t *dnns;
 } OpenAPI_candidate_for_replacement_t;
 
 OpenAPI_candidate_for_replacement_t *OpenAPI_candidate_for_replacement_create(
     OpenAPI_snssai_t *snssai,
+    bool is_dnns_null,
     OpenAPI_list_t *dnns
 );
 void OpenAPI_candidate_for_replacement_free(OpenAPI_candidate_for_replacement_t *candidate_for_replacement);

--- a/lib/sbi/openapi/model/change_item.h
+++ b/lib/sbi/openapi/model/change_item.h
@@ -24,7 +24,9 @@ typedef struct OpenAPI_change_item_s {
     OpenAPI_change_type_e op;
     char *path;
     char *from;
+    bool is_orig_value_null;
     OpenAPI_any_type_t *orig_value;
+    bool is_new_value_null;
     OpenAPI_any_type_t *new_value;
 } OpenAPI_change_item_t;
 
@@ -32,7 +34,9 @@ OpenAPI_change_item_t *OpenAPI_change_item_create(
     OpenAPI_change_type_e op,
     char *path,
     char *from,
+    bool is_orig_value_null,
     OpenAPI_any_type_t *orig_value,
+    bool is_new_value_null,
     OpenAPI_any_type_t *new_value
 );
 void OpenAPI_change_item_free(OpenAPI_change_item_t *change_item);

--- a/lib/sbi/openapi/model/communication_characteristics.c
+++ b/lib/sbi/openapi/model/communication_characteristics.c
@@ -5,24 +5,36 @@
 #include "communication_characteristics.h"
 
 OpenAPI_communication_characteristics_t *OpenAPI_communication_characteristics_create(
+    bool is_pp_subs_reg_timer_null,
     OpenAPI_pp_subs_reg_timer_t *pp_subs_reg_timer,
+    bool is_pp_active_time_null,
     OpenAPI_pp_active_time_t *pp_active_time,
+    bool is_pp_dl_packet_count_null,
     bool is_pp_dl_packet_count,
     int pp_dl_packet_count,
+    bool is_pp_dl_packet_count_ext_null,
     OpenAPI_pp_dl_packet_count_ext_t *pp_dl_packet_count_ext,
+    bool is_pp_maximum_response_time_null,
     OpenAPI_pp_maximum_response_time_t *pp_maximum_response_time,
+    bool is_pp_maximum_latency_null,
     OpenAPI_pp_maximum_latency_t *pp_maximum_latency
 )
 {
     OpenAPI_communication_characteristics_t *communication_characteristics_local_var = ogs_malloc(sizeof(OpenAPI_communication_characteristics_t));
     ogs_assert(communication_characteristics_local_var);
 
+    communication_characteristics_local_var->is_pp_subs_reg_timer_null = is_pp_subs_reg_timer_null;
     communication_characteristics_local_var->pp_subs_reg_timer = pp_subs_reg_timer;
+    communication_characteristics_local_var->is_pp_active_time_null = is_pp_active_time_null;
     communication_characteristics_local_var->pp_active_time = pp_active_time;
+    communication_characteristics_local_var->is_pp_dl_packet_count_null = is_pp_dl_packet_count_null;
     communication_characteristics_local_var->is_pp_dl_packet_count = is_pp_dl_packet_count;
     communication_characteristics_local_var->pp_dl_packet_count = pp_dl_packet_count;
+    communication_characteristics_local_var->is_pp_dl_packet_count_ext_null = is_pp_dl_packet_count_ext_null;
     communication_characteristics_local_var->pp_dl_packet_count_ext = pp_dl_packet_count_ext;
+    communication_characteristics_local_var->is_pp_maximum_response_time_null = is_pp_maximum_response_time_null;
     communication_characteristics_local_var->pp_maximum_response_time = pp_maximum_response_time;
+    communication_characteristics_local_var->is_pp_maximum_latency_null = is_pp_maximum_latency_null;
     communication_characteristics_local_var->pp_maximum_latency = pp_maximum_latency;
 
     return communication_characteristics_local_var;
@@ -80,6 +92,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_subs_reg_timer]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_subs_reg_timer_null) {
+        if (cJSON_AddNullToObject(item, "ppSubsRegTimer") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_subs_reg_timer]");
+            goto end;
+        }
     }
 
     if (communication_characteristics->pp_active_time) {
@@ -93,6 +110,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_active_time]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_active_time_null) {
+        if (cJSON_AddNullToObject(item, "ppActiveTime") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_active_time]");
+            goto end;
+        }
     }
 
     if (communication_characteristics->is_pp_dl_packet_count) {
@@ -100,6 +122,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_dl_packet_count]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_dl_packet_count_null) {
+        if (cJSON_AddNullToObject(item, "ppDlPacketCount") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_dl_packet_count]");
+            goto end;
+        }
     }
 
     if (communication_characteristics->pp_dl_packet_count_ext) {
@@ -113,6 +140,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_dl_packet_count_ext]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_dl_packet_count_ext_null) {
+        if (cJSON_AddNullToObject(item, "ppDlPacketCountExt") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_dl_packet_count_ext]");
+            goto end;
+        }
     }
 
     if (communication_characteristics->pp_maximum_response_time) {
@@ -126,6 +158,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_maximum_response_time]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_maximum_response_time_null) {
+        if (cJSON_AddNullToObject(item, "ppMaximumResponseTime") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_maximum_response_time]");
+            goto end;
+        }
     }
 
     if (communication_characteristics->pp_maximum_latency) {
@@ -139,6 +176,11 @@ cJSON *OpenAPI_communication_characteristics_convertToJSON(OpenAPI_communication
         ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_maximum_latency]");
         goto end;
     }
+    } else if (communication_characteristics->is_pp_maximum_latency_null) {
+        if (cJSON_AddNullToObject(item, "ppMaximumLatency") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_convertToJSON() failed [pp_maximum_latency]");
+            goto end;
+        }
     }
 
 end:
@@ -162,64 +204,82 @@ OpenAPI_communication_characteristics_t *OpenAPI_communication_characteristics_p
     OpenAPI_pp_maximum_latency_t *pp_maximum_latency_local_nonprim = NULL;
     pp_subs_reg_timer = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppSubsRegTimer");
     if (pp_subs_reg_timer) {
+    if (!cJSON_IsNull(pp_subs_reg_timer)) {
     pp_subs_reg_timer_local_nonprim = OpenAPI_pp_subs_reg_timer_parseFromJSON(pp_subs_reg_timer);
     if (!pp_subs_reg_timer_local_nonprim) {
         ogs_error("OpenAPI_pp_subs_reg_timer_parseFromJSON failed [pp_subs_reg_timer]");
         goto end;
     }
     }
+    }
 
     pp_active_time = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppActiveTime");
     if (pp_active_time) {
+    if (!cJSON_IsNull(pp_active_time)) {
     pp_active_time_local_nonprim = OpenAPI_pp_active_time_parseFromJSON(pp_active_time);
     if (!pp_active_time_local_nonprim) {
         ogs_error("OpenAPI_pp_active_time_parseFromJSON failed [pp_active_time]");
         goto end;
     }
     }
+    }
 
     pp_dl_packet_count = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppDlPacketCount");
     if (pp_dl_packet_count) {
+    if (!cJSON_IsNull(pp_dl_packet_count)) {
     if (!cJSON_IsNumber(pp_dl_packet_count)) {
         ogs_error("OpenAPI_communication_characteristics_parseFromJSON() failed [pp_dl_packet_count]");
         goto end;
     }
     }
+    }
 
     pp_dl_packet_count_ext = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppDlPacketCountExt");
     if (pp_dl_packet_count_ext) {
+    if (!cJSON_IsNull(pp_dl_packet_count_ext)) {
     pp_dl_packet_count_ext_local_nonprim = OpenAPI_pp_dl_packet_count_ext_parseFromJSON(pp_dl_packet_count_ext);
     if (!pp_dl_packet_count_ext_local_nonprim) {
         ogs_error("OpenAPI_pp_dl_packet_count_ext_parseFromJSON failed [pp_dl_packet_count_ext]");
         goto end;
     }
     }
+    }
 
     pp_maximum_response_time = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppMaximumResponseTime");
     if (pp_maximum_response_time) {
+    if (!cJSON_IsNull(pp_maximum_response_time)) {
     pp_maximum_response_time_local_nonprim = OpenAPI_pp_maximum_response_time_parseFromJSON(pp_maximum_response_time);
     if (!pp_maximum_response_time_local_nonprim) {
         ogs_error("OpenAPI_pp_maximum_response_time_parseFromJSON failed [pp_maximum_response_time]");
         goto end;
     }
     }
+    }
 
     pp_maximum_latency = cJSON_GetObjectItemCaseSensitive(communication_characteristicsJSON, "ppMaximumLatency");
     if (pp_maximum_latency) {
+    if (!cJSON_IsNull(pp_maximum_latency)) {
     pp_maximum_latency_local_nonprim = OpenAPI_pp_maximum_latency_parseFromJSON(pp_maximum_latency);
     if (!pp_maximum_latency_local_nonprim) {
         ogs_error("OpenAPI_pp_maximum_latency_parseFromJSON failed [pp_maximum_latency]");
         goto end;
     }
     }
+    }
 
     communication_characteristics_local_var = OpenAPI_communication_characteristics_create (
+        pp_subs_reg_timer && cJSON_IsNull(pp_subs_reg_timer) ? true : false,
         pp_subs_reg_timer ? pp_subs_reg_timer_local_nonprim : NULL,
+        pp_active_time && cJSON_IsNull(pp_active_time) ? true : false,
         pp_active_time ? pp_active_time_local_nonprim : NULL,
+        pp_dl_packet_count && cJSON_IsNull(pp_dl_packet_count) ? true : false,
         pp_dl_packet_count ? true : false,
         pp_dl_packet_count ? pp_dl_packet_count->valuedouble : 0,
+        pp_dl_packet_count_ext && cJSON_IsNull(pp_dl_packet_count_ext) ? true : false,
         pp_dl_packet_count_ext ? pp_dl_packet_count_ext_local_nonprim : NULL,
+        pp_maximum_response_time && cJSON_IsNull(pp_maximum_response_time) ? true : false,
         pp_maximum_response_time ? pp_maximum_response_time_local_nonprim : NULL,
+        pp_maximum_latency && cJSON_IsNull(pp_maximum_latency) ? true : false,
         pp_maximum_latency ? pp_maximum_latency_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/communication_characteristics.h
+++ b/lib/sbi/openapi/model/communication_characteristics.h
@@ -24,22 +24,34 @@ extern "C" {
 
 typedef struct OpenAPI_communication_characteristics_s OpenAPI_communication_characteristics_t;
 typedef struct OpenAPI_communication_characteristics_s {
+    bool is_pp_subs_reg_timer_null;
     struct OpenAPI_pp_subs_reg_timer_s *pp_subs_reg_timer;
+    bool is_pp_active_time_null;
     struct OpenAPI_pp_active_time_s *pp_active_time;
+    bool is_pp_dl_packet_count_null;
     bool is_pp_dl_packet_count;
     int pp_dl_packet_count;
+    bool is_pp_dl_packet_count_ext_null;
     struct OpenAPI_pp_dl_packet_count_ext_s *pp_dl_packet_count_ext;
+    bool is_pp_maximum_response_time_null;
     struct OpenAPI_pp_maximum_response_time_s *pp_maximum_response_time;
+    bool is_pp_maximum_latency_null;
     struct OpenAPI_pp_maximum_latency_s *pp_maximum_latency;
 } OpenAPI_communication_characteristics_t;
 
 OpenAPI_communication_characteristics_t *OpenAPI_communication_characteristics_create(
+    bool is_pp_subs_reg_timer_null,
     OpenAPI_pp_subs_reg_timer_t *pp_subs_reg_timer,
+    bool is_pp_active_time_null,
     OpenAPI_pp_active_time_t *pp_active_time,
+    bool is_pp_dl_packet_count_null,
     bool is_pp_dl_packet_count,
     int pp_dl_packet_count,
+    bool is_pp_dl_packet_count_ext_null,
     OpenAPI_pp_dl_packet_count_ext_t *pp_dl_packet_count_ext,
+    bool is_pp_maximum_response_time_null,
     OpenAPI_pp_maximum_response_time_t *pp_maximum_response_time,
+    bool is_pp_maximum_latency_null,
     OpenAPI_pp_maximum_latency_t *pp_maximum_latency
 );
 void OpenAPI_communication_characteristics_free(OpenAPI_communication_characteristics_t *communication_characteristics);

--- a/lib/sbi/openapi/model/communication_characteristics_af.c
+++ b/lib/sbi/openapi/model/communication_characteristics_af.c
@@ -5,6 +5,7 @@
 #include "communication_characteristics_af.h"
 
 OpenAPI_communication_characteristics_af_t *OpenAPI_communication_characteristics_af_create(
+    bool is_pp_dl_packet_count_null,
     bool is_pp_dl_packet_count,
     int pp_dl_packet_count,
     bool is_maximum_response_time,
@@ -16,6 +17,7 @@ OpenAPI_communication_characteristics_af_t *OpenAPI_communication_characteristic
     OpenAPI_communication_characteristics_af_t *communication_characteristics_af_local_var = ogs_malloc(sizeof(OpenAPI_communication_characteristics_af_t));
     ogs_assert(communication_characteristics_af_local_var);
 
+    communication_characteristics_af_local_var->is_pp_dl_packet_count_null = is_pp_dl_packet_count_null;
     communication_characteristics_af_local_var->is_pp_dl_packet_count = is_pp_dl_packet_count;
     communication_characteristics_af_local_var->pp_dl_packet_count = pp_dl_packet_count;
     communication_characteristics_af_local_var->is_maximum_response_time = is_maximum_response_time;
@@ -52,6 +54,11 @@ cJSON *OpenAPI_communication_characteristics_af_convertToJSON(OpenAPI_communicat
         ogs_error("OpenAPI_communication_characteristics_af_convertToJSON() failed [pp_dl_packet_count]");
         goto end;
     }
+    } else if (communication_characteristics_af->is_pp_dl_packet_count_null) {
+        if (cJSON_AddNullToObject(item, "ppDlPacketCount") == NULL) {
+            ogs_error("OpenAPI_communication_characteristics_af_convertToJSON() failed [pp_dl_packet_count]");
+            goto end;
+        }
     }
 
     if (communication_characteristics_af->is_maximum_response_time) {
@@ -81,9 +88,11 @@ OpenAPI_communication_characteristics_af_t *OpenAPI_communication_characteristic
     cJSON *maximum_latency = NULL;
     pp_dl_packet_count = cJSON_GetObjectItemCaseSensitive(communication_characteristics_afJSON, "ppDlPacketCount");
     if (pp_dl_packet_count) {
+    if (!cJSON_IsNull(pp_dl_packet_count)) {
     if (!cJSON_IsNumber(pp_dl_packet_count)) {
         ogs_error("OpenAPI_communication_characteristics_af_parseFromJSON() failed [pp_dl_packet_count]");
         goto end;
+    }
     }
     }
 
@@ -104,6 +113,7 @@ OpenAPI_communication_characteristics_af_t *OpenAPI_communication_characteristic
     }
 
     communication_characteristics_af_local_var = OpenAPI_communication_characteristics_af_create (
+        pp_dl_packet_count && cJSON_IsNull(pp_dl_packet_count) ? true : false,
         pp_dl_packet_count ? true : false,
         pp_dl_packet_count ? pp_dl_packet_count->valuedouble : 0,
         maximum_response_time ? true : false,

--- a/lib/sbi/openapi/model/communication_characteristics_af.h
+++ b/lib/sbi/openapi/model/communication_characteristics_af.h
@@ -19,6 +19,7 @@ extern "C" {
 
 typedef struct OpenAPI_communication_characteristics_af_s OpenAPI_communication_characteristics_af_t;
 typedef struct OpenAPI_communication_characteristics_af_s {
+    bool is_pp_dl_packet_count_null;
     bool is_pp_dl_packet_count;
     int pp_dl_packet_count;
     bool is_maximum_response_time;
@@ -28,6 +29,7 @@ typedef struct OpenAPI_communication_characteristics_af_s {
 } OpenAPI_communication_characteristics_af_t;
 
 OpenAPI_communication_characteristics_af_t *OpenAPI_communication_characteristics_af_create(
+    bool is_pp_dl_packet_count_null,
     bool is_pp_dl_packet_count,
     int pp_dl_packet_count,
     bool is_maximum_response_time,

--- a/lib/sbi/openapi/model/condition_data.c
+++ b/lib/sbi/openapi/model/condition_data.c
@@ -6,7 +6,9 @@
 
 OpenAPI_condition_data_t *OpenAPI_condition_data_create(
     char *cond_id,
+    bool is_activation_time_null,
     char *activation_time,
+    bool is_deactivation_time_null,
     char *deactivation_time,
     OpenAPI_access_type_e access_type,
     OpenAPI_rat_type_e rat_type
@@ -16,7 +18,9 @@ OpenAPI_condition_data_t *OpenAPI_condition_data_create(
     ogs_assert(condition_data_local_var);
 
     condition_data_local_var->cond_id = cond_id;
+    condition_data_local_var->is_activation_time_null = is_activation_time_null;
     condition_data_local_var->activation_time = activation_time;
+    condition_data_local_var->is_deactivation_time_null = is_deactivation_time_null;
     condition_data_local_var->deactivation_time = deactivation_time;
     condition_data_local_var->access_type = access_type;
     condition_data_local_var->rat_type = rat_type;
@@ -71,6 +75,11 @@ cJSON *OpenAPI_condition_data_convertToJSON(OpenAPI_condition_data_t *condition_
         ogs_error("OpenAPI_condition_data_convertToJSON() failed [activation_time]");
         goto end;
     }
+    } else if (condition_data->is_activation_time_null) {
+        if (cJSON_AddNullToObject(item, "activationTime") == NULL) {
+            ogs_error("OpenAPI_condition_data_convertToJSON() failed [activation_time]");
+            goto end;
+        }
     }
 
     if (condition_data->deactivation_time) {
@@ -78,6 +87,11 @@ cJSON *OpenAPI_condition_data_convertToJSON(OpenAPI_condition_data_t *condition_
         ogs_error("OpenAPI_condition_data_convertToJSON() failed [deactivation_time]");
         goto end;
     }
+    } else if (condition_data->is_deactivation_time_null) {
+        if (cJSON_AddNullToObject(item, "deactivationTime") == NULL) {
+            ogs_error("OpenAPI_condition_data_convertToJSON() failed [deactivation_time]");
+            goto end;
+        }
     }
 
     if (condition_data->access_type != OpenAPI_access_type_NULL) {
@@ -121,17 +135,21 @@ OpenAPI_condition_data_t *OpenAPI_condition_data_parseFromJSON(cJSON *condition_
 
     activation_time = cJSON_GetObjectItemCaseSensitive(condition_dataJSON, "activationTime");
     if (activation_time) {
+    if (!cJSON_IsNull(activation_time)) {
     if (!cJSON_IsString(activation_time) && !cJSON_IsNull(activation_time)) {
         ogs_error("OpenAPI_condition_data_parseFromJSON() failed [activation_time]");
         goto end;
     }
     }
+    }
 
     deactivation_time = cJSON_GetObjectItemCaseSensitive(condition_dataJSON, "deactivationTime");
     if (deactivation_time) {
+    if (!cJSON_IsNull(deactivation_time)) {
     if (!cJSON_IsString(deactivation_time) && !cJSON_IsNull(deactivation_time)) {
         ogs_error("OpenAPI_condition_data_parseFromJSON() failed [deactivation_time]");
         goto end;
+    }
     }
     }
 
@@ -155,7 +173,9 @@ OpenAPI_condition_data_t *OpenAPI_condition_data_parseFromJSON(cJSON *condition_
 
     condition_data_local_var = OpenAPI_condition_data_create (
         ogs_strdup(cond_id->valuestring),
+        activation_time && cJSON_IsNull(activation_time) ? true : false,
         activation_time && !cJSON_IsNull(activation_time) ? ogs_strdup(activation_time->valuestring) : NULL,
+        deactivation_time && cJSON_IsNull(deactivation_time) ? true : false,
         deactivation_time && !cJSON_IsNull(deactivation_time) ? ogs_strdup(deactivation_time->valuestring) : NULL,
         access_type ? access_typeVariable : 0,
         rat_type ? rat_typeVariable : 0

--- a/lib/sbi/openapi/model/condition_data.h
+++ b/lib/sbi/openapi/model/condition_data.h
@@ -22,7 +22,9 @@ extern "C" {
 typedef struct OpenAPI_condition_data_s OpenAPI_condition_data_t;
 typedef struct OpenAPI_condition_data_s {
     char *cond_id;
+    bool is_activation_time_null;
     char *activation_time;
+    bool is_deactivation_time_null;
     char *deactivation_time;
     OpenAPI_access_type_e access_type;
     OpenAPI_rat_type_e rat_type;
@@ -30,7 +32,9 @@ typedef struct OpenAPI_condition_data_s {
 
 OpenAPI_condition_data_t *OpenAPI_condition_data_create(
     char *cond_id,
+    bool is_activation_time_null,
     char *activation_time,
+    bool is_deactivation_time_null,
     char *deactivation_time,
     OpenAPI_access_type_e access_type,
     OpenAPI_rat_type_e rat_type

--- a/lib/sbi/openapi/model/confirmation_data.c
+++ b/lib/sbi/openapi/model/confirmation_data.c
@@ -5,6 +5,7 @@
 #include "confirmation_data.h"
 
 OpenAPI_confirmation_data_t *OpenAPI_confirmation_data_create(
+    bool is_res_star_null,
     char *res_star,
     char *supported_features
 )
@@ -12,6 +13,7 @@ OpenAPI_confirmation_data_t *OpenAPI_confirmation_data_create(
     OpenAPI_confirmation_data_t *confirmation_data_local_var = ogs_malloc(sizeof(OpenAPI_confirmation_data_t));
     ogs_assert(confirmation_data_local_var);
 
+    confirmation_data_local_var->is_res_star_null = is_res_star_null;
     confirmation_data_local_var->res_star = res_star;
     confirmation_data_local_var->supported_features = supported_features;
 
@@ -92,6 +94,7 @@ OpenAPI_confirmation_data_t *OpenAPI_confirmation_data_parseFromJSON(cJSON *conf
     }
 
     confirmation_data_local_var = OpenAPI_confirmation_data_create (
+        res_star && cJSON_IsNull(res_star) ? true : false,
         ogs_strdup(res_star->valuestring),
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL
     );

--- a/lib/sbi/openapi/model/confirmation_data.h
+++ b/lib/sbi/openapi/model/confirmation_data.h
@@ -19,11 +19,13 @@ extern "C" {
 
 typedef struct OpenAPI_confirmation_data_s OpenAPI_confirmation_data_t;
 typedef struct OpenAPI_confirmation_data_s {
+    bool is_res_star_null;
     char *res_star;
     char *supported_features;
 } OpenAPI_confirmation_data_t;
 
 OpenAPI_confirmation_data_t *OpenAPI_confirmation_data_create(
+    bool is_res_star_null,
     char *res_star,
     char *supported_features
 );

--- a/lib/sbi/openapi/model/dnn_configuration.c
+++ b/lib/sbi/openapi/model/dnn_configuration.c
@@ -36,6 +36,7 @@ OpenAPI_dnn_configuration_t *OpenAPI_dnn_configuration_create(
     char *iptv_acc_ctrl_info,
     OpenAPI_ip_index_t *ipv4_index,
     OpenAPI_ip_index_t *ipv6_index,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
     char *shared_ecs_addr_config_info,
@@ -83,6 +84,7 @@ OpenAPI_dnn_configuration_t *OpenAPI_dnn_configuration_create(
     dnn_configuration_local_var->iptv_acc_ctrl_info = iptv_acc_ctrl_info;
     dnn_configuration_local_var->ipv4_index = ipv4_index;
     dnn_configuration_local_var->ipv6_index = ipv6_index;
+    dnn_configuration_local_var->is_ecs_addr_config_info_null = is_ecs_addr_config_info_null;
     dnn_configuration_local_var->ecs_addr_config_info = ecs_addr_config_info;
     dnn_configuration_local_var->additional_ecs_addr_config_infos = additional_ecs_addr_config_infos;
     dnn_configuration_local_var->shared_ecs_addr_config_info = shared_ecs_addr_config_info;
@@ -511,6 +513,11 @@ cJSON *OpenAPI_dnn_configuration_convertToJSON(OpenAPI_dnn_configuration_t *dnn_
         ogs_error("OpenAPI_dnn_configuration_convertToJSON() failed [ecs_addr_config_info]");
         goto end;
     }
+    } else if (dnn_configuration->is_ecs_addr_config_info_null) {
+        if (cJSON_AddNullToObject(item, "ecsAddrConfigInfo") == NULL) {
+            ogs_error("OpenAPI_dnn_configuration_convertToJSON() failed [ecs_addr_config_info]");
+            goto end;
+        }
     }
 
     if (dnn_configuration->additional_ecs_addr_config_infos) {
@@ -919,10 +926,12 @@ OpenAPI_dnn_configuration_t *OpenAPI_dnn_configuration_parseFromJSON(cJSON *dnn_
 
     ecs_addr_config_info = cJSON_GetObjectItemCaseSensitive(dnn_configurationJSON, "ecsAddrConfigInfo");
     if (ecs_addr_config_info) {
+    if (!cJSON_IsNull(ecs_addr_config_info)) {
     ecs_addr_config_info_local_nonprim = OpenAPI_ecs_addr_config_info_parseFromJSON(ecs_addr_config_info);
     if (!ecs_addr_config_info_local_nonprim) {
         ogs_error("OpenAPI_ecs_addr_config_info_parseFromJSON failed [ecs_addr_config_info]");
         goto end;
+    }
     }
     }
 
@@ -1044,6 +1053,7 @@ OpenAPI_dnn_configuration_t *OpenAPI_dnn_configuration_parseFromJSON(cJSON *dnn_
         iptv_acc_ctrl_info && !cJSON_IsNull(iptv_acc_ctrl_info) ? ogs_strdup(iptv_acc_ctrl_info->valuestring) : NULL,
         ipv4_index ? ipv4_index_local_nonprim : NULL,
         ipv6_index ? ipv6_index_local_nonprim : NULL,
+        ecs_addr_config_info && cJSON_IsNull(ecs_addr_config_info) ? true : false,
         ecs_addr_config_info ? ecs_addr_config_info_local_nonprim : NULL,
         additional_ecs_addr_config_infos ? additional_ecs_addr_config_infosList : NULL,
         shared_ecs_addr_config_info && !cJSON_IsNull(shared_ecs_addr_config_info) ? ogs_strdup(shared_ecs_addr_config_info->valuestring) : NULL,

--- a/lib/sbi/openapi/model/dnn_configuration.h
+++ b/lib/sbi/openapi/model/dnn_configuration.h
@@ -63,6 +63,7 @@ typedef struct OpenAPI_dnn_configuration_s {
     char *iptv_acc_ctrl_info;
     struct OpenAPI_ip_index_s *ipv4_index;
     struct OpenAPI_ip_index_s *ipv6_index;
+    bool is_ecs_addr_config_info_null;
     struct OpenAPI_ecs_addr_config_info_s *ecs_addr_config_info;
     OpenAPI_list_t *additional_ecs_addr_config_infos;
     char *shared_ecs_addr_config_info;
@@ -108,6 +109,7 @@ OpenAPI_dnn_configuration_t *OpenAPI_dnn_configuration_create(
     char *iptv_acc_ctrl_info,
     OpenAPI_ip_index_t *ipv4_index,
     OpenAPI_ip_index_t *ipv6_index,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
     char *shared_ecs_addr_config_info,

--- a/lib/sbi/openapi/model/dnn_configuration_1.c
+++ b/lib/sbi/openapi/model/dnn_configuration_1.c
@@ -36,6 +36,7 @@ OpenAPI_dnn_configuration_1_t *OpenAPI_dnn_configuration_1_create(
     char *iptv_acc_ctrl_info,
     OpenAPI_ip_index_t *ipv4_index,
     OpenAPI_ip_index_t *ipv6_index,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_1_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
     char *shared_ecs_addr_config_info,
@@ -83,6 +84,7 @@ OpenAPI_dnn_configuration_1_t *OpenAPI_dnn_configuration_1_create(
     dnn_configuration_1_local_var->iptv_acc_ctrl_info = iptv_acc_ctrl_info;
     dnn_configuration_1_local_var->ipv4_index = ipv4_index;
     dnn_configuration_1_local_var->ipv6_index = ipv6_index;
+    dnn_configuration_1_local_var->is_ecs_addr_config_info_null = is_ecs_addr_config_info_null;
     dnn_configuration_1_local_var->ecs_addr_config_info = ecs_addr_config_info;
     dnn_configuration_1_local_var->additional_ecs_addr_config_infos = additional_ecs_addr_config_infos;
     dnn_configuration_1_local_var->shared_ecs_addr_config_info = shared_ecs_addr_config_info;
@@ -511,6 +513,11 @@ cJSON *OpenAPI_dnn_configuration_1_convertToJSON(OpenAPI_dnn_configuration_1_t *
         ogs_error("OpenAPI_dnn_configuration_1_convertToJSON() failed [ecs_addr_config_info]");
         goto end;
     }
+    } else if (dnn_configuration_1->is_ecs_addr_config_info_null) {
+        if (cJSON_AddNullToObject(item, "ecsAddrConfigInfo") == NULL) {
+            ogs_error("OpenAPI_dnn_configuration_1_convertToJSON() failed [ecs_addr_config_info]");
+            goto end;
+        }
     }
 
     if (dnn_configuration_1->additional_ecs_addr_config_infos) {
@@ -919,10 +926,12 @@ OpenAPI_dnn_configuration_1_t *OpenAPI_dnn_configuration_1_parseFromJSON(cJSON *
 
     ecs_addr_config_info = cJSON_GetObjectItemCaseSensitive(dnn_configuration_1JSON, "ecsAddrConfigInfo");
     if (ecs_addr_config_info) {
+    if (!cJSON_IsNull(ecs_addr_config_info)) {
     ecs_addr_config_info_local_nonprim = OpenAPI_ecs_addr_config_info_1_parseFromJSON(ecs_addr_config_info);
     if (!ecs_addr_config_info_local_nonprim) {
         ogs_error("OpenAPI_ecs_addr_config_info_1_parseFromJSON failed [ecs_addr_config_info]");
         goto end;
+    }
     }
     }
 
@@ -1044,6 +1053,7 @@ OpenAPI_dnn_configuration_1_t *OpenAPI_dnn_configuration_1_parseFromJSON(cJSON *
         iptv_acc_ctrl_info && !cJSON_IsNull(iptv_acc_ctrl_info) ? ogs_strdup(iptv_acc_ctrl_info->valuestring) : NULL,
         ipv4_index ? ipv4_index_local_nonprim : NULL,
         ipv6_index ? ipv6_index_local_nonprim : NULL,
+        ecs_addr_config_info && cJSON_IsNull(ecs_addr_config_info) ? true : false,
         ecs_addr_config_info ? ecs_addr_config_info_local_nonprim : NULL,
         additional_ecs_addr_config_infos ? additional_ecs_addr_config_infosList : NULL,
         shared_ecs_addr_config_info && !cJSON_IsNull(shared_ecs_addr_config_info) ? ogs_strdup(shared_ecs_addr_config_info->valuestring) : NULL,

--- a/lib/sbi/openapi/model/dnn_configuration_1.h
+++ b/lib/sbi/openapi/model/dnn_configuration_1.h
@@ -63,6 +63,7 @@ typedef struct OpenAPI_dnn_configuration_1_s {
     char *iptv_acc_ctrl_info;
     struct OpenAPI_ip_index_s *ipv4_index;
     struct OpenAPI_ip_index_s *ipv6_index;
+    bool is_ecs_addr_config_info_null;
     struct OpenAPI_ecs_addr_config_info_1_s *ecs_addr_config_info;
     OpenAPI_list_t *additional_ecs_addr_config_infos;
     char *shared_ecs_addr_config_info;
@@ -108,6 +109,7 @@ OpenAPI_dnn_configuration_1_t *OpenAPI_dnn_configuration_1_create(
     char *iptv_acc_ctrl_info,
     OpenAPI_ip_index_t *ipv4_index,
     OpenAPI_ip_index_t *ipv6_index,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_1_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
     char *shared_ecs_addr_config_info,

--- a/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
+++ b/lib/sbi/openapi/model/downlink_data_notification_control_rm.c
@@ -5,14 +5,18 @@
 #include "downlink_data_notification_control_rm.h"
 
 OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notification_control_rm_create(
+    bool is_notif_ctrl_inds_null,
     OpenAPI_list_t *notif_ctrl_inds,
+    bool is_types_of_notif_null,
     OpenAPI_list_t *types_of_notif
 )
 {
     OpenAPI_downlink_data_notification_control_rm_t *downlink_data_notification_control_rm_local_var = ogs_malloc(sizeof(OpenAPI_downlink_data_notification_control_rm_t));
     ogs_assert(downlink_data_notification_control_rm_local_var);
 
+    downlink_data_notification_control_rm_local_var->is_notif_ctrl_inds_null = is_notif_ctrl_inds_null;
     downlink_data_notification_control_rm_local_var->notif_ctrl_inds = notif_ctrl_inds;
+    downlink_data_notification_control_rm_local_var->is_types_of_notif_null = is_types_of_notif_null;
     downlink_data_notification_control_rm_local_var->types_of_notif = types_of_notif;
 
     return downlink_data_notification_control_rm_local_var;
@@ -59,6 +63,11 @@ cJSON *OpenAPI_downlink_data_notification_control_rm_convertToJSON(OpenAPI_downl
             goto end;
         }
     }
+    } else if (downlink_data_notification_control_rm->is_notif_ctrl_inds_null) {
+        if (cJSON_AddNullToObject(item, "notifCtrlInds") == NULL) {
+            ogs_error("OpenAPI_downlink_data_notification_control_rm_convertToJSON() failed [notif_ctrl_inds]");
+            goto end;
+        }
     }
 
     if (downlink_data_notification_control_rm->types_of_notif != OpenAPI_dl_data_delivery_status_NULL) {
@@ -73,6 +82,11 @@ cJSON *OpenAPI_downlink_data_notification_control_rm_convertToJSON(OpenAPI_downl
             goto end;
         }
     }
+    } else if (downlink_data_notification_control_rm->is_types_of_notif_null) {
+        if (cJSON_AddNullToObject(item, "typesOfNotif") == NULL) {
+            ogs_error("OpenAPI_downlink_data_notification_control_rm_convertToJSON() failed [types_of_notif]");
+            goto end;
+        }
     }
 
 end:
@@ -89,6 +103,7 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
     OpenAPI_list_t *types_of_notifList = NULL;
     notif_ctrl_inds = cJSON_GetObjectItemCaseSensitive(downlink_data_notification_control_rmJSON, "notifCtrlInds");
     if (notif_ctrl_inds) {
+    if (!cJSON_IsNull(notif_ctrl_inds)) {
         cJSON *notif_ctrl_inds_local = NULL;
         if (!cJSON_IsArray(notif_ctrl_inds)) {
             ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed [notif_ctrl_inds]");
@@ -111,9 +126,11 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
             OpenAPI_list_add(notif_ctrl_indsList, (void *)localEnum);
         }
     }
+    }
 
     types_of_notif = cJSON_GetObjectItemCaseSensitive(downlink_data_notification_control_rmJSON, "typesOfNotif");
     if (types_of_notif) {
+    if (!cJSON_IsNull(types_of_notif)) {
         cJSON *types_of_notif_local = NULL;
         if (!cJSON_IsArray(types_of_notif)) {
             ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON() failed [types_of_notif]");
@@ -136,9 +153,12 @@ OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notificat
             OpenAPI_list_add(types_of_notifList, (void *)localEnum);
         }
     }
+    }
 
     downlink_data_notification_control_rm_local_var = OpenAPI_downlink_data_notification_control_rm_create (
+        notif_ctrl_inds && cJSON_IsNull(notif_ctrl_inds) ? true : false,
         notif_ctrl_inds ? notif_ctrl_indsList : NULL,
+        types_of_notif && cJSON_IsNull(types_of_notif) ? true : false,
         types_of_notif ? types_of_notifList : NULL
     );
 

--- a/lib/sbi/openapi/model/downlink_data_notification_control_rm.h
+++ b/lib/sbi/openapi/model/downlink_data_notification_control_rm.h
@@ -21,12 +21,16 @@ extern "C" {
 
 typedef struct OpenAPI_downlink_data_notification_control_rm_s OpenAPI_downlink_data_notification_control_rm_t;
 typedef struct OpenAPI_downlink_data_notification_control_rm_s {
+    bool is_notif_ctrl_inds_null;
     OpenAPI_list_t *notif_ctrl_inds;
+    bool is_types_of_notif_null;
     OpenAPI_list_t *types_of_notif;
 } OpenAPI_downlink_data_notification_control_rm_t;
 
 OpenAPI_downlink_data_notification_control_rm_t *OpenAPI_downlink_data_notification_control_rm_create(
+    bool is_notif_ctrl_inds_null,
     OpenAPI_list_t *notif_ctrl_inds,
+    bool is_types_of_notif_null,
     OpenAPI_list_t *types_of_notif
 );
 void OpenAPI_downlink_data_notification_control_rm_free(OpenAPI_downlink_data_notification_control_rm_t *downlink_data_notification_control_rm);

--- a/lib/sbi/openapi/model/eap_auth_method_200_response.c
+++ b/lib/sbi/openapi/model/eap_auth_method_200_response.c
@@ -5,6 +5,7 @@
 #include "eap_auth_method_200_response.h"
 
 OpenAPI_eap_auth_method_200_response_t *OpenAPI_eap_auth_method_200_response_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     OpenAPI_list_t* _links
 )
@@ -12,6 +13,7 @@ OpenAPI_eap_auth_method_200_response_t *OpenAPI_eap_auth_method_200_response_cre
     OpenAPI_eap_auth_method_200_response_t *eap_auth_method_200_response_local_var = ogs_malloc(sizeof(OpenAPI_eap_auth_method_200_response_t));
     ogs_assert(eap_auth_method_200_response_local_var);
 
+    eap_auth_method_200_response_local_var->is_eap_payload_null = is_eap_payload_null;
     eap_auth_method_200_response_local_var->eap_payload = eap_payload;
     eap_auth_method_200_response_local_var->_links = _links;
 
@@ -144,6 +146,7 @@ OpenAPI_eap_auth_method_200_response_t *OpenAPI_eap_auth_method_200_response_par
         }
 
     eap_auth_method_200_response_local_var = OpenAPI_eap_auth_method_200_response_create (
+        eap_payload && cJSON_IsNull(eap_payload) ? true : false,
         ogs_strdup(eap_payload->valuestring),
         _linksList
     );

--- a/lib/sbi/openapi/model/eap_auth_method_200_response.h
+++ b/lib/sbi/openapi/model/eap_auth_method_200_response.h
@@ -20,11 +20,13 @@ extern "C" {
 
 typedef struct OpenAPI_eap_auth_method_200_response_s OpenAPI_eap_auth_method_200_response_t;
 typedef struct OpenAPI_eap_auth_method_200_response_s {
+    bool is_eap_payload_null;
     char *eap_payload;
     OpenAPI_list_t* _links;
 } OpenAPI_eap_auth_method_200_response_t;
 
 OpenAPI_eap_auth_method_200_response_t *OpenAPI_eap_auth_method_200_response_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     OpenAPI_list_t* _links
 );

--- a/lib/sbi/openapi/model/eap_session.c
+++ b/lib/sbi/openapi/model/eap_session.c
@@ -5,6 +5,7 @@
 #include "eap_session.h"
 
 OpenAPI_eap_session_t *OpenAPI_eap_session_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     char *k_seaf,
     OpenAPI_list_t* _links,
@@ -18,6 +19,7 @@ OpenAPI_eap_session_t *OpenAPI_eap_session_create(
     OpenAPI_eap_session_t *eap_session_local_var = ogs_malloc(sizeof(OpenAPI_eap_session_t));
     ogs_assert(eap_session_local_var);
 
+    eap_session_local_var->is_eap_payload_null = is_eap_payload_null;
     eap_session_local_var->eap_payload = eap_payload;
     eap_session_local_var->k_seaf = k_seaf;
     eap_session_local_var->_links = _links;
@@ -299,6 +301,7 @@ OpenAPI_eap_session_t *OpenAPI_eap_session_parseFromJSON(cJSON *eap_sessionJSON)
     }
 
     eap_session_local_var = OpenAPI_eap_session_create (
+        eap_payload && cJSON_IsNull(eap_payload) ? true : false,
         ogs_strdup(eap_payload->valuestring),
         k_seaf && !cJSON_IsNull(k_seaf) ? ogs_strdup(k_seaf->valuestring) : NULL,
         _links ? _linksList : NULL,

--- a/lib/sbi/openapi/model/eap_session.h
+++ b/lib/sbi/openapi/model/eap_session.h
@@ -22,6 +22,7 @@ extern "C" {
 
 typedef struct OpenAPI_eap_session_s OpenAPI_eap_session_t;
 typedef struct OpenAPI_eap_session_s {
+    bool is_eap_payload_null;
     char *eap_payload;
     char *k_seaf;
     OpenAPI_list_t* _links;
@@ -33,6 +34,7 @@ typedef struct OpenAPI_eap_session_s {
 } OpenAPI_eap_session_t;
 
 OpenAPI_eap_session_t *OpenAPI_eap_session_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     char *k_seaf,
     OpenAPI_list_t* _links,

--- a/lib/sbi/openapi/model/events_subsc_req_data_rm.c
+++ b/lib/sbi/openapi/model/events_subsc_req_data_rm.c
@@ -8,10 +8,13 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_create(
     OpenAPI_list_t *events,
     char *notif_uri,
     OpenAPI_list_t *req_qos_mon_params,
+    bool is_qos_mon_null,
     OpenAPI_qos_monitoring_information_rm_t *qos_mon,
     OpenAPI_list_t *req_anis,
+    bool is_usg_thres_null,
     OpenAPI_usage_threshold_rm_t *usg_thres,
     char *notif_corre_id,
+    bool is_direct_notif_ind_null,
     bool is_direct_notif_ind,
     int direct_notif_ind
 )
@@ -22,10 +25,13 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_create(
     events_subsc_req_data_rm_local_var->events = events;
     events_subsc_req_data_rm_local_var->notif_uri = notif_uri;
     events_subsc_req_data_rm_local_var->req_qos_mon_params = req_qos_mon_params;
+    events_subsc_req_data_rm_local_var->is_qos_mon_null = is_qos_mon_null;
     events_subsc_req_data_rm_local_var->qos_mon = qos_mon;
     events_subsc_req_data_rm_local_var->req_anis = req_anis;
+    events_subsc_req_data_rm_local_var->is_usg_thres_null = is_usg_thres_null;
     events_subsc_req_data_rm_local_var->usg_thres = usg_thres;
     events_subsc_req_data_rm_local_var->notif_corre_id = notif_corre_id;
+    events_subsc_req_data_rm_local_var->is_direct_notif_ind_null = is_direct_notif_ind_null;
     events_subsc_req_data_rm_local_var->is_direct_notif_ind = is_direct_notif_ind;
     events_subsc_req_data_rm_local_var->direct_notif_ind = direct_notif_ind;
 
@@ -134,6 +140,11 @@ cJSON *OpenAPI_events_subsc_req_data_rm_convertToJSON(OpenAPI_events_subsc_req_d
         ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [qos_mon]");
         goto end;
     }
+    } else if (events_subsc_req_data_rm->is_qos_mon_null) {
+        if (cJSON_AddNullToObject(item, "qosMon") == NULL) {
+            ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [qos_mon]");
+            goto end;
+        }
     }
 
     if (events_subsc_req_data_rm->req_anis != OpenAPI_required_access_info_NULL) {
@@ -161,6 +172,11 @@ cJSON *OpenAPI_events_subsc_req_data_rm_convertToJSON(OpenAPI_events_subsc_req_d
         ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [usg_thres]");
         goto end;
     }
+    } else if (events_subsc_req_data_rm->is_usg_thres_null) {
+        if (cJSON_AddNullToObject(item, "usgThres") == NULL) {
+            ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [usg_thres]");
+            goto end;
+        }
     }
 
     if (events_subsc_req_data_rm->notif_corre_id) {
@@ -175,6 +191,11 @@ cJSON *OpenAPI_events_subsc_req_data_rm_convertToJSON(OpenAPI_events_subsc_req_d
         ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [direct_notif_ind]");
         goto end;
     }
+    } else if (events_subsc_req_data_rm->is_direct_notif_ind_null) {
+        if (cJSON_AddNullToObject(item, "directNotifInd") == NULL) {
+            ogs_error("OpenAPI_events_subsc_req_data_rm_convertToJSON() failed [direct_notif_ind]");
+            goto end;
+        }
     }
 
 end:
@@ -259,10 +280,12 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
 
     qos_mon = cJSON_GetObjectItemCaseSensitive(events_subsc_req_data_rmJSON, "qosMon");
     if (qos_mon) {
+    if (!cJSON_IsNull(qos_mon)) {
     qos_mon_local_nonprim = OpenAPI_qos_monitoring_information_rm_parseFromJSON(qos_mon);
     if (!qos_mon_local_nonprim) {
         ogs_error("OpenAPI_qos_monitoring_information_rm_parseFromJSON failed [qos_mon]");
         goto end;
+    }
     }
     }
 
@@ -293,10 +316,12 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
 
     usg_thres = cJSON_GetObjectItemCaseSensitive(events_subsc_req_data_rmJSON, "usgThres");
     if (usg_thres) {
+    if (!cJSON_IsNull(usg_thres)) {
     usg_thres_local_nonprim = OpenAPI_usage_threshold_rm_parseFromJSON(usg_thres);
     if (!usg_thres_local_nonprim) {
         ogs_error("OpenAPI_usage_threshold_rm_parseFromJSON failed [usg_thres]");
         goto end;
+    }
     }
     }
 
@@ -310,9 +335,11 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
 
     direct_notif_ind = cJSON_GetObjectItemCaseSensitive(events_subsc_req_data_rmJSON, "directNotifInd");
     if (direct_notif_ind) {
+    if (!cJSON_IsNull(direct_notif_ind)) {
     if (!cJSON_IsBool(direct_notif_ind)) {
         ogs_error("OpenAPI_events_subsc_req_data_rm_parseFromJSON() failed [direct_notif_ind]");
         goto end;
+    }
     }
     }
 
@@ -320,10 +347,13 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_parseFromJS
         eventsList,
         notif_uri && !cJSON_IsNull(notif_uri) ? ogs_strdup(notif_uri->valuestring) : NULL,
         req_qos_mon_params ? req_qos_mon_paramsList : NULL,
+        qos_mon && cJSON_IsNull(qos_mon) ? true : false,
         qos_mon ? qos_mon_local_nonprim : NULL,
         req_anis ? req_anisList : NULL,
+        usg_thres && cJSON_IsNull(usg_thres) ? true : false,
         usg_thres ? usg_thres_local_nonprim : NULL,
         notif_corre_id && !cJSON_IsNull(notif_corre_id) ? ogs_strdup(notif_corre_id->valuestring) : NULL,
+        direct_notif_ind && cJSON_IsNull(direct_notif_ind) ? true : false,
         direct_notif_ind ? true : false,
         direct_notif_ind ? direct_notif_ind->valueint : 0
     );

--- a/lib/sbi/openapi/model/events_subsc_req_data_rm.h
+++ b/lib/sbi/openapi/model/events_subsc_req_data_rm.h
@@ -27,10 +27,13 @@ typedef struct OpenAPI_events_subsc_req_data_rm_s {
     OpenAPI_list_t *events;
     char *notif_uri;
     OpenAPI_list_t *req_qos_mon_params;
+    bool is_qos_mon_null;
     struct OpenAPI_qos_monitoring_information_rm_s *qos_mon;
     OpenAPI_list_t *req_anis;
+    bool is_usg_thres_null;
     struct OpenAPI_usage_threshold_rm_s *usg_thres;
     char *notif_corre_id;
+    bool is_direct_notif_ind_null;
     bool is_direct_notif_ind;
     int direct_notif_ind;
 } OpenAPI_events_subsc_req_data_rm_t;
@@ -39,10 +42,13 @@ OpenAPI_events_subsc_req_data_rm_t *OpenAPI_events_subsc_req_data_rm_create(
     OpenAPI_list_t *events,
     char *notif_uri,
     OpenAPI_list_t *req_qos_mon_params,
+    bool is_qos_mon_null,
     OpenAPI_qos_monitoring_information_rm_t *qos_mon,
     OpenAPI_list_t *req_anis,
+    bool is_usg_thres_null,
     OpenAPI_usage_threshold_rm_t *usg_thres,
     char *notif_corre_id,
+    bool is_direct_notif_ind_null,
     bool is_direct_notif_ind,
     int direct_notif_ind
 );

--- a/lib/sbi/openapi/model/expected_ue_behaviour.c
+++ b/lib/sbi/openapi/model/expected_ue_behaviour.c
@@ -8,12 +8,15 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_create(
     char *af_instance_id,
     int reference_id,
     OpenAPI_stationary_indication_rm_t *stationary_indication,
+    bool is_communication_duration_time_null,
     bool is_communication_duration_time,
     int communication_duration_time,
     OpenAPI_scheduled_communication_type_rm_t *scheduled_communication_type,
+    bool is_periodic_time_null,
     bool is_periodic_time,
     int periodic_time,
     OpenAPI_scheduled_communication_time_rm_t *scheduled_communication_time,
+    bool is_expected_umts_null,
     OpenAPI_list_t *expected_umts,
     OpenAPI_traffic_profile_rm_t *traffic_profile,
     OpenAPI_battery_indication_rm_t *battery_indication,
@@ -27,12 +30,15 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_create(
     expected_ue_behaviour_local_var->af_instance_id = af_instance_id;
     expected_ue_behaviour_local_var->reference_id = reference_id;
     expected_ue_behaviour_local_var->stationary_indication = stationary_indication;
+    expected_ue_behaviour_local_var->is_communication_duration_time_null = is_communication_duration_time_null;
     expected_ue_behaviour_local_var->is_communication_duration_time = is_communication_duration_time;
     expected_ue_behaviour_local_var->communication_duration_time = communication_duration_time;
     expected_ue_behaviour_local_var->scheduled_communication_type = scheduled_communication_type;
+    expected_ue_behaviour_local_var->is_periodic_time_null = is_periodic_time_null;
     expected_ue_behaviour_local_var->is_periodic_time = is_periodic_time;
     expected_ue_behaviour_local_var->periodic_time = periodic_time;
     expected_ue_behaviour_local_var->scheduled_communication_time = scheduled_communication_time;
+    expected_ue_behaviour_local_var->is_expected_umts_null = is_expected_umts_null;
     expected_ue_behaviour_local_var->expected_umts = expected_umts;
     expected_ue_behaviour_local_var->traffic_profile = traffic_profile;
     expected_ue_behaviour_local_var->battery_indication = battery_indication;
@@ -134,6 +140,11 @@ cJSON *OpenAPI_expected_ue_behaviour_convertToJSON(OpenAPI_expected_ue_behaviour
         ogs_error("OpenAPI_expected_ue_behaviour_convertToJSON() failed [communication_duration_time]");
         goto end;
     }
+    } else if (expected_ue_behaviour->is_communication_duration_time_null) {
+        if (cJSON_AddNullToObject(item, "communicationDurationTime") == NULL) {
+            ogs_error("OpenAPI_expected_ue_behaviour_convertToJSON() failed [communication_duration_time]");
+            goto end;
+        }
     }
 
     if (expected_ue_behaviour->scheduled_communication_type) {
@@ -154,6 +165,11 @@ cJSON *OpenAPI_expected_ue_behaviour_convertToJSON(OpenAPI_expected_ue_behaviour
         ogs_error("OpenAPI_expected_ue_behaviour_convertToJSON() failed [periodic_time]");
         goto end;
     }
+    } else if (expected_ue_behaviour->is_periodic_time_null) {
+        if (cJSON_AddNullToObject(item, "periodicTime") == NULL) {
+            ogs_error("OpenAPI_expected_ue_behaviour_convertToJSON() failed [periodic_time]");
+            goto end;
+        }
     }
 
     if (expected_ue_behaviour->scheduled_communication_time) {
@@ -183,6 +199,11 @@ cJSON *OpenAPI_expected_ue_behaviour_convertToJSON(OpenAPI_expected_ue_behaviour
         }
         cJSON_AddItemToArray(expected_umtsList, itemLocal);
     }
+    } else if (expected_ue_behaviour->is_expected_umts_null) {
+        if (cJSON_AddNullToObject(item, "expectedUmts") == NULL) {
+            ogs_error("OpenAPI_expected_ue_behaviour_convertToJSON() failed [expected_umts]");
+            goto end;
+        }
     }
 
     if (expected_ue_behaviour->traffic_profile) {
@@ -282,9 +303,11 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_parseFromJSON(cJS
 
     communication_duration_time = cJSON_GetObjectItemCaseSensitive(expected_ue_behaviourJSON, "communicationDurationTime");
     if (communication_duration_time) {
+    if (!cJSON_IsNull(communication_duration_time)) {
     if (!cJSON_IsNumber(communication_duration_time)) {
         ogs_error("OpenAPI_expected_ue_behaviour_parseFromJSON() failed [communication_duration_time]");
         goto end;
+    }
     }
     }
 
@@ -299,9 +322,11 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_parseFromJSON(cJS
 
     periodic_time = cJSON_GetObjectItemCaseSensitive(expected_ue_behaviourJSON, "periodicTime");
     if (periodic_time) {
+    if (!cJSON_IsNull(periodic_time)) {
     if (!cJSON_IsNumber(periodic_time)) {
         ogs_error("OpenAPI_expected_ue_behaviour_parseFromJSON() failed [periodic_time]");
         goto end;
+    }
     }
     }
 
@@ -316,6 +341,7 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_parseFromJSON(cJS
 
     expected_umts = cJSON_GetObjectItemCaseSensitive(expected_ue_behaviourJSON, "expectedUmts");
     if (expected_umts) {
+    if (!cJSON_IsNull(expected_umts)) {
         cJSON *expected_umts_local = NULL;
         if (!cJSON_IsArray(expected_umts)) {
             ogs_error("OpenAPI_expected_ue_behaviour_parseFromJSON() failed [expected_umts]");
@@ -336,6 +362,7 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_parseFromJSON(cJS
             }
             OpenAPI_list_add(expected_umtsList, expected_umtsItem);
         }
+    }
     }
 
     traffic_profile = cJSON_GetObjectItemCaseSensitive(expected_ue_behaviourJSON, "trafficProfile");
@@ -377,12 +404,15 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_parseFromJSON(cJS
         
         reference_id->valuedouble,
         stationary_indication ? stationary_indication_local_nonprim : NULL,
+        communication_duration_time && cJSON_IsNull(communication_duration_time) ? true : false,
         communication_duration_time ? true : false,
         communication_duration_time ? communication_duration_time->valuedouble : 0,
         scheduled_communication_type ? scheduled_communication_type_local_nonprim : NULL,
+        periodic_time && cJSON_IsNull(periodic_time) ? true : false,
         periodic_time ? true : false,
         periodic_time ? periodic_time->valuedouble : 0,
         scheduled_communication_time ? scheduled_communication_time_local_nonprim : NULL,
+        expected_umts && cJSON_IsNull(expected_umts) ? true : false,
         expected_umts ? expected_umtsList : NULL,
         traffic_profile ? traffic_profile_local_nonprim : NULL,
         battery_indication ? battery_indication_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/expected_ue_behaviour.h
+++ b/lib/sbi/openapi/model/expected_ue_behaviour.h
@@ -28,12 +28,15 @@ typedef struct OpenAPI_expected_ue_behaviour_s {
     char *af_instance_id;
     int reference_id;
     struct OpenAPI_stationary_indication_rm_s *stationary_indication;
+    bool is_communication_duration_time_null;
     bool is_communication_duration_time;
     int communication_duration_time;
     struct OpenAPI_scheduled_communication_type_rm_s *scheduled_communication_type;
+    bool is_periodic_time_null;
     bool is_periodic_time;
     int periodic_time;
     struct OpenAPI_scheduled_communication_time_rm_s *scheduled_communication_time;
+    bool is_expected_umts_null;
     OpenAPI_list_t *expected_umts;
     struct OpenAPI_traffic_profile_rm_s *traffic_profile;
     struct OpenAPI_battery_indication_rm_s *battery_indication;
@@ -45,12 +48,15 @@ OpenAPI_expected_ue_behaviour_t *OpenAPI_expected_ue_behaviour_create(
     char *af_instance_id,
     int reference_id,
     OpenAPI_stationary_indication_rm_t *stationary_indication,
+    bool is_communication_duration_time_null,
     bool is_communication_duration_time,
     int communication_duration_time,
     OpenAPI_scheduled_communication_type_rm_t *scheduled_communication_type,
+    bool is_periodic_time_null,
     bool is_periodic_time,
     int periodic_time,
     OpenAPI_scheduled_communication_time_rm_t *scheduled_communication_time,
+    bool is_expected_umts_null,
     OpenAPI_list_t *expected_umts,
     OpenAPI_traffic_profile_rm_t *traffic_profile,
     OpenAPI_battery_indication_rm_t *battery_indication,

--- a/lib/sbi/openapi/model/flow_information.c
+++ b/lib/sbi/openapi/model/flow_information.c
@@ -10,8 +10,11 @@ OpenAPI_flow_information_t *OpenAPI_flow_information_create(
     char *pack_filt_id,
     bool is_packet_filter_usage,
     int packet_filter_usage,
+    bool is_tos_traffic_class_null,
     char *tos_traffic_class,
+    bool is_spi_null,
     char *spi,
+    bool is_flow_label_null,
     char *flow_label,
     OpenAPI_flow_direction_e flow_direction
 )
@@ -24,8 +27,11 @@ OpenAPI_flow_information_t *OpenAPI_flow_information_create(
     flow_information_local_var->pack_filt_id = pack_filt_id;
     flow_information_local_var->is_packet_filter_usage = is_packet_filter_usage;
     flow_information_local_var->packet_filter_usage = packet_filter_usage;
+    flow_information_local_var->is_tos_traffic_class_null = is_tos_traffic_class_null;
     flow_information_local_var->tos_traffic_class = tos_traffic_class;
+    flow_information_local_var->is_spi_null = is_spi_null;
     flow_information_local_var->spi = spi;
+    flow_information_local_var->is_flow_label_null = is_flow_label_null;
     flow_information_local_var->flow_label = flow_label;
     flow_information_local_var->flow_direction = flow_direction;
 
@@ -116,6 +122,11 @@ cJSON *OpenAPI_flow_information_convertToJSON(OpenAPI_flow_information_t *flow_i
         ogs_error("OpenAPI_flow_information_convertToJSON() failed [tos_traffic_class]");
         goto end;
     }
+    } else if (flow_information->is_tos_traffic_class_null) {
+        if (cJSON_AddNullToObject(item, "tosTrafficClass") == NULL) {
+            ogs_error("OpenAPI_flow_information_convertToJSON() failed [tos_traffic_class]");
+            goto end;
+        }
     }
 
     if (flow_information->spi) {
@@ -123,6 +134,11 @@ cJSON *OpenAPI_flow_information_convertToJSON(OpenAPI_flow_information_t *flow_i
         ogs_error("OpenAPI_flow_information_convertToJSON() failed [spi]");
         goto end;
     }
+    } else if (flow_information->is_spi_null) {
+        if (cJSON_AddNullToObject(item, "spi") == NULL) {
+            ogs_error("OpenAPI_flow_information_convertToJSON() failed [spi]");
+            goto end;
+        }
     }
 
     if (flow_information->flow_label) {
@@ -130,6 +146,11 @@ cJSON *OpenAPI_flow_information_convertToJSON(OpenAPI_flow_information_t *flow_i
         ogs_error("OpenAPI_flow_information_convertToJSON() failed [flow_label]");
         goto end;
     }
+    } else if (flow_information->is_flow_label_null) {
+        if (cJSON_AddNullToObject(item, "flowLabel") == NULL) {
+            ogs_error("OpenAPI_flow_information_convertToJSON() failed [flow_label]");
+            goto end;
+        }
     }
 
     if (flow_information->flow_direction != OpenAPI_flow_direction_NULL) {
@@ -192,25 +213,31 @@ OpenAPI_flow_information_t *OpenAPI_flow_information_parseFromJSON(cJSON *flow_i
 
     tos_traffic_class = cJSON_GetObjectItemCaseSensitive(flow_informationJSON, "tosTrafficClass");
     if (tos_traffic_class) {
+    if (!cJSON_IsNull(tos_traffic_class)) {
     if (!cJSON_IsString(tos_traffic_class) && !cJSON_IsNull(tos_traffic_class)) {
         ogs_error("OpenAPI_flow_information_parseFromJSON() failed [tos_traffic_class]");
         goto end;
     }
     }
+    }
 
     spi = cJSON_GetObjectItemCaseSensitive(flow_informationJSON, "spi");
     if (spi) {
+    if (!cJSON_IsNull(spi)) {
     if (!cJSON_IsString(spi) && !cJSON_IsNull(spi)) {
         ogs_error("OpenAPI_flow_information_parseFromJSON() failed [spi]");
         goto end;
     }
     }
+    }
 
     flow_label = cJSON_GetObjectItemCaseSensitive(flow_informationJSON, "flowLabel");
     if (flow_label) {
+    if (!cJSON_IsNull(flow_label)) {
     if (!cJSON_IsString(flow_label) && !cJSON_IsNull(flow_label)) {
         ogs_error("OpenAPI_flow_information_parseFromJSON() failed [flow_label]");
         goto end;
+    }
     }
     }
 
@@ -229,8 +256,11 @@ OpenAPI_flow_information_t *OpenAPI_flow_information_parseFromJSON(cJSON *flow_i
         pack_filt_id && !cJSON_IsNull(pack_filt_id) ? ogs_strdup(pack_filt_id->valuestring) : NULL,
         packet_filter_usage ? true : false,
         packet_filter_usage ? packet_filter_usage->valueint : 0,
+        tos_traffic_class && cJSON_IsNull(tos_traffic_class) ? true : false,
         tos_traffic_class && !cJSON_IsNull(tos_traffic_class) ? ogs_strdup(tos_traffic_class->valuestring) : NULL,
+        spi && cJSON_IsNull(spi) ? true : false,
         spi && !cJSON_IsNull(spi) ? ogs_strdup(spi->valuestring) : NULL,
+        flow_label && cJSON_IsNull(flow_label) ? true : false,
         flow_label && !cJSON_IsNull(flow_label) ? ogs_strdup(flow_label->valuestring) : NULL,
         flow_direction ? flow_directionVariable : 0
     );

--- a/lib/sbi/openapi/model/flow_information.h
+++ b/lib/sbi/openapi/model/flow_information.h
@@ -26,8 +26,11 @@ typedef struct OpenAPI_flow_information_s {
     char *pack_filt_id;
     bool is_packet_filter_usage;
     int packet_filter_usage;
+    bool is_tos_traffic_class_null;
     char *tos_traffic_class;
+    bool is_spi_null;
     char *spi;
+    bool is_flow_label_null;
     char *flow_label;
     OpenAPI_flow_direction_e flow_direction;
 } OpenAPI_flow_information_t;
@@ -38,8 +41,11 @@ OpenAPI_flow_information_t *OpenAPI_flow_information_create(
     char *pack_filt_id,
     bool is_packet_filter_usage,
     int packet_filter_usage,
+    bool is_tos_traffic_class_null,
     char *tos_traffic_class,
+    bool is_spi_null,
     char *spi,
+    bool is_flow_label_null,
     char *flow_label,
     OpenAPI_flow_direction_e flow_direction
 );

--- a/lib/sbi/openapi/model/hsmf_update_data.c
+++ b/lib/sbi/openapi/model/hsmf_update_data.c
@@ -82,6 +82,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     char *ismf_pdu_session_uri,
     char *ismf_id,
     char *i_smf_service_instance_id,
+    bool is_dl_serving_plmn_rate_ctl_null,
     bool is_dl_serving_plmn_rate_ctl,
     int dl_serving_plmn_rate_ctl,
     OpenAPI_list_t *dnai_list,
@@ -95,6 +96,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     OpenAPI_guami_t *guami,
     OpenAPI_list_t *secondary_rat_usage_data_report_container,
     OpenAPI_hsmf_update_data_sm_policy_notify_ind_e sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat,
     OpenAPI_max_integrity_protected_data_rate_e max_integrity_protected_data_rate_ul,
@@ -159,6 +161,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     hsmf_update_data_local_var->ismf_pdu_session_uri = ismf_pdu_session_uri;
     hsmf_update_data_local_var->ismf_id = ismf_id;
     hsmf_update_data_local_var->i_smf_service_instance_id = i_smf_service_instance_id;
+    hsmf_update_data_local_var->is_dl_serving_plmn_rate_ctl_null = is_dl_serving_plmn_rate_ctl_null;
     hsmf_update_data_local_var->is_dl_serving_plmn_rate_ctl = is_dl_serving_plmn_rate_ctl;
     hsmf_update_data_local_var->dl_serving_plmn_rate_ctl = dl_serving_plmn_rate_ctl;
     hsmf_update_data_local_var->dnai_list = dnai_list;
@@ -172,6 +175,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     hsmf_update_data_local_var->guami = guami;
     hsmf_update_data_local_var->secondary_rat_usage_data_report_container = secondary_rat_usage_data_report_container;
     hsmf_update_data_local_var->sm_policy_notify_ind = sm_policy_notify_ind;
+    hsmf_update_data_local_var->is_pcf_ue_callback_info_null = is_pcf_ue_callback_info_null;
     hsmf_update_data_local_var->pcf_ue_callback_info = pcf_ue_callback_info;
     hsmf_update_data_local_var->satellite_backhaul_cat = satellite_backhaul_cat;
     hsmf_update_data_local_var->max_integrity_protected_data_rate_ul = max_integrity_protected_data_rate_ul;
@@ -875,6 +879,11 @@ cJSON *OpenAPI_hsmf_update_data_convertToJSON(OpenAPI_hsmf_update_data_t *hsmf_u
         ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [dl_serving_plmn_rate_ctl]");
         goto end;
     }
+    } else if (hsmf_update_data->is_dl_serving_plmn_rate_ctl_null) {
+        if (cJSON_AddNullToObject(item, "dlServingPlmnRateCtl") == NULL) {
+            ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [dl_serving_plmn_rate_ctl]");
+            goto end;
+        }
     }
 
     if (hsmf_update_data->dnai_list) {
@@ -1015,6 +1024,11 @@ cJSON *OpenAPI_hsmf_update_data_convertToJSON(OpenAPI_hsmf_update_data_t *hsmf_u
         ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [pcf_ue_callback_info]");
         goto end;
     }
+    } else if (hsmf_update_data->is_pcf_ue_callback_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeCallbackInfo") == NULL) {
+            ogs_error("OpenAPI_hsmf_update_data_convertToJSON() failed [pcf_ue_callback_info]");
+            goto end;
+        }
     }
 
     if (hsmf_update_data->satellite_backhaul_cat != OpenAPI_satellite_backhaul_category_NULL) {
@@ -1688,9 +1702,11 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_parseFromJSON(cJSON *hsmf_u
 
     dl_serving_plmn_rate_ctl = cJSON_GetObjectItemCaseSensitive(hsmf_update_dataJSON, "dlServingPlmnRateCtl");
     if (dl_serving_plmn_rate_ctl) {
+    if (!cJSON_IsNull(dl_serving_plmn_rate_ctl)) {
     if (!cJSON_IsNumber(dl_serving_plmn_rate_ctl)) {
         ogs_error("OpenAPI_hsmf_update_data_parseFromJSON() failed [dl_serving_plmn_rate_ctl]");
         goto end;
+    }
     }
     }
 
@@ -1817,10 +1833,12 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_parseFromJSON(cJSON *hsmf_u
 
     pcf_ue_callback_info = cJSON_GetObjectItemCaseSensitive(hsmf_update_dataJSON, "pcfUeCallbackInfo");
     if (pcf_ue_callback_info) {
+    if (!cJSON_IsNull(pcf_ue_callback_info)) {
     pcf_ue_callback_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_callback_info);
     if (!pcf_ue_callback_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_callback_info]");
         goto end;
+    }
     }
     }
 
@@ -1915,6 +1933,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_parseFromJSON(cJSON *hsmf_u
         ismf_pdu_session_uri && !cJSON_IsNull(ismf_pdu_session_uri) ? ogs_strdup(ismf_pdu_session_uri->valuestring) : NULL,
         ismf_id && !cJSON_IsNull(ismf_id) ? ogs_strdup(ismf_id->valuestring) : NULL,
         i_smf_service_instance_id && !cJSON_IsNull(i_smf_service_instance_id) ? ogs_strdup(i_smf_service_instance_id->valuestring) : NULL,
+        dl_serving_plmn_rate_ctl && cJSON_IsNull(dl_serving_plmn_rate_ctl) ? true : false,
         dl_serving_plmn_rate_ctl ? true : false,
         dl_serving_plmn_rate_ctl ? dl_serving_plmn_rate_ctl->valuedouble : 0,
         dnai_list ? dnai_listList : NULL,
@@ -1928,6 +1947,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_parseFromJSON(cJSON *hsmf_u
         guami ? guami_local_nonprim : NULL,
         secondary_rat_usage_data_report_container ? secondary_rat_usage_data_report_containerList : NULL,
         sm_policy_notify_ind ? sm_policy_notify_indVariable : 0,
+        pcf_ue_callback_info && cJSON_IsNull(pcf_ue_callback_info) ? true : false,
         pcf_ue_callback_info ? pcf_ue_callback_info_local_nonprim : NULL,
         satellite_backhaul_cat ? satellite_backhaul_catVariable : 0,
         max_integrity_protected_data_rate_ul ? max_integrity_protected_data_rate_ulVariable : 0,

--- a/lib/sbi/openapi/model/hsmf_update_data.h
+++ b/lib/sbi/openapi/model/hsmf_update_data.h
@@ -109,6 +109,7 @@ typedef struct OpenAPI_hsmf_update_data_s {
     char *ismf_pdu_session_uri;
     char *ismf_id;
     char *i_smf_service_instance_id;
+    bool is_dl_serving_plmn_rate_ctl_null;
     bool is_dl_serving_plmn_rate_ctl;
     int dl_serving_plmn_rate_ctl;
     OpenAPI_list_t *dnai_list;
@@ -122,6 +123,7 @@ typedef struct OpenAPI_hsmf_update_data_s {
     struct OpenAPI_guami_s *guami;
     OpenAPI_list_t *secondary_rat_usage_data_report_container;
     OpenAPI_hsmf_update_data_sm_policy_notify_ind_e sm_policy_notify_ind;
+    bool is_pcf_ue_callback_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_callback_info;
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat;
     OpenAPI_max_integrity_protected_data_rate_e max_integrity_protected_data_rate_ul;
@@ -184,6 +186,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     char *ismf_pdu_session_uri,
     char *ismf_id,
     char *i_smf_service_instance_id,
+    bool is_dl_serving_plmn_rate_ctl_null,
     bool is_dl_serving_plmn_rate_ctl,
     int dl_serving_plmn_rate_ctl,
     OpenAPI_list_t *dnai_list,
@@ -197,6 +200,7 @@ OpenAPI_hsmf_update_data_t *OpenAPI_hsmf_update_data_create(
     OpenAPI_guami_t *guami,
     OpenAPI_list_t *secondary_rat_usage_data_report_container,
     OpenAPI_hsmf_update_data_sm_policy_notify_ind_e sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat,
     OpenAPI_max_integrity_protected_data_rate_e max_integrity_protected_data_rate_ul,

--- a/lib/sbi/openapi/model/immediate_report.c
+++ b/lib/sbi/openapi/model/immediate_report.c
@@ -12,6 +12,7 @@ OpenAPI_immediate_report_t *OpenAPI_immediate_report_create(
     OpenAPI_ue_context_in_smsf_data_t *uec_smsf_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,
@@ -33,6 +34,7 @@ OpenAPI_immediate_report_t *OpenAPI_immediate_report_create(
     immediate_report_local_var->uec_smsf_data = uec_smsf_data;
     immediate_report_local_var->sms_subs_data = sms_subs_data;
     immediate_report_local_var->sm_data = sm_data;
+    immediate_report_local_var->is_trace_data_null = is_trace_data_null;
     immediate_report_local_var->trace_data = trace_data;
     immediate_report_local_var->sms_mng_data = sms_mng_data;
     immediate_report_local_var->lcs_privacy_data = lcs_privacy_data;
@@ -233,6 +235,11 @@ cJSON *OpenAPI_immediate_report_convertToJSON(OpenAPI_immediate_report_t *immedi
         ogs_error("OpenAPI_immediate_report_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (immediate_report->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_immediate_report_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (immediate_report->sms_mng_data) {
@@ -444,10 +451,12 @@ OpenAPI_immediate_report_t *OpenAPI_immediate_report_parseFromJSON(cJSON *immedi
 
     trace_data = cJSON_GetObjectItemCaseSensitive(immediate_reportJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -531,6 +540,7 @@ OpenAPI_immediate_report_t *OpenAPI_immediate_report_parseFromJSON(cJSON *immedi
         uec_smsf_data ? uec_smsf_data_local_nonprim : NULL,
         sms_subs_data ? sms_subs_data_local_nonprim : NULL,
         sm_data ? sm_data_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         sms_mng_data ? sms_mng_data_local_nonprim : NULL,
         lcs_privacy_data ? lcs_privacy_data_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/immediate_report.h
+++ b/lib/sbi/openapi/model/immediate_report.h
@@ -44,6 +44,7 @@ typedef struct OpenAPI_immediate_report_s {
     struct OpenAPI_ue_context_in_smsf_data_s *uec_smsf_data;
     struct OpenAPI_sms_subscription_data_s *sms_subs_data;
     struct OpenAPI_sm_subs_data_s *sm_data;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     struct OpenAPI_sms_management_subscription_data_s *sms_mng_data;
     struct OpenAPI_lcs_privacy_data_s *lcs_privacy_data;
@@ -63,6 +64,7 @@ OpenAPI_immediate_report_t *OpenAPI_immediate_report_create(
     OpenAPI_ue_context_in_smsf_data_t *uec_smsf_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,

--- a/lib/sbi/openapi/model/iptv_config_data.c
+++ b/lib/sbi/openapi/model/iptv_config_data.c
@@ -6,6 +6,7 @@
 
 OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_create(
     char *supi,
+    bool is_inter_group_id_null,
     OpenAPI_any_type_t *inter_group_id,
     char *dnn,
     OpenAPI_snssai_t *snssai,
@@ -20,6 +21,7 @@ OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_create(
     ogs_assert(iptv_config_data_local_var);
 
     iptv_config_data_local_var->supi = supi;
+    iptv_config_data_local_var->is_inter_group_id_null = is_inter_group_id_null;
     iptv_config_data_local_var->inter_group_id = inter_group_id;
     iptv_config_data_local_var->dnn = dnn;
     iptv_config_data_local_var->snssai = snssai;
@@ -116,6 +118,11 @@ cJSON *OpenAPI_iptv_config_data_convertToJSON(OpenAPI_iptv_config_data_t *iptv_c
         ogs_error("OpenAPI_iptv_config_data_convertToJSON() failed [inter_group_id]");
         goto end;
     }
+    } else if (iptv_config_data->is_inter_group_id_null) {
+        if (cJSON_AddNullToObject(item, "interGroupId") == NULL) {
+            ogs_error("OpenAPI_iptv_config_data_convertToJSON() failed [inter_group_id]");
+            goto end;
+        }
     }
 
     if (iptv_config_data->dnn) {
@@ -238,7 +245,9 @@ OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_parseFromJSON(cJSON *iptv_c
 
     inter_group_id = cJSON_GetObjectItemCaseSensitive(iptv_config_dataJSON, "interGroupId");
     if (inter_group_id) {
+    if (!cJSON_IsNull(inter_group_id)) {
     inter_group_id_local_object = OpenAPI_any_type_parseFromJSON(inter_group_id);
+    }
     }
 
     dnn = cJSON_GetObjectItemCaseSensitive(iptv_config_dataJSON, "dnn");
@@ -335,6 +344,7 @@ OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_parseFromJSON(cJSON *iptv_c
 
     iptv_config_data_local_var = OpenAPI_iptv_config_data_create (
         supi && !cJSON_IsNull(supi) ? ogs_strdup(supi->valuestring) : NULL,
+        inter_group_id && cJSON_IsNull(inter_group_id) ? true : false,
         inter_group_id ? inter_group_id_local_object : NULL,
         dnn && !cJSON_IsNull(dnn) ? ogs_strdup(dnn->valuestring) : NULL,
         snssai ? snssai_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/iptv_config_data.h
+++ b/lib/sbi/openapi/model/iptv_config_data.h
@@ -23,6 +23,7 @@ extern "C" {
 typedef struct OpenAPI_iptv_config_data_s OpenAPI_iptv_config_data_t;
 typedef struct OpenAPI_iptv_config_data_s {
     char *supi;
+    bool is_inter_group_id_null;
     OpenAPI_any_type_t *inter_group_id;
     char *dnn;
     struct OpenAPI_snssai_s *snssai;
@@ -35,6 +36,7 @@ typedef struct OpenAPI_iptv_config_data_s {
 
 OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_create(
     char *supi,
+    bool is_inter_group_id_null,
     OpenAPI_any_type_t *inter_group_id,
     char *dnn,
     OpenAPI_snssai_t *snssai,

--- a/lib/sbi/openapi/model/media_component.c
+++ b/lib/sbi/openapi/model/media_component.c
@@ -23,8 +23,10 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     OpenAPI_flow_status_e f_status,
     char *mar_bw_dl,
     char *mar_bw_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
     char *max_supp_bw_dl,
@@ -47,7 +49,9 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     bool is_sharing_key_ul,
     int sharing_key_ul,
     OpenAPI_tsn_qos_container_t *tsn_qos,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom
@@ -74,8 +78,10 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     media_component_local_var->f_status = f_status;
     media_component_local_var->mar_bw_dl = mar_bw_dl;
     media_component_local_var->mar_bw_ul = mar_bw_ul;
+    media_component_local_var->is_max_packet_loss_rate_dl_null = is_max_packet_loss_rate_dl_null;
     media_component_local_var->is_max_packet_loss_rate_dl = is_max_packet_loss_rate_dl;
     media_component_local_var->max_packet_loss_rate_dl = max_packet_loss_rate_dl;
+    media_component_local_var->is_max_packet_loss_rate_ul_null = is_max_packet_loss_rate_ul_null;
     media_component_local_var->is_max_packet_loss_rate_ul = is_max_packet_loss_rate_ul;
     media_component_local_var->max_packet_loss_rate_ul = max_packet_loss_rate_ul;
     media_component_local_var->max_supp_bw_dl = max_supp_bw_dl;
@@ -98,7 +104,9 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     media_component_local_var->is_sharing_key_ul = is_sharing_key_ul;
     media_component_local_var->sharing_key_ul = sharing_key_ul;
     media_component_local_var->tsn_qos = tsn_qos;
+    media_component_local_var->is_tscai_input_dl_null = is_tscai_input_dl_null;
     media_component_local_var->tscai_input_dl = tscai_input_dl;
+    media_component_local_var->is_tscai_input_ul_null = is_tscai_input_ul_null;
     media_component_local_var->tscai_input_ul = tscai_input_ul;
     media_component_local_var->is_tscai_time_dom = is_tscai_time_dom;
     media_component_local_var->tscai_time_dom = tscai_time_dom;
@@ -358,6 +366,11 @@ cJSON *OpenAPI_media_component_convertToJSON(OpenAPI_media_component_t *media_co
         ogs_error("OpenAPI_media_component_convertToJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
+    } else if (media_component->is_max_packet_loss_rate_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateDl") == NULL) {
+            ogs_error("OpenAPI_media_component_convertToJSON() failed [max_packet_loss_rate_dl]");
+            goto end;
+        }
     }
 
     if (media_component->is_max_packet_loss_rate_ul) {
@@ -365,6 +378,11 @@ cJSON *OpenAPI_media_component_convertToJSON(OpenAPI_media_component_t *media_co
         ogs_error("OpenAPI_media_component_convertToJSON() failed [max_packet_loss_rate_ul]");
         goto end;
     }
+    } else if (media_component->is_max_packet_loss_rate_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateUl") == NULL) {
+            ogs_error("OpenAPI_media_component_convertToJSON() failed [max_packet_loss_rate_ul]");
+            goto end;
+        }
     }
 
     if (media_component->max_supp_bw_dl) {
@@ -531,6 +549,11 @@ cJSON *OpenAPI_media_component_convertToJSON(OpenAPI_media_component_t *media_co
         ogs_error("OpenAPI_media_component_convertToJSON() failed [tscai_input_dl]");
         goto end;
     }
+    } else if (media_component->is_tscai_input_dl_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputDl") == NULL) {
+            ogs_error("OpenAPI_media_component_convertToJSON() failed [tscai_input_dl]");
+            goto end;
+        }
     }
 
     if (media_component->tscai_input_ul) {
@@ -544,6 +567,11 @@ cJSON *OpenAPI_media_component_convertToJSON(OpenAPI_media_component_t *media_co
         ogs_error("OpenAPI_media_component_convertToJSON() failed [tscai_input_ul]");
         goto end;
     }
+    } else if (media_component->is_tscai_input_ul_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputUl") == NULL) {
+            ogs_error("OpenAPI_media_component_convertToJSON() failed [tscai_input_ul]");
+            goto end;
+        }
     }
 
     if (media_component->is_tscai_time_dom) {
@@ -770,17 +798,21 @@ OpenAPI_media_component_t *OpenAPI_media_component_parseFromJSON(cJSON *media_co
 
     max_packet_loss_rate_dl = cJSON_GetObjectItemCaseSensitive(media_componentJSON, "maxPacketLossRateDl");
     if (max_packet_loss_rate_dl) {
+    if (!cJSON_IsNull(max_packet_loss_rate_dl)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_dl)) {
         ogs_error("OpenAPI_media_component_parseFromJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
     }
+    }
 
     max_packet_loss_rate_ul = cJSON_GetObjectItemCaseSensitive(media_componentJSON, "maxPacketLossRateUl");
     if (max_packet_loss_rate_ul) {
+    if (!cJSON_IsNull(max_packet_loss_rate_ul)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_ul)) {
         ogs_error("OpenAPI_media_component_parseFromJSON() failed [max_packet_loss_rate_ul]");
         goto end;
+    }
     }
     }
 
@@ -956,19 +988,23 @@ OpenAPI_media_component_t *OpenAPI_media_component_parseFromJSON(cJSON *media_co
 
     tscai_input_dl = cJSON_GetObjectItemCaseSensitive(media_componentJSON, "tscaiInputDl");
     if (tscai_input_dl) {
+    if (!cJSON_IsNull(tscai_input_dl)) {
     tscai_input_dl_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_dl);
     if (!tscai_input_dl_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_dl]");
         goto end;
     }
     }
+    }
 
     tscai_input_ul = cJSON_GetObjectItemCaseSensitive(media_componentJSON, "tscaiInputUl");
     if (tscai_input_ul) {
+    if (!cJSON_IsNull(tscai_input_ul)) {
     tscai_input_ul_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_ul);
     if (!tscai_input_ul_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_ul]");
         goto end;
+    }
     }
     }
 
@@ -999,8 +1035,10 @@ OpenAPI_media_component_t *OpenAPI_media_component_parseFromJSON(cJSON *media_co
         f_status ? f_statusVariable : 0,
         mar_bw_dl && !cJSON_IsNull(mar_bw_dl) ? ogs_strdup(mar_bw_dl->valuestring) : NULL,
         mar_bw_ul && !cJSON_IsNull(mar_bw_ul) ? ogs_strdup(mar_bw_ul->valuestring) : NULL,
+        max_packet_loss_rate_dl && cJSON_IsNull(max_packet_loss_rate_dl) ? true : false,
         max_packet_loss_rate_dl ? true : false,
         max_packet_loss_rate_dl ? max_packet_loss_rate_dl->valuedouble : 0,
+        max_packet_loss_rate_ul && cJSON_IsNull(max_packet_loss_rate_ul) ? true : false,
         max_packet_loss_rate_ul ? true : false,
         max_packet_loss_rate_ul ? max_packet_loss_rate_ul->valuedouble : 0,
         max_supp_bw_dl && !cJSON_IsNull(max_supp_bw_dl) ? ogs_strdup(max_supp_bw_dl->valuestring) : NULL,
@@ -1024,7 +1062,9 @@ OpenAPI_media_component_t *OpenAPI_media_component_parseFromJSON(cJSON *media_co
         sharing_key_ul ? true : false,
         sharing_key_ul ? sharing_key_ul->valuedouble : 0,
         tsn_qos ? tsn_qos_local_nonprim : NULL,
+        tscai_input_dl && cJSON_IsNull(tscai_input_dl) ? true : false,
         tscai_input_dl ? tscai_input_dl_local_nonprim : NULL,
+        tscai_input_ul && cJSON_IsNull(tscai_input_ul) ? true : false,
         tscai_input_ul ? tscai_input_ul_local_nonprim : NULL,
         tscai_time_dom ? true : false,
         tscai_time_dom ? tscai_time_dom->valuedouble : 0

--- a/lib/sbi/openapi/model/media_component.h
+++ b/lib/sbi/openapi/model/media_component.h
@@ -48,8 +48,10 @@ typedef struct OpenAPI_media_component_s {
     OpenAPI_flow_status_e f_status;
     char *mar_bw_dl;
     char *mar_bw_ul;
+    bool is_max_packet_loss_rate_dl_null;
     bool is_max_packet_loss_rate_dl;
     int max_packet_loss_rate_dl;
+    bool is_max_packet_loss_rate_ul_null;
     bool is_max_packet_loss_rate_ul;
     int max_packet_loss_rate_ul;
     char *max_supp_bw_dl;
@@ -72,7 +74,9 @@ typedef struct OpenAPI_media_component_s {
     bool is_sharing_key_ul;
     int sharing_key_ul;
     struct OpenAPI_tsn_qos_container_s *tsn_qos;
+    bool is_tscai_input_dl_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_dl;
+    bool is_tscai_input_ul_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_ul;
     bool is_tscai_time_dom;
     int tscai_time_dom;
@@ -97,8 +101,10 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     OpenAPI_flow_status_e f_status,
     char *mar_bw_dl,
     char *mar_bw_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
     char *max_supp_bw_dl,
@@ -121,7 +127,9 @@ OpenAPI_media_component_t *OpenAPI_media_component_create(
     bool is_sharing_key_ul,
     int sharing_key_ul,
     OpenAPI_tsn_qos_container_t *tsn_qos,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom

--- a/lib/sbi/openapi/model/media_component_rm.c
+++ b/lib/sbi/openapi/model/media_component_rm.c
@@ -6,48 +6,72 @@
 
 OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_create(
     char *af_app_id,
+    bool is_af_rout_req_null,
     OpenAPI_af_routing_requirement_rm_t *af_rout_req,
+    bool is_qos_reference_null,
     char *qos_reference,
+    bool is_alt_ser_reqs_null,
     OpenAPI_list_t *alt_ser_reqs,
+    bool is_alt_ser_reqs_data_null,
     OpenAPI_list_t *alt_ser_reqs_data,
     bool is_dis_ue_notif,
     int dis_ue_notif,
     bool is_cont_ver,
     int cont_ver,
     OpenAPI_list_t *codecs,
+    bool is_des_max_latency_null,
     bool is_des_max_latency,
     float des_max_latency,
+    bool is_des_max_loss_null,
     bool is_des_max_loss,
     float des_max_loss,
+    bool is_flus_id_null,
     char *flus_id,
     OpenAPI_flow_status_e f_status,
+    bool is_mar_bw_dl_null,
     char *mar_bw_dl,
+    bool is_mar_bw_ul_null,
     char *mar_bw_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
+    bool is_max_supp_bw_dl_null,
     char *max_supp_bw_dl,
+    bool is_max_supp_bw_ul_null,
     char *max_supp_bw_ul,
     int med_comp_n,
     OpenAPI_list_t* med_sub_comps,
     OpenAPI_media_type_e med_type,
+    bool is_min_des_bw_dl_null,
     char *min_des_bw_dl,
+    bool is_min_des_bw_ul_null,
     char *min_des_bw_ul,
+    bool is_mir_bw_dl_null,
     char *mir_bw_dl,
+    bool is_mir_bw_ul_null,
     char *mir_bw_ul,
     OpenAPI_preemption_capability_rm_t *preempt_cap,
     OpenAPI_preemption_vulnerability_rm_t *preempt_vuln,
     OpenAPI_priority_sharing_indicator_e prio_sharing_ind,
     OpenAPI_reserv_priority_e res_prio,
+    bool is_rr_bw_null,
     char *rr_bw,
+    bool is_rs_bw_null,
     char *rs_bw,
+    bool is_sharing_key_dl_null,
     bool is_sharing_key_dl,
     int sharing_key_dl,
+    bool is_sharing_key_ul_null,
     bool is_sharing_key_ul,
     int sharing_key_ul,
+    bool is_tsn_qos_null,
     OpenAPI_tsn_qos_container_rm_t *tsn_qos,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom
@@ -57,48 +81,72 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_create(
     ogs_assert(media_component_rm_local_var);
 
     media_component_rm_local_var->af_app_id = af_app_id;
+    media_component_rm_local_var->is_af_rout_req_null = is_af_rout_req_null;
     media_component_rm_local_var->af_rout_req = af_rout_req;
+    media_component_rm_local_var->is_qos_reference_null = is_qos_reference_null;
     media_component_rm_local_var->qos_reference = qos_reference;
+    media_component_rm_local_var->is_alt_ser_reqs_null = is_alt_ser_reqs_null;
     media_component_rm_local_var->alt_ser_reqs = alt_ser_reqs;
+    media_component_rm_local_var->is_alt_ser_reqs_data_null = is_alt_ser_reqs_data_null;
     media_component_rm_local_var->alt_ser_reqs_data = alt_ser_reqs_data;
     media_component_rm_local_var->is_dis_ue_notif = is_dis_ue_notif;
     media_component_rm_local_var->dis_ue_notif = dis_ue_notif;
     media_component_rm_local_var->is_cont_ver = is_cont_ver;
     media_component_rm_local_var->cont_ver = cont_ver;
     media_component_rm_local_var->codecs = codecs;
+    media_component_rm_local_var->is_des_max_latency_null = is_des_max_latency_null;
     media_component_rm_local_var->is_des_max_latency = is_des_max_latency;
     media_component_rm_local_var->des_max_latency = des_max_latency;
+    media_component_rm_local_var->is_des_max_loss_null = is_des_max_loss_null;
     media_component_rm_local_var->is_des_max_loss = is_des_max_loss;
     media_component_rm_local_var->des_max_loss = des_max_loss;
+    media_component_rm_local_var->is_flus_id_null = is_flus_id_null;
     media_component_rm_local_var->flus_id = flus_id;
     media_component_rm_local_var->f_status = f_status;
+    media_component_rm_local_var->is_mar_bw_dl_null = is_mar_bw_dl_null;
     media_component_rm_local_var->mar_bw_dl = mar_bw_dl;
+    media_component_rm_local_var->is_mar_bw_ul_null = is_mar_bw_ul_null;
     media_component_rm_local_var->mar_bw_ul = mar_bw_ul;
+    media_component_rm_local_var->is_max_packet_loss_rate_dl_null = is_max_packet_loss_rate_dl_null;
     media_component_rm_local_var->is_max_packet_loss_rate_dl = is_max_packet_loss_rate_dl;
     media_component_rm_local_var->max_packet_loss_rate_dl = max_packet_loss_rate_dl;
+    media_component_rm_local_var->is_max_packet_loss_rate_ul_null = is_max_packet_loss_rate_ul_null;
     media_component_rm_local_var->is_max_packet_loss_rate_ul = is_max_packet_loss_rate_ul;
     media_component_rm_local_var->max_packet_loss_rate_ul = max_packet_loss_rate_ul;
+    media_component_rm_local_var->is_max_supp_bw_dl_null = is_max_supp_bw_dl_null;
     media_component_rm_local_var->max_supp_bw_dl = max_supp_bw_dl;
+    media_component_rm_local_var->is_max_supp_bw_ul_null = is_max_supp_bw_ul_null;
     media_component_rm_local_var->max_supp_bw_ul = max_supp_bw_ul;
     media_component_rm_local_var->med_comp_n = med_comp_n;
     media_component_rm_local_var->med_sub_comps = med_sub_comps;
     media_component_rm_local_var->med_type = med_type;
+    media_component_rm_local_var->is_min_des_bw_dl_null = is_min_des_bw_dl_null;
     media_component_rm_local_var->min_des_bw_dl = min_des_bw_dl;
+    media_component_rm_local_var->is_min_des_bw_ul_null = is_min_des_bw_ul_null;
     media_component_rm_local_var->min_des_bw_ul = min_des_bw_ul;
+    media_component_rm_local_var->is_mir_bw_dl_null = is_mir_bw_dl_null;
     media_component_rm_local_var->mir_bw_dl = mir_bw_dl;
+    media_component_rm_local_var->is_mir_bw_ul_null = is_mir_bw_ul_null;
     media_component_rm_local_var->mir_bw_ul = mir_bw_ul;
     media_component_rm_local_var->preempt_cap = preempt_cap;
     media_component_rm_local_var->preempt_vuln = preempt_vuln;
     media_component_rm_local_var->prio_sharing_ind = prio_sharing_ind;
     media_component_rm_local_var->res_prio = res_prio;
+    media_component_rm_local_var->is_rr_bw_null = is_rr_bw_null;
     media_component_rm_local_var->rr_bw = rr_bw;
+    media_component_rm_local_var->is_rs_bw_null = is_rs_bw_null;
     media_component_rm_local_var->rs_bw = rs_bw;
+    media_component_rm_local_var->is_sharing_key_dl_null = is_sharing_key_dl_null;
     media_component_rm_local_var->is_sharing_key_dl = is_sharing_key_dl;
     media_component_rm_local_var->sharing_key_dl = sharing_key_dl;
+    media_component_rm_local_var->is_sharing_key_ul_null = is_sharing_key_ul_null;
     media_component_rm_local_var->is_sharing_key_ul = is_sharing_key_ul;
     media_component_rm_local_var->sharing_key_ul = sharing_key_ul;
+    media_component_rm_local_var->is_tsn_qos_null = is_tsn_qos_null;
     media_component_rm_local_var->tsn_qos = tsn_qos;
+    media_component_rm_local_var->is_tscai_input_dl_null = is_tscai_input_dl_null;
     media_component_rm_local_var->tscai_input_dl = tscai_input_dl;
+    media_component_rm_local_var->is_tscai_input_ul_null = is_tscai_input_ul_null;
     media_component_rm_local_var->tscai_input_ul = tscai_input_ul;
     media_component_rm_local_var->is_tscai_time_dom = is_tscai_time_dom;
     media_component_rm_local_var->tscai_time_dom = tscai_time_dom;
@@ -252,6 +300,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [af_rout_req]");
         goto end;
     }
+    } else if (media_component_rm->is_af_rout_req_null) {
+        if (cJSON_AddNullToObject(item, "afRoutReq") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [af_rout_req]");
+            goto end;
+        }
     }
 
     if (media_component_rm->qos_reference) {
@@ -259,6 +312,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [qos_reference]");
         goto end;
     }
+    } else if (media_component_rm->is_qos_reference_null) {
+        if (cJSON_AddNullToObject(item, "qosReference") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [qos_reference]");
+            goto end;
+        }
     }
 
     if (media_component_rm->alt_ser_reqs) {
@@ -273,6 +331,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
             goto end;
         }
     }
+    } else if (media_component_rm->is_alt_ser_reqs_null) {
+        if (cJSON_AddNullToObject(item, "altSerReqs") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [alt_ser_reqs]");
+            goto end;
+        }
     }
 
     if (media_component_rm->alt_ser_reqs_data) {
@@ -289,6 +352,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         }
         cJSON_AddItemToArray(alt_ser_reqs_dataList, itemLocal);
     }
+    } else if (media_component_rm->is_alt_ser_reqs_data_null) {
+        if (cJSON_AddNullToObject(item, "altSerReqsData") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [alt_ser_reqs_data]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_dis_ue_notif) {
@@ -324,6 +392,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [des_max_latency]");
         goto end;
     }
+    } else if (media_component_rm->is_des_max_latency_null) {
+        if (cJSON_AddNullToObject(item, "desMaxLatency") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [des_max_latency]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_des_max_loss) {
@@ -331,6 +404,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [des_max_loss]");
         goto end;
     }
+    } else if (media_component_rm->is_des_max_loss_null) {
+        if (cJSON_AddNullToObject(item, "desMaxLoss") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [des_max_loss]");
+            goto end;
+        }
     }
 
     if (media_component_rm->flus_id) {
@@ -338,6 +416,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [flus_id]");
         goto end;
     }
+    } else if (media_component_rm->is_flus_id_null) {
+        if (cJSON_AddNullToObject(item, "flusId") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [flus_id]");
+            goto end;
+        }
     }
 
     if (media_component_rm->f_status != OpenAPI_flow_status_NULL) {
@@ -352,6 +435,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mar_bw_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_mar_bw_dl_null) {
+        if (cJSON_AddNullToObject(item, "marBwDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mar_bw_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->mar_bw_ul) {
@@ -359,6 +447,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mar_bw_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_mar_bw_ul_null) {
+        if (cJSON_AddNullToObject(item, "marBwUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mar_bw_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_max_packet_loss_rate_dl) {
@@ -366,6 +459,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_max_packet_loss_rate_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_packet_loss_rate_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_max_packet_loss_rate_ul) {
@@ -373,6 +471,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_packet_loss_rate_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_max_packet_loss_rate_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_packet_loss_rate_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->max_supp_bw_dl) {
@@ -380,6 +483,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_supp_bw_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_max_supp_bw_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxSuppBwDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_supp_bw_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->max_supp_bw_ul) {
@@ -387,6 +495,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_supp_bw_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_max_supp_bw_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxSuppBwUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [max_supp_bw_ul]");
+            goto end;
+        }
     }
 
     if (cJSON_AddNumberToObject(item, "medCompN", media_component_rm->med_comp_n) == NULL) {
@@ -436,6 +549,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [min_des_bw_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_min_des_bw_dl_null) {
+        if (cJSON_AddNullToObject(item, "minDesBwDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [min_des_bw_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->min_des_bw_ul) {
@@ -443,6 +561,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [min_des_bw_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_min_des_bw_ul_null) {
+        if (cJSON_AddNullToObject(item, "minDesBwUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [min_des_bw_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->mir_bw_dl) {
@@ -450,6 +573,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mir_bw_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_mir_bw_dl_null) {
+        if (cJSON_AddNullToObject(item, "mirBwDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mir_bw_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->mir_bw_ul) {
@@ -457,6 +585,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mir_bw_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_mir_bw_ul_null) {
+        if (cJSON_AddNullToObject(item, "mirBwUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [mir_bw_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->preempt_cap) {
@@ -504,6 +637,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [rr_bw]");
         goto end;
     }
+    } else if (media_component_rm->is_rr_bw_null) {
+        if (cJSON_AddNullToObject(item, "rrBw") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [rr_bw]");
+            goto end;
+        }
     }
 
     if (media_component_rm->rs_bw) {
@@ -511,6 +649,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [rs_bw]");
         goto end;
     }
+    } else if (media_component_rm->is_rs_bw_null) {
+        if (cJSON_AddNullToObject(item, "rsBw") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [rs_bw]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_sharing_key_dl) {
@@ -518,6 +661,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [sharing_key_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_sharing_key_dl_null) {
+        if (cJSON_AddNullToObject(item, "sharingKeyDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [sharing_key_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_sharing_key_ul) {
@@ -525,6 +673,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [sharing_key_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_sharing_key_ul_null) {
+        if (cJSON_AddNullToObject(item, "sharingKeyUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [sharing_key_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->tsn_qos) {
@@ -538,6 +691,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tsn_qos]");
         goto end;
     }
+    } else if (media_component_rm->is_tsn_qos_null) {
+        if (cJSON_AddNullToObject(item, "tsnQos") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tsn_qos]");
+            goto end;
+        }
     }
 
     if (media_component_rm->tscai_input_dl) {
@@ -551,6 +709,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tscai_input_dl]");
         goto end;
     }
+    } else if (media_component_rm->is_tscai_input_dl_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputDl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tscai_input_dl]");
+            goto end;
+        }
     }
 
     if (media_component_rm->tscai_input_ul) {
@@ -564,6 +727,11 @@ cJSON *OpenAPI_media_component_rm_convertToJSON(OpenAPI_media_component_rm_t *me
         ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tscai_input_ul]");
         goto end;
     }
+    } else if (media_component_rm->is_tscai_input_ul_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputUl") == NULL) {
+            ogs_error("OpenAPI_media_component_rm_convertToJSON() failed [tscai_input_ul]");
+            goto end;
+        }
     }
 
     if (media_component_rm->is_tscai_time_dom) {
@@ -642,23 +810,28 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     af_rout_req = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "afRoutReq");
     if (af_rout_req) {
+    if (!cJSON_IsNull(af_rout_req)) {
     af_rout_req_local_nonprim = OpenAPI_af_routing_requirement_rm_parseFromJSON(af_rout_req);
     if (!af_rout_req_local_nonprim) {
         ogs_error("OpenAPI_af_routing_requirement_rm_parseFromJSON failed [af_rout_req]");
         goto end;
     }
     }
+    }
 
     qos_reference = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "qosReference");
     if (qos_reference) {
+    if (!cJSON_IsNull(qos_reference)) {
     if (!cJSON_IsString(qos_reference) && !cJSON_IsNull(qos_reference)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [qos_reference]");
         goto end;
     }
     }
+    }
 
     alt_ser_reqs = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "altSerReqs");
     if (alt_ser_reqs) {
+    if (!cJSON_IsNull(alt_ser_reqs)) {
         cJSON *alt_ser_reqs_local = NULL;
         if (!cJSON_IsArray(alt_ser_reqs)) {
             ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [alt_ser_reqs]");
@@ -677,9 +850,11 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
             OpenAPI_list_add(alt_ser_reqsList, ogs_strdup(alt_ser_reqs_local->valuestring));
         }
     }
+    }
 
     alt_ser_reqs_data = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "altSerReqsData");
     if (alt_ser_reqs_data) {
+    if (!cJSON_IsNull(alt_ser_reqs_data)) {
         cJSON *alt_ser_reqs_data_local = NULL;
         if (!cJSON_IsArray(alt_ser_reqs_data)) {
             ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [alt_ser_reqs_data]");
@@ -700,6 +875,7 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
             }
             OpenAPI_list_add(alt_ser_reqs_dataList, alt_ser_reqs_dataItem);
         }
+    }
     }
 
     dis_ue_notif = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "disUeNotif");
@@ -741,25 +917,31 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     des_max_latency = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "desMaxLatency");
     if (des_max_latency) {
+    if (!cJSON_IsNull(des_max_latency)) {
     if (!cJSON_IsNumber(des_max_latency)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [des_max_latency]");
         goto end;
     }
     }
+    }
 
     des_max_loss = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "desMaxLoss");
     if (des_max_loss) {
+    if (!cJSON_IsNull(des_max_loss)) {
     if (!cJSON_IsNumber(des_max_loss)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [des_max_loss]");
         goto end;
     }
     }
+    }
 
     flus_id = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "flusId");
     if (flus_id) {
+    if (!cJSON_IsNull(flus_id)) {
     if (!cJSON_IsString(flus_id) && !cJSON_IsNull(flus_id)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [flus_id]");
         goto end;
+    }
     }
     }
 
@@ -774,49 +956,61 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     mar_bw_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "marBwDl");
     if (mar_bw_dl) {
+    if (!cJSON_IsNull(mar_bw_dl)) {
     if (!cJSON_IsString(mar_bw_dl) && !cJSON_IsNull(mar_bw_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [mar_bw_dl]");
         goto end;
     }
     }
+    }
 
     mar_bw_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "marBwUl");
     if (mar_bw_ul) {
+    if (!cJSON_IsNull(mar_bw_ul)) {
     if (!cJSON_IsString(mar_bw_ul) && !cJSON_IsNull(mar_bw_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [mar_bw_ul]");
         goto end;
     }
     }
+    }
 
     max_packet_loss_rate_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "maxPacketLossRateDl");
     if (max_packet_loss_rate_dl) {
+    if (!cJSON_IsNull(max_packet_loss_rate_dl)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
     }
+    }
 
     max_packet_loss_rate_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "maxPacketLossRateUl");
     if (max_packet_loss_rate_ul) {
+    if (!cJSON_IsNull(max_packet_loss_rate_ul)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [max_packet_loss_rate_ul]");
         goto end;
     }
     }
+    }
 
     max_supp_bw_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "maxSuppBwDl");
     if (max_supp_bw_dl) {
+    if (!cJSON_IsNull(max_supp_bw_dl)) {
     if (!cJSON_IsString(max_supp_bw_dl) && !cJSON_IsNull(max_supp_bw_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [max_supp_bw_dl]");
         goto end;
     }
     }
+    }
 
     max_supp_bw_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "maxSuppBwUl");
     if (max_supp_bw_ul) {
+    if (!cJSON_IsNull(max_supp_bw_ul)) {
     if (!cJSON_IsString(max_supp_bw_ul) && !cJSON_IsNull(max_supp_bw_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [max_supp_bw_ul]");
         goto end;
+    }
     }
     }
 
@@ -867,33 +1061,41 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     min_des_bw_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "minDesBwDl");
     if (min_des_bw_dl) {
+    if (!cJSON_IsNull(min_des_bw_dl)) {
     if (!cJSON_IsString(min_des_bw_dl) && !cJSON_IsNull(min_des_bw_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [min_des_bw_dl]");
         goto end;
     }
     }
+    }
 
     min_des_bw_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "minDesBwUl");
     if (min_des_bw_ul) {
+    if (!cJSON_IsNull(min_des_bw_ul)) {
     if (!cJSON_IsString(min_des_bw_ul) && !cJSON_IsNull(min_des_bw_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [min_des_bw_ul]");
         goto end;
     }
     }
+    }
 
     mir_bw_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "mirBwDl");
     if (mir_bw_dl) {
+    if (!cJSON_IsNull(mir_bw_dl)) {
     if (!cJSON_IsString(mir_bw_dl) && !cJSON_IsNull(mir_bw_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [mir_bw_dl]");
         goto end;
     }
     }
+    }
 
     mir_bw_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "mirBwUl");
     if (mir_bw_ul) {
+    if (!cJSON_IsNull(mir_bw_ul)) {
     if (!cJSON_IsString(mir_bw_ul) && !cJSON_IsNull(mir_bw_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [mir_bw_ul]");
         goto end;
+    }
     }
     }
 
@@ -935,60 +1137,74 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     rr_bw = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "rrBw");
     if (rr_bw) {
+    if (!cJSON_IsNull(rr_bw)) {
     if (!cJSON_IsString(rr_bw) && !cJSON_IsNull(rr_bw)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [rr_bw]");
         goto end;
     }
     }
+    }
 
     rs_bw = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "rsBw");
     if (rs_bw) {
+    if (!cJSON_IsNull(rs_bw)) {
     if (!cJSON_IsString(rs_bw) && !cJSON_IsNull(rs_bw)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [rs_bw]");
         goto end;
     }
     }
+    }
 
     sharing_key_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "sharingKeyDl");
     if (sharing_key_dl) {
+    if (!cJSON_IsNull(sharing_key_dl)) {
     if (!cJSON_IsNumber(sharing_key_dl)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [sharing_key_dl]");
         goto end;
     }
     }
+    }
 
     sharing_key_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "sharingKeyUl");
     if (sharing_key_ul) {
+    if (!cJSON_IsNull(sharing_key_ul)) {
     if (!cJSON_IsNumber(sharing_key_ul)) {
         ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [sharing_key_ul]");
         goto end;
     }
     }
+    }
 
     tsn_qos = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "tsnQos");
     if (tsn_qos) {
+    if (!cJSON_IsNull(tsn_qos)) {
     tsn_qos_local_nonprim = OpenAPI_tsn_qos_container_rm_parseFromJSON(tsn_qos);
     if (!tsn_qos_local_nonprim) {
         ogs_error("OpenAPI_tsn_qos_container_rm_parseFromJSON failed [tsn_qos]");
         goto end;
     }
     }
+    }
 
     tscai_input_dl = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "tscaiInputDl");
     if (tscai_input_dl) {
+    if (!cJSON_IsNull(tscai_input_dl)) {
     tscai_input_dl_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_dl);
     if (!tscai_input_dl_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_dl]");
         goto end;
     }
     }
+    }
 
     tscai_input_ul = cJSON_GetObjectItemCaseSensitive(media_component_rmJSON, "tscaiInputUl");
     if (tscai_input_ul) {
+    if (!cJSON_IsNull(tscai_input_ul)) {
     tscai_input_ul_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_ul);
     if (!tscai_input_ul_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_ul]");
         goto end;
+    }
     }
     }
 
@@ -1002,49 +1218,73 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
 
     media_component_rm_local_var = OpenAPI_media_component_rm_create (
         af_app_id && !cJSON_IsNull(af_app_id) ? ogs_strdup(af_app_id->valuestring) : NULL,
+        af_rout_req && cJSON_IsNull(af_rout_req) ? true : false,
         af_rout_req ? af_rout_req_local_nonprim : NULL,
+        qos_reference && cJSON_IsNull(qos_reference) ? true : false,
         qos_reference && !cJSON_IsNull(qos_reference) ? ogs_strdup(qos_reference->valuestring) : NULL,
+        alt_ser_reqs && cJSON_IsNull(alt_ser_reqs) ? true : false,
         alt_ser_reqs ? alt_ser_reqsList : NULL,
+        alt_ser_reqs_data && cJSON_IsNull(alt_ser_reqs_data) ? true : false,
         alt_ser_reqs_data ? alt_ser_reqs_dataList : NULL,
         dis_ue_notif ? true : false,
         dis_ue_notif ? dis_ue_notif->valueint : 0,
         cont_ver ? true : false,
         cont_ver ? cont_ver->valuedouble : 0,
         codecs ? codecsList : NULL,
+        des_max_latency && cJSON_IsNull(des_max_latency) ? true : false,
         des_max_latency ? true : false,
         des_max_latency ? des_max_latency->valuedouble : 0,
+        des_max_loss && cJSON_IsNull(des_max_loss) ? true : false,
         des_max_loss ? true : false,
         des_max_loss ? des_max_loss->valuedouble : 0,
+        flus_id && cJSON_IsNull(flus_id) ? true : false,
         flus_id && !cJSON_IsNull(flus_id) ? ogs_strdup(flus_id->valuestring) : NULL,
         f_status ? f_statusVariable : 0,
+        mar_bw_dl && cJSON_IsNull(mar_bw_dl) ? true : false,
         mar_bw_dl && !cJSON_IsNull(mar_bw_dl) ? ogs_strdup(mar_bw_dl->valuestring) : NULL,
+        mar_bw_ul && cJSON_IsNull(mar_bw_ul) ? true : false,
         mar_bw_ul && !cJSON_IsNull(mar_bw_ul) ? ogs_strdup(mar_bw_ul->valuestring) : NULL,
+        max_packet_loss_rate_dl && cJSON_IsNull(max_packet_loss_rate_dl) ? true : false,
         max_packet_loss_rate_dl ? true : false,
         max_packet_loss_rate_dl ? max_packet_loss_rate_dl->valuedouble : 0,
+        max_packet_loss_rate_ul && cJSON_IsNull(max_packet_loss_rate_ul) ? true : false,
         max_packet_loss_rate_ul ? true : false,
         max_packet_loss_rate_ul ? max_packet_loss_rate_ul->valuedouble : 0,
+        max_supp_bw_dl && cJSON_IsNull(max_supp_bw_dl) ? true : false,
         max_supp_bw_dl && !cJSON_IsNull(max_supp_bw_dl) ? ogs_strdup(max_supp_bw_dl->valuestring) : NULL,
+        max_supp_bw_ul && cJSON_IsNull(max_supp_bw_ul) ? true : false,
         max_supp_bw_ul && !cJSON_IsNull(max_supp_bw_ul) ? ogs_strdup(max_supp_bw_ul->valuestring) : NULL,
         
         med_comp_n->valuedouble,
         med_sub_comps ? med_sub_compsList : NULL,
         med_type ? med_typeVariable : 0,
+        min_des_bw_dl && cJSON_IsNull(min_des_bw_dl) ? true : false,
         min_des_bw_dl && !cJSON_IsNull(min_des_bw_dl) ? ogs_strdup(min_des_bw_dl->valuestring) : NULL,
+        min_des_bw_ul && cJSON_IsNull(min_des_bw_ul) ? true : false,
         min_des_bw_ul && !cJSON_IsNull(min_des_bw_ul) ? ogs_strdup(min_des_bw_ul->valuestring) : NULL,
+        mir_bw_dl && cJSON_IsNull(mir_bw_dl) ? true : false,
         mir_bw_dl && !cJSON_IsNull(mir_bw_dl) ? ogs_strdup(mir_bw_dl->valuestring) : NULL,
+        mir_bw_ul && cJSON_IsNull(mir_bw_ul) ? true : false,
         mir_bw_ul && !cJSON_IsNull(mir_bw_ul) ? ogs_strdup(mir_bw_ul->valuestring) : NULL,
         preempt_cap ? preempt_cap_local_nonprim : NULL,
         preempt_vuln ? preempt_vuln_local_nonprim : NULL,
         prio_sharing_ind ? prio_sharing_indVariable : 0,
         res_prio ? res_prioVariable : 0,
+        rr_bw && cJSON_IsNull(rr_bw) ? true : false,
         rr_bw && !cJSON_IsNull(rr_bw) ? ogs_strdup(rr_bw->valuestring) : NULL,
+        rs_bw && cJSON_IsNull(rs_bw) ? true : false,
         rs_bw && !cJSON_IsNull(rs_bw) ? ogs_strdup(rs_bw->valuestring) : NULL,
+        sharing_key_dl && cJSON_IsNull(sharing_key_dl) ? true : false,
         sharing_key_dl ? true : false,
         sharing_key_dl ? sharing_key_dl->valuedouble : 0,
+        sharing_key_ul && cJSON_IsNull(sharing_key_ul) ? true : false,
         sharing_key_ul ? true : false,
         sharing_key_ul ? sharing_key_ul->valuedouble : 0,
+        tsn_qos && cJSON_IsNull(tsn_qos) ? true : false,
         tsn_qos ? tsn_qos_local_nonprim : NULL,
+        tscai_input_dl && cJSON_IsNull(tscai_input_dl) ? true : false,
         tscai_input_dl ? tscai_input_dl_local_nonprim : NULL,
+        tscai_input_ul && cJSON_IsNull(tscai_input_ul) ? true : false,
         tscai_input_ul ? tscai_input_ul_local_nonprim : NULL,
         tscai_time_dom ? true : false,
         tscai_time_dom ? tscai_time_dom->valuedouble : 0

--- a/lib/sbi/openapi/model/media_component_rm.h
+++ b/lib/sbi/openapi/model/media_component_rm.h
@@ -31,48 +31,72 @@ extern "C" {
 typedef struct OpenAPI_media_component_rm_s OpenAPI_media_component_rm_t;
 typedef struct OpenAPI_media_component_rm_s {
     char *af_app_id;
+    bool is_af_rout_req_null;
     struct OpenAPI_af_routing_requirement_rm_s *af_rout_req;
+    bool is_qos_reference_null;
     char *qos_reference;
+    bool is_alt_ser_reqs_null;
     OpenAPI_list_t *alt_ser_reqs;
+    bool is_alt_ser_reqs_data_null;
     OpenAPI_list_t *alt_ser_reqs_data;
     bool is_dis_ue_notif;
     int dis_ue_notif;
     bool is_cont_ver;
     int cont_ver;
     OpenAPI_list_t *codecs;
+    bool is_des_max_latency_null;
     bool is_des_max_latency;
     float des_max_latency;
+    bool is_des_max_loss_null;
     bool is_des_max_loss;
     float des_max_loss;
+    bool is_flus_id_null;
     char *flus_id;
     OpenAPI_flow_status_e f_status;
+    bool is_mar_bw_dl_null;
     char *mar_bw_dl;
+    bool is_mar_bw_ul_null;
     char *mar_bw_ul;
+    bool is_max_packet_loss_rate_dl_null;
     bool is_max_packet_loss_rate_dl;
     int max_packet_loss_rate_dl;
+    bool is_max_packet_loss_rate_ul_null;
     bool is_max_packet_loss_rate_ul;
     int max_packet_loss_rate_ul;
+    bool is_max_supp_bw_dl_null;
     char *max_supp_bw_dl;
+    bool is_max_supp_bw_ul_null;
     char *max_supp_bw_ul;
     int med_comp_n;
     OpenAPI_list_t* med_sub_comps;
     OpenAPI_media_type_e med_type;
+    bool is_min_des_bw_dl_null;
     char *min_des_bw_dl;
+    bool is_min_des_bw_ul_null;
     char *min_des_bw_ul;
+    bool is_mir_bw_dl_null;
     char *mir_bw_dl;
+    bool is_mir_bw_ul_null;
     char *mir_bw_ul;
     struct OpenAPI_preemption_capability_rm_s *preempt_cap;
     struct OpenAPI_preemption_vulnerability_rm_s *preempt_vuln;
     OpenAPI_priority_sharing_indicator_e prio_sharing_ind;
     OpenAPI_reserv_priority_e res_prio;
+    bool is_rr_bw_null;
     char *rr_bw;
+    bool is_rs_bw_null;
     char *rs_bw;
+    bool is_sharing_key_dl_null;
     bool is_sharing_key_dl;
     int sharing_key_dl;
+    bool is_sharing_key_ul_null;
     bool is_sharing_key_ul;
     int sharing_key_ul;
+    bool is_tsn_qos_null;
     struct OpenAPI_tsn_qos_container_rm_s *tsn_qos;
+    bool is_tscai_input_dl_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_dl;
+    bool is_tscai_input_ul_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_ul;
     bool is_tscai_time_dom;
     int tscai_time_dom;
@@ -80,48 +104,72 @@ typedef struct OpenAPI_media_component_rm_s {
 
 OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_create(
     char *af_app_id,
+    bool is_af_rout_req_null,
     OpenAPI_af_routing_requirement_rm_t *af_rout_req,
+    bool is_qos_reference_null,
     char *qos_reference,
+    bool is_alt_ser_reqs_null,
     OpenAPI_list_t *alt_ser_reqs,
+    bool is_alt_ser_reqs_data_null,
     OpenAPI_list_t *alt_ser_reqs_data,
     bool is_dis_ue_notif,
     int dis_ue_notif,
     bool is_cont_ver,
     int cont_ver,
     OpenAPI_list_t *codecs,
+    bool is_des_max_latency_null,
     bool is_des_max_latency,
     float des_max_latency,
+    bool is_des_max_loss_null,
     bool is_des_max_loss,
     float des_max_loss,
+    bool is_flus_id_null,
     char *flus_id,
     OpenAPI_flow_status_e f_status,
+    bool is_mar_bw_dl_null,
     char *mar_bw_dl,
+    bool is_mar_bw_ul_null,
     char *mar_bw_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
+    bool is_max_supp_bw_dl_null,
     char *max_supp_bw_dl,
+    bool is_max_supp_bw_ul_null,
     char *max_supp_bw_ul,
     int med_comp_n,
     OpenAPI_list_t* med_sub_comps,
     OpenAPI_media_type_e med_type,
+    bool is_min_des_bw_dl_null,
     char *min_des_bw_dl,
+    bool is_min_des_bw_ul_null,
     char *min_des_bw_ul,
+    bool is_mir_bw_dl_null,
     char *mir_bw_dl,
+    bool is_mir_bw_ul_null,
     char *mir_bw_ul,
     OpenAPI_preemption_capability_rm_t *preempt_cap,
     OpenAPI_preemption_vulnerability_rm_t *preempt_vuln,
     OpenAPI_priority_sharing_indicator_e prio_sharing_ind,
     OpenAPI_reserv_priority_e res_prio,
+    bool is_rr_bw_null,
     char *rr_bw,
+    bool is_rs_bw_null,
     char *rs_bw,
+    bool is_sharing_key_dl_null,
     bool is_sharing_key_dl,
     int sharing_key_dl,
+    bool is_sharing_key_ul_null,
     bool is_sharing_key_ul,
     int sharing_key_ul,
+    bool is_tsn_qos_null,
     OpenAPI_tsn_qos_container_rm_t *tsn_qos,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom

--- a/lib/sbi/openapi/model/media_sub_component_rm.c
+++ b/lib/sbi/openapi/model/media_sub_component_rm.c
@@ -6,12 +6,17 @@
 
 OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_create(
     OpenAPI_af_sig_protocol_e af_sig_protocol,
+    bool is_ethf_descs_null,
     OpenAPI_list_t *ethf_descs,
     int f_num,
+    bool is_f_descs_null,
     OpenAPI_list_t *f_descs,
     OpenAPI_flow_status_e f_status,
+    bool is_mar_bw_dl_null,
     char *mar_bw_dl,
+    bool is_mar_bw_ul_null,
     char *mar_bw_ul,
+    bool is_tos_tr_cl_null,
     char *tos_tr_cl,
     OpenAPI_flow_usage_e flow_usage
 )
@@ -20,12 +25,17 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_create(
     ogs_assert(media_sub_component_rm_local_var);
 
     media_sub_component_rm_local_var->af_sig_protocol = af_sig_protocol;
+    media_sub_component_rm_local_var->is_ethf_descs_null = is_ethf_descs_null;
     media_sub_component_rm_local_var->ethf_descs = ethf_descs;
     media_sub_component_rm_local_var->f_num = f_num;
+    media_sub_component_rm_local_var->is_f_descs_null = is_f_descs_null;
     media_sub_component_rm_local_var->f_descs = f_descs;
     media_sub_component_rm_local_var->f_status = f_status;
+    media_sub_component_rm_local_var->is_mar_bw_dl_null = is_mar_bw_dl_null;
     media_sub_component_rm_local_var->mar_bw_dl = mar_bw_dl;
+    media_sub_component_rm_local_var->is_mar_bw_ul_null = is_mar_bw_ul_null;
     media_sub_component_rm_local_var->mar_bw_ul = mar_bw_ul;
+    media_sub_component_rm_local_var->is_tos_tr_cl_null = is_tos_tr_cl_null;
     media_sub_component_rm_local_var->tos_tr_cl = tos_tr_cl;
     media_sub_component_rm_local_var->flow_usage = flow_usage;
 
@@ -100,6 +110,11 @@ cJSON *OpenAPI_media_sub_component_rm_convertToJSON(OpenAPI_media_sub_component_
         }
         cJSON_AddItemToArray(ethf_descsList, itemLocal);
     }
+    } else if (media_sub_component_rm->is_ethf_descs_null) {
+        if (cJSON_AddNullToObject(item, "ethfDescs") == NULL) {
+            ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [ethf_descs]");
+            goto end;
+        }
     }
 
     if (cJSON_AddNumberToObject(item, "fNum", media_sub_component_rm->f_num) == NULL) {
@@ -119,6 +134,11 @@ cJSON *OpenAPI_media_sub_component_rm_convertToJSON(OpenAPI_media_sub_component_
             goto end;
         }
     }
+    } else if (media_sub_component_rm->is_f_descs_null) {
+        if (cJSON_AddNullToObject(item, "fDescs") == NULL) {
+            ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [f_descs]");
+            goto end;
+        }
     }
 
     if (media_sub_component_rm->f_status != OpenAPI_flow_status_NULL) {
@@ -133,6 +153,11 @@ cJSON *OpenAPI_media_sub_component_rm_convertToJSON(OpenAPI_media_sub_component_
         ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [mar_bw_dl]");
         goto end;
     }
+    } else if (media_sub_component_rm->is_mar_bw_dl_null) {
+        if (cJSON_AddNullToObject(item, "marBwDl") == NULL) {
+            ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [mar_bw_dl]");
+            goto end;
+        }
     }
 
     if (media_sub_component_rm->mar_bw_ul) {
@@ -140,6 +165,11 @@ cJSON *OpenAPI_media_sub_component_rm_convertToJSON(OpenAPI_media_sub_component_
         ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [mar_bw_ul]");
         goto end;
     }
+    } else if (media_sub_component_rm->is_mar_bw_ul_null) {
+        if (cJSON_AddNullToObject(item, "marBwUl") == NULL) {
+            ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [mar_bw_ul]");
+            goto end;
+        }
     }
 
     if (media_sub_component_rm->tos_tr_cl) {
@@ -147,6 +177,11 @@ cJSON *OpenAPI_media_sub_component_rm_convertToJSON(OpenAPI_media_sub_component_
         ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [tos_tr_cl]");
         goto end;
     }
+    } else if (media_sub_component_rm->is_tos_tr_cl_null) {
+        if (cJSON_AddNullToObject(item, "tosTrCl") == NULL) {
+            ogs_error("OpenAPI_media_sub_component_rm_convertToJSON() failed [tos_tr_cl]");
+            goto end;
+        }
     }
 
     if (media_sub_component_rm->flow_usage != OpenAPI_flow_usage_NULL) {
@@ -189,6 +224,7 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
 
     ethf_descs = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "ethfDescs");
     if (ethf_descs) {
+    if (!cJSON_IsNull(ethf_descs)) {
         cJSON *ethf_descs_local = NULL;
         if (!cJSON_IsArray(ethf_descs)) {
             ogs_error("OpenAPI_media_sub_component_rm_parseFromJSON() failed [ethf_descs]");
@@ -210,6 +246,7 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
             OpenAPI_list_add(ethf_descsList, ethf_descsItem);
         }
     }
+    }
 
     f_num = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "fNum");
     if (!f_num) {
@@ -223,6 +260,7 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
 
     f_descs = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "fDescs");
     if (f_descs) {
+    if (!cJSON_IsNull(f_descs)) {
         cJSON *f_descs_local = NULL;
         if (!cJSON_IsArray(f_descs)) {
             ogs_error("OpenAPI_media_sub_component_rm_parseFromJSON() failed [f_descs]");
@@ -241,6 +279,7 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
             OpenAPI_list_add(f_descsList, ogs_strdup(f_descs_local->valuestring));
         }
     }
+    }
 
     f_status = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "fStatus");
     if (f_status) {
@@ -253,25 +292,31 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
 
     mar_bw_dl = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "marBwDl");
     if (mar_bw_dl) {
+    if (!cJSON_IsNull(mar_bw_dl)) {
     if (!cJSON_IsString(mar_bw_dl) && !cJSON_IsNull(mar_bw_dl)) {
         ogs_error("OpenAPI_media_sub_component_rm_parseFromJSON() failed [mar_bw_dl]");
         goto end;
     }
     }
+    }
 
     mar_bw_ul = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "marBwUl");
     if (mar_bw_ul) {
+    if (!cJSON_IsNull(mar_bw_ul)) {
     if (!cJSON_IsString(mar_bw_ul) && !cJSON_IsNull(mar_bw_ul)) {
         ogs_error("OpenAPI_media_sub_component_rm_parseFromJSON() failed [mar_bw_ul]");
         goto end;
     }
     }
+    }
 
     tos_tr_cl = cJSON_GetObjectItemCaseSensitive(media_sub_component_rmJSON, "tosTrCl");
     if (tos_tr_cl) {
+    if (!cJSON_IsNull(tos_tr_cl)) {
     if (!cJSON_IsString(tos_tr_cl) && !cJSON_IsNull(tos_tr_cl)) {
         ogs_error("OpenAPI_media_sub_component_rm_parseFromJSON() failed [tos_tr_cl]");
         goto end;
+    }
     }
     }
 
@@ -286,13 +331,18 @@ OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_parseFromJSON(c
 
     media_sub_component_rm_local_var = OpenAPI_media_sub_component_rm_create (
         af_sig_protocol ? af_sig_protocolVariable : 0,
+        ethf_descs && cJSON_IsNull(ethf_descs) ? true : false,
         ethf_descs ? ethf_descsList : NULL,
         
         f_num->valuedouble,
+        f_descs && cJSON_IsNull(f_descs) ? true : false,
         f_descs ? f_descsList : NULL,
         f_status ? f_statusVariable : 0,
+        mar_bw_dl && cJSON_IsNull(mar_bw_dl) ? true : false,
         mar_bw_dl && !cJSON_IsNull(mar_bw_dl) ? ogs_strdup(mar_bw_dl->valuestring) : NULL,
+        mar_bw_ul && cJSON_IsNull(mar_bw_ul) ? true : false,
         mar_bw_ul && !cJSON_IsNull(mar_bw_ul) ? ogs_strdup(mar_bw_ul->valuestring) : NULL,
+        tos_tr_cl && cJSON_IsNull(tos_tr_cl) ? true : false,
         tos_tr_cl && !cJSON_IsNull(tos_tr_cl) ? ogs_strdup(tos_tr_cl->valuestring) : NULL,
         flow_usage ? flow_usageVariable : 0
     );

--- a/lib/sbi/openapi/model/media_sub_component_rm.h
+++ b/lib/sbi/openapi/model/media_sub_component_rm.h
@@ -24,24 +24,34 @@ extern "C" {
 typedef struct OpenAPI_media_sub_component_rm_s OpenAPI_media_sub_component_rm_t;
 typedef struct OpenAPI_media_sub_component_rm_s {
     OpenAPI_af_sig_protocol_e af_sig_protocol;
+    bool is_ethf_descs_null;
     OpenAPI_list_t *ethf_descs;
     int f_num;
+    bool is_f_descs_null;
     OpenAPI_list_t *f_descs;
     OpenAPI_flow_status_e f_status;
+    bool is_mar_bw_dl_null;
     char *mar_bw_dl;
+    bool is_mar_bw_ul_null;
     char *mar_bw_ul;
+    bool is_tos_tr_cl_null;
     char *tos_tr_cl;
     OpenAPI_flow_usage_e flow_usage;
 } OpenAPI_media_sub_component_rm_t;
 
 OpenAPI_media_sub_component_rm_t *OpenAPI_media_sub_component_rm_create(
     OpenAPI_af_sig_protocol_e af_sig_protocol,
+    bool is_ethf_descs_null,
     OpenAPI_list_t *ethf_descs,
     int f_num,
+    bool is_f_descs_null,
     OpenAPI_list_t *f_descs,
     OpenAPI_flow_status_e f_status,
+    bool is_mar_bw_dl_null,
     char *mar_bw_dl,
+    bool is_mar_bw_ul_null,
     char *mar_bw_ul,
+    bool is_tos_tr_cl_null,
     char *tos_tr_cl,
     OpenAPI_flow_usage_e flow_usage
 );

--- a/lib/sbi/openapi/model/patch_item.h
+++ b/lib/sbi/openapi/model/patch_item.h
@@ -24,6 +24,7 @@ typedef struct OpenAPI_patch_item_s {
     OpenAPI_patch_operation_e op;
     char *path;
     char *from;
+    bool is_value_null;
     OpenAPI_any_type_t *value;
 } OpenAPI_patch_item_t;
 
@@ -31,6 +32,7 @@ OpenAPI_patch_item_t *OpenAPI_patch_item_create(
     OpenAPI_patch_operation_e op,
     char *path,
     char *from,
+    bool is_value_null,
     OpenAPI_any_type_t *value
 );
 void OpenAPI_patch_item_free(OpenAPI_patch_item_t *patch_item);

--- a/lib/sbi/openapi/model/pcc_rule.c
+++ b/lib/sbi/openapi/model/pcc_rule.c
@@ -21,20 +21,31 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_create(
     OpenAPI_list_t *ref_qos_data,
     OpenAPI_list_t *ref_alt_qos_params,
     OpenAPI_list_t *ref_tc_data,
+    bool is_ref_chg_data_null,
     OpenAPI_list_t *ref_chg_data,
+    bool is_ref_chg_n3g_data_null,
     OpenAPI_list_t *ref_chg_n3g_data,
+    bool is_ref_um_data_null,
     OpenAPI_list_t *ref_um_data,
+    bool is_ref_um_n3g_data_null,
     OpenAPI_list_t *ref_um_n3g_data,
+    bool is_ref_cond_data_null,
     char *ref_cond_data,
+    bool is_ref_qos_mon_null,
     OpenAPI_list_t *ref_qos_mon,
+    bool is_addr_preser_ind_null,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom,
     OpenAPI_downlink_data_notification_control_t *dd_notif_ctrl,
+    bool is_dd_notif_ctrl2_null,
     OpenAPI_downlink_data_notification_control_rm_t *dd_notif_ctrl2,
+    bool is_dis_ue_notif_null,
     bool is_dis_ue_notif,
     int dis_ue_notif,
     bool is_pack_filt_all_prec,
@@ -60,20 +71,31 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_create(
     pcc_rule_local_var->ref_qos_data = ref_qos_data;
     pcc_rule_local_var->ref_alt_qos_params = ref_alt_qos_params;
     pcc_rule_local_var->ref_tc_data = ref_tc_data;
+    pcc_rule_local_var->is_ref_chg_data_null = is_ref_chg_data_null;
     pcc_rule_local_var->ref_chg_data = ref_chg_data;
+    pcc_rule_local_var->is_ref_chg_n3g_data_null = is_ref_chg_n3g_data_null;
     pcc_rule_local_var->ref_chg_n3g_data = ref_chg_n3g_data;
+    pcc_rule_local_var->is_ref_um_data_null = is_ref_um_data_null;
     pcc_rule_local_var->ref_um_data = ref_um_data;
+    pcc_rule_local_var->is_ref_um_n3g_data_null = is_ref_um_n3g_data_null;
     pcc_rule_local_var->ref_um_n3g_data = ref_um_n3g_data;
+    pcc_rule_local_var->is_ref_cond_data_null = is_ref_cond_data_null;
     pcc_rule_local_var->ref_cond_data = ref_cond_data;
+    pcc_rule_local_var->is_ref_qos_mon_null = is_ref_qos_mon_null;
     pcc_rule_local_var->ref_qos_mon = ref_qos_mon;
+    pcc_rule_local_var->is_addr_preser_ind_null = is_addr_preser_ind_null;
     pcc_rule_local_var->is_addr_preser_ind = is_addr_preser_ind;
     pcc_rule_local_var->addr_preser_ind = addr_preser_ind;
+    pcc_rule_local_var->is_tscai_input_dl_null = is_tscai_input_dl_null;
     pcc_rule_local_var->tscai_input_dl = tscai_input_dl;
+    pcc_rule_local_var->is_tscai_input_ul_null = is_tscai_input_ul_null;
     pcc_rule_local_var->tscai_input_ul = tscai_input_ul;
     pcc_rule_local_var->is_tscai_time_dom = is_tscai_time_dom;
     pcc_rule_local_var->tscai_time_dom = tscai_time_dom;
     pcc_rule_local_var->dd_notif_ctrl = dd_notif_ctrl;
+    pcc_rule_local_var->is_dd_notif_ctrl2_null = is_dd_notif_ctrl2_null;
     pcc_rule_local_var->dd_notif_ctrl2 = dd_notif_ctrl2;
+    pcc_rule_local_var->is_dis_ue_notif_null = is_dis_ue_notif_null;
     pcc_rule_local_var->is_dis_ue_notif = is_dis_ue_notif;
     pcc_rule_local_var->dis_ue_notif = dis_ue_notif;
     pcc_rule_local_var->is_pack_filt_all_prec = is_pack_filt_all_prec;
@@ -326,6 +348,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
             goto end;
         }
     }
+    } else if (pcc_rule->is_ref_chg_data_null) {
+        if (cJSON_AddNullToObject(item, "refChgData") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_chg_data]");
+            goto end;
+        }
     }
 
     if (pcc_rule->ref_chg_n3g_data) {
@@ -340,6 +367,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
             goto end;
         }
     }
+    } else if (pcc_rule->is_ref_chg_n3g_data_null) {
+        if (cJSON_AddNullToObject(item, "refChgN3gData") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_chg_n3g_data]");
+            goto end;
+        }
     }
 
     if (pcc_rule->ref_um_data) {
@@ -354,6 +386,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
             goto end;
         }
     }
+    } else if (pcc_rule->is_ref_um_data_null) {
+        if (cJSON_AddNullToObject(item, "refUmData") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_um_data]");
+            goto end;
+        }
     }
 
     if (pcc_rule->ref_um_n3g_data) {
@@ -368,6 +405,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
             goto end;
         }
     }
+    } else if (pcc_rule->is_ref_um_n3g_data_null) {
+        if (cJSON_AddNullToObject(item, "refUmN3gData") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_um_n3g_data]");
+            goto end;
+        }
     }
 
     if (pcc_rule->ref_cond_data) {
@@ -375,6 +417,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_cond_data]");
         goto end;
     }
+    } else if (pcc_rule->is_ref_cond_data_null) {
+        if (cJSON_AddNullToObject(item, "refCondData") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_cond_data]");
+            goto end;
+        }
     }
 
     if (pcc_rule->ref_qos_mon) {
@@ -389,6 +436,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
             goto end;
         }
     }
+    } else if (pcc_rule->is_ref_qos_mon_null) {
+        if (cJSON_AddNullToObject(item, "refQosMon") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [ref_qos_mon]");
+            goto end;
+        }
     }
 
     if (pcc_rule->is_addr_preser_ind) {
@@ -396,6 +448,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [addr_preser_ind]");
         goto end;
     }
+    } else if (pcc_rule->is_addr_preser_ind_null) {
+        if (cJSON_AddNullToObject(item, "addrPreserInd") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [addr_preser_ind]");
+            goto end;
+        }
     }
 
     if (pcc_rule->tscai_input_dl) {
@@ -409,6 +466,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [tscai_input_dl]");
         goto end;
     }
+    } else if (pcc_rule->is_tscai_input_dl_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputDl") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [tscai_input_dl]");
+            goto end;
+        }
     }
 
     if (pcc_rule->tscai_input_ul) {
@@ -422,6 +484,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [tscai_input_ul]");
         goto end;
     }
+    } else if (pcc_rule->is_tscai_input_ul_null) {
+        if (cJSON_AddNullToObject(item, "tscaiInputUl") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [tscai_input_ul]");
+            goto end;
+        }
     }
 
     if (pcc_rule->is_tscai_time_dom) {
@@ -455,6 +522,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [dd_notif_ctrl2]");
         goto end;
     }
+    } else if (pcc_rule->is_dd_notif_ctrl2_null) {
+        if (cJSON_AddNullToObject(item, "ddNotifCtrl2") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [dd_notif_ctrl2]");
+            goto end;
+        }
     }
 
     if (pcc_rule->is_dis_ue_notif) {
@@ -462,6 +534,11 @@ cJSON *OpenAPI_pcc_rule_convertToJSON(OpenAPI_pcc_rule_t *pcc_rule)
         ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [dis_ue_notif]");
         goto end;
     }
+    } else if (pcc_rule->is_dis_ue_notif_null) {
+        if (cJSON_AddNullToObject(item, "disUeNotif") == NULL) {
+            ogs_error("OpenAPI_pcc_rule_convertToJSON() failed [dis_ue_notif]");
+            goto end;
+        }
     }
 
     if (pcc_rule->is_pack_filt_all_prec) {
@@ -675,6 +752,7 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
 
     ref_chg_data = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refChgData");
     if (ref_chg_data) {
+    if (!cJSON_IsNull(ref_chg_data)) {
         cJSON *ref_chg_data_local = NULL;
         if (!cJSON_IsArray(ref_chg_data)) {
             ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_chg_data]");
@@ -693,9 +771,11 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
             OpenAPI_list_add(ref_chg_dataList, ogs_strdup(ref_chg_data_local->valuestring));
         }
     }
+    }
 
     ref_chg_n3g_data = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refChgN3gData");
     if (ref_chg_n3g_data) {
+    if (!cJSON_IsNull(ref_chg_n3g_data)) {
         cJSON *ref_chg_n3g_data_local = NULL;
         if (!cJSON_IsArray(ref_chg_n3g_data)) {
             ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_chg_n3g_data]");
@@ -714,9 +794,11 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
             OpenAPI_list_add(ref_chg_n3g_dataList, ogs_strdup(ref_chg_n3g_data_local->valuestring));
         }
     }
+    }
 
     ref_um_data = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refUmData");
     if (ref_um_data) {
+    if (!cJSON_IsNull(ref_um_data)) {
         cJSON *ref_um_data_local = NULL;
         if (!cJSON_IsArray(ref_um_data)) {
             ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_um_data]");
@@ -735,9 +817,11 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
             OpenAPI_list_add(ref_um_dataList, ogs_strdup(ref_um_data_local->valuestring));
         }
     }
+    }
 
     ref_um_n3g_data = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refUmN3gData");
     if (ref_um_n3g_data) {
+    if (!cJSON_IsNull(ref_um_n3g_data)) {
         cJSON *ref_um_n3g_data_local = NULL;
         if (!cJSON_IsArray(ref_um_n3g_data)) {
             ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_um_n3g_data]");
@@ -756,17 +840,21 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
             OpenAPI_list_add(ref_um_n3g_dataList, ogs_strdup(ref_um_n3g_data_local->valuestring));
         }
     }
+    }
 
     ref_cond_data = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refCondData");
     if (ref_cond_data) {
+    if (!cJSON_IsNull(ref_cond_data)) {
     if (!cJSON_IsString(ref_cond_data) && !cJSON_IsNull(ref_cond_data)) {
         ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_cond_data]");
         goto end;
     }
     }
+    }
 
     ref_qos_mon = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "refQosMon");
     if (ref_qos_mon) {
+    if (!cJSON_IsNull(ref_qos_mon)) {
         cJSON *ref_qos_mon_local = NULL;
         if (!cJSON_IsArray(ref_qos_mon)) {
             ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [ref_qos_mon]");
@@ -785,30 +873,37 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
             OpenAPI_list_add(ref_qos_monList, ogs_strdup(ref_qos_mon_local->valuestring));
         }
     }
+    }
 
     addr_preser_ind = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "addrPreserInd");
     if (addr_preser_ind) {
+    if (!cJSON_IsNull(addr_preser_ind)) {
     if (!cJSON_IsBool(addr_preser_ind)) {
         ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [addr_preser_ind]");
         goto end;
     }
     }
+    }
 
     tscai_input_dl = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "tscaiInputDl");
     if (tscai_input_dl) {
+    if (!cJSON_IsNull(tscai_input_dl)) {
     tscai_input_dl_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_dl);
     if (!tscai_input_dl_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_dl]");
         goto end;
     }
     }
+    }
 
     tscai_input_ul = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "tscaiInputUl");
     if (tscai_input_ul) {
+    if (!cJSON_IsNull(tscai_input_ul)) {
     tscai_input_ul_local_nonprim = OpenAPI_tscai_input_container_parseFromJSON(tscai_input_ul);
     if (!tscai_input_ul_local_nonprim) {
         ogs_error("OpenAPI_tscai_input_container_parseFromJSON failed [tscai_input_ul]");
         goto end;
+    }
     }
     }
 
@@ -831,18 +926,22 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
 
     dd_notif_ctrl2 = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "ddNotifCtrl2");
     if (dd_notif_ctrl2) {
+    if (!cJSON_IsNull(dd_notif_ctrl2)) {
     dd_notif_ctrl2_local_nonprim = OpenAPI_downlink_data_notification_control_rm_parseFromJSON(dd_notif_ctrl2);
     if (!dd_notif_ctrl2_local_nonprim) {
         ogs_error("OpenAPI_downlink_data_notification_control_rm_parseFromJSON failed [dd_notif_ctrl2]");
         goto end;
     }
     }
+    }
 
     dis_ue_notif = cJSON_GetObjectItemCaseSensitive(pcc_ruleJSON, "disUeNotif");
     if (dis_ue_notif) {
+    if (!cJSON_IsNull(dis_ue_notif)) {
     if (!cJSON_IsBool(dis_ue_notif)) {
         ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [dis_ue_notif]");
         goto end;
+    }
     }
     }
 
@@ -871,20 +970,31 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
         ref_qos_data ? ref_qos_dataList : NULL,
         ref_alt_qos_params ? ref_alt_qos_paramsList : NULL,
         ref_tc_data ? ref_tc_dataList : NULL,
+        ref_chg_data && cJSON_IsNull(ref_chg_data) ? true : false,
         ref_chg_data ? ref_chg_dataList : NULL,
+        ref_chg_n3g_data && cJSON_IsNull(ref_chg_n3g_data) ? true : false,
         ref_chg_n3g_data ? ref_chg_n3g_dataList : NULL,
+        ref_um_data && cJSON_IsNull(ref_um_data) ? true : false,
         ref_um_data ? ref_um_dataList : NULL,
+        ref_um_n3g_data && cJSON_IsNull(ref_um_n3g_data) ? true : false,
         ref_um_n3g_data ? ref_um_n3g_dataList : NULL,
+        ref_cond_data && cJSON_IsNull(ref_cond_data) ? true : false,
         ref_cond_data && !cJSON_IsNull(ref_cond_data) ? ogs_strdup(ref_cond_data->valuestring) : NULL,
+        ref_qos_mon && cJSON_IsNull(ref_qos_mon) ? true : false,
         ref_qos_mon ? ref_qos_monList : NULL,
+        addr_preser_ind && cJSON_IsNull(addr_preser_ind) ? true : false,
         addr_preser_ind ? true : false,
         addr_preser_ind ? addr_preser_ind->valueint : 0,
+        tscai_input_dl && cJSON_IsNull(tscai_input_dl) ? true : false,
         tscai_input_dl ? tscai_input_dl_local_nonprim : NULL,
+        tscai_input_ul && cJSON_IsNull(tscai_input_ul) ? true : false,
         tscai_input_ul ? tscai_input_ul_local_nonprim : NULL,
         tscai_time_dom ? true : false,
         tscai_time_dom ? tscai_time_dom->valuedouble : 0,
         dd_notif_ctrl ? dd_notif_ctrl_local_nonprim : NULL,
+        dd_notif_ctrl2 && cJSON_IsNull(dd_notif_ctrl2) ? true : false,
         dd_notif_ctrl2 ? dd_notif_ctrl2_local_nonprim : NULL,
+        dis_ue_notif && cJSON_IsNull(dis_ue_notif) ? true : false,
         dis_ue_notif ? true : false,
         dis_ue_notif ? dis_ue_notif->valueint : 0,
         pack_filt_all_prec ? true : false,

--- a/lib/sbi/openapi/model/pcc_rule.h
+++ b/lib/sbi/openapi/model/pcc_rule.h
@@ -40,20 +40,31 @@ typedef struct OpenAPI_pcc_rule_s {
     OpenAPI_list_t *ref_qos_data;
     OpenAPI_list_t *ref_alt_qos_params;
     OpenAPI_list_t *ref_tc_data;
+    bool is_ref_chg_data_null;
     OpenAPI_list_t *ref_chg_data;
+    bool is_ref_chg_n3g_data_null;
     OpenAPI_list_t *ref_chg_n3g_data;
+    bool is_ref_um_data_null;
     OpenAPI_list_t *ref_um_data;
+    bool is_ref_um_n3g_data_null;
     OpenAPI_list_t *ref_um_n3g_data;
+    bool is_ref_cond_data_null;
     char *ref_cond_data;
+    bool is_ref_qos_mon_null;
     OpenAPI_list_t *ref_qos_mon;
+    bool is_addr_preser_ind_null;
     bool is_addr_preser_ind;
     int addr_preser_ind;
+    bool is_tscai_input_dl_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_dl;
+    bool is_tscai_input_ul_null;
     struct OpenAPI_tscai_input_container_s *tscai_input_ul;
     bool is_tscai_time_dom;
     int tscai_time_dom;
     struct OpenAPI_downlink_data_notification_control_s *dd_notif_ctrl;
+    bool is_dd_notif_ctrl2_null;
     struct OpenAPI_downlink_data_notification_control_rm_s *dd_notif_ctrl2;
+    bool is_dis_ue_notif_null;
     bool is_dis_ue_notif;
     int dis_ue_notif;
     bool is_pack_filt_all_prec;
@@ -77,20 +88,31 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_create(
     OpenAPI_list_t *ref_qos_data,
     OpenAPI_list_t *ref_alt_qos_params,
     OpenAPI_list_t *ref_tc_data,
+    bool is_ref_chg_data_null,
     OpenAPI_list_t *ref_chg_data,
+    bool is_ref_chg_n3g_data_null,
     OpenAPI_list_t *ref_chg_n3g_data,
+    bool is_ref_um_data_null,
     OpenAPI_list_t *ref_um_data,
+    bool is_ref_um_n3g_data_null,
     OpenAPI_list_t *ref_um_n3g_data,
+    bool is_ref_cond_data_null,
     char *ref_cond_data,
+    bool is_ref_qos_mon_null,
     OpenAPI_list_t *ref_qos_mon,
+    bool is_addr_preser_ind_null,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_tscai_input_dl_null,
     OpenAPI_tscai_input_container_t *tscai_input_dl,
+    bool is_tscai_input_ul_null,
     OpenAPI_tscai_input_container_t *tscai_input_ul,
     bool is_tscai_time_dom,
     int tscai_time_dom,
     OpenAPI_downlink_data_notification_control_t *dd_notif_ctrl,
+    bool is_dd_notif_ctrl2_null,
     OpenAPI_downlink_data_notification_control_rm_t *dd_notif_ctrl2,
+    bool is_dis_ue_notif_null,
     bool is_dis_ue_notif,
     int dis_ue_notif,
     bool is_pack_filt_all_prec,

--- a/lib/sbi/openapi/model/pcf_binding_patch.c
+++ b/lib/sbi/openapi/model/pcf_binding_patch.c
@@ -5,11 +5,17 @@
 #include "pcf_binding_patch.h"
 
 OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_create(
+    bool is_ipv4_addr_null,
     char *ipv4_addr,
+    bool is_ip_domain_null,
     char *ip_domain,
+    bool is_ipv6_prefix_null,
     char *ipv6_prefix,
+    bool is_add_ipv6_prefixes_null,
     OpenAPI_list_t *add_ipv6_prefixes,
+    bool is_mac_addr48_null,
     char *mac_addr48,
+    bool is_add_mac_addrs_null,
     OpenAPI_list_t *add_mac_addrs,
     char *pcf_id,
     char *pcf_fqdn,
@@ -21,11 +27,17 @@ OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_create(
     OpenAPI_pcf_binding_patch_t *pcf_binding_patch_local_var = ogs_malloc(sizeof(OpenAPI_pcf_binding_patch_t));
     ogs_assert(pcf_binding_patch_local_var);
 
+    pcf_binding_patch_local_var->is_ipv4_addr_null = is_ipv4_addr_null;
     pcf_binding_patch_local_var->ipv4_addr = ipv4_addr;
+    pcf_binding_patch_local_var->is_ip_domain_null = is_ip_domain_null;
     pcf_binding_patch_local_var->ip_domain = ip_domain;
+    pcf_binding_patch_local_var->is_ipv6_prefix_null = is_ipv6_prefix_null;
     pcf_binding_patch_local_var->ipv6_prefix = ipv6_prefix;
+    pcf_binding_patch_local_var->is_add_ipv6_prefixes_null = is_add_ipv6_prefixes_null;
     pcf_binding_patch_local_var->add_ipv6_prefixes = add_ipv6_prefixes;
+    pcf_binding_patch_local_var->is_mac_addr48_null = is_mac_addr48_null;
     pcf_binding_patch_local_var->mac_addr48 = mac_addr48;
+    pcf_binding_patch_local_var->is_add_mac_addrs_null = is_add_mac_addrs_null;
     pcf_binding_patch_local_var->add_mac_addrs = add_mac_addrs;
     pcf_binding_patch_local_var->pcf_id = pcf_id;
     pcf_binding_patch_local_var->pcf_fqdn = pcf_fqdn;
@@ -115,6 +127,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
         ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ipv4_addr]");
         goto end;
     }
+    } else if (pcf_binding_patch->is_ipv4_addr_null) {
+        if (cJSON_AddNullToObject(item, "ipv4Addr") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ipv4_addr]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->ip_domain) {
@@ -122,6 +139,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
         ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ip_domain]");
         goto end;
     }
+    } else if (pcf_binding_patch->is_ip_domain_null) {
+        if (cJSON_AddNullToObject(item, "ipDomain") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ip_domain]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->ipv6_prefix) {
@@ -129,6 +151,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
         ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ipv6_prefix]");
         goto end;
     }
+    } else if (pcf_binding_patch->is_ipv6_prefix_null) {
+        if (cJSON_AddNullToObject(item, "ipv6Prefix") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [ipv6_prefix]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->add_ipv6_prefixes) {
@@ -143,6 +170,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
             goto end;
         }
     }
+    } else if (pcf_binding_patch->is_add_ipv6_prefixes_null) {
+        if (cJSON_AddNullToObject(item, "addIpv6Prefixes") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [add_ipv6_prefixes]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->mac_addr48) {
@@ -150,6 +182,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
         ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [mac_addr48]");
         goto end;
     }
+    } else if (pcf_binding_patch->is_mac_addr48_null) {
+        if (cJSON_AddNullToObject(item, "macAddr48") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [mac_addr48]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->add_mac_addrs) {
@@ -164,6 +201,11 @@ cJSON *OpenAPI_pcf_binding_patch_convertToJSON(OpenAPI_pcf_binding_patch_t *pcf_
             goto end;
         }
     }
+    } else if (pcf_binding_patch->is_add_mac_addrs_null) {
+        if (cJSON_AddNullToObject(item, "addMacAddrs") == NULL) {
+            ogs_error("OpenAPI_pcf_binding_patch_convertToJSON() failed [add_mac_addrs]");
+            goto end;
+        }
     }
 
     if (pcf_binding_patch->pcf_id) {
@@ -234,30 +276,37 @@ OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_parseFromJSON(cJSON *pcf_
     cJSON *pcf_diam_realm = NULL;
     ipv4_addr = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "ipv4Addr");
     if (ipv4_addr) {
+    if (!cJSON_IsNull(ipv4_addr)) {
     if (!cJSON_IsString(ipv4_addr) && !cJSON_IsNull(ipv4_addr)) {
         ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [ipv4_addr]");
         goto end;
     }
     }
+    }
 
     ip_domain = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "ipDomain");
     if (ip_domain) {
+    if (!cJSON_IsNull(ip_domain)) {
     if (!cJSON_IsString(ip_domain) && !cJSON_IsNull(ip_domain)) {
         ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [ip_domain]");
         goto end;
     }
     }
+    }
 
     ipv6_prefix = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "ipv6Prefix");
     if (ipv6_prefix) {
+    if (!cJSON_IsNull(ipv6_prefix)) {
     if (!cJSON_IsString(ipv6_prefix) && !cJSON_IsNull(ipv6_prefix)) {
         ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [ipv6_prefix]");
         goto end;
     }
     }
+    }
 
     add_ipv6_prefixes = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "addIpv6Prefixes");
     if (add_ipv6_prefixes) {
+    if (!cJSON_IsNull(add_ipv6_prefixes)) {
         cJSON *add_ipv6_prefixes_local = NULL;
         if (!cJSON_IsArray(add_ipv6_prefixes)) {
             ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [add_ipv6_prefixes]");
@@ -276,17 +325,21 @@ OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_parseFromJSON(cJSON *pcf_
             OpenAPI_list_add(add_ipv6_prefixesList, ogs_strdup(add_ipv6_prefixes_local->valuestring));
         }
     }
+    }
 
     mac_addr48 = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "macAddr48");
     if (mac_addr48) {
+    if (!cJSON_IsNull(mac_addr48)) {
     if (!cJSON_IsString(mac_addr48) && !cJSON_IsNull(mac_addr48)) {
         ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [mac_addr48]");
         goto end;
     }
     }
+    }
 
     add_mac_addrs = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "addMacAddrs");
     if (add_mac_addrs) {
+    if (!cJSON_IsNull(add_mac_addrs)) {
         cJSON *add_mac_addrs_local = NULL;
         if (!cJSON_IsArray(add_mac_addrs)) {
             ogs_error("OpenAPI_pcf_binding_patch_parseFromJSON() failed [add_mac_addrs]");
@@ -304,6 +357,7 @@ OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_parseFromJSON(cJSON *pcf_
             }
             OpenAPI_list_add(add_mac_addrsList, ogs_strdup(add_mac_addrs_local->valuestring));
         }
+    }
     }
 
     pcf_id = cJSON_GetObjectItemCaseSensitive(pcf_binding_patchJSON, "pcfId");
@@ -363,11 +417,17 @@ OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_parseFromJSON(cJSON *pcf_
     }
 
     pcf_binding_patch_local_var = OpenAPI_pcf_binding_patch_create (
+        ipv4_addr && cJSON_IsNull(ipv4_addr) ? true : false,
         ipv4_addr && !cJSON_IsNull(ipv4_addr) ? ogs_strdup(ipv4_addr->valuestring) : NULL,
+        ip_domain && cJSON_IsNull(ip_domain) ? true : false,
         ip_domain && !cJSON_IsNull(ip_domain) ? ogs_strdup(ip_domain->valuestring) : NULL,
+        ipv6_prefix && cJSON_IsNull(ipv6_prefix) ? true : false,
         ipv6_prefix && !cJSON_IsNull(ipv6_prefix) ? ogs_strdup(ipv6_prefix->valuestring) : NULL,
+        add_ipv6_prefixes && cJSON_IsNull(add_ipv6_prefixes) ? true : false,
         add_ipv6_prefixes ? add_ipv6_prefixesList : NULL,
+        mac_addr48 && cJSON_IsNull(mac_addr48) ? true : false,
         mac_addr48 && !cJSON_IsNull(mac_addr48) ? ogs_strdup(mac_addr48->valuestring) : NULL,
+        add_mac_addrs && cJSON_IsNull(add_mac_addrs) ? true : false,
         add_mac_addrs ? add_mac_addrsList : NULL,
         pcf_id && !cJSON_IsNull(pcf_id) ? ogs_strdup(pcf_id->valuestring) : NULL,
         pcf_fqdn && !cJSON_IsNull(pcf_fqdn) ? ogs_strdup(pcf_fqdn->valuestring) : NULL,

--- a/lib/sbi/openapi/model/pcf_binding_patch.h
+++ b/lib/sbi/openapi/model/pcf_binding_patch.h
@@ -20,11 +20,17 @@ extern "C" {
 
 typedef struct OpenAPI_pcf_binding_patch_s OpenAPI_pcf_binding_patch_t;
 typedef struct OpenAPI_pcf_binding_patch_s {
+    bool is_ipv4_addr_null;
     char *ipv4_addr;
+    bool is_ip_domain_null;
     char *ip_domain;
+    bool is_ipv6_prefix_null;
     char *ipv6_prefix;
+    bool is_add_ipv6_prefixes_null;
     OpenAPI_list_t *add_ipv6_prefixes;
+    bool is_mac_addr48_null;
     char *mac_addr48;
+    bool is_add_mac_addrs_null;
     OpenAPI_list_t *add_mac_addrs;
     char *pcf_id;
     char *pcf_fqdn;
@@ -34,11 +40,17 @@ typedef struct OpenAPI_pcf_binding_patch_s {
 } OpenAPI_pcf_binding_patch_t;
 
 OpenAPI_pcf_binding_patch_t *OpenAPI_pcf_binding_patch_create(
+    bool is_ipv4_addr_null,
     char *ipv4_addr,
+    bool is_ip_domain_null,
     char *ip_domain,
+    bool is_ipv6_prefix_null,
     char *ipv6_prefix,
+    bool is_add_ipv6_prefixes_null,
     OpenAPI_list_t *add_ipv6_prefixes,
+    bool is_mac_addr48_null,
     char *mac_addr48,
+    bool is_add_mac_addrs_null,
     OpenAPI_list_t *add_mac_addrs,
     char *pcf_id,
     char *pcf_fqdn,

--- a/lib/sbi/openapi/model/pcf_for_pdu_session_info.c
+++ b/lib/sbi/openapi/model/pcf_for_pdu_session_info.c
@@ -9,6 +9,7 @@ OpenAPI_pcf_for_pdu_session_info_t *OpenAPI_pcf_for_pdu_session_info_create(
     OpenAPI_snssai_t *snssai,
     char *pcf_fqdn,
     OpenAPI_list_t *pcf_ip_end_points,
+    bool is_ipv4_addr_null,
     char *ipv4_addr,
     char *ip_domain,
     OpenAPI_list_t *ipv6_prefixes,
@@ -25,6 +26,7 @@ OpenAPI_pcf_for_pdu_session_info_t *OpenAPI_pcf_for_pdu_session_info_create(
     pcf_for_pdu_session_info_local_var->snssai = snssai;
     pcf_for_pdu_session_info_local_var->pcf_fqdn = pcf_fqdn;
     pcf_for_pdu_session_info_local_var->pcf_ip_end_points = pcf_ip_end_points;
+    pcf_for_pdu_session_info_local_var->is_ipv4_addr_null = is_ipv4_addr_null;
     pcf_for_pdu_session_info_local_var->ipv4_addr = ipv4_addr;
     pcf_for_pdu_session_info_local_var->ip_domain = ip_domain;
     pcf_for_pdu_session_info_local_var->ipv6_prefixes = ipv6_prefixes;
@@ -158,6 +160,11 @@ cJSON *OpenAPI_pcf_for_pdu_session_info_convertToJSON(OpenAPI_pcf_for_pdu_sessio
         ogs_error("OpenAPI_pcf_for_pdu_session_info_convertToJSON() failed [ipv4_addr]");
         goto end;
     }
+    } else if (pcf_for_pdu_session_info->is_ipv4_addr_null) {
+        if (cJSON_AddNullToObject(item, "ipv4Addr") == NULL) {
+            ogs_error("OpenAPI_pcf_for_pdu_session_info_convertToJSON() failed [ipv4_addr]");
+            goto end;
+        }
     }
 
     if (pcf_for_pdu_session_info->ip_domain) {
@@ -295,9 +302,11 @@ OpenAPI_pcf_for_pdu_session_info_t *OpenAPI_pcf_for_pdu_session_info_parseFromJS
 
     ipv4_addr = cJSON_GetObjectItemCaseSensitive(pcf_for_pdu_session_infoJSON, "ipv4Addr");
     if (ipv4_addr) {
+    if (!cJSON_IsNull(ipv4_addr)) {
     if (!cJSON_IsString(ipv4_addr) && !cJSON_IsNull(ipv4_addr)) {
         ogs_error("OpenAPI_pcf_for_pdu_session_info_parseFromJSON() failed [ipv4_addr]");
         goto end;
+    }
     }
     }
 
@@ -381,6 +390,7 @@ OpenAPI_pcf_for_pdu_session_info_t *OpenAPI_pcf_for_pdu_session_info_parseFromJS
         snssai_local_nonprim,
         pcf_fqdn && !cJSON_IsNull(pcf_fqdn) ? ogs_strdup(pcf_fqdn->valuestring) : NULL,
         pcf_ip_end_points ? pcf_ip_end_pointsList : NULL,
+        ipv4_addr && cJSON_IsNull(ipv4_addr) ? true : false,
         ipv4_addr && !cJSON_IsNull(ipv4_addr) ? ogs_strdup(ipv4_addr->valuestring) : NULL,
         ip_domain && !cJSON_IsNull(ip_domain) ? ogs_strdup(ip_domain->valuestring) : NULL,
         ipv6_prefixes ? ipv6_prefixesList : NULL,

--- a/lib/sbi/openapi/model/pcf_for_pdu_session_info.h
+++ b/lib/sbi/openapi/model/pcf_for_pdu_session_info.h
@@ -26,6 +26,7 @@ typedef struct OpenAPI_pcf_for_pdu_session_info_s {
     struct OpenAPI_snssai_s *snssai;
     char *pcf_fqdn;
     OpenAPI_list_t *pcf_ip_end_points;
+    bool is_ipv4_addr_null;
     char *ipv4_addr;
     char *ip_domain;
     OpenAPI_list_t *ipv6_prefixes;
@@ -40,6 +41,7 @@ OpenAPI_pcf_for_pdu_session_info_t *OpenAPI_pcf_for_pdu_session_info_create(
     OpenAPI_snssai_t *snssai,
     char *pcf_fqdn,
     OpenAPI_list_t *pcf_ip_end_points,
+    bool is_ipv4_addr_null,
     char *ipv4_addr,
     char *ip_domain,
     OpenAPI_list_t *ipv6_prefixes,

--- a/lib/sbi/openapi/model/pdu_session_create_data.c
+++ b/lib/sbi/openapi/model/pdu_session_create_data.c
@@ -87,6 +87,7 @@ OpenAPI_pdu_session_create_data_t *OpenAPI_pdu_session_create_data_create(
     char *old_pdu_session_ref,
     bool is_sm_policy_notify_ind,
     int sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat,
     bool is_upip_supported,
@@ -181,6 +182,7 @@ OpenAPI_pdu_session_create_data_t *OpenAPI_pdu_session_create_data_create(
     pdu_session_create_data_local_var->old_pdu_session_ref = old_pdu_session_ref;
     pdu_session_create_data_local_var->is_sm_policy_notify_ind = is_sm_policy_notify_ind;
     pdu_session_create_data_local_var->sm_policy_notify_ind = sm_policy_notify_ind;
+    pdu_session_create_data_local_var->is_pcf_ue_callback_info_null = is_pcf_ue_callback_info_null;
     pdu_session_create_data_local_var->pcf_ue_callback_info = pcf_ue_callback_info;
     pdu_session_create_data_local_var->satellite_backhaul_cat = satellite_backhaul_cat;
     pdu_session_create_data_local_var->is_upip_supported = is_upip_supported;
@@ -1049,6 +1051,11 @@ cJSON *OpenAPI_pdu_session_create_data_convertToJSON(OpenAPI_pdu_session_create_
         ogs_error("OpenAPI_pdu_session_create_data_convertToJSON() failed [pcf_ue_callback_info]");
         goto end;
     }
+    } else if (pdu_session_create_data->is_pcf_ue_callback_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeCallbackInfo") == NULL) {
+            ogs_error("OpenAPI_pdu_session_create_data_convertToJSON() failed [pcf_ue_callback_info]");
+            goto end;
+        }
     }
 
     if (pdu_session_create_data->satellite_backhaul_cat != OpenAPI_satellite_backhaul_category_NULL) {
@@ -1829,10 +1836,12 @@ OpenAPI_pdu_session_create_data_t *OpenAPI_pdu_session_create_data_parseFromJSON
 
     pcf_ue_callback_info = cJSON_GetObjectItemCaseSensitive(pdu_session_create_dataJSON, "pcfUeCallbackInfo");
     if (pcf_ue_callback_info) {
+    if (!cJSON_IsNull(pcf_ue_callback_info)) {
     pcf_ue_callback_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_callback_info);
     if (!pcf_ue_callback_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_callback_info]");
         goto end;
+    }
     }
     }
 
@@ -1953,6 +1962,7 @@ OpenAPI_pdu_session_create_data_t *OpenAPI_pdu_session_create_data_parseFromJSON
         old_pdu_session_ref && !cJSON_IsNull(old_pdu_session_ref) ? ogs_strdup(old_pdu_session_ref->valuestring) : NULL,
         sm_policy_notify_ind ? true : false,
         sm_policy_notify_ind ? sm_policy_notify_ind->valueint : 0,
+        pcf_ue_callback_info && cJSON_IsNull(pcf_ue_callback_info) ? true : false,
         pcf_ue_callback_info ? pcf_ue_callback_info_local_nonprim : NULL,
         satellite_backhaul_cat ? satellite_backhaul_catVariable : 0,
         upip_supported ? true : false,

--- a/lib/sbi/openapi/model/pdu_session_create_data.h
+++ b/lib/sbi/openapi/model/pdu_session_create_data.h
@@ -124,6 +124,7 @@ typedef struct OpenAPI_pdu_session_create_data_s {
     char *old_pdu_session_ref;
     bool is_sm_policy_notify_ind;
     int sm_policy_notify_ind;
+    bool is_pcf_ue_callback_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_callback_info;
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat;
     bool is_upip_supported;
@@ -216,6 +217,7 @@ OpenAPI_pdu_session_create_data_t *OpenAPI_pdu_session_create_data_create(
     char *old_pdu_session_ref,
     bool is_sm_policy_notify_ind,
     int sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat,
     bool is_upip_supported,

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -13,13 +13,17 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_create(
     int rfsp,
     bool is_target_rfsp,
     int target_rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
     OpenAPI_list_t* pras,
     char *supp_feat,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_match_pdus_null,
     OpenAPI_list_t *match_pdus,
+    bool is_as_time_dis_param_null,
     OpenAPI_as_time_distribution_param_t *as_time_dis_param
 )
 {
@@ -34,13 +38,17 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_create(
     policy_association_local_var->rfsp = rfsp;
     policy_association_local_var->is_target_rfsp = is_target_rfsp;
     policy_association_local_var->target_rfsp = target_rfsp;
+    policy_association_local_var->is_smf_sel_info_null = is_smf_sel_info_null;
     policy_association_local_var->smf_sel_info = smf_sel_info;
     policy_association_local_var->ue_ambr = ue_ambr;
     policy_association_local_var->ue_slice_mbrs = ue_slice_mbrs;
     policy_association_local_var->pras = pras;
     policy_association_local_var->supp_feat = supp_feat;
+    policy_association_local_var->is_pcf_ue_info_null = is_pcf_ue_info_null;
     policy_association_local_var->pcf_ue_info = pcf_ue_info;
+    policy_association_local_var->is_match_pdus_null = is_match_pdus_null;
     policy_association_local_var->match_pdus = match_pdus;
+    policy_association_local_var->is_as_time_dis_param_null = is_as_time_dis_param_null;
     policy_association_local_var->as_time_dis_param = as_time_dis_param;
 
     return policy_association_local_var;
@@ -205,6 +213,11 @@ cJSON *OpenAPI_policy_association_convertToJSON(OpenAPI_policy_association_t *po
         ogs_error("OpenAPI_policy_association_convertToJSON() failed [smf_sel_info]");
         goto end;
     }
+    } else if (policy_association->is_smf_sel_info_null) {
+        if (cJSON_AddNullToObject(item, "smfSelInfo") == NULL) {
+            ogs_error("OpenAPI_policy_association_convertToJSON() failed [smf_sel_info]");
+            goto end;
+        }
     }
 
     if (policy_association->ue_ambr) {
@@ -286,6 +299,11 @@ cJSON *OpenAPI_policy_association_convertToJSON(OpenAPI_policy_association_t *po
         ogs_error("OpenAPI_policy_association_convertToJSON() failed [pcf_ue_info]");
         goto end;
     }
+    } else if (policy_association->is_pcf_ue_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeInfo") == NULL) {
+            ogs_error("OpenAPI_policy_association_convertToJSON() failed [pcf_ue_info]");
+            goto end;
+        }
     }
 
     if (policy_association->match_pdus) {
@@ -302,6 +320,11 @@ cJSON *OpenAPI_policy_association_convertToJSON(OpenAPI_policy_association_t *po
         }
         cJSON_AddItemToArray(match_pdusList, itemLocal);
     }
+    } else if (policy_association->is_match_pdus_null) {
+        if (cJSON_AddNullToObject(item, "matchPdus") == NULL) {
+            ogs_error("OpenAPI_policy_association_convertToJSON() failed [match_pdus]");
+            goto end;
+        }
     }
 
     if (policy_association->as_time_dis_param) {
@@ -315,6 +338,11 @@ cJSON *OpenAPI_policy_association_convertToJSON(OpenAPI_policy_association_t *po
         ogs_error("OpenAPI_policy_association_convertToJSON() failed [as_time_dis_param]");
         goto end;
     }
+    } else if (policy_association->is_as_time_dis_param_null) {
+        if (cJSON_AddNullToObject(item, "asTimeDisParam") == NULL) {
+            ogs_error("OpenAPI_policy_association_convertToJSON() failed [as_time_dis_param]");
+            goto end;
+        }
     }
 
 end:
@@ -420,10 +448,12 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
 
     smf_sel_info = cJSON_GetObjectItemCaseSensitive(policy_associationJSON, "smfSelInfo");
     if (smf_sel_info) {
+    if (!cJSON_IsNull(smf_sel_info)) {
     smf_sel_info_local_nonprim = OpenAPI_smf_selection_data_parseFromJSON(smf_sel_info);
     if (!smf_sel_info_local_nonprim) {
         ogs_error("OpenAPI_smf_selection_data_parseFromJSON failed [smf_sel_info]");
         goto end;
+    }
     }
     }
 
@@ -498,15 +528,18 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
 
     pcf_ue_info = cJSON_GetObjectItemCaseSensitive(policy_associationJSON, "pcfUeInfo");
     if (pcf_ue_info) {
+    if (!cJSON_IsNull(pcf_ue_info)) {
     pcf_ue_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_info);
     if (!pcf_ue_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_info]");
         goto end;
     }
     }
+    }
 
     match_pdus = cJSON_GetObjectItemCaseSensitive(policy_associationJSON, "matchPdus");
     if (match_pdus) {
+    if (!cJSON_IsNull(match_pdus)) {
         cJSON *match_pdus_local = NULL;
         if (!cJSON_IsArray(match_pdus)) {
             ogs_error("OpenAPI_policy_association_parseFromJSON() failed [match_pdus]");
@@ -528,13 +561,16 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
             OpenAPI_list_add(match_pdusList, match_pdusItem);
         }
     }
+    }
 
     as_time_dis_param = cJSON_GetObjectItemCaseSensitive(policy_associationJSON, "asTimeDisParam");
     if (as_time_dis_param) {
+    if (!cJSON_IsNull(as_time_dis_param)) {
     as_time_dis_param_local_nonprim = OpenAPI_as_time_distribution_param_parseFromJSON(as_time_dis_param);
     if (!as_time_dis_param_local_nonprim) {
         ogs_error("OpenAPI_as_time_distribution_param_parseFromJSON failed [as_time_dis_param]");
         goto end;
+    }
     }
     }
 
@@ -547,13 +583,17 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
         rfsp ? rfsp->valuedouble : 0,
         target_rfsp ? true : false,
         target_rfsp ? target_rfsp->valuedouble : 0,
+        smf_sel_info && cJSON_IsNull(smf_sel_info) ? true : false,
         smf_sel_info ? smf_sel_info_local_nonprim : NULL,
         ue_ambr ? ue_ambr_local_nonprim : NULL,
         ue_slice_mbrs ? ue_slice_mbrsList : NULL,
         pras ? prasList : NULL,
         ogs_strdup(supp_feat->valuestring),
+        pcf_ue_info && cJSON_IsNull(pcf_ue_info) ? true : false,
         pcf_ue_info ? pcf_ue_info_local_nonprim : NULL,
+        match_pdus && cJSON_IsNull(match_pdus) ? true : false,
         match_pdus ? match_pdusList : NULL,
+        as_time_dis_param && cJSON_IsNull(as_time_dis_param) ? true : false,
         as_time_dis_param ? as_time_dis_param_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/policy_association.h
+++ b/lib/sbi/openapi/model/policy_association.h
@@ -38,13 +38,17 @@ typedef struct OpenAPI_policy_association_s {
     int rfsp;
     bool is_target_rfsp;
     int target_rfsp;
+    bool is_smf_sel_info_null;
     struct OpenAPI_smf_selection_data_s *smf_sel_info;
     struct OpenAPI_ambr_s *ue_ambr;
     OpenAPI_list_t *ue_slice_mbrs;
     OpenAPI_list_t* pras;
     char *supp_feat;
+    bool is_pcf_ue_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_info;
+    bool is_match_pdus_null;
     OpenAPI_list_t *match_pdus;
+    bool is_as_time_dis_param_null;
     struct OpenAPI_as_time_distribution_param_s *as_time_dis_param;
 } OpenAPI_policy_association_t;
 
@@ -57,13 +61,17 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_create(
     int rfsp,
     bool is_target_rfsp,
     int target_rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
     OpenAPI_list_t* pras,
     char *supp_feat,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_match_pdus_null,
     OpenAPI_list_t *match_pdus,
+    bool is_as_time_dis_param_null,
     OpenAPI_as_time_distribution_param_t *as_time_dis_param
 );
 void OpenAPI_policy_association_free(OpenAPI_policy_association_t *policy_association);

--- a/lib/sbi/openapi/model/policy_association_request.h
+++ b/lib/sbi/openapi/model/policy_association_request.h
@@ -59,6 +59,7 @@ typedef struct OpenAPI_policy_association_request_s {
     OpenAPI_list_t *n3g_allowed_snssais;
     struct OpenAPI_guami_s *guami;
     char *service_name;
+    bool is_trace_req_null;
     struct OpenAPI_trace_data_s *trace_req;
     OpenAPI_list_t *nwdaf_datas;
     char *supp_feat;
@@ -92,6 +93,7 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_create(
     OpenAPI_list_t *n3g_allowed_snssais,
     OpenAPI_guami_t *guami,
     char *service_name,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_list_t *nwdaf_datas,
     char *supp_feat

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -14,6 +14,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     OpenAPI_wireline_service_area_restriction_t *wl_serv_area_res,
     bool is_rfsp,
     int rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
@@ -25,8 +26,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     OpenAPI_list_t *access_types,
     OpenAPI_list_t *rat_types,
     OpenAPI_list_t *n3g_allowed_snssais,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_guami_t *guami,
+    bool is_nwdaf_datas_null,
     OpenAPI_list_t *nwdaf_datas
 )
 {
@@ -42,6 +45,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     policy_association_update_request_local_var->wl_serv_area_res = wl_serv_area_res;
     policy_association_update_request_local_var->is_rfsp = is_rfsp;
     policy_association_update_request_local_var->rfsp = rfsp;
+    policy_association_update_request_local_var->is_smf_sel_info_null = is_smf_sel_info_null;
     policy_association_update_request_local_var->smf_sel_info = smf_sel_info;
     policy_association_update_request_local_var->ue_ambr = ue_ambr;
     policy_association_update_request_local_var->ue_slice_mbrs = ue_slice_mbrs;
@@ -53,8 +57,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     policy_association_update_request_local_var->access_types = access_types;
     policy_association_update_request_local_var->rat_types = rat_types;
     policy_association_update_request_local_var->n3g_allowed_snssais = n3g_allowed_snssais;
+    policy_association_update_request_local_var->is_trace_req_null = is_trace_req_null;
     policy_association_update_request_local_var->trace_req = trace_req;
     policy_association_update_request_local_var->guami = guami;
+    policy_association_update_request_local_var->is_nwdaf_datas_null = is_nwdaf_datas_null;
     policy_association_update_request_local_var->nwdaf_datas = nwdaf_datas;
 
     return policy_association_update_request_local_var;
@@ -305,6 +311,11 @@ cJSON *OpenAPI_policy_association_update_request_convertToJSON(OpenAPI_policy_as
         ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [smf_sel_info]");
         goto end;
     }
+    } else if (policy_association_update_request->is_smf_sel_info_null) {
+        if (cJSON_AddNullToObject(item, "smfSelInfo") == NULL) {
+            ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [smf_sel_info]");
+            goto end;
+        }
     }
 
     if (policy_association_update_request->ue_ambr) {
@@ -482,6 +493,11 @@ cJSON *OpenAPI_policy_association_update_request_convertToJSON(OpenAPI_policy_as
         ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [trace_req]");
         goto end;
     }
+    } else if (policy_association_update_request->is_trace_req_null) {
+        if (cJSON_AddNullToObject(item, "traceReq") == NULL) {
+            ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [trace_req]");
+            goto end;
+        }
     }
 
     if (policy_association_update_request->guami) {
@@ -511,6 +527,11 @@ cJSON *OpenAPI_policy_association_update_request_convertToJSON(OpenAPI_policy_as
         }
         cJSON_AddItemToArray(nwdaf_datasList, itemLocal);
     }
+    } else if (policy_association_update_request->is_nwdaf_datas_null) {
+        if (cJSON_AddNullToObject(item, "nwdafDatas") == NULL) {
+            ogs_error("OpenAPI_policy_association_update_request_convertToJSON() failed [nwdaf_datas]");
+            goto end;
+        }
     }
 
 end:
@@ -687,10 +708,12 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
 
     smf_sel_info = cJSON_GetObjectItemCaseSensitive(policy_association_update_requestJSON, "smfSelInfo");
     if (smf_sel_info) {
+    if (!cJSON_IsNull(smf_sel_info)) {
     smf_sel_info_local_nonprim = OpenAPI_smf_selection_data_parseFromJSON(smf_sel_info);
     if (!smf_sel_info_local_nonprim) {
         ogs_error("OpenAPI_smf_selection_data_parseFromJSON failed [smf_sel_info]");
         goto end;
+    }
     }
     }
 
@@ -910,10 +933,12 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
 
     trace_req = cJSON_GetObjectItemCaseSensitive(policy_association_update_requestJSON, "traceReq");
     if (trace_req) {
+    if (!cJSON_IsNull(trace_req)) {
     trace_req_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_req);
     if (!trace_req_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_req]");
         goto end;
+    }
     }
     }
 
@@ -928,6 +953,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
 
     nwdaf_datas = cJSON_GetObjectItemCaseSensitive(policy_association_update_requestJSON, "nwdafDatas");
     if (nwdaf_datas) {
+    if (!cJSON_IsNull(nwdaf_datas)) {
         cJSON *nwdaf_datas_local = NULL;
         if (!cJSON_IsArray(nwdaf_datas)) {
             ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [nwdaf_datas]");
@@ -949,6 +975,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
             OpenAPI_list_add(nwdaf_datasList, nwdaf_datasItem);
         }
     }
+    }
 
     policy_association_update_request_local_var = OpenAPI_policy_association_update_request_create (
         notification_uri && !cJSON_IsNull(notification_uri) ? ogs_strdup(notification_uri->valuestring) : NULL,
@@ -960,6 +987,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
         wl_serv_area_res ? wl_serv_area_res_local_nonprim : NULL,
         rfsp ? true : false,
         rfsp ? rfsp->valuedouble : 0,
+        smf_sel_info && cJSON_IsNull(smf_sel_info) ? true : false,
         smf_sel_info ? smf_sel_info_local_nonprim : NULL,
         ue_ambr ? ue_ambr_local_nonprim : NULL,
         ue_slice_mbrs ? ue_slice_mbrsList : NULL,
@@ -971,8 +999,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
         access_types ? access_typesList : NULL,
         rat_types ? rat_typesList : NULL,
         n3g_allowed_snssais ? n3g_allowed_snssaisList : NULL,
+        trace_req && cJSON_IsNull(trace_req) ? true : false,
         trace_req ? trace_req_local_nonprim : NULL,
         guami ? guami_local_nonprim : NULL,
+        nwdaf_datas && cJSON_IsNull(nwdaf_datas) ? true : false,
         nwdaf_datas ? nwdaf_datasList : NULL
     );
 

--- a/lib/sbi/openapi/model/policy_association_update_request.h
+++ b/lib/sbi/openapi/model/policy_association_update_request.h
@@ -43,6 +43,7 @@ typedef struct OpenAPI_policy_association_update_request_s {
     struct OpenAPI_wireline_service_area_restriction_s *wl_serv_area_res;
     bool is_rfsp;
     int rfsp;
+    bool is_smf_sel_info_null;
     struct OpenAPI_smf_selection_data_s *smf_sel_info;
     struct OpenAPI_ambr_s *ue_ambr;
     OpenAPI_list_t *ue_slice_mbrs;
@@ -54,8 +55,10 @@ typedef struct OpenAPI_policy_association_update_request_s {
     OpenAPI_list_t *access_types;
     OpenAPI_list_t *rat_types;
     OpenAPI_list_t *n3g_allowed_snssais;
+    bool is_trace_req_null;
     struct OpenAPI_trace_data_s *trace_req;
     struct OpenAPI_guami_s *guami;
+    bool is_nwdaf_datas_null;
     OpenAPI_list_t *nwdaf_datas;
 } OpenAPI_policy_association_update_request_t;
 
@@ -69,6 +72,7 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     OpenAPI_wireline_service_area_restriction_t *wl_serv_area_res,
     bool is_rfsp,
     int rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
@@ -80,8 +84,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
     OpenAPI_list_t *access_types,
     OpenAPI_list_t *rat_types,
     OpenAPI_list_t *n3g_allowed_snssais,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_guami_t *guami,
+    bool is_nwdaf_datas_null,
     OpenAPI_list_t *nwdaf_datas
 );
 void OpenAPI_policy_association_update_request_free(OpenAPI_policy_association_update_request_t *policy_association_update_request);

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -6,6 +6,7 @@
 
 OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     char *resource_uri,
+    bool is_triggers_null,
     OpenAPI_list_t *triggers,
     OpenAPI_service_area_restriction_t *serv_area_res,
     OpenAPI_wireline_service_area_restriction_t *wl_serv_area_res,
@@ -13,12 +14,17 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     int rfsp,
     bool is_target_rfsp,
     int target_rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
+    bool is_pras_null,
     OpenAPI_list_t* pras,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_match_pdus_null,
     OpenAPI_list_t *match_pdus,
+    bool is_as_time_dis_param_null,
     OpenAPI_as_time_distribution_param_t *as_time_dis_param
 )
 {
@@ -26,6 +32,7 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     ogs_assert(policy_update_local_var);
 
     policy_update_local_var->resource_uri = resource_uri;
+    policy_update_local_var->is_triggers_null = is_triggers_null;
     policy_update_local_var->triggers = triggers;
     policy_update_local_var->serv_area_res = serv_area_res;
     policy_update_local_var->wl_serv_area_res = wl_serv_area_res;
@@ -33,12 +40,17 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     policy_update_local_var->rfsp = rfsp;
     policy_update_local_var->is_target_rfsp = is_target_rfsp;
     policy_update_local_var->target_rfsp = target_rfsp;
+    policy_update_local_var->is_smf_sel_info_null = is_smf_sel_info_null;
     policy_update_local_var->smf_sel_info = smf_sel_info;
     policy_update_local_var->ue_ambr = ue_ambr;
     policy_update_local_var->ue_slice_mbrs = ue_slice_mbrs;
+    policy_update_local_var->is_pras_null = is_pras_null;
     policy_update_local_var->pras = pras;
+    policy_update_local_var->is_pcf_ue_info_null = is_pcf_ue_info_null;
     policy_update_local_var->pcf_ue_info = pcf_ue_info;
+    policy_update_local_var->is_match_pdus_null = is_match_pdus_null;
     policy_update_local_var->match_pdus = match_pdus;
+    policy_update_local_var->is_as_time_dis_param_null = is_as_time_dis_param_null;
     policy_update_local_var->as_time_dis_param = as_time_dis_param;
 
     return policy_update_local_var;
@@ -142,6 +154,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
             goto end;
         }
     }
+    } else if (policy_update->is_triggers_null) {
+        if (cJSON_AddNullToObject(item, "triggers") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [triggers]");
+            goto end;
+        }
     }
 
     if (policy_update->serv_area_res) {
@@ -195,6 +212,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
         ogs_error("OpenAPI_policy_update_convertToJSON() failed [smf_sel_info]");
         goto end;
     }
+    } else if (policy_update->is_smf_sel_info_null) {
+        if (cJSON_AddNullToObject(item, "smfSelInfo") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [smf_sel_info]");
+            goto end;
+        }
     }
 
     if (policy_update->ue_ambr) {
@@ -254,6 +276,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (policy_update->is_pras_null) {
+        if (cJSON_AddNullToObject(item, "pras") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [pras]");
+            goto end;
+        }
     }
 
     if (policy_update->pcf_ue_info) {
@@ -267,6 +294,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
         ogs_error("OpenAPI_policy_update_convertToJSON() failed [pcf_ue_info]");
         goto end;
     }
+    } else if (policy_update->is_pcf_ue_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeInfo") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [pcf_ue_info]");
+            goto end;
+        }
     }
 
     if (policy_update->match_pdus) {
@@ -283,6 +315,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
         }
         cJSON_AddItemToArray(match_pdusList, itemLocal);
     }
+    } else if (policy_update->is_match_pdus_null) {
+        if (cJSON_AddNullToObject(item, "matchPdus") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [match_pdus]");
+            goto end;
+        }
     }
 
     if (policy_update->as_time_dis_param) {
@@ -296,6 +333,11 @@ cJSON *OpenAPI_policy_update_convertToJSON(OpenAPI_policy_update_t *policy_updat
         ogs_error("OpenAPI_policy_update_convertToJSON() failed [as_time_dis_param]");
         goto end;
     }
+    } else if (policy_update->is_as_time_dis_param_null) {
+        if (cJSON_AddNullToObject(item, "asTimeDisParam") == NULL) {
+            ogs_error("OpenAPI_policy_update_convertToJSON() failed [as_time_dis_param]");
+            goto end;
+        }
     }
 
 end:
@@ -341,6 +383,7 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
 
     triggers = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "triggers");
     if (triggers) {
+    if (!cJSON_IsNull(triggers)) {
         cJSON *triggers_local = NULL;
         if (!cJSON_IsArray(triggers)) {
             ogs_error("OpenAPI_policy_update_parseFromJSON() failed [triggers]");
@@ -362,6 +405,7 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
             }
             OpenAPI_list_add(triggersList, (void *)localEnum);
         }
+    }
     }
 
     serv_area_res = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "servAreaRes");
@@ -400,10 +444,12 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
 
     smf_sel_info = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "smfSelInfo");
     if (smf_sel_info) {
+    if (!cJSON_IsNull(smf_sel_info)) {
     smf_sel_info_local_nonprim = OpenAPI_smf_selection_data_parseFromJSON(smf_sel_info);
     if (!smf_sel_info_local_nonprim) {
         ogs_error("OpenAPI_smf_selection_data_parseFromJSON failed [smf_sel_info]");
         goto end;
+    }
     }
     }
 
@@ -442,6 +488,7 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
 
     pras = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "pras");
     if (pras) {
+    if (!cJSON_IsNull(pras)) {
         cJSON *pras_local_map = NULL;
         if (!cJSON_IsObject(pras) && !cJSON_IsNull(pras)) {
             ogs_error("OpenAPI_policy_update_parseFromJSON() failed [pras]");
@@ -465,18 +512,22 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
             }
         }
     }
+    }
 
     pcf_ue_info = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "pcfUeInfo");
     if (pcf_ue_info) {
+    if (!cJSON_IsNull(pcf_ue_info)) {
     pcf_ue_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_info);
     if (!pcf_ue_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_info]");
         goto end;
     }
     }
+    }
 
     match_pdus = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "matchPdus");
     if (match_pdus) {
+    if (!cJSON_IsNull(match_pdus)) {
         cJSON *match_pdus_local = NULL;
         if (!cJSON_IsArray(match_pdus)) {
             ogs_error("OpenAPI_policy_update_parseFromJSON() failed [match_pdus]");
@@ -498,18 +549,22 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
             OpenAPI_list_add(match_pdusList, match_pdusItem);
         }
     }
+    }
 
     as_time_dis_param = cJSON_GetObjectItemCaseSensitive(policy_updateJSON, "asTimeDisParam");
     if (as_time_dis_param) {
+    if (!cJSON_IsNull(as_time_dis_param)) {
     as_time_dis_param_local_nonprim = OpenAPI_as_time_distribution_param_parseFromJSON(as_time_dis_param);
     if (!as_time_dis_param_local_nonprim) {
         ogs_error("OpenAPI_as_time_distribution_param_parseFromJSON failed [as_time_dis_param]");
         goto end;
     }
     }
+    }
 
     policy_update_local_var = OpenAPI_policy_update_create (
         ogs_strdup(resource_uri->valuestring),
+        triggers && cJSON_IsNull(triggers) ? true : false,
         triggers ? triggersList : NULL,
         serv_area_res ? serv_area_res_local_nonprim : NULL,
         wl_serv_area_res ? wl_serv_area_res_local_nonprim : NULL,
@@ -517,12 +572,17 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
         rfsp ? rfsp->valuedouble : 0,
         target_rfsp ? true : false,
         target_rfsp ? target_rfsp->valuedouble : 0,
+        smf_sel_info && cJSON_IsNull(smf_sel_info) ? true : false,
         smf_sel_info ? smf_sel_info_local_nonprim : NULL,
         ue_ambr ? ue_ambr_local_nonprim : NULL,
         ue_slice_mbrs ? ue_slice_mbrsList : NULL,
+        pras && cJSON_IsNull(pras) ? true : false,
         pras ? prasList : NULL,
+        pcf_ue_info && cJSON_IsNull(pcf_ue_info) ? true : false,
         pcf_ue_info ? pcf_ue_info_local_nonprim : NULL,
+        match_pdus && cJSON_IsNull(match_pdus) ? true : false,
         match_pdus ? match_pdusList : NULL,
+        as_time_dis_param && cJSON_IsNull(as_time_dis_param) ? true : false,
         as_time_dis_param ? as_time_dis_param_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/policy_update.h
+++ b/lib/sbi/openapi/model/policy_update.h
@@ -30,6 +30,7 @@ extern "C" {
 typedef struct OpenAPI_policy_update_s OpenAPI_policy_update_t;
 typedef struct OpenAPI_policy_update_s {
     char *resource_uri;
+    bool is_triggers_null;
     OpenAPI_list_t *triggers;
     struct OpenAPI_service_area_restriction_s *serv_area_res;
     struct OpenAPI_wireline_service_area_restriction_s *wl_serv_area_res;
@@ -37,17 +38,23 @@ typedef struct OpenAPI_policy_update_s {
     int rfsp;
     bool is_target_rfsp;
     int target_rfsp;
+    bool is_smf_sel_info_null;
     struct OpenAPI_smf_selection_data_s *smf_sel_info;
     struct OpenAPI_ambr_s *ue_ambr;
     OpenAPI_list_t *ue_slice_mbrs;
+    bool is_pras_null;
     OpenAPI_list_t* pras;
+    bool is_pcf_ue_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_info;
+    bool is_match_pdus_null;
     OpenAPI_list_t *match_pdus;
+    bool is_as_time_dis_param_null;
     struct OpenAPI_as_time_distribution_param_s *as_time_dis_param;
 } OpenAPI_policy_update_t;
 
 OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     char *resource_uri,
+    bool is_triggers_null,
     OpenAPI_list_t *triggers,
     OpenAPI_service_area_restriction_t *serv_area_res,
     OpenAPI_wireline_service_area_restriction_t *wl_serv_area_res,
@@ -55,12 +62,17 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_create(
     int rfsp,
     bool is_target_rfsp,
     int target_rfsp,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_ambr_t *ue_ambr,
     OpenAPI_list_t *ue_slice_mbrs,
+    bool is_pras_null,
     OpenAPI_list_t* pras,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_match_pdus_null,
     OpenAPI_list_t *match_pdus,
+    bool is_as_time_dis_param_null,
     OpenAPI_as_time_distribution_param_t *as_time_dis_param
 );
 void OpenAPI_policy_update_free(OpenAPI_policy_update_t *policy_update);

--- a/lib/sbi/openapi/model/pp_data.c
+++ b/lib/sbi/openapi/model/pp_data.c
@@ -5,28 +5,40 @@
 #include "pp_data.h"
 
 OpenAPI_pp_data_t *OpenAPI_pp_data_create(
+    bool is_communication_characteristics_null,
     OpenAPI_communication_characteristics_t *communication_characteristics,
     char *supported_features,
+    bool is_expected_ue_behaviour_parameters_null,
     OpenAPI_expected_ue_behaviour_t *expected_ue_behaviour_parameters,
+    bool is_ec_restriction_null,
     OpenAPI_ec_restriction_t *ec_restriction,
     OpenAPI_acs_info_rm_t *acs_info,
+    bool is_stn_sr_null,
     char *stn_sr,
+    bool is_lcs_privacy_null,
     OpenAPI_lcs_privacy_t *lcs_privacy,
     OpenAPI_sor_info_t *sor_info,
+    bool is__5mbs_authorization_info_null,
     OpenAPI_model_5_mbs_authorization_info_t *_5mbs_authorization_info
 )
 {
     OpenAPI_pp_data_t *pp_data_local_var = ogs_malloc(sizeof(OpenAPI_pp_data_t));
     ogs_assert(pp_data_local_var);
 
+    pp_data_local_var->is_communication_characteristics_null = is_communication_characteristics_null;
     pp_data_local_var->communication_characteristics = communication_characteristics;
     pp_data_local_var->supported_features = supported_features;
+    pp_data_local_var->is_expected_ue_behaviour_parameters_null = is_expected_ue_behaviour_parameters_null;
     pp_data_local_var->expected_ue_behaviour_parameters = expected_ue_behaviour_parameters;
+    pp_data_local_var->is_ec_restriction_null = is_ec_restriction_null;
     pp_data_local_var->ec_restriction = ec_restriction;
     pp_data_local_var->acs_info = acs_info;
+    pp_data_local_var->is_stn_sr_null = is_stn_sr_null;
     pp_data_local_var->stn_sr = stn_sr;
+    pp_data_local_var->is_lcs_privacy_null = is_lcs_privacy_null;
     pp_data_local_var->lcs_privacy = lcs_privacy;
     pp_data_local_var->sor_info = sor_info;
+    pp_data_local_var->is__5mbs_authorization_info_null = is__5mbs_authorization_info_null;
     pp_data_local_var->_5mbs_authorization_info = _5mbs_authorization_info;
 
     return pp_data_local_var;
@@ -100,6 +112,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [communication_characteristics]");
         goto end;
     }
+    } else if (pp_data->is_communication_characteristics_null) {
+        if (cJSON_AddNullToObject(item, "communicationCharacteristics") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [communication_characteristics]");
+            goto end;
+        }
     }
 
     if (pp_data->supported_features) {
@@ -120,6 +137,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [expected_ue_behaviour_parameters]");
         goto end;
     }
+    } else if (pp_data->is_expected_ue_behaviour_parameters_null) {
+        if (cJSON_AddNullToObject(item, "expectedUeBehaviourParameters") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [expected_ue_behaviour_parameters]");
+            goto end;
+        }
     }
 
     if (pp_data->ec_restriction) {
@@ -133,6 +155,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [ec_restriction]");
         goto end;
     }
+    } else if (pp_data->is_ec_restriction_null) {
+        if (cJSON_AddNullToObject(item, "ecRestriction") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [ec_restriction]");
+            goto end;
+        }
     }
 
     if (pp_data->acs_info) {
@@ -153,6 +180,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [stn_sr]");
         goto end;
     }
+    } else if (pp_data->is_stn_sr_null) {
+        if (cJSON_AddNullToObject(item, "stnSr") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [stn_sr]");
+            goto end;
+        }
     }
 
     if (pp_data->lcs_privacy) {
@@ -166,6 +198,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [lcs_privacy]");
         goto end;
     }
+    } else if (pp_data->is_lcs_privacy_null) {
+        if (cJSON_AddNullToObject(item, "lcsPrivacy") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [lcs_privacy]");
+            goto end;
+        }
     }
 
     if (pp_data->sor_info) {
@@ -192,6 +229,11 @@ cJSON *OpenAPI_pp_data_convertToJSON(OpenAPI_pp_data_t *pp_data)
         ogs_error("OpenAPI_pp_data_convertToJSON() failed [_5mbs_authorization_info]");
         goto end;
     }
+    } else if (pp_data->is__5mbs_authorization_info_null) {
+        if (cJSON_AddNullToObject(item, "5mbsAuthorizationInfo") == NULL) {
+            ogs_error("OpenAPI_pp_data_convertToJSON() failed [_5mbs_authorization_info]");
+            goto end;
+        }
     }
 
 end:
@@ -220,10 +262,12 @@ OpenAPI_pp_data_t *OpenAPI_pp_data_parseFromJSON(cJSON *pp_dataJSON)
     OpenAPI_model_5_mbs_authorization_info_t *_5mbs_authorization_info_local_nonprim = NULL;
     communication_characteristics = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "communicationCharacteristics");
     if (communication_characteristics) {
+    if (!cJSON_IsNull(communication_characteristics)) {
     communication_characteristics_local_nonprim = OpenAPI_communication_characteristics_parseFromJSON(communication_characteristics);
     if (!communication_characteristics_local_nonprim) {
         ogs_error("OpenAPI_communication_characteristics_parseFromJSON failed [communication_characteristics]");
         goto end;
+    }
     }
     }
 
@@ -237,19 +281,23 @@ OpenAPI_pp_data_t *OpenAPI_pp_data_parseFromJSON(cJSON *pp_dataJSON)
 
     expected_ue_behaviour_parameters = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "expectedUeBehaviourParameters");
     if (expected_ue_behaviour_parameters) {
+    if (!cJSON_IsNull(expected_ue_behaviour_parameters)) {
     expected_ue_behaviour_parameters_local_nonprim = OpenAPI_expected_ue_behaviour_parseFromJSON(expected_ue_behaviour_parameters);
     if (!expected_ue_behaviour_parameters_local_nonprim) {
         ogs_error("OpenAPI_expected_ue_behaviour_parseFromJSON failed [expected_ue_behaviour_parameters]");
         goto end;
     }
     }
+    }
 
     ec_restriction = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "ecRestriction");
     if (ec_restriction) {
+    if (!cJSON_IsNull(ec_restriction)) {
     ec_restriction_local_nonprim = OpenAPI_ec_restriction_parseFromJSON(ec_restriction);
     if (!ec_restriction_local_nonprim) {
         ogs_error("OpenAPI_ec_restriction_parseFromJSON failed [ec_restriction]");
         goto end;
+    }
     }
     }
 
@@ -264,18 +312,22 @@ OpenAPI_pp_data_t *OpenAPI_pp_data_parseFromJSON(cJSON *pp_dataJSON)
 
     stn_sr = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "stnSr");
     if (stn_sr) {
+    if (!cJSON_IsNull(stn_sr)) {
     if (!cJSON_IsString(stn_sr) && !cJSON_IsNull(stn_sr)) {
         ogs_error("OpenAPI_pp_data_parseFromJSON() failed [stn_sr]");
         goto end;
     }
     }
+    }
 
     lcs_privacy = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "lcsPrivacy");
     if (lcs_privacy) {
+    if (!cJSON_IsNull(lcs_privacy)) {
     lcs_privacy_local_nonprim = OpenAPI_lcs_privacy_parseFromJSON(lcs_privacy);
     if (!lcs_privacy_local_nonprim) {
         ogs_error("OpenAPI_lcs_privacy_parseFromJSON failed [lcs_privacy]");
         goto end;
+    }
     }
     }
 
@@ -290,22 +342,30 @@ OpenAPI_pp_data_t *OpenAPI_pp_data_parseFromJSON(cJSON *pp_dataJSON)
 
     _5mbs_authorization_info = cJSON_GetObjectItemCaseSensitive(pp_dataJSON, "5mbsAuthorizationInfo");
     if (_5mbs_authorization_info) {
+    if (!cJSON_IsNull(_5mbs_authorization_info)) {
     _5mbs_authorization_info_local_nonprim = OpenAPI_model_5_mbs_authorization_info_parseFromJSON(_5mbs_authorization_info);
     if (!_5mbs_authorization_info_local_nonprim) {
         ogs_error("OpenAPI_model_5_mbs_authorization_info_parseFromJSON failed [_5mbs_authorization_info]");
         goto end;
     }
     }
+    }
 
     pp_data_local_var = OpenAPI_pp_data_create (
+        communication_characteristics && cJSON_IsNull(communication_characteristics) ? true : false,
         communication_characteristics ? communication_characteristics_local_nonprim : NULL,
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL,
+        expected_ue_behaviour_parameters && cJSON_IsNull(expected_ue_behaviour_parameters) ? true : false,
         expected_ue_behaviour_parameters ? expected_ue_behaviour_parameters_local_nonprim : NULL,
+        ec_restriction && cJSON_IsNull(ec_restriction) ? true : false,
         ec_restriction ? ec_restriction_local_nonprim : NULL,
         acs_info ? acs_info_local_nonprim : NULL,
+        stn_sr && cJSON_IsNull(stn_sr) ? true : false,
         stn_sr && !cJSON_IsNull(stn_sr) ? ogs_strdup(stn_sr->valuestring) : NULL,
+        lcs_privacy && cJSON_IsNull(lcs_privacy) ? true : false,
         lcs_privacy ? lcs_privacy_local_nonprim : NULL,
         sor_info ? sor_info_local_nonprim : NULL,
+        _5mbs_authorization_info && cJSON_IsNull(_5mbs_authorization_info) ? true : false,
         _5mbs_authorization_info ? _5mbs_authorization_info_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/pp_data.h
+++ b/lib/sbi/openapi/model/pp_data.h
@@ -26,26 +26,38 @@ extern "C" {
 
 typedef struct OpenAPI_pp_data_s OpenAPI_pp_data_t;
 typedef struct OpenAPI_pp_data_s {
+    bool is_communication_characteristics_null;
     struct OpenAPI_communication_characteristics_s *communication_characteristics;
     char *supported_features;
+    bool is_expected_ue_behaviour_parameters_null;
     struct OpenAPI_expected_ue_behaviour_s *expected_ue_behaviour_parameters;
+    bool is_ec_restriction_null;
     struct OpenAPI_ec_restriction_s *ec_restriction;
     struct OpenAPI_acs_info_rm_s *acs_info;
+    bool is_stn_sr_null;
     char *stn_sr;
+    bool is_lcs_privacy_null;
     struct OpenAPI_lcs_privacy_s *lcs_privacy;
     struct OpenAPI_sor_info_s *sor_info;
+    bool is__5mbs_authorization_info_null;
     struct OpenAPI_model_5_mbs_authorization_info_s *_5mbs_authorization_info;
 } OpenAPI_pp_data_t;
 
 OpenAPI_pp_data_t *OpenAPI_pp_data_create(
+    bool is_communication_characteristics_null,
     OpenAPI_communication_characteristics_t *communication_characteristics,
     char *supported_features,
+    bool is_expected_ue_behaviour_parameters_null,
     OpenAPI_expected_ue_behaviour_t *expected_ue_behaviour_parameters,
+    bool is_ec_restriction_null,
     OpenAPI_ec_restriction_t *ec_restriction,
     OpenAPI_acs_info_rm_t *acs_info,
+    bool is_stn_sr_null,
     char *stn_sr,
+    bool is_lcs_privacy_null,
     OpenAPI_lcs_privacy_t *lcs_privacy,
     OpenAPI_sor_info_t *sor_info,
+    bool is__5mbs_authorization_info_null,
     OpenAPI_model_5_mbs_authorization_info_t *_5mbs_authorization_info
 );
 void OpenAPI_pp_data_free(OpenAPI_pp_data_t *pp_data);

--- a/lib/sbi/openapi/model/pp_data_entry.c
+++ b/lib/sbi/openapi/model/pp_data_entry.c
@@ -5,28 +5,34 @@
 #include "pp_data_entry.h"
 
 OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_create(
+    bool is_communication_characteristics_null,
     OpenAPI_communication_characteristics_af_t *communication_characteristics,
     bool is_reference_id,
     int reference_id,
     char *validity_time,
     char *mtc_provider_information,
     char *supported_features,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_1_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
+    bool is_ec_restriction_null,
     OpenAPI_ec_restriction_1_t *ec_restriction
 )
 {
     OpenAPI_pp_data_entry_t *pp_data_entry_local_var = ogs_malloc(sizeof(OpenAPI_pp_data_entry_t));
     ogs_assert(pp_data_entry_local_var);
 
+    pp_data_entry_local_var->is_communication_characteristics_null = is_communication_characteristics_null;
     pp_data_entry_local_var->communication_characteristics = communication_characteristics;
     pp_data_entry_local_var->is_reference_id = is_reference_id;
     pp_data_entry_local_var->reference_id = reference_id;
     pp_data_entry_local_var->validity_time = validity_time;
     pp_data_entry_local_var->mtc_provider_information = mtc_provider_information;
     pp_data_entry_local_var->supported_features = supported_features;
+    pp_data_entry_local_var->is_ecs_addr_config_info_null = is_ecs_addr_config_info_null;
     pp_data_entry_local_var->ecs_addr_config_info = ecs_addr_config_info;
     pp_data_entry_local_var->additional_ecs_addr_config_infos = additional_ecs_addr_config_infos;
+    pp_data_entry_local_var->is_ec_restriction_null = is_ec_restriction_null;
     pp_data_entry_local_var->ec_restriction = ec_restriction;
 
     return pp_data_entry_local_var;
@@ -95,6 +101,11 @@ cJSON *OpenAPI_pp_data_entry_convertToJSON(OpenAPI_pp_data_entry_t *pp_data_entr
         ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [communication_characteristics]");
         goto end;
     }
+    } else if (pp_data_entry->is_communication_characteristics_null) {
+        if (cJSON_AddNullToObject(item, "communicationCharacteristics") == NULL) {
+            ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [communication_characteristics]");
+            goto end;
+        }
     }
 
     if (pp_data_entry->is_reference_id) {
@@ -136,6 +147,11 @@ cJSON *OpenAPI_pp_data_entry_convertToJSON(OpenAPI_pp_data_entry_t *pp_data_entr
         ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [ecs_addr_config_info]");
         goto end;
     }
+    } else if (pp_data_entry->is_ecs_addr_config_info_null) {
+        if (cJSON_AddNullToObject(item, "ecsAddrConfigInfo") == NULL) {
+            ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [ecs_addr_config_info]");
+            goto end;
+        }
     }
 
     if (pp_data_entry->additional_ecs_addr_config_infos) {
@@ -165,6 +181,11 @@ cJSON *OpenAPI_pp_data_entry_convertToJSON(OpenAPI_pp_data_entry_t *pp_data_entr
         ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [ec_restriction]");
         goto end;
     }
+    } else if (pp_data_entry->is_ec_restriction_null) {
+        if (cJSON_AddNullToObject(item, "ecRestriction") == NULL) {
+            ogs_error("OpenAPI_pp_data_entry_convertToJSON() failed [ec_restriction]");
+            goto end;
+        }
     }
 
 end:
@@ -189,10 +210,12 @@ OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_parseFromJSON(cJSON *pp_data_entr
     OpenAPI_ec_restriction_1_t *ec_restriction_local_nonprim = NULL;
     communication_characteristics = cJSON_GetObjectItemCaseSensitive(pp_data_entryJSON, "communicationCharacteristics");
     if (communication_characteristics) {
+    if (!cJSON_IsNull(communication_characteristics)) {
     communication_characteristics_local_nonprim = OpenAPI_communication_characteristics_af_parseFromJSON(communication_characteristics);
     if (!communication_characteristics_local_nonprim) {
         ogs_error("OpenAPI_communication_characteristics_af_parseFromJSON failed [communication_characteristics]");
         goto end;
+    }
     }
     }
 
@@ -230,10 +253,12 @@ OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_parseFromJSON(cJSON *pp_data_entr
 
     ecs_addr_config_info = cJSON_GetObjectItemCaseSensitive(pp_data_entryJSON, "ecsAddrConfigInfo");
     if (ecs_addr_config_info) {
+    if (!cJSON_IsNull(ecs_addr_config_info)) {
     ecs_addr_config_info_local_nonprim = OpenAPI_ecs_addr_config_info_1_parseFromJSON(ecs_addr_config_info);
     if (!ecs_addr_config_info_local_nonprim) {
         ogs_error("OpenAPI_ecs_addr_config_info_1_parseFromJSON failed [ecs_addr_config_info]");
         goto end;
+    }
     }
     }
 
@@ -263,22 +288,27 @@ OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_parseFromJSON(cJSON *pp_data_entr
 
     ec_restriction = cJSON_GetObjectItemCaseSensitive(pp_data_entryJSON, "ecRestriction");
     if (ec_restriction) {
+    if (!cJSON_IsNull(ec_restriction)) {
     ec_restriction_local_nonprim = OpenAPI_ec_restriction_1_parseFromJSON(ec_restriction);
     if (!ec_restriction_local_nonprim) {
         ogs_error("OpenAPI_ec_restriction_1_parseFromJSON failed [ec_restriction]");
         goto end;
     }
     }
+    }
 
     pp_data_entry_local_var = OpenAPI_pp_data_entry_create (
+        communication_characteristics && cJSON_IsNull(communication_characteristics) ? true : false,
         communication_characteristics ? communication_characteristics_local_nonprim : NULL,
         reference_id ? true : false,
         reference_id ? reference_id->valuedouble : 0,
         validity_time && !cJSON_IsNull(validity_time) ? ogs_strdup(validity_time->valuestring) : NULL,
         mtc_provider_information && !cJSON_IsNull(mtc_provider_information) ? ogs_strdup(mtc_provider_information->valuestring) : NULL,
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL,
+        ecs_addr_config_info && cJSON_IsNull(ecs_addr_config_info) ? true : false,
         ecs_addr_config_info ? ecs_addr_config_info_local_nonprim : NULL,
         additional_ecs_addr_config_infos ? additional_ecs_addr_config_infosList : NULL,
+        ec_restriction && cJSON_IsNull(ec_restriction) ? true : false,
         ec_restriction ? ec_restriction_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/pp_data_entry.h
+++ b/lib/sbi/openapi/model/pp_data_entry.h
@@ -22,26 +22,32 @@ extern "C" {
 
 typedef struct OpenAPI_pp_data_entry_s OpenAPI_pp_data_entry_t;
 typedef struct OpenAPI_pp_data_entry_s {
+    bool is_communication_characteristics_null;
     struct OpenAPI_communication_characteristics_af_s *communication_characteristics;
     bool is_reference_id;
     int reference_id;
     char *validity_time;
     char *mtc_provider_information;
     char *supported_features;
+    bool is_ecs_addr_config_info_null;
     struct OpenAPI_ecs_addr_config_info_1_s *ecs_addr_config_info;
     OpenAPI_list_t *additional_ecs_addr_config_infos;
+    bool is_ec_restriction_null;
     struct OpenAPI_ec_restriction_1_s *ec_restriction;
 } OpenAPI_pp_data_entry_t;
 
 OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_create(
+    bool is_communication_characteristics_null,
     OpenAPI_communication_characteristics_af_t *communication_characteristics,
     bool is_reference_id,
     int reference_id,
     char *validity_time,
     char *mtc_provider_information,
     char *supported_features,
+    bool is_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_1_t *ecs_addr_config_info,
     OpenAPI_list_t *additional_ecs_addr_config_infos,
+    bool is_ec_restriction_null,
     OpenAPI_ec_restriction_1_t *ec_restriction
 );
 void OpenAPI_pp_data_entry_free(OpenAPI_pp_data_entry_t *pp_data_entry);

--- a/lib/sbi/openapi/model/pro_se_authentication_info.c
+++ b/lib/sbi/openapi/model/pro_se_authentication_info.c
@@ -8,6 +8,7 @@ OpenAPI_pro_se_authentication_info_t *OpenAPI_pro_se_authentication_info_create(
     char *supi_or_suci,
     char *_5g_pruk_id,
     int relay_service_code,
+    bool is_nonce1_null,
     char *nonce1,
     char *supported_features
 )
@@ -18,6 +19,7 @@ OpenAPI_pro_se_authentication_info_t *OpenAPI_pro_se_authentication_info_create(
     pro_se_authentication_info_local_var->supi_or_suci = supi_or_suci;
     pro_se_authentication_info_local_var->_5g_pruk_id = _5g_pruk_id;
     pro_se_authentication_info_local_var->relay_service_code = relay_service_code;
+    pro_se_authentication_info_local_var->is_nonce1_null = is_nonce1_null;
     pro_se_authentication_info_local_var->nonce1 = nonce1;
     pro_se_authentication_info_local_var->supported_features = supported_features;
 
@@ -158,6 +160,7 @@ OpenAPI_pro_se_authentication_info_t *OpenAPI_pro_se_authentication_info_parseFr
         _5g_pruk_id && !cJSON_IsNull(_5g_pruk_id) ? ogs_strdup(_5g_pruk_id->valuestring) : NULL,
         
         relay_service_code->valuedouble,
+        nonce1 && cJSON_IsNull(nonce1) ? true : false,
         ogs_strdup(nonce1->valuestring),
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL
     );

--- a/lib/sbi/openapi/model/pro_se_authentication_info.h
+++ b/lib/sbi/openapi/model/pro_se_authentication_info.h
@@ -22,6 +22,7 @@ typedef struct OpenAPI_pro_se_authentication_info_s {
     char *supi_or_suci;
     char *_5g_pruk_id;
     int relay_service_code;
+    bool is_nonce1_null;
     char *nonce1;
     char *supported_features;
 } OpenAPI_pro_se_authentication_info_t;
@@ -30,6 +31,7 @@ OpenAPI_pro_se_authentication_info_t *OpenAPI_pro_se_authentication_info_create(
     char *supi_or_suci,
     char *_5g_pruk_id,
     int relay_service_code,
+    bool is_nonce1_null,
     char *nonce1,
     char *supported_features
 );

--- a/lib/sbi/openapi/model/pro_se_authentication_result.c
+++ b/lib/sbi/openapi/model/pro_se_authentication_result.c
@@ -6,6 +6,7 @@
 
 OpenAPI_pro_se_authentication_result_t *OpenAPI_pro_se_authentication_result_create(
     char *knr_pro_se,
+    bool is_nonce2_null,
     char *nonce2,
     char *supported_features
 )
@@ -14,6 +15,7 @@ OpenAPI_pro_se_authentication_result_t *OpenAPI_pro_se_authentication_result_cre
     ogs_assert(pro_se_authentication_result_local_var);
 
     pro_se_authentication_result_local_var->knr_pro_se = knr_pro_se;
+    pro_se_authentication_result_local_var->is_nonce2_null = is_nonce2_null;
     pro_se_authentication_result_local_var->nonce2 = nonce2;
     pro_se_authentication_result_local_var->supported_features = supported_features;
 
@@ -65,6 +67,11 @@ cJSON *OpenAPI_pro_se_authentication_result_convertToJSON(OpenAPI_pro_se_authent
         ogs_error("OpenAPI_pro_se_authentication_result_convertToJSON() failed [nonce2]");
         goto end;
     }
+    } else if (pro_se_authentication_result->is_nonce2_null) {
+        if (cJSON_AddNullToObject(item, "nonce2") == NULL) {
+            ogs_error("OpenAPI_pro_se_authentication_result_convertToJSON() failed [nonce2]");
+            goto end;
+        }
     }
 
     if (pro_se_authentication_result->supported_features) {
@@ -95,9 +102,11 @@ OpenAPI_pro_se_authentication_result_t *OpenAPI_pro_se_authentication_result_par
 
     nonce2 = cJSON_GetObjectItemCaseSensitive(pro_se_authentication_resultJSON, "nonce2");
     if (nonce2) {
+    if (!cJSON_IsNull(nonce2)) {
     if (!cJSON_IsString(nonce2) && !cJSON_IsNull(nonce2)) {
         ogs_error("OpenAPI_pro_se_authentication_result_parseFromJSON() failed [nonce2]");
         goto end;
+    }
     }
     }
 
@@ -111,6 +120,7 @@ OpenAPI_pro_se_authentication_result_t *OpenAPI_pro_se_authentication_result_par
 
     pro_se_authentication_result_local_var = OpenAPI_pro_se_authentication_result_create (
         knr_pro_se && !cJSON_IsNull(knr_pro_se) ? ogs_strdup(knr_pro_se->valuestring) : NULL,
+        nonce2 && cJSON_IsNull(nonce2) ? true : false,
         nonce2 && !cJSON_IsNull(nonce2) ? ogs_strdup(nonce2->valuestring) : NULL,
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL
     );

--- a/lib/sbi/openapi/model/pro_se_authentication_result.h
+++ b/lib/sbi/openapi/model/pro_se_authentication_result.h
@@ -20,12 +20,14 @@ extern "C" {
 typedef struct OpenAPI_pro_se_authentication_result_s OpenAPI_pro_se_authentication_result_t;
 typedef struct OpenAPI_pro_se_authentication_result_s {
     char *knr_pro_se;
+    bool is_nonce2_null;
     char *nonce2;
     char *supported_features;
 } OpenAPI_pro_se_authentication_result_t;
 
 OpenAPI_pro_se_authentication_result_t *OpenAPI_pro_se_authentication_result_create(
     char *knr_pro_se,
+    bool is_nonce2_null,
     char *nonce2,
     char *supported_features
 );

--- a/lib/sbi/openapi/model/pro_se_eap_session.c
+++ b/lib/sbi/openapi/model/pro_se_eap_session.c
@@ -5,11 +5,13 @@
 #include "pro_se_eap_session.h"
 
 OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     char *knr_pro_se,
     OpenAPI_list_t* _links,
     OpenAPI_auth_result_e auth_result,
     char *supported_features,
+    bool is_nonce2_null,
     char *nonce2,
     char *_5g_pruk_id
 )
@@ -17,11 +19,13 @@ OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_create(
     OpenAPI_pro_se_eap_session_t *pro_se_eap_session_local_var = ogs_malloc(sizeof(OpenAPI_pro_se_eap_session_t));
     ogs_assert(pro_se_eap_session_local_var);
 
+    pro_se_eap_session_local_var->is_eap_payload_null = is_eap_payload_null;
     pro_se_eap_session_local_var->eap_payload = eap_payload;
     pro_se_eap_session_local_var->knr_pro_se = knr_pro_se;
     pro_se_eap_session_local_var->_links = _links;
     pro_se_eap_session_local_var->auth_result = auth_result;
     pro_se_eap_session_local_var->supported_features = supported_features;
+    pro_se_eap_session_local_var->is_nonce2_null = is_nonce2_null;
     pro_se_eap_session_local_var->nonce2 = nonce2;
     pro_se_eap_session_local_var->_5g_pruk_id = _5g_pruk_id;
 
@@ -144,6 +148,11 @@ cJSON *OpenAPI_pro_se_eap_session_convertToJSON(OpenAPI_pro_se_eap_session_t *pr
         ogs_error("OpenAPI_pro_se_eap_session_convertToJSON() failed [nonce2]");
         goto end;
     }
+    } else if (pro_se_eap_session->is_nonce2_null) {
+        if (cJSON_AddNullToObject(item, "nonce2") == NULL) {
+            ogs_error("OpenAPI_pro_se_eap_session_convertToJSON() failed [nonce2]");
+            goto end;
+        }
     }
 
     if (pro_se_eap_session->_5g_pruk_id) {
@@ -233,9 +242,11 @@ OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_parseFromJSON(cJSON *pr
 
     nonce2 = cJSON_GetObjectItemCaseSensitive(pro_se_eap_sessionJSON, "nonce2");
     if (nonce2) {
+    if (!cJSON_IsNull(nonce2)) {
     if (!cJSON_IsString(nonce2) && !cJSON_IsNull(nonce2)) {
         ogs_error("OpenAPI_pro_se_eap_session_parseFromJSON() failed [nonce2]");
         goto end;
+    }
     }
     }
 
@@ -248,11 +259,13 @@ OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_parseFromJSON(cJSON *pr
     }
 
     pro_se_eap_session_local_var = OpenAPI_pro_se_eap_session_create (
+        eap_payload && cJSON_IsNull(eap_payload) ? true : false,
         ogs_strdup(eap_payload->valuestring),
         knr_pro_se && !cJSON_IsNull(knr_pro_se) ? ogs_strdup(knr_pro_se->valuestring) : NULL,
         _links ? _linksList : NULL,
         auth_result ? auth_resultVariable : 0,
         supported_features && !cJSON_IsNull(supported_features) ? ogs_strdup(supported_features->valuestring) : NULL,
+        nonce2 && cJSON_IsNull(nonce2) ? true : false,
         nonce2 && !cJSON_IsNull(nonce2) ? ogs_strdup(nonce2->valuestring) : NULL,
         _5g_pruk_id && !cJSON_IsNull(_5g_pruk_id) ? ogs_strdup(_5g_pruk_id->valuestring) : NULL
     );

--- a/lib/sbi/openapi/model/pro_se_eap_session.h
+++ b/lib/sbi/openapi/model/pro_se_eap_session.h
@@ -21,21 +21,25 @@ extern "C" {
 
 typedef struct OpenAPI_pro_se_eap_session_s OpenAPI_pro_se_eap_session_t;
 typedef struct OpenAPI_pro_se_eap_session_s {
+    bool is_eap_payload_null;
     char *eap_payload;
     char *knr_pro_se;
     OpenAPI_list_t* _links;
     OpenAPI_auth_result_e auth_result;
     char *supported_features;
+    bool is_nonce2_null;
     char *nonce2;
     char *_5g_pruk_id;
 } OpenAPI_pro_se_eap_session_t;
 
 OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_create(
+    bool is_eap_payload_null,
     char *eap_payload,
     char *knr_pro_se,
     OpenAPI_list_t* _links,
     OpenAPI_auth_result_e auth_result,
     char *supported_features,
+    bool is_nonce2_null,
     char *nonce2,
     char *_5g_pruk_id
 );

--- a/lib/sbi/openapi/model/provisioned_data_sets.c
+++ b/lib/sbi/openapi/model/provisioned_data_sets.c
@@ -9,6 +9,7 @@ OpenAPI_provisioned_data_sets_t *OpenAPI_provisioned_data_sets_create(
     OpenAPI_smf_selection_subscription_data_t *smf_sel_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,
@@ -30,6 +31,7 @@ OpenAPI_provisioned_data_sets_t *OpenAPI_provisioned_data_sets_create(
     provisioned_data_sets_local_var->smf_sel_data = smf_sel_data;
     provisioned_data_sets_local_var->sms_subs_data = sms_subs_data;
     provisioned_data_sets_local_var->sm_data = sm_data;
+    provisioned_data_sets_local_var->is_trace_data_null = is_trace_data_null;
     provisioned_data_sets_local_var->trace_data = trace_data;
     provisioned_data_sets_local_var->sms_mng_data = sms_mng_data;
     provisioned_data_sets_local_var->lcs_privacy_data = lcs_privacy_data;
@@ -194,6 +196,11 @@ cJSON *OpenAPI_provisioned_data_sets_convertToJSON(OpenAPI_provisioned_data_sets
         ogs_error("OpenAPI_provisioned_data_sets_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (provisioned_data_sets->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_provisioned_data_sets_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (provisioned_data_sets->sms_mng_data) {
@@ -417,10 +424,12 @@ OpenAPI_provisioned_data_sets_t *OpenAPI_provisioned_data_sets_parseFromJSON(cJS
 
     trace_data = cJSON_GetObjectItemCaseSensitive(provisioned_data_setsJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -528,6 +537,7 @@ OpenAPI_provisioned_data_sets_t *OpenAPI_provisioned_data_sets_parseFromJSON(cJS
         smf_sel_data ? smf_sel_data_local_nonprim : NULL,
         sms_subs_data ? sms_subs_data_local_nonprim : NULL,
         sm_data ? sm_data_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         sms_mng_data ? sms_mng_data_local_nonprim : NULL,
         lcs_privacy_data ? lcs_privacy_data_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/provisioned_data_sets.h
+++ b/lib/sbi/openapi/model/provisioned_data_sets.h
@@ -39,6 +39,7 @@ typedef struct OpenAPI_provisioned_data_sets_s {
     struct OpenAPI_smf_selection_subscription_data_s *smf_sel_data;
     struct OpenAPI_sms_subscription_data_s *sms_subs_data;
     struct OpenAPI_sm_subs_data_s *sm_data;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     struct OpenAPI_sms_management_subscription_data_s *sms_mng_data;
     struct OpenAPI_lcs_privacy_data_s *lcs_privacy_data;
@@ -58,6 +59,7 @@ OpenAPI_provisioned_data_sets_t *OpenAPI_provisioned_data_sets_create(
     OpenAPI_smf_selection_subscription_data_t *smf_sel_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,

--- a/lib/sbi/openapi/model/qos_data.c
+++ b/lib/sbi/openapi/model/qos_data.c
@@ -8,29 +8,39 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_create(
     char *qos_id,
     bool is__5qi,
     int _5qi,
+    bool is_maxbr_ul_null,
     char *maxbr_ul,
+    bool is_maxbr_dl_null,
     char *maxbr_dl,
+    bool is_gbr_ul_null,
     char *gbr_ul,
+    bool is_gbr_dl_null,
     char *gbr_dl,
     OpenAPI_arp_t *arp,
     bool is_qnc,
     int qnc,
+    bool is_priority_level_null,
     bool is_priority_level,
     int priority_level,
+    bool is_aver_window_null,
     bool is_aver_window,
     int aver_window,
+    bool is_max_data_burst_vol_null,
     bool is_max_data_burst_vol,
     int max_data_burst_vol,
     bool is_reflective_qos,
     int reflective_qos,
     char *sharing_key_dl,
     char *sharing_key_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
     bool is_def_qos_flow_indication,
     int def_qos_flow_indication,
+    bool is_ext_max_data_burst_vol_null,
     bool is_ext_max_data_burst_vol,
     int ext_max_data_burst_vol,
     bool is_packet_delay_budget,
@@ -44,29 +54,39 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_create(
     qos_data_local_var->qos_id = qos_id;
     qos_data_local_var->is__5qi = is__5qi;
     qos_data_local_var->_5qi = _5qi;
+    qos_data_local_var->is_maxbr_ul_null = is_maxbr_ul_null;
     qos_data_local_var->maxbr_ul = maxbr_ul;
+    qos_data_local_var->is_maxbr_dl_null = is_maxbr_dl_null;
     qos_data_local_var->maxbr_dl = maxbr_dl;
+    qos_data_local_var->is_gbr_ul_null = is_gbr_ul_null;
     qos_data_local_var->gbr_ul = gbr_ul;
+    qos_data_local_var->is_gbr_dl_null = is_gbr_dl_null;
     qos_data_local_var->gbr_dl = gbr_dl;
     qos_data_local_var->arp = arp;
     qos_data_local_var->is_qnc = is_qnc;
     qos_data_local_var->qnc = qnc;
+    qos_data_local_var->is_priority_level_null = is_priority_level_null;
     qos_data_local_var->is_priority_level = is_priority_level;
     qos_data_local_var->priority_level = priority_level;
+    qos_data_local_var->is_aver_window_null = is_aver_window_null;
     qos_data_local_var->is_aver_window = is_aver_window;
     qos_data_local_var->aver_window = aver_window;
+    qos_data_local_var->is_max_data_burst_vol_null = is_max_data_burst_vol_null;
     qos_data_local_var->is_max_data_burst_vol = is_max_data_burst_vol;
     qos_data_local_var->max_data_burst_vol = max_data_burst_vol;
     qos_data_local_var->is_reflective_qos = is_reflective_qos;
     qos_data_local_var->reflective_qos = reflective_qos;
     qos_data_local_var->sharing_key_dl = sharing_key_dl;
     qos_data_local_var->sharing_key_ul = sharing_key_ul;
+    qos_data_local_var->is_max_packet_loss_rate_dl_null = is_max_packet_loss_rate_dl_null;
     qos_data_local_var->is_max_packet_loss_rate_dl = is_max_packet_loss_rate_dl;
     qos_data_local_var->max_packet_loss_rate_dl = max_packet_loss_rate_dl;
+    qos_data_local_var->is_max_packet_loss_rate_ul_null = is_max_packet_loss_rate_ul_null;
     qos_data_local_var->is_max_packet_loss_rate_ul = is_max_packet_loss_rate_ul;
     qos_data_local_var->max_packet_loss_rate_ul = max_packet_loss_rate_ul;
     qos_data_local_var->is_def_qos_flow_indication = is_def_qos_flow_indication;
     qos_data_local_var->def_qos_flow_indication = def_qos_flow_indication;
+    qos_data_local_var->is_ext_max_data_burst_vol_null = is_ext_max_data_burst_vol_null;
     qos_data_local_var->is_ext_max_data_burst_vol = is_ext_max_data_burst_vol;
     qos_data_local_var->ext_max_data_burst_vol = ext_max_data_burst_vol;
     qos_data_local_var->is_packet_delay_budget = is_packet_delay_budget;
@@ -154,6 +174,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [maxbr_ul]");
         goto end;
     }
+    } else if (qos_data->is_maxbr_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxbrUl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [maxbr_ul]");
+            goto end;
+        }
     }
 
     if (qos_data->maxbr_dl) {
@@ -161,6 +186,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [maxbr_dl]");
         goto end;
     }
+    } else if (qos_data->is_maxbr_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxbrDl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [maxbr_dl]");
+            goto end;
+        }
     }
 
     if (qos_data->gbr_ul) {
@@ -168,6 +198,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [gbr_ul]");
         goto end;
     }
+    } else if (qos_data->is_gbr_ul_null) {
+        if (cJSON_AddNullToObject(item, "gbrUl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [gbr_ul]");
+            goto end;
+        }
     }
 
     if (qos_data->gbr_dl) {
@@ -175,6 +210,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [gbr_dl]");
         goto end;
     }
+    } else if (qos_data->is_gbr_dl_null) {
+        if (cJSON_AddNullToObject(item, "gbrDl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [gbr_dl]");
+            goto end;
+        }
     }
 
     if (qos_data->arp) {
@@ -202,6 +242,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [priority_level]");
         goto end;
     }
+    } else if (qos_data->is_priority_level_null) {
+        if (cJSON_AddNullToObject(item, "priorityLevel") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [priority_level]");
+            goto end;
+        }
     }
 
     if (qos_data->is_aver_window) {
@@ -209,6 +254,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [aver_window]");
         goto end;
     }
+    } else if (qos_data->is_aver_window_null) {
+        if (cJSON_AddNullToObject(item, "averWindow") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [aver_window]");
+            goto end;
+        }
     }
 
     if (qos_data->is_max_data_burst_vol) {
@@ -216,6 +266,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_data_burst_vol]");
         goto end;
     }
+    } else if (qos_data->is_max_data_burst_vol_null) {
+        if (cJSON_AddNullToObject(item, "maxDataBurstVol") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_data_burst_vol]");
+            goto end;
+        }
     }
 
     if (qos_data->is_reflective_qos) {
@@ -244,6 +299,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
+    } else if (qos_data->is_max_packet_loss_rate_dl_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateDl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_packet_loss_rate_dl]");
+            goto end;
+        }
     }
 
     if (qos_data->is_max_packet_loss_rate_ul) {
@@ -251,6 +311,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_packet_loss_rate_ul]");
         goto end;
     }
+    } else if (qos_data->is_max_packet_loss_rate_ul_null) {
+        if (cJSON_AddNullToObject(item, "maxPacketLossRateUl") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [max_packet_loss_rate_ul]");
+            goto end;
+        }
     }
 
     if (qos_data->is_def_qos_flow_indication) {
@@ -265,6 +330,11 @@ cJSON *OpenAPI_qos_data_convertToJSON(OpenAPI_qos_data_t *qos_data)
         ogs_error("OpenAPI_qos_data_convertToJSON() failed [ext_max_data_burst_vol]");
         goto end;
     }
+    } else if (qos_data->is_ext_max_data_burst_vol_null) {
+        if (cJSON_AddNullToObject(item, "extMaxDataBurstVol") == NULL) {
+            ogs_error("OpenAPI_qos_data_convertToJSON() failed [ext_max_data_burst_vol]");
+            goto end;
+        }
     }
 
     if (qos_data->is_packet_delay_budget) {
@@ -330,33 +400,41 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_parseFromJSON(cJSON *qos_dataJSON)
 
     maxbr_ul = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "maxbrUl");
     if (maxbr_ul) {
+    if (!cJSON_IsNull(maxbr_ul)) {
     if (!cJSON_IsString(maxbr_ul) && !cJSON_IsNull(maxbr_ul)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [maxbr_ul]");
         goto end;
     }
     }
+    }
 
     maxbr_dl = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "maxbrDl");
     if (maxbr_dl) {
+    if (!cJSON_IsNull(maxbr_dl)) {
     if (!cJSON_IsString(maxbr_dl) && !cJSON_IsNull(maxbr_dl)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [maxbr_dl]");
         goto end;
     }
     }
+    }
 
     gbr_ul = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "gbrUl");
     if (gbr_ul) {
+    if (!cJSON_IsNull(gbr_ul)) {
     if (!cJSON_IsString(gbr_ul) && !cJSON_IsNull(gbr_ul)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [gbr_ul]");
         goto end;
     }
     }
+    }
 
     gbr_dl = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "gbrDl");
     if (gbr_dl) {
+    if (!cJSON_IsNull(gbr_dl)) {
     if (!cJSON_IsString(gbr_dl) && !cJSON_IsNull(gbr_dl)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [gbr_dl]");
         goto end;
+    }
     }
     }
 
@@ -379,25 +457,31 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_parseFromJSON(cJSON *qos_dataJSON)
 
     priority_level = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "priorityLevel");
     if (priority_level) {
+    if (!cJSON_IsNull(priority_level)) {
     if (!cJSON_IsNumber(priority_level)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [priority_level]");
         goto end;
     }
     }
+    }
 
     aver_window = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "averWindow");
     if (aver_window) {
+    if (!cJSON_IsNull(aver_window)) {
     if (!cJSON_IsNumber(aver_window)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [aver_window]");
         goto end;
     }
     }
+    }
 
     max_data_burst_vol = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "maxDataBurstVol");
     if (max_data_burst_vol) {
+    if (!cJSON_IsNull(max_data_burst_vol)) {
     if (!cJSON_IsNumber(max_data_burst_vol)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [max_data_burst_vol]");
         goto end;
+    }
     }
     }
 
@@ -427,17 +511,21 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_parseFromJSON(cJSON *qos_dataJSON)
 
     max_packet_loss_rate_dl = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "maxPacketLossRateDl");
     if (max_packet_loss_rate_dl) {
+    if (!cJSON_IsNull(max_packet_loss_rate_dl)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_dl)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [max_packet_loss_rate_dl]");
         goto end;
     }
     }
+    }
 
     max_packet_loss_rate_ul = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "maxPacketLossRateUl");
     if (max_packet_loss_rate_ul) {
+    if (!cJSON_IsNull(max_packet_loss_rate_ul)) {
     if (!cJSON_IsNumber(max_packet_loss_rate_ul)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [max_packet_loss_rate_ul]");
         goto end;
+    }
     }
     }
 
@@ -451,9 +539,11 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_parseFromJSON(cJSON *qos_dataJSON)
 
     ext_max_data_burst_vol = cJSON_GetObjectItemCaseSensitive(qos_dataJSON, "extMaxDataBurstVol");
     if (ext_max_data_burst_vol) {
+    if (!cJSON_IsNull(ext_max_data_burst_vol)) {
     if (!cJSON_IsNumber(ext_max_data_burst_vol)) {
         ogs_error("OpenAPI_qos_data_parseFromJSON() failed [ext_max_data_burst_vol]");
         goto end;
+    }
     }
     }
 
@@ -477,29 +567,39 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_parseFromJSON(cJSON *qos_dataJSON)
         ogs_strdup(qos_id->valuestring),
         _5qi ? true : false,
         _5qi ? _5qi->valuedouble : 0,
+        maxbr_ul && cJSON_IsNull(maxbr_ul) ? true : false,
         maxbr_ul && !cJSON_IsNull(maxbr_ul) ? ogs_strdup(maxbr_ul->valuestring) : NULL,
+        maxbr_dl && cJSON_IsNull(maxbr_dl) ? true : false,
         maxbr_dl && !cJSON_IsNull(maxbr_dl) ? ogs_strdup(maxbr_dl->valuestring) : NULL,
+        gbr_ul && cJSON_IsNull(gbr_ul) ? true : false,
         gbr_ul && !cJSON_IsNull(gbr_ul) ? ogs_strdup(gbr_ul->valuestring) : NULL,
+        gbr_dl && cJSON_IsNull(gbr_dl) ? true : false,
         gbr_dl && !cJSON_IsNull(gbr_dl) ? ogs_strdup(gbr_dl->valuestring) : NULL,
         arp ? arp_local_nonprim : NULL,
         qnc ? true : false,
         qnc ? qnc->valueint : 0,
+        priority_level && cJSON_IsNull(priority_level) ? true : false,
         priority_level ? true : false,
         priority_level ? priority_level->valuedouble : 0,
+        aver_window && cJSON_IsNull(aver_window) ? true : false,
         aver_window ? true : false,
         aver_window ? aver_window->valuedouble : 0,
+        max_data_burst_vol && cJSON_IsNull(max_data_burst_vol) ? true : false,
         max_data_burst_vol ? true : false,
         max_data_burst_vol ? max_data_burst_vol->valuedouble : 0,
         reflective_qos ? true : false,
         reflective_qos ? reflective_qos->valueint : 0,
         sharing_key_dl && !cJSON_IsNull(sharing_key_dl) ? ogs_strdup(sharing_key_dl->valuestring) : NULL,
         sharing_key_ul && !cJSON_IsNull(sharing_key_ul) ? ogs_strdup(sharing_key_ul->valuestring) : NULL,
+        max_packet_loss_rate_dl && cJSON_IsNull(max_packet_loss_rate_dl) ? true : false,
         max_packet_loss_rate_dl ? true : false,
         max_packet_loss_rate_dl ? max_packet_loss_rate_dl->valuedouble : 0,
+        max_packet_loss_rate_ul && cJSON_IsNull(max_packet_loss_rate_ul) ? true : false,
         max_packet_loss_rate_ul ? true : false,
         max_packet_loss_rate_ul ? max_packet_loss_rate_ul->valuedouble : 0,
         def_qos_flow_indication ? true : false,
         def_qos_flow_indication ? def_qos_flow_indication->valueint : 0,
+        ext_max_data_burst_vol && cJSON_IsNull(ext_max_data_burst_vol) ? true : false,
         ext_max_data_burst_vol ? true : false,
         ext_max_data_burst_vol ? ext_max_data_burst_vol->valuedouble : 0,
         packet_delay_budget ? true : false,

--- a/lib/sbi/openapi/model/qos_data.h
+++ b/lib/sbi/openapi/model/qos_data.h
@@ -23,29 +23,39 @@ typedef struct OpenAPI_qos_data_s {
     char *qos_id;
     bool is__5qi;
     int _5qi;
+    bool is_maxbr_ul_null;
     char *maxbr_ul;
+    bool is_maxbr_dl_null;
     char *maxbr_dl;
+    bool is_gbr_ul_null;
     char *gbr_ul;
+    bool is_gbr_dl_null;
     char *gbr_dl;
     struct OpenAPI_arp_s *arp;
     bool is_qnc;
     int qnc;
+    bool is_priority_level_null;
     bool is_priority_level;
     int priority_level;
+    bool is_aver_window_null;
     bool is_aver_window;
     int aver_window;
+    bool is_max_data_burst_vol_null;
     bool is_max_data_burst_vol;
     int max_data_burst_vol;
     bool is_reflective_qos;
     int reflective_qos;
     char *sharing_key_dl;
     char *sharing_key_ul;
+    bool is_max_packet_loss_rate_dl_null;
     bool is_max_packet_loss_rate_dl;
     int max_packet_loss_rate_dl;
+    bool is_max_packet_loss_rate_ul_null;
     bool is_max_packet_loss_rate_ul;
     int max_packet_loss_rate_ul;
     bool is_def_qos_flow_indication;
     int def_qos_flow_indication;
+    bool is_ext_max_data_burst_vol_null;
     bool is_ext_max_data_burst_vol;
     int ext_max_data_burst_vol;
     bool is_packet_delay_budget;
@@ -57,29 +67,39 @@ OpenAPI_qos_data_t *OpenAPI_qos_data_create(
     char *qos_id,
     bool is__5qi,
     int _5qi,
+    bool is_maxbr_ul_null,
     char *maxbr_ul,
+    bool is_maxbr_dl_null,
     char *maxbr_dl,
+    bool is_gbr_ul_null,
     char *gbr_ul,
+    bool is_gbr_dl_null,
     char *gbr_dl,
     OpenAPI_arp_t *arp,
     bool is_qnc,
     int qnc,
+    bool is_priority_level_null,
     bool is_priority_level,
     int priority_level,
+    bool is_aver_window_null,
     bool is_aver_window,
     int aver_window,
+    bool is_max_data_burst_vol_null,
     bool is_max_data_burst_vol,
     int max_data_burst_vol,
     bool is_reflective_qos,
     int reflective_qos,
     char *sharing_key_dl,
     char *sharing_key_ul,
+    bool is_max_packet_loss_rate_dl_null,
     bool is_max_packet_loss_rate_dl,
     int max_packet_loss_rate_dl,
+    bool is_max_packet_loss_rate_ul_null,
     bool is_max_packet_loss_rate_ul,
     int max_packet_loss_rate_ul,
     bool is_def_qos_flow_indication,
     int def_qos_flow_indication,
+    bool is_ext_max_data_burst_vol_null,
     bool is_ext_max_data_burst_vol,
     int ext_max_data_burst_vol,
     bool is_packet_delay_budget,

--- a/lib/sbi/openapi/model/qos_monitoring_data.c
+++ b/lib/sbi/openapi/model/qos_monitoring_data.c
@@ -8,17 +8,24 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_create(
     char *qm_id,
     OpenAPI_list_t *req_qos_mon_params,
     OpenAPI_list_t *rep_freqs,
+    bool is_rep_thresh_dl_null,
     bool is_rep_thresh_dl,
     int rep_thresh_dl,
+    bool is_rep_thresh_ul_null,
     bool is_rep_thresh_ul,
     int rep_thresh_ul,
+    bool is_rep_thresh_rp_null,
     bool is_rep_thresh_rp,
     int rep_thresh_rp,
+    bool is_wait_time_null,
     bool is_wait_time,
     int wait_time,
+    bool is_rep_period_null,
     bool is_rep_period,
     int rep_period,
+    bool is_notify_uri_null,
     char *notify_uri,
+    bool is_notify_corre_id_null,
     char *notify_corre_id,
     bool is_direct_notif_ind,
     int direct_notif_ind
@@ -30,17 +37,24 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_create(
     qos_monitoring_data_local_var->qm_id = qm_id;
     qos_monitoring_data_local_var->req_qos_mon_params = req_qos_mon_params;
     qos_monitoring_data_local_var->rep_freqs = rep_freqs;
+    qos_monitoring_data_local_var->is_rep_thresh_dl_null = is_rep_thresh_dl_null;
     qos_monitoring_data_local_var->is_rep_thresh_dl = is_rep_thresh_dl;
     qos_monitoring_data_local_var->rep_thresh_dl = rep_thresh_dl;
+    qos_monitoring_data_local_var->is_rep_thresh_ul_null = is_rep_thresh_ul_null;
     qos_monitoring_data_local_var->is_rep_thresh_ul = is_rep_thresh_ul;
     qos_monitoring_data_local_var->rep_thresh_ul = rep_thresh_ul;
+    qos_monitoring_data_local_var->is_rep_thresh_rp_null = is_rep_thresh_rp_null;
     qos_monitoring_data_local_var->is_rep_thresh_rp = is_rep_thresh_rp;
     qos_monitoring_data_local_var->rep_thresh_rp = rep_thresh_rp;
+    qos_monitoring_data_local_var->is_wait_time_null = is_wait_time_null;
     qos_monitoring_data_local_var->is_wait_time = is_wait_time;
     qos_monitoring_data_local_var->wait_time = wait_time;
+    qos_monitoring_data_local_var->is_rep_period_null = is_rep_period_null;
     qos_monitoring_data_local_var->is_rep_period = is_rep_period;
     qos_monitoring_data_local_var->rep_period = rep_period;
+    qos_monitoring_data_local_var->is_notify_uri_null = is_notify_uri_null;
     qos_monitoring_data_local_var->notify_uri = notify_uri;
+    qos_monitoring_data_local_var->is_notify_corre_id_null = is_notify_corre_id_null;
     qos_monitoring_data_local_var->notify_corre_id = notify_corre_id;
     qos_monitoring_data_local_var->is_direct_notif_ind = is_direct_notif_ind;
     qos_monitoring_data_local_var->direct_notif_ind = direct_notif_ind;
@@ -135,6 +149,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_dl]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_rep_thresh_dl_null) {
+        if (cJSON_AddNullToObject(item, "repThreshDl") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_dl]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->is_rep_thresh_ul) {
@@ -142,6 +161,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_ul]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_rep_thresh_ul_null) {
+        if (cJSON_AddNullToObject(item, "repThreshUl") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_ul]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->is_rep_thresh_rp) {
@@ -149,6 +173,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_rp]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_rep_thresh_rp_null) {
+        if (cJSON_AddNullToObject(item, "repThreshRp") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_thresh_rp]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->is_wait_time) {
@@ -156,6 +185,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [wait_time]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_wait_time_null) {
+        if (cJSON_AddNullToObject(item, "waitTime") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [wait_time]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->is_rep_period) {
@@ -163,6 +197,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_period]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_rep_period_null) {
+        if (cJSON_AddNullToObject(item, "repPeriod") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [rep_period]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->notify_uri) {
@@ -170,6 +209,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [notify_uri]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_notify_uri_null) {
+        if (cJSON_AddNullToObject(item, "notifyUri") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [notify_uri]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->notify_corre_id) {
@@ -177,6 +221,11 @@ cJSON *OpenAPI_qos_monitoring_data_convertToJSON(OpenAPI_qos_monitoring_data_t *
         ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [notify_corre_id]");
         goto end;
     }
+    } else if (qos_monitoring_data->is_notify_corre_id_null) {
+        if (cJSON_AddNullToObject(item, "notifyCorreId") == NULL) {
+            ogs_error("OpenAPI_qos_monitoring_data_convertToJSON() failed [notify_corre_id]");
+            goto end;
+        }
     }
 
     if (qos_monitoring_data->is_direct_notif_ind) {
@@ -273,57 +322,71 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
 
     rep_thresh_dl = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshDl");
     if (rep_thresh_dl) {
+    if (!cJSON_IsNull(rep_thresh_dl)) {
     if (!cJSON_IsNumber(rep_thresh_dl)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [rep_thresh_dl]");
         goto end;
     }
     }
+    }
 
     rep_thresh_ul = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshUl");
     if (rep_thresh_ul) {
+    if (!cJSON_IsNull(rep_thresh_ul)) {
     if (!cJSON_IsNumber(rep_thresh_ul)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [rep_thresh_ul]");
         goto end;
     }
     }
+    }
 
     rep_thresh_rp = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repThreshRp");
     if (rep_thresh_rp) {
+    if (!cJSON_IsNull(rep_thresh_rp)) {
     if (!cJSON_IsNumber(rep_thresh_rp)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [rep_thresh_rp]");
         goto end;
     }
     }
+    }
 
     wait_time = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "waitTime");
     if (wait_time) {
+    if (!cJSON_IsNull(wait_time)) {
     if (!cJSON_IsNumber(wait_time)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [wait_time]");
         goto end;
     }
     }
+    }
 
     rep_period = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "repPeriod");
     if (rep_period) {
+    if (!cJSON_IsNull(rep_period)) {
     if (!cJSON_IsNumber(rep_period)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [rep_period]");
         goto end;
     }
     }
+    }
 
     notify_uri = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "notifyUri");
     if (notify_uri) {
+    if (!cJSON_IsNull(notify_uri)) {
     if (!cJSON_IsString(notify_uri) && !cJSON_IsNull(notify_uri)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [notify_uri]");
         goto end;
     }
     }
+    }
 
     notify_corre_id = cJSON_GetObjectItemCaseSensitive(qos_monitoring_dataJSON, "notifyCorreId");
     if (notify_corre_id) {
+    if (!cJSON_IsNull(notify_corre_id)) {
     if (!cJSON_IsString(notify_corre_id) && !cJSON_IsNull(notify_corre_id)) {
         ogs_error("OpenAPI_qos_monitoring_data_parseFromJSON() failed [notify_corre_id]");
         goto end;
+    }
     }
     }
 
@@ -339,17 +402,24 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_parseFromJSON(cJSON *
         ogs_strdup(qm_id->valuestring),
         req_qos_mon_paramsList,
         rep_freqsList,
+        rep_thresh_dl && cJSON_IsNull(rep_thresh_dl) ? true : false,
         rep_thresh_dl ? true : false,
         rep_thresh_dl ? rep_thresh_dl->valuedouble : 0,
+        rep_thresh_ul && cJSON_IsNull(rep_thresh_ul) ? true : false,
         rep_thresh_ul ? true : false,
         rep_thresh_ul ? rep_thresh_ul->valuedouble : 0,
+        rep_thresh_rp && cJSON_IsNull(rep_thresh_rp) ? true : false,
         rep_thresh_rp ? true : false,
         rep_thresh_rp ? rep_thresh_rp->valuedouble : 0,
+        wait_time && cJSON_IsNull(wait_time) ? true : false,
         wait_time ? true : false,
         wait_time ? wait_time->valuedouble : 0,
+        rep_period && cJSON_IsNull(rep_period) ? true : false,
         rep_period ? true : false,
         rep_period ? rep_period->valuedouble : 0,
+        notify_uri && cJSON_IsNull(notify_uri) ? true : false,
         notify_uri && !cJSON_IsNull(notify_uri) ? ogs_strdup(notify_uri->valuestring) : NULL,
+        notify_corre_id && cJSON_IsNull(notify_corre_id) ? true : false,
         notify_corre_id && !cJSON_IsNull(notify_corre_id) ? ogs_strdup(notify_corre_id->valuestring) : NULL,
         direct_notif_ind ? true : false,
         direct_notif_ind ? direct_notif_ind->valueint : 0

--- a/lib/sbi/openapi/model/qos_monitoring_data.h
+++ b/lib/sbi/openapi/model/qos_monitoring_data.h
@@ -24,17 +24,24 @@ typedef struct OpenAPI_qos_monitoring_data_s {
     char *qm_id;
     OpenAPI_list_t *req_qos_mon_params;
     OpenAPI_list_t *rep_freqs;
+    bool is_rep_thresh_dl_null;
     bool is_rep_thresh_dl;
     int rep_thresh_dl;
+    bool is_rep_thresh_ul_null;
     bool is_rep_thresh_ul;
     int rep_thresh_ul;
+    bool is_rep_thresh_rp_null;
     bool is_rep_thresh_rp;
     int rep_thresh_rp;
+    bool is_wait_time_null;
     bool is_wait_time;
     int wait_time;
+    bool is_rep_period_null;
     bool is_rep_period;
     int rep_period;
+    bool is_notify_uri_null;
     char *notify_uri;
+    bool is_notify_corre_id_null;
     char *notify_corre_id;
     bool is_direct_notif_ind;
     int direct_notif_ind;
@@ -44,17 +51,24 @@ OpenAPI_qos_monitoring_data_t *OpenAPI_qos_monitoring_data_create(
     char *qm_id,
     OpenAPI_list_t *req_qos_mon_params,
     OpenAPI_list_t *rep_freqs,
+    bool is_rep_thresh_dl_null,
     bool is_rep_thresh_dl,
     int rep_thresh_dl,
+    bool is_rep_thresh_ul_null,
     bool is_rep_thresh_ul,
     int rep_thresh_ul,
+    bool is_rep_thresh_rp_null,
     bool is_rep_thresh_rp,
     int rep_thresh_rp,
+    bool is_wait_time_null,
     bool is_wait_time,
     int wait_time,
+    bool is_rep_period_null,
     bool is_rep_period,
     int rep_period,
+    bool is_notify_uri_null,
     char *notify_uri,
+    bool is_notify_corre_id_null,
     char *notify_corre_id,
     bool is_direct_notif_ind,
     int direct_notif_ind

--- a/lib/sbi/openapi/model/route_to_location.c
+++ b/lib/sbi/openapi/model/route_to_location.c
@@ -6,7 +6,9 @@
 
 OpenAPI_route_to_location_t *OpenAPI_route_to_location_create(
     char *dnai,
+    bool is_route_info_null,
     OpenAPI_route_information_t *route_info,
+    bool is_route_prof_id_null,
     char *route_prof_id
 )
 {
@@ -14,7 +16,9 @@ OpenAPI_route_to_location_t *OpenAPI_route_to_location_create(
     ogs_assert(route_to_location_local_var);
 
     route_to_location_local_var->dnai = dnai;
+    route_to_location_local_var->is_route_info_null = is_route_info_null;
     route_to_location_local_var->route_info = route_info;
+    route_to_location_local_var->is_route_prof_id_null = is_route_prof_id_null;
     route_to_location_local_var->route_prof_id = route_prof_id;
 
     return route_to_location_local_var;
@@ -73,6 +77,11 @@ cJSON *OpenAPI_route_to_location_convertToJSON(OpenAPI_route_to_location_t *rout
         ogs_error("OpenAPI_route_to_location_convertToJSON() failed [route_info]");
         goto end;
     }
+    } else if (route_to_location->is_route_info_null) {
+        if (cJSON_AddNullToObject(item, "routeInfo") == NULL) {
+            ogs_error("OpenAPI_route_to_location_convertToJSON() failed [route_info]");
+            goto end;
+        }
     }
 
     if (route_to_location->route_prof_id) {
@@ -80,6 +89,11 @@ cJSON *OpenAPI_route_to_location_convertToJSON(OpenAPI_route_to_location_t *rout
         ogs_error("OpenAPI_route_to_location_convertToJSON() failed [route_prof_id]");
         goto end;
     }
+    } else if (route_to_location->is_route_prof_id_null) {
+        if (cJSON_AddNullToObject(item, "routeProfId") == NULL) {
+            ogs_error("OpenAPI_route_to_location_convertToJSON() failed [route_prof_id]");
+            goto end;
+        }
     }
 
 end:
@@ -106,24 +120,30 @@ OpenAPI_route_to_location_t *OpenAPI_route_to_location_parseFromJSON(cJSON *rout
 
     route_info = cJSON_GetObjectItemCaseSensitive(route_to_locationJSON, "routeInfo");
     if (route_info) {
+    if (!cJSON_IsNull(route_info)) {
     route_info_local_nonprim = OpenAPI_route_information_parseFromJSON(route_info);
     if (!route_info_local_nonprim) {
         ogs_error("OpenAPI_route_information_parseFromJSON failed [route_info]");
         goto end;
     }
     }
+    }
 
     route_prof_id = cJSON_GetObjectItemCaseSensitive(route_to_locationJSON, "routeProfId");
     if (route_prof_id) {
+    if (!cJSON_IsNull(route_prof_id)) {
     if (!cJSON_IsString(route_prof_id) && !cJSON_IsNull(route_prof_id)) {
         ogs_error("OpenAPI_route_to_location_parseFromJSON() failed [route_prof_id]");
         goto end;
     }
     }
+    }
 
     route_to_location_local_var = OpenAPI_route_to_location_create (
         ogs_strdup(dnai->valuestring),
+        route_info && cJSON_IsNull(route_info) ? true : false,
         route_info ? route_info_local_nonprim : NULL,
+        route_prof_id && cJSON_IsNull(route_prof_id) ? true : false,
         route_prof_id && !cJSON_IsNull(route_prof_id) ? ogs_strdup(route_prof_id->valuestring) : NULL
     );
 

--- a/lib/sbi/openapi/model/route_to_location.h
+++ b/lib/sbi/openapi/model/route_to_location.h
@@ -21,13 +21,17 @@ extern "C" {
 typedef struct OpenAPI_route_to_location_s OpenAPI_route_to_location_t;
 typedef struct OpenAPI_route_to_location_s {
     char *dnai;
+    bool is_route_info_null;
     struct OpenAPI_route_information_s *route_info;
+    bool is_route_prof_id_null;
     char *route_prof_id;
 } OpenAPI_route_to_location_t;
 
 OpenAPI_route_to_location_t *OpenAPI_route_to_location_create(
     char *dnai,
+    bool is_route_info_null,
     OpenAPI_route_information_t *route_info,
+    bool is_route_prof_id_null,
     char *route_prof_id
 );
 void OpenAPI_route_to_location_free(OpenAPI_route_to_location_t *route_to_location);

--- a/lib/sbi/openapi/model/session_management_subscription_data.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data.c
@@ -11,6 +11,7 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
     OpenAPI_list_t* shared_vn_group_data_ids,
     char *shared_dnn_configurations_id,
     OpenAPI_odb_packet_services_e odb_packet_services,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *shared_trace_data_id,
     OpenAPI_list_t* expected_ue_behaviours_list,
@@ -28,6 +29,7 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
     session_management_subscription_data_local_var->shared_vn_group_data_ids = shared_vn_group_data_ids;
     session_management_subscription_data_local_var->shared_dnn_configurations_id = shared_dnn_configurations_id;
     session_management_subscription_data_local_var->odb_packet_services = odb_packet_services;
+    session_management_subscription_data_local_var->is_trace_data_null = is_trace_data_null;
     session_management_subscription_data_local_var->trace_data = trace_data;
     session_management_subscription_data_local_var->shared_trace_data_id = shared_trace_data_id;
     session_management_subscription_data_local_var->expected_ue_behaviours_list = expected_ue_behaviours_list;
@@ -240,6 +242,11 @@ cJSON *OpenAPI_session_management_subscription_data_convertToJSON(OpenAPI_sessio
         ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (session_management_subscription_data->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_session_management_subscription_data_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (session_management_subscription_data->shared_trace_data_id) {
@@ -452,10 +459,12 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
 
     trace_data = cJSON_GetObjectItemCaseSensitive(session_management_subscription_dataJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -542,6 +551,7 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
         shared_vn_group_data_ids ? shared_vn_group_data_idsList : NULL,
         shared_dnn_configurations_id && !cJSON_IsNull(shared_dnn_configurations_id) ? ogs_strdup(shared_dnn_configurations_id->valuestring) : NULL,
         odb_packet_services ? odb_packet_servicesVariable : 0,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         shared_trace_data_id && !cJSON_IsNull(shared_trace_data_id) ? ogs_strdup(shared_trace_data_id->valuestring) : NULL,
         expected_ue_behaviours_list ? expected_ue_behaviours_listList : NULL,

--- a/lib/sbi/openapi/model/session_management_subscription_data.h
+++ b/lib/sbi/openapi/model/session_management_subscription_data.h
@@ -31,6 +31,7 @@ typedef struct OpenAPI_session_management_subscription_data_s {
     OpenAPI_list_t* shared_vn_group_data_ids;
     char *shared_dnn_configurations_id;
     OpenAPI_odb_packet_services_e odb_packet_services;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *shared_trace_data_id;
     OpenAPI_list_t* expected_ue_behaviours_list;
@@ -46,6 +47,7 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
     OpenAPI_list_t* shared_vn_group_data_ids,
     char *shared_dnn_configurations_id,
     OpenAPI_odb_packet_services_e odb_packet_services,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *shared_trace_data_id,
     OpenAPI_list_t* expected_ue_behaviours_list,

--- a/lib/sbi/openapi/model/session_management_subscription_data_1.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data_1.c
@@ -11,6 +11,7 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
     OpenAPI_list_t* shared_vn_group_data_ids,
     char *shared_dnn_configurations_id,
     OpenAPI_odb_packet_services_e odb_packet_services,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *shared_trace_data_id,
     OpenAPI_list_t* expected_ue_behaviours_list,
@@ -28,6 +29,7 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
     session_management_subscription_data_1_local_var->shared_vn_group_data_ids = shared_vn_group_data_ids;
     session_management_subscription_data_1_local_var->shared_dnn_configurations_id = shared_dnn_configurations_id;
     session_management_subscription_data_1_local_var->odb_packet_services = odb_packet_services;
+    session_management_subscription_data_1_local_var->is_trace_data_null = is_trace_data_null;
     session_management_subscription_data_1_local_var->trace_data = trace_data;
     session_management_subscription_data_1_local_var->shared_trace_data_id = shared_trace_data_id;
     session_management_subscription_data_1_local_var->expected_ue_behaviours_list = expected_ue_behaviours_list;
@@ -240,6 +242,11 @@ cJSON *OpenAPI_session_management_subscription_data_1_convertToJSON(OpenAPI_sess
         ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (session_management_subscription_data_1->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_session_management_subscription_data_1_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (session_management_subscription_data_1->shared_trace_data_id) {
@@ -452,10 +459,12 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
 
     trace_data = cJSON_GetObjectItemCaseSensitive(session_management_subscription_data_1JSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -542,6 +551,7 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
         shared_vn_group_data_ids ? shared_vn_group_data_idsList : NULL,
         shared_dnn_configurations_id && !cJSON_IsNull(shared_dnn_configurations_id) ? ogs_strdup(shared_dnn_configurations_id->valuestring) : NULL,
         odb_packet_services ? odb_packet_servicesVariable : 0,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         shared_trace_data_id && !cJSON_IsNull(shared_trace_data_id) ? ogs_strdup(shared_trace_data_id->valuestring) : NULL,
         expected_ue_behaviours_list ? expected_ue_behaviours_listList : NULL,

--- a/lib/sbi/openapi/model/session_management_subscription_data_1.h
+++ b/lib/sbi/openapi/model/session_management_subscription_data_1.h
@@ -31,6 +31,7 @@ typedef struct OpenAPI_session_management_subscription_data_1_s {
     OpenAPI_list_t* shared_vn_group_data_ids;
     char *shared_dnn_configurations_id;
     OpenAPI_odb_packet_services_e odb_packet_services;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *shared_trace_data_id;
     OpenAPI_list_t* expected_ue_behaviours_list;
@@ -46,6 +47,7 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
     OpenAPI_list_t* shared_vn_group_data_ids,
     char *shared_dnn_configurations_id,
     OpenAPI_odb_packet_services_e odb_packet_services,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *shared_trace_data_id,
     OpenAPI_list_t* expected_ue_behaviours_list,

--- a/lib/sbi/openapi/model/session_rule.c
+++ b/lib/sbi/openapi/model/session_rule.c
@@ -8,8 +8,11 @@ OpenAPI_session_rule_t *OpenAPI_session_rule_create(
     OpenAPI_ambr_t *auth_sess_ambr,
     OpenAPI_authorized_default_qos_t *auth_def_qos,
     char *sess_rule_id,
+    bool is_ref_um_data_null,
     char *ref_um_data,
+    bool is_ref_um_n3g_data_null,
     char *ref_um_n3g_data,
+    bool is_ref_cond_data_null,
     char *ref_cond_data
 )
 {
@@ -19,8 +22,11 @@ OpenAPI_session_rule_t *OpenAPI_session_rule_create(
     session_rule_local_var->auth_sess_ambr = auth_sess_ambr;
     session_rule_local_var->auth_def_qos = auth_def_qos;
     session_rule_local_var->sess_rule_id = sess_rule_id;
+    session_rule_local_var->is_ref_um_data_null = is_ref_um_data_null;
     session_rule_local_var->ref_um_data = ref_um_data;
+    session_rule_local_var->is_ref_um_n3g_data_null = is_ref_um_n3g_data_null;
     session_rule_local_var->ref_um_n3g_data = ref_um_n3g_data;
+    session_rule_local_var->is_ref_cond_data_null = is_ref_cond_data_null;
     session_rule_local_var->ref_cond_data = ref_cond_data;
 
     return session_rule_local_var;
@@ -111,6 +117,11 @@ cJSON *OpenAPI_session_rule_convertToJSON(OpenAPI_session_rule_t *session_rule)
         ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_um_data]");
         goto end;
     }
+    } else if (session_rule->is_ref_um_data_null) {
+        if (cJSON_AddNullToObject(item, "refUmData") == NULL) {
+            ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_um_data]");
+            goto end;
+        }
     }
 
     if (session_rule->ref_um_n3g_data) {
@@ -118,6 +129,11 @@ cJSON *OpenAPI_session_rule_convertToJSON(OpenAPI_session_rule_t *session_rule)
         ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_um_n3g_data]");
         goto end;
     }
+    } else if (session_rule->is_ref_um_n3g_data_null) {
+        if (cJSON_AddNullToObject(item, "refUmN3gData") == NULL) {
+            ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_um_n3g_data]");
+            goto end;
+        }
     }
 
     if (session_rule->ref_cond_data) {
@@ -125,6 +141,11 @@ cJSON *OpenAPI_session_rule_convertToJSON(OpenAPI_session_rule_t *session_rule)
         ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_cond_data]");
         goto end;
     }
+    } else if (session_rule->is_ref_cond_data_null) {
+        if (cJSON_AddNullToObject(item, "refCondData") == NULL) {
+            ogs_error("OpenAPI_session_rule_convertToJSON() failed [ref_cond_data]");
+            goto end;
+        }
     }
 
 end:
@@ -173,25 +194,31 @@ OpenAPI_session_rule_t *OpenAPI_session_rule_parseFromJSON(cJSON *session_ruleJS
 
     ref_um_data = cJSON_GetObjectItemCaseSensitive(session_ruleJSON, "refUmData");
     if (ref_um_data) {
+    if (!cJSON_IsNull(ref_um_data)) {
     if (!cJSON_IsString(ref_um_data) && !cJSON_IsNull(ref_um_data)) {
         ogs_error("OpenAPI_session_rule_parseFromJSON() failed [ref_um_data]");
         goto end;
     }
     }
+    }
 
     ref_um_n3g_data = cJSON_GetObjectItemCaseSensitive(session_ruleJSON, "refUmN3gData");
     if (ref_um_n3g_data) {
+    if (!cJSON_IsNull(ref_um_n3g_data)) {
     if (!cJSON_IsString(ref_um_n3g_data) && !cJSON_IsNull(ref_um_n3g_data)) {
         ogs_error("OpenAPI_session_rule_parseFromJSON() failed [ref_um_n3g_data]");
         goto end;
     }
     }
+    }
 
     ref_cond_data = cJSON_GetObjectItemCaseSensitive(session_ruleJSON, "refCondData");
     if (ref_cond_data) {
+    if (!cJSON_IsNull(ref_cond_data)) {
     if (!cJSON_IsString(ref_cond_data) && !cJSON_IsNull(ref_cond_data)) {
         ogs_error("OpenAPI_session_rule_parseFromJSON() failed [ref_cond_data]");
         goto end;
+    }
     }
     }
 
@@ -199,8 +226,11 @@ OpenAPI_session_rule_t *OpenAPI_session_rule_parseFromJSON(cJSON *session_ruleJS
         auth_sess_ambr ? auth_sess_ambr_local_nonprim : NULL,
         auth_def_qos ? auth_def_qos_local_nonprim : NULL,
         ogs_strdup(sess_rule_id->valuestring),
+        ref_um_data && cJSON_IsNull(ref_um_data) ? true : false,
         ref_um_data && !cJSON_IsNull(ref_um_data) ? ogs_strdup(ref_um_data->valuestring) : NULL,
+        ref_um_n3g_data && cJSON_IsNull(ref_um_n3g_data) ? true : false,
         ref_um_n3g_data && !cJSON_IsNull(ref_um_n3g_data) ? ogs_strdup(ref_um_n3g_data->valuestring) : NULL,
+        ref_cond_data && cJSON_IsNull(ref_cond_data) ? true : false,
         ref_cond_data && !cJSON_IsNull(ref_cond_data) ? ogs_strdup(ref_cond_data->valuestring) : NULL
     );
 

--- a/lib/sbi/openapi/model/session_rule.h
+++ b/lib/sbi/openapi/model/session_rule.h
@@ -24,8 +24,11 @@ typedef struct OpenAPI_session_rule_s {
     struct OpenAPI_ambr_s *auth_sess_ambr;
     struct OpenAPI_authorized_default_qos_s *auth_def_qos;
     char *sess_rule_id;
+    bool is_ref_um_data_null;
     char *ref_um_data;
+    bool is_ref_um_n3g_data_null;
     char *ref_um_n3g_data;
+    bool is_ref_cond_data_null;
     char *ref_cond_data;
 } OpenAPI_session_rule_t;
 
@@ -33,8 +36,11 @@ OpenAPI_session_rule_t *OpenAPI_session_rule_create(
     OpenAPI_ambr_t *auth_sess_ambr,
     OpenAPI_authorized_default_qos_t *auth_def_qos,
     char *sess_rule_id,
+    bool is_ref_um_data_null,
     char *ref_um_data,
+    bool is_ref_um_n3g_data_null,
     char *ref_um_n3g_data,
+    bool is_ref_cond_data_null,
     char *ref_cond_data
 );
 void OpenAPI_session_rule_free(OpenAPI_session_rule_t *session_rule);

--- a/lib/sbi/openapi/model/shared_data.c
+++ b/lib/sbi/openapi/model/shared_data.c
@@ -10,11 +10,13 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_create(
     OpenAPI_sms_subscription_data_t *shared_sms_subs_data,
     OpenAPI_sms_management_subscription_data_t *shared_sms_mng_subs_data,
     OpenAPI_list_t* shared_dnn_configurations,
+    bool is_shared_trace_data_null,
     OpenAPI_trace_data_t *shared_trace_data,
     OpenAPI_list_t* shared_snssai_infos,
     OpenAPI_list_t* shared_vn_group_datas,
     OpenAPI_list_t* treatment_instructions,
     OpenAPI_session_management_subscription_data_t *shared_sm_subs_data,
+    bool is_shared_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_t *shared_ecs_addr_config_info
 )
 {
@@ -26,11 +28,13 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_create(
     shared_data_local_var->shared_sms_subs_data = shared_sms_subs_data;
     shared_data_local_var->shared_sms_mng_subs_data = shared_sms_mng_subs_data;
     shared_data_local_var->shared_dnn_configurations = shared_dnn_configurations;
+    shared_data_local_var->is_shared_trace_data_null = is_shared_trace_data_null;
     shared_data_local_var->shared_trace_data = shared_trace_data;
     shared_data_local_var->shared_snssai_infos = shared_snssai_infos;
     shared_data_local_var->shared_vn_group_datas = shared_vn_group_datas;
     shared_data_local_var->treatment_instructions = treatment_instructions;
     shared_data_local_var->shared_sm_subs_data = shared_sm_subs_data;
+    shared_data_local_var->is_shared_ecs_addr_config_info_null = is_shared_ecs_addr_config_info_null;
     shared_data_local_var->shared_ecs_addr_config_info = shared_ecs_addr_config_info;
 
     return shared_data_local_var;
@@ -213,6 +217,11 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
         ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_trace_data]");
         goto end;
     }
+    } else if (shared_data->is_shared_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "sharedTraceData") == NULL) {
+            ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_trace_data]");
+            goto end;
+        }
     }
 
     if (shared_data->shared_snssai_infos) {
@@ -325,6 +334,11 @@ cJSON *OpenAPI_shared_data_convertToJSON(OpenAPI_shared_data_t *shared_data)
         ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_ecs_addr_config_info]");
         goto end;
     }
+    } else if (shared_data->is_shared_ecs_addr_config_info_null) {
+        if (cJSON_AddNullToObject(item, "sharedEcsAddrConfigInfo") == NULL) {
+            ogs_error("OpenAPI_shared_data_convertToJSON() failed [shared_ecs_addr_config_info]");
+            goto end;
+        }
     }
 
 end:
@@ -421,10 +435,12 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_parseFromJSON(cJSON *shared_dataJSON)
 
     shared_trace_data = cJSON_GetObjectItemCaseSensitive(shared_dataJSON, "sharedTraceData");
     if (shared_trace_data) {
+    if (!cJSON_IsNull(shared_trace_data)) {
     shared_trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(shared_trace_data);
     if (!shared_trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [shared_trace_data]");
         goto end;
+    }
     }
     }
 
@@ -513,10 +529,12 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_parseFromJSON(cJSON *shared_dataJSON)
 
     shared_ecs_addr_config_info = cJSON_GetObjectItemCaseSensitive(shared_dataJSON, "sharedEcsAddrConfigInfo");
     if (shared_ecs_addr_config_info) {
+    if (!cJSON_IsNull(shared_ecs_addr_config_info)) {
     shared_ecs_addr_config_info_local_nonprim = OpenAPI_ecs_addr_config_info_parseFromJSON(shared_ecs_addr_config_info);
     if (!shared_ecs_addr_config_info_local_nonprim) {
         ogs_error("OpenAPI_ecs_addr_config_info_parseFromJSON failed [shared_ecs_addr_config_info]");
         goto end;
+    }
     }
     }
 
@@ -526,11 +544,13 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_parseFromJSON(cJSON *shared_dataJSON)
         shared_sms_subs_data ? shared_sms_subs_data_local_nonprim : NULL,
         shared_sms_mng_subs_data ? shared_sms_mng_subs_data_local_nonprim : NULL,
         shared_dnn_configurations ? shared_dnn_configurationsList : NULL,
+        shared_trace_data && cJSON_IsNull(shared_trace_data) ? true : false,
         shared_trace_data ? shared_trace_data_local_nonprim : NULL,
         shared_snssai_infos ? shared_snssai_infosList : NULL,
         shared_vn_group_datas ? shared_vn_group_datasList : NULL,
         treatment_instructions ? treatment_instructionsList : NULL,
         shared_sm_subs_data ? shared_sm_subs_data_local_nonprim : NULL,
+        shared_ecs_addr_config_info && cJSON_IsNull(shared_ecs_addr_config_info) ? true : false,
         shared_ecs_addr_config_info ? shared_ecs_addr_config_info_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/shared_data.h
+++ b/lib/sbi/openapi/model/shared_data.h
@@ -34,11 +34,13 @@ typedef struct OpenAPI_shared_data_s {
     struct OpenAPI_sms_subscription_data_s *shared_sms_subs_data;
     struct OpenAPI_sms_management_subscription_data_s *shared_sms_mng_subs_data;
     OpenAPI_list_t* shared_dnn_configurations;
+    bool is_shared_trace_data_null;
     struct OpenAPI_trace_data_s *shared_trace_data;
     OpenAPI_list_t* shared_snssai_infos;
     OpenAPI_list_t* shared_vn_group_datas;
     OpenAPI_list_t* treatment_instructions;
     struct OpenAPI_session_management_subscription_data_s *shared_sm_subs_data;
+    bool is_shared_ecs_addr_config_info_null;
     struct OpenAPI_ecs_addr_config_info_s *shared_ecs_addr_config_info;
 } OpenAPI_shared_data_t;
 
@@ -48,11 +50,13 @@ OpenAPI_shared_data_t *OpenAPI_shared_data_create(
     OpenAPI_sms_subscription_data_t *shared_sms_subs_data,
     OpenAPI_sms_management_subscription_data_t *shared_sms_mng_subs_data,
     OpenAPI_list_t* shared_dnn_configurations,
+    bool is_shared_trace_data_null,
     OpenAPI_trace_data_t *shared_trace_data,
     OpenAPI_list_t* shared_snssai_infos,
     OpenAPI_list_t* shared_vn_group_datas,
     OpenAPI_list_t* treatment_instructions,
     OpenAPI_session_management_subscription_data_t *shared_sm_subs_data,
+    bool is_shared_ecs_addr_config_info_null,
     OpenAPI_ecs_addr_config_info_t *shared_ecs_addr_config_info
 );
 void OpenAPI_shared_data_free(OpenAPI_shared_data_t *shared_data);

--- a/lib/sbi/openapi/model/sm_context_create_data.h
+++ b/lib/sbi/openapi/model/sm_context_create_data.h
@@ -91,6 +91,7 @@ typedef struct OpenAPI_sm_context_create_data_s {
     char *supported_features;
     OpenAPI_dnn_selection_mode_e sel_mode;
     OpenAPI_list_t *backup_amf_info;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *udm_group_id;
     char *routing_indicator;
@@ -154,6 +155,7 @@ typedef struct OpenAPI_sm_context_create_data_s {
     char *old_pdu_session_ref;
     bool is_sm_policy_notify_ind;
     int sm_policy_notify_ind;
+    bool is_pcf_ue_callback_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_callback_info;
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat;
     bool is_upip_supported;
@@ -214,6 +216,7 @@ OpenAPI_sm_context_create_data_t *OpenAPI_sm_context_create_data_create(
     char *supported_features,
     OpenAPI_dnn_selection_mode_e sel_mode,
     OpenAPI_list_t *backup_amf_info,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *udm_group_id,
     char *routing_indicator,
@@ -277,6 +280,7 @@ OpenAPI_sm_context_create_data_t *OpenAPI_sm_context_create_data_create(
     char *old_pdu_session_ref,
     bool is_sm_policy_notify_ind,
     int sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat,
     bool is_upip_supported,

--- a/lib/sbi/openapi/model/sm_context_update_data.c
+++ b/lib/sbi/openapi/model/sm_context_update_data.c
@@ -32,6 +32,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     char *serving_nf_id,
     OpenAPI_guami_t *guami,
     OpenAPI_plmn_id_nid_t *serving_network,
+    bool is_backup_amf_info_null,
     OpenAPI_list_t *backup_amf_info,
     OpenAPI_access_type_e an_type,
     OpenAPI_access_type_e additional_an_type,
@@ -70,6 +71,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     bool is__5g_mm_cause_value,
     int _5g_mm_cause_value,
     OpenAPI_snssai_t *s_nssai,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_eps_interworking_indication_e eps_interworking_ind,
     bool is_an_type_can_be_changed,
@@ -93,6 +95,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     int skip_n2_pdu_session_res_rel_ind,
     OpenAPI_list_t *secondary_rat_usage_data_report_container,
     OpenAPI_sm_context_update_data_sm_policy_notify_ind_e sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat
 )
@@ -104,6 +107,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     sm_context_update_data_local_var->serving_nf_id = serving_nf_id;
     sm_context_update_data_local_var->guami = guami;
     sm_context_update_data_local_var->serving_network = serving_network;
+    sm_context_update_data_local_var->is_backup_amf_info_null = is_backup_amf_info_null;
     sm_context_update_data_local_var->backup_amf_info = backup_amf_info;
     sm_context_update_data_local_var->an_type = an_type;
     sm_context_update_data_local_var->additional_an_type = additional_an_type;
@@ -142,6 +146,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     sm_context_update_data_local_var->is__5g_mm_cause_value = is__5g_mm_cause_value;
     sm_context_update_data_local_var->_5g_mm_cause_value = _5g_mm_cause_value;
     sm_context_update_data_local_var->s_nssai = s_nssai;
+    sm_context_update_data_local_var->is_trace_data_null = is_trace_data_null;
     sm_context_update_data_local_var->trace_data = trace_data;
     sm_context_update_data_local_var->eps_interworking_ind = eps_interworking_ind;
     sm_context_update_data_local_var->is_an_type_can_be_changed = is_an_type_can_be_changed;
@@ -165,6 +170,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     sm_context_update_data_local_var->skip_n2_pdu_session_res_rel_ind = skip_n2_pdu_session_res_rel_ind;
     sm_context_update_data_local_var->secondary_rat_usage_data_report_container = secondary_rat_usage_data_report_container;
     sm_context_update_data_local_var->sm_policy_notify_ind = sm_policy_notify_ind;
+    sm_context_update_data_local_var->is_pcf_ue_callback_info_null = is_pcf_ue_callback_info_null;
     sm_context_update_data_local_var->pcf_ue_callback_info = pcf_ue_callback_info;
     sm_context_update_data_local_var->satellite_backhaul_cat = satellite_backhaul_cat;
 
@@ -391,6 +397,11 @@ cJSON *OpenAPI_sm_context_update_data_convertToJSON(OpenAPI_sm_context_update_da
         }
         cJSON_AddItemToArray(backup_amf_infoList, itemLocal);
     }
+    } else if (sm_context_update_data->is_backup_amf_info_null) {
+        if (cJSON_AddNullToObject(item, "backupAmfInfo") == NULL) {
+            ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [backup_amf_info]");
+            goto end;
+        }
     }
 
     if (sm_context_update_data->an_type != OpenAPI_access_type_NULL) {
@@ -711,6 +722,11 @@ cJSON *OpenAPI_sm_context_update_data_convertToJSON(OpenAPI_sm_context_update_da
         ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (sm_context_update_data->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (sm_context_update_data->eps_interworking_ind != OpenAPI_eps_interworking_indication_NULL) {
@@ -881,6 +897,11 @@ cJSON *OpenAPI_sm_context_update_data_convertToJSON(OpenAPI_sm_context_update_da
         ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [pcf_ue_callback_info]");
         goto end;
     }
+    } else if (sm_context_update_data->is_pcf_ue_callback_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeCallbackInfo") == NULL) {
+            ogs_error("OpenAPI_sm_context_update_data_convertToJSON() failed [pcf_ue_callback_info]");
+            goto end;
+        }
     }
 
     if (sm_context_update_data->satellite_backhaul_cat != OpenAPI_satellite_backhaul_category_NULL) {
@@ -1028,6 +1049,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
 
     backup_amf_info = cJSON_GetObjectItemCaseSensitive(sm_context_update_dataJSON, "backupAmfInfo");
     if (backup_amf_info) {
+    if (!cJSON_IsNull(backup_amf_info)) {
         cJSON *backup_amf_info_local = NULL;
         if (!cJSON_IsArray(backup_amf_info)) {
             ogs_error("OpenAPI_sm_context_update_data_parseFromJSON() failed [backup_amf_info]");
@@ -1048,6 +1070,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
             }
             OpenAPI_list_add(backup_amf_infoList, backup_amf_infoItem);
         }
+    }
     }
 
     an_type = cJSON_GetObjectItemCaseSensitive(sm_context_update_dataJSON, "anType");
@@ -1382,10 +1405,12 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
 
     trace_data = cJSON_GetObjectItemCaseSensitive(sm_context_update_dataJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -1561,10 +1586,12 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
 
     pcf_ue_callback_info = cJSON_GetObjectItemCaseSensitive(sm_context_update_dataJSON, "pcfUeCallbackInfo");
     if (pcf_ue_callback_info) {
+    if (!cJSON_IsNull(pcf_ue_callback_info)) {
     pcf_ue_callback_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_callback_info);
     if (!pcf_ue_callback_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_callback_info]");
         goto end;
+    }
     }
     }
 
@@ -1582,6 +1609,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
         serving_nf_id && !cJSON_IsNull(serving_nf_id) ? ogs_strdup(serving_nf_id->valuestring) : NULL,
         guami ? guami_local_nonprim : NULL,
         serving_network ? serving_network_local_nonprim : NULL,
+        backup_amf_info && cJSON_IsNull(backup_amf_info) ? true : false,
         backup_amf_info ? backup_amf_infoList : NULL,
         an_type ? an_typeVariable : 0,
         additional_an_type ? additional_an_typeVariable : 0,
@@ -1620,6 +1648,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
         _5g_mm_cause_value ? true : false,
         _5g_mm_cause_value ? _5g_mm_cause_value->valuedouble : 0,
         s_nssai ? s_nssai_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         eps_interworking_ind ? eps_interworking_indVariable : 0,
         an_type_can_be_changed ? true : false,
@@ -1643,6 +1672,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_parseFromJSON(c
         skip_n2_pdu_session_res_rel_ind ? skip_n2_pdu_session_res_rel_ind->valueint : 0,
         secondary_rat_usage_data_report_container ? secondary_rat_usage_data_report_containerList : NULL,
         sm_policy_notify_ind ? sm_policy_notify_indVariable : 0,
+        pcf_ue_callback_info && cJSON_IsNull(pcf_ue_callback_info) ? true : false,
         pcf_ue_callback_info ? pcf_ue_callback_info_local_nonprim : NULL,
         satellite_backhaul_cat ? satellite_backhaul_catVariable : 0
     );

--- a/lib/sbi/openapi/model/sm_context_update_data.h
+++ b/lib/sbi/openapi/model/sm_context_update_data.h
@@ -53,6 +53,7 @@ typedef struct OpenAPI_sm_context_update_data_s {
     char *serving_nf_id;
     struct OpenAPI_guami_s *guami;
     struct OpenAPI_plmn_id_nid_s *serving_network;
+    bool is_backup_amf_info_null;
     OpenAPI_list_t *backup_amf_info;
     OpenAPI_access_type_e an_type;
     OpenAPI_access_type_e additional_an_type;
@@ -91,6 +92,7 @@ typedef struct OpenAPI_sm_context_update_data_s {
     bool is__5g_mm_cause_value;
     int _5g_mm_cause_value;
     struct OpenAPI_snssai_s *s_nssai;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     OpenAPI_eps_interworking_indication_e eps_interworking_ind;
     bool is_an_type_can_be_changed;
@@ -114,6 +116,7 @@ typedef struct OpenAPI_sm_context_update_data_s {
     int skip_n2_pdu_session_res_rel_ind;
     OpenAPI_list_t *secondary_rat_usage_data_report_container;
     OpenAPI_sm_context_update_data_sm_policy_notify_ind_e sm_policy_notify_ind;
+    bool is_pcf_ue_callback_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_callback_info;
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat;
 } OpenAPI_sm_context_update_data_t;
@@ -123,6 +126,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     char *serving_nf_id,
     OpenAPI_guami_t *guami,
     OpenAPI_plmn_id_nid_t *serving_network,
+    bool is_backup_amf_info_null,
     OpenAPI_list_t *backup_amf_info,
     OpenAPI_access_type_e an_type,
     OpenAPI_access_type_e additional_an_type,
@@ -161,6 +165,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     bool is__5g_mm_cause_value,
     int _5g_mm_cause_value,
     OpenAPI_snssai_t *s_nssai,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_eps_interworking_indication_e eps_interworking_ind,
     bool is_an_type_can_be_changed,
@@ -184,6 +189,7 @@ OpenAPI_sm_context_update_data_t *OpenAPI_sm_context_update_data_create(
     int skip_n2_pdu_session_res_rel_ind,
     OpenAPI_list_t *secondary_rat_usage_data_report_container,
     OpenAPI_sm_context_update_data_sm_policy_notify_ind_e sm_policy_notify_ind,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     OpenAPI_satellite_backhaul_category_e satellite_backhaul_cat
 );

--- a/lib/sbi/openapi/model/sm_policy_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_context_data.c
@@ -42,6 +42,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     int _3gpp_ps_data_off_status,
     bool is_ref_qos_indication,
     int ref_qos_indication,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_snssai_t *slice_info,
     OpenAPI_qos_flow_usage_e qos_flow_usage,
@@ -54,6 +55,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     OpenAPI_list_t *ipv4_frame_route_list,
     OpenAPI_list_t *ipv6_frame_route_list,
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
     OpenAPI_list_t *pvs_info,
     bool is_onboard_ind,
@@ -101,6 +103,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     sm_policy_context_data_local_var->_3gpp_ps_data_off_status = _3gpp_ps_data_off_status;
     sm_policy_context_data_local_var->is_ref_qos_indication = is_ref_qos_indication;
     sm_policy_context_data_local_var->ref_qos_indication = ref_qos_indication;
+    sm_policy_context_data_local_var->is_trace_req_null = is_trace_req_null;
     sm_policy_context_data_local_var->trace_req = trace_req;
     sm_policy_context_data_local_var->slice_info = slice_info;
     sm_policy_context_data_local_var->qos_flow_usage = qos_flow_usage;
@@ -113,6 +116,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     sm_policy_context_data_local_var->ipv4_frame_route_list = ipv4_frame_route_list;
     sm_policy_context_data_local_var->ipv6_frame_route_list = ipv6_frame_route_list;
     sm_policy_context_data_local_var->sat_backhaul_category = sat_backhaul_category;
+    sm_policy_context_data_local_var->is_pcf_ue_info_null = is_pcf_ue_info_null;
     sm_policy_context_data_local_var->pcf_ue_info = pcf_ue_info;
     sm_policy_context_data_local_var->pvs_info = pvs_info;
     sm_policy_context_data_local_var->is_onboard_ind = is_onboard_ind;
@@ -571,6 +575,11 @@ cJSON *OpenAPI_sm_policy_context_data_convertToJSON(OpenAPI_sm_policy_context_da
         ogs_error("OpenAPI_sm_policy_context_data_convertToJSON() failed [trace_req]");
         goto end;
     }
+    } else if (sm_policy_context_data->is_trace_req_null) {
+        if (cJSON_AddNullToObject(item, "traceReq") == NULL) {
+            ogs_error("OpenAPI_sm_policy_context_data_convertToJSON() failed [trace_req]");
+            goto end;
+        }
     }
 
     if (!sm_policy_context_data->slice_info) {
@@ -689,6 +698,11 @@ cJSON *OpenAPI_sm_policy_context_data_convertToJSON(OpenAPI_sm_policy_context_da
         ogs_error("OpenAPI_sm_policy_context_data_convertToJSON() failed [pcf_ue_info]");
         goto end;
     }
+    } else if (sm_policy_context_data->is_pcf_ue_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeInfo") == NULL) {
+            ogs_error("OpenAPI_sm_policy_context_data_convertToJSON() failed [pcf_ue_info]");
+            goto end;
+        }
     }
 
     if (sm_policy_context_data->pvs_info) {
@@ -1095,10 +1109,12 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_parseFromJSON(c
 
     trace_req = cJSON_GetObjectItemCaseSensitive(sm_policy_context_dataJSON, "traceReq");
     if (trace_req) {
+    if (!cJSON_IsNull(trace_req)) {
     trace_req_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_req);
     if (!trace_req_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_req]");
         goto end;
+    }
     }
     }
 
@@ -1226,10 +1242,12 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_parseFromJSON(c
 
     pcf_ue_info = cJSON_GetObjectItemCaseSensitive(sm_policy_context_dataJSON, "pcfUeInfo");
     if (pcf_ue_info) {
+    if (!cJSON_IsNull(pcf_ue_info)) {
     pcf_ue_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_info);
     if (!pcf_ue_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_info]");
         goto end;
+    }
     }
     }
 
@@ -1328,6 +1346,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_parseFromJSON(c
         _3gpp_ps_data_off_status ? _3gpp_ps_data_off_status->valueint : 0,
         ref_qos_indication ? true : false,
         ref_qos_indication ? ref_qos_indication->valueint : 0,
+        trace_req && cJSON_IsNull(trace_req) ? true : false,
         trace_req ? trace_req_local_nonprim : NULL,
         slice_info_local_nonprim,
         qos_flow_usage ? qos_flow_usageVariable : 0,
@@ -1340,6 +1359,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_parseFromJSON(c
         ipv4_frame_route_list ? ipv4_frame_route_listList : NULL,
         ipv6_frame_route_list ? ipv6_frame_route_listList : NULL,
         sat_backhaul_category ? sat_backhaul_categoryVariable : 0,
+        pcf_ue_info && cJSON_IsNull(pcf_ue_info) ? true : false,
         pcf_ue_info ? pcf_ue_info_local_nonprim : NULL,
         pvs_info ? pvs_infoList : NULL,
         onboard_ind ? true : false,

--- a/lib/sbi/openapi/model/sm_policy_context_data.h
+++ b/lib/sbi/openapi/model/sm_policy_context_data.h
@@ -78,6 +78,7 @@ typedef struct OpenAPI_sm_policy_context_data_s {
     int _3gpp_ps_data_off_status;
     bool is_ref_qos_indication;
     int ref_qos_indication;
+    bool is_trace_req_null;
     struct OpenAPI_trace_data_s *trace_req;
     struct OpenAPI_snssai_s *slice_info;
     OpenAPI_qos_flow_usage_e qos_flow_usage;
@@ -90,6 +91,7 @@ typedef struct OpenAPI_sm_policy_context_data_s {
     OpenAPI_list_t *ipv4_frame_route_list;
     OpenAPI_list_t *ipv6_frame_route_list;
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category;
+    bool is_pcf_ue_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_info;
     OpenAPI_list_t *pvs_info;
     bool is_onboard_ind;
@@ -135,6 +137,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     int _3gpp_ps_data_off_status,
     bool is_ref_qos_indication,
     int ref_qos_indication,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_snssai_t *slice_info,
     OpenAPI_qos_flow_usage_e qos_flow_usage,
@@ -147,6 +150,7 @@ OpenAPI_sm_policy_context_data_t *OpenAPI_sm_policy_context_data_create(
     OpenAPI_list_t *ipv4_frame_route_list,
     OpenAPI_list_t *ipv6_frame_route_list,
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
     OpenAPI_list_t *pvs_info,
     bool is_onboard_ind,

--- a/lib/sbi/openapi/model/sm_policy_data_patch.h
+++ b/lib/sbi/openapi/model/sm_policy_data_patch.h
@@ -21,11 +21,13 @@ extern "C" {
 
 typedef struct OpenAPI_sm_policy_data_patch_s OpenAPI_sm_policy_data_patch_t;
 typedef struct OpenAPI_sm_policy_data_patch_s {
+    bool is_um_data_null;
     OpenAPI_list_t* um_data;
     OpenAPI_list_t* sm_policy_snssai_data;
 } OpenAPI_sm_policy_data_patch_t;
 
 OpenAPI_sm_policy_data_patch_t *OpenAPI_sm_policy_data_patch_create(
+    bool is_um_data_null,
     OpenAPI_list_t* um_data,
     OpenAPI_list_t* sm_policy_snssai_data
 );

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -6,18 +6,23 @@
 
 OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     OpenAPI_list_t* sess_rules,
+    bool is_pcc_rules_null,
     OpenAPI_list_t* pcc_rules,
     bool is_pcscf_rest_indication,
     int pcscf_rest_indication,
     OpenAPI_list_t* qos_decs,
+    bool is_chg_decs_null,
     OpenAPI_list_t* chg_decs,
     OpenAPI_charging_information_t *charging_info,
     OpenAPI_list_t* traff_cont_decs,
+    bool is_um_decs_null,
     OpenAPI_list_t* um_decs,
     OpenAPI_list_t* qos_chars,
+    bool is_qos_mon_decs_null,
     OpenAPI_list_t* qos_mon_decs,
     bool is_reflective_qo_s_timer,
     int reflective_qo_s_timer,
+    bool is_conds_null,
     OpenAPI_list_t* conds,
     char *revalidation_time,
     bool is_offline,
@@ -26,9 +31,11 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     int online,
     bool is_offline_ch_only,
     int offline_ch_only,
+    bool is_policy_ctrl_req_triggers_null,
     OpenAPI_list_t *policy_ctrl_req_triggers,
     OpenAPI_list_t *last_req_rule_data,
     OpenAPI_requested_usage_data_t *last_req_usage_data,
+    bool is_pra_infos_null,
     OpenAPI_list_t* pra_infos,
     bool is_ipv4_index,
     int ipv4_index,
@@ -48,18 +55,23 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     ogs_assert(sm_policy_decision_local_var);
 
     sm_policy_decision_local_var->sess_rules = sess_rules;
+    sm_policy_decision_local_var->is_pcc_rules_null = is_pcc_rules_null;
     sm_policy_decision_local_var->pcc_rules = pcc_rules;
     sm_policy_decision_local_var->is_pcscf_rest_indication = is_pcscf_rest_indication;
     sm_policy_decision_local_var->pcscf_rest_indication = pcscf_rest_indication;
     sm_policy_decision_local_var->qos_decs = qos_decs;
+    sm_policy_decision_local_var->is_chg_decs_null = is_chg_decs_null;
     sm_policy_decision_local_var->chg_decs = chg_decs;
     sm_policy_decision_local_var->charging_info = charging_info;
     sm_policy_decision_local_var->traff_cont_decs = traff_cont_decs;
+    sm_policy_decision_local_var->is_um_decs_null = is_um_decs_null;
     sm_policy_decision_local_var->um_decs = um_decs;
     sm_policy_decision_local_var->qos_chars = qos_chars;
+    sm_policy_decision_local_var->is_qos_mon_decs_null = is_qos_mon_decs_null;
     sm_policy_decision_local_var->qos_mon_decs = qos_mon_decs;
     sm_policy_decision_local_var->is_reflective_qo_s_timer = is_reflective_qo_s_timer;
     sm_policy_decision_local_var->reflective_qo_s_timer = reflective_qo_s_timer;
+    sm_policy_decision_local_var->is_conds_null = is_conds_null;
     sm_policy_decision_local_var->conds = conds;
     sm_policy_decision_local_var->revalidation_time = revalidation_time;
     sm_policy_decision_local_var->is_offline = is_offline;
@@ -68,9 +80,11 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     sm_policy_decision_local_var->online = online;
     sm_policy_decision_local_var->is_offline_ch_only = is_offline_ch_only;
     sm_policy_decision_local_var->offline_ch_only = offline_ch_only;
+    sm_policy_decision_local_var->is_policy_ctrl_req_triggers_null = is_policy_ctrl_req_triggers_null;
     sm_policy_decision_local_var->policy_ctrl_req_triggers = policy_ctrl_req_triggers;
     sm_policy_decision_local_var->last_req_rule_data = last_req_rule_data;
     sm_policy_decision_local_var->last_req_usage_data = last_req_usage_data;
+    sm_policy_decision_local_var->is_pra_infos_null = is_pra_infos_null;
     sm_policy_decision_local_var->pra_infos = pra_infos;
     sm_policy_decision_local_var->is_ipv4_index = is_ipv4_index;
     sm_policy_decision_local_var->ipv4_index = ipv4_index;
@@ -309,6 +323,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_pcc_rules_null) {
+        if (cJSON_AddNullToObject(item, "pccRules") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pcc_rules]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->is_pcscf_rest_indication) {
@@ -376,6 +395,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_chg_decs_null) {
+        if (cJSON_AddNullToObject(item, "chgDecs") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [chg_decs]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->charging_info) {
@@ -449,6 +473,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_um_decs_null) {
+        if (cJSON_AddNullToObject(item, "umDecs") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [um_decs]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->qos_chars) {
@@ -509,6 +538,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_qos_mon_decs_null) {
+        if (cJSON_AddNullToObject(item, "qosMonDecs") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [qos_mon_decs]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->is_reflective_qo_s_timer) {
@@ -546,6 +580,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_conds_null) {
+        if (cJSON_AddNullToObject(item, "conds") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [conds]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->revalidation_time) {
@@ -588,6 +627,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             goto end;
         }
     }
+    } else if (sm_policy_decision->is_policy_ctrl_req_triggers_null) {
+        if (cJSON_AddNullToObject(item, "policyCtrlReqTriggers") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [policy_ctrl_req_triggers]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->last_req_rule_data) {
@@ -647,6 +691,11 @@ cJSON *OpenAPI_sm_policy_decision_convertToJSON(OpenAPI_sm_policy_decision_t *sm
             cJSON_AddItemToObject(localMapObject, localKeyValue->key, itemLocal);
         }
     }
+    } else if (sm_policy_decision->is_pra_infos_null) {
+        if (cJSON_AddNullToObject(item, "praInfos") == NULL) {
+            ogs_error("OpenAPI_sm_policy_decision_convertToJSON() failed [pra_infos]");
+            goto end;
+        }
     }
 
     if (sm_policy_decision->is_ipv4_index) {
@@ -817,6 +866,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     pcc_rules = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "pccRules");
     if (pcc_rules) {
+    if (!cJSON_IsNull(pcc_rules)) {
         cJSON *pcc_rules_local_map = NULL;
         if (!cJSON_IsObject(pcc_rules) && !cJSON_IsNull(pcc_rules)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [pcc_rules]");
@@ -839,6 +889,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(pcc_rulesList, localMapKeyPair);
             }
         }
+    }
     }
 
     pcscf_rest_indication = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "pcscfRestIndication");
@@ -877,6 +928,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     chg_decs = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "chgDecs");
     if (chg_decs) {
+    if (!cJSON_IsNull(chg_decs)) {
         cJSON *chg_decs_local_map = NULL;
         if (!cJSON_IsObject(chg_decs) && !cJSON_IsNull(chg_decs)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [chg_decs]");
@@ -899,6 +951,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(chg_decsList, localMapKeyPair);
             }
         }
+    }
     }
 
     charging_info = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "chargingInfo");
@@ -938,6 +991,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     um_decs = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "umDecs");
     if (um_decs) {
+    if (!cJSON_IsNull(um_decs)) {
         cJSON *um_decs_local_map = NULL;
         if (!cJSON_IsObject(um_decs) && !cJSON_IsNull(um_decs)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [um_decs]");
@@ -960,6 +1014,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(um_decsList, localMapKeyPair);
             }
         }
+    }
     }
 
     qos_chars = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "qosChars");
@@ -990,6 +1045,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     qos_mon_decs = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "qosMonDecs");
     if (qos_mon_decs) {
+    if (!cJSON_IsNull(qos_mon_decs)) {
         cJSON *qos_mon_decs_local_map = NULL;
         if (!cJSON_IsObject(qos_mon_decs) && !cJSON_IsNull(qos_mon_decs)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [qos_mon_decs]");
@@ -1013,6 +1069,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
             }
         }
     }
+    }
 
     reflective_qo_s_timer = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "reflectiveQoSTimer");
     if (reflective_qo_s_timer) {
@@ -1024,6 +1081,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     conds = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "conds");
     if (conds) {
+    if (!cJSON_IsNull(conds)) {
         cJSON *conds_local_map = NULL;
         if (!cJSON_IsObject(conds) && !cJSON_IsNull(conds)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [conds]");
@@ -1046,6 +1104,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(condsList, localMapKeyPair);
             }
         }
+    }
     }
 
     revalidation_time = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "revalidationTime");
@@ -1082,6 +1141,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     policy_ctrl_req_triggers = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "policyCtrlReqTriggers");
     if (policy_ctrl_req_triggers) {
+    if (!cJSON_IsNull(policy_ctrl_req_triggers)) {
         cJSON *policy_ctrl_req_triggers_local = NULL;
         if (!cJSON_IsArray(policy_ctrl_req_triggers)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [policy_ctrl_req_triggers]");
@@ -1103,6 +1163,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
             }
             OpenAPI_list_add(policy_ctrl_req_triggersList, (void *)localEnum);
         }
+    }
     }
 
     last_req_rule_data = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "lastReqRuleData");
@@ -1140,6 +1201,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     pra_infos = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "praInfos");
     if (pra_infos) {
+    if (!cJSON_IsNull(pra_infos)) {
         cJSON *pra_infos_local_map = NULL;
         if (!cJSON_IsObject(pra_infos) && !cJSON_IsNull(pra_infos)) {
             ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [pra_infos]");
@@ -1162,6 +1224,7 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(pra_infosList, localMapKeyPair);
             }
         }
+    }
     }
 
     ipv4_index = cJSON_GetObjectItemCaseSensitive(sm_policy_decisionJSON, "ipv4Index");
@@ -1258,18 +1321,23 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
 
     sm_policy_decision_local_var = OpenAPI_sm_policy_decision_create (
         sess_rules ? sess_rulesList : NULL,
+        pcc_rules && cJSON_IsNull(pcc_rules) ? true : false,
         pcc_rules ? pcc_rulesList : NULL,
         pcscf_rest_indication ? true : false,
         pcscf_rest_indication ? pcscf_rest_indication->valueint : 0,
         qos_decs ? qos_decsList : NULL,
+        chg_decs && cJSON_IsNull(chg_decs) ? true : false,
         chg_decs ? chg_decsList : NULL,
         charging_info ? charging_info_local_nonprim : NULL,
         traff_cont_decs ? traff_cont_decsList : NULL,
+        um_decs && cJSON_IsNull(um_decs) ? true : false,
         um_decs ? um_decsList : NULL,
         qos_chars ? qos_charsList : NULL,
+        qos_mon_decs && cJSON_IsNull(qos_mon_decs) ? true : false,
         qos_mon_decs ? qos_mon_decsList : NULL,
         reflective_qo_s_timer ? true : false,
         reflective_qo_s_timer ? reflective_qo_s_timer->valuedouble : 0,
+        conds && cJSON_IsNull(conds) ? true : false,
         conds ? condsList : NULL,
         revalidation_time && !cJSON_IsNull(revalidation_time) ? ogs_strdup(revalidation_time->valuestring) : NULL,
         offline ? true : false,
@@ -1278,9 +1346,11 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
         online ? online->valueint : 0,
         offline_ch_only ? true : false,
         offline_ch_only ? offline_ch_only->valueint : 0,
+        policy_ctrl_req_triggers && cJSON_IsNull(policy_ctrl_req_triggers) ? true : false,
         policy_ctrl_req_triggers ? policy_ctrl_req_triggersList : NULL,
         last_req_rule_data ? last_req_rule_dataList : NULL,
         last_req_usage_data ? last_req_usage_data_local_nonprim : NULL,
+        pra_infos && cJSON_IsNull(pra_infos) ? true : false,
         pra_infos ? pra_infosList : NULL,
         ipv4_index ? true : false,
         ipv4_index ? ipv4_index->valuedouble : 0,

--- a/lib/sbi/openapi/model/sm_policy_decision.h
+++ b/lib/sbi/openapi/model/sm_policy_decision.h
@@ -38,18 +38,23 @@ extern "C" {
 typedef struct OpenAPI_sm_policy_decision_s OpenAPI_sm_policy_decision_t;
 typedef struct OpenAPI_sm_policy_decision_s {
     OpenAPI_list_t* sess_rules;
+    bool is_pcc_rules_null;
     OpenAPI_list_t* pcc_rules;
     bool is_pcscf_rest_indication;
     int pcscf_rest_indication;
     OpenAPI_list_t* qos_decs;
+    bool is_chg_decs_null;
     OpenAPI_list_t* chg_decs;
     struct OpenAPI_charging_information_s *charging_info;
     OpenAPI_list_t* traff_cont_decs;
+    bool is_um_decs_null;
     OpenAPI_list_t* um_decs;
     OpenAPI_list_t* qos_chars;
+    bool is_qos_mon_decs_null;
     OpenAPI_list_t* qos_mon_decs;
     bool is_reflective_qo_s_timer;
     int reflective_qo_s_timer;
+    bool is_conds_null;
     OpenAPI_list_t* conds;
     char *revalidation_time;
     bool is_offline;
@@ -58,9 +63,11 @@ typedef struct OpenAPI_sm_policy_decision_s {
     int online;
     bool is_offline_ch_only;
     int offline_ch_only;
+    bool is_policy_ctrl_req_triggers_null;
     OpenAPI_list_t *policy_ctrl_req_triggers;
     OpenAPI_list_t *last_req_rule_data;
     struct OpenAPI_requested_usage_data_s *last_req_usage_data;
+    bool is_pra_infos_null;
     OpenAPI_list_t* pra_infos;
     bool is_ipv4_index;
     int ipv4_index;
@@ -78,18 +85,23 @@ typedef struct OpenAPI_sm_policy_decision_s {
 
 OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     OpenAPI_list_t* sess_rules,
+    bool is_pcc_rules_null,
     OpenAPI_list_t* pcc_rules,
     bool is_pcscf_rest_indication,
     int pcscf_rest_indication,
     OpenAPI_list_t* qos_decs,
+    bool is_chg_decs_null,
     OpenAPI_list_t* chg_decs,
     OpenAPI_charging_information_t *charging_info,
     OpenAPI_list_t* traff_cont_decs,
+    bool is_um_decs_null,
     OpenAPI_list_t* um_decs,
     OpenAPI_list_t* qos_chars,
+    bool is_qos_mon_decs_null,
     OpenAPI_list_t* qos_mon_decs,
     bool is_reflective_qo_s_timer,
     int reflective_qo_s_timer,
+    bool is_conds_null,
     OpenAPI_list_t* conds,
     char *revalidation_time,
     bool is_offline,
@@ -98,9 +110,11 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_create(
     int online,
     bool is_offline_ch_only,
     int offline_ch_only,
+    bool is_policy_ctrl_req_triggers_null,
     OpenAPI_list_t *policy_ctrl_req_triggers,
     OpenAPI_list_t *last_req_rule_data,
     OpenAPI_requested_usage_data_t *last_req_usage_data,
+    bool is_pra_infos_null,
     OpenAPI_list_t* pra_infos,
     bool is_ipv4_index,
     int ipv4_index,

--- a/lib/sbi/openapi/model/sm_policy_dnn_data.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data.c
@@ -35,6 +35,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_create(
     bool is_mcs_priority_level,
     int mcs_priority_level,
     OpenAPI_list_t* pra_infos,
+    bool is_bdt_ref_ids_null,
     OpenAPI_list_t* bdt_ref_ids,
     bool is_loc_rout_not_allowed,
     int loc_rout_not_allowed
@@ -73,6 +74,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_create(
     sm_policy_dnn_data_local_var->is_mcs_priority_level = is_mcs_priority_level;
     sm_policy_dnn_data_local_var->mcs_priority_level = mcs_priority_level;
     sm_policy_dnn_data_local_var->pra_infos = pra_infos;
+    sm_policy_dnn_data_local_var->is_bdt_ref_ids_null = is_bdt_ref_ids_null;
     sm_policy_dnn_data_local_var->bdt_ref_ids = bdt_ref_ids;
     sm_policy_dnn_data_local_var->is_loc_rout_not_allowed = is_loc_rout_not_allowed;
     sm_policy_dnn_data_local_var->loc_rout_not_allowed = loc_rout_not_allowed;
@@ -386,6 +388,11 @@ cJSON *OpenAPI_sm_policy_dnn_data_convertToJSON(OpenAPI_sm_policy_dnn_data_t *sm
             }
         }
     }
+    } else if (sm_policy_dnn_data->is_bdt_ref_ids_null) {
+        if (cJSON_AddNullToObject(item, "bdtRefIds") == NULL) {
+            ogs_error("OpenAPI_sm_policy_dnn_data_convertToJSON() failed [bdt_ref_ids]");
+            goto end;
+        }
     }
 
     if (sm_policy_dnn_data->is_loc_rout_not_allowed) {
@@ -649,6 +656,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
 
     bdt_ref_ids = cJSON_GetObjectItemCaseSensitive(sm_policy_dnn_dataJSON, "bdtRefIds");
     if (bdt_ref_ids) {
+    if (!cJSON_IsNull(bdt_ref_ids)) {
         cJSON *bdt_ref_ids_local_map = NULL;
         if (!cJSON_IsObject(bdt_ref_ids) && !cJSON_IsNull(bdt_ref_ids)) {
             ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [bdt_ref_ids]");
@@ -669,6 +677,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
                 OpenAPI_list_add(bdt_ref_idsList, localMapKeyPair);
             }
         }
+    }
     }
 
     loc_rout_not_allowed = cJSON_GetObjectItemCaseSensitive(sm_policy_dnn_dataJSON, "locRoutNotAllowed");
@@ -710,6 +719,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
         mcs_priority_level ? true : false,
         mcs_priority_level ? mcs_priority_level->valuedouble : 0,
         pra_infos ? pra_infosList : NULL,
+        bdt_ref_ids && cJSON_IsNull(bdt_ref_ids) ? true : false,
         bdt_ref_ids ? bdt_ref_idsList : NULL,
         loc_rout_not_allowed ? true : false,
         loc_rout_not_allowed ? loc_rout_not_allowed->valueint : 0

--- a/lib/sbi/openapi/model/sm_policy_dnn_data.h
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data.h
@@ -52,6 +52,7 @@ typedef struct OpenAPI_sm_policy_dnn_data_s {
     bool is_mcs_priority_level;
     int mcs_priority_level;
     OpenAPI_list_t* pra_infos;
+    bool is_bdt_ref_ids_null;
     OpenAPI_list_t* bdt_ref_ids;
     bool is_loc_rout_not_allowed;
     int loc_rout_not_allowed;
@@ -88,6 +89,7 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_create(
     bool is_mcs_priority_level,
     int mcs_priority_level,
     OpenAPI_list_t* pra_infos,
+    bool is_bdt_ref_ids_null,
     OpenAPI_list_t* bdt_ref_ids,
     bool is_loc_rout_not_allowed,
     int loc_rout_not_allowed

--- a/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
@@ -6,6 +6,7 @@
 
 OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_create(
     char *dnn,
+    bool is_bdt_ref_ids_null,
     OpenAPI_list_t* bdt_ref_ids
 )
 {
@@ -13,6 +14,7 @@ OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_create(
     ogs_assert(sm_policy_dnn_data_patch_local_var);
 
     sm_policy_dnn_data_patch_local_var->dnn = dnn;
+    sm_policy_dnn_data_patch_local_var->is_bdt_ref_ids_null = is_bdt_ref_ids_null;
     sm_policy_dnn_data_patch_local_var->bdt_ref_ids = bdt_ref_ids;
 
     return sm_policy_dnn_data_patch_local_var;
@@ -86,6 +88,11 @@ cJSON *OpenAPI_sm_policy_dnn_data_patch_convertToJSON(OpenAPI_sm_policy_dnn_data
             }
         }
     }
+    } else if (sm_policy_dnn_data_patch->is_bdt_ref_ids_null) {
+        if (cJSON_AddNullToObject(item, "bdtRefIds") == NULL) {
+            ogs_error("OpenAPI_sm_policy_dnn_data_patch_convertToJSON() failed [bdt_ref_ids]");
+            goto end;
+        }
     }
 
 end:
@@ -111,6 +118,7 @@ OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_parseFromJS
 
     bdt_ref_ids = cJSON_GetObjectItemCaseSensitive(sm_policy_dnn_data_patchJSON, "bdtRefIds");
     if (bdt_ref_ids) {
+    if (!cJSON_IsNull(bdt_ref_ids)) {
         cJSON *bdt_ref_ids_local_map = NULL;
         if (!cJSON_IsObject(bdt_ref_ids) && !cJSON_IsNull(bdt_ref_ids)) {
             ogs_error("OpenAPI_sm_policy_dnn_data_patch_parseFromJSON() failed [bdt_ref_ids]");
@@ -132,9 +140,11 @@ OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_parseFromJS
             }
         }
     }
+    }
 
     sm_policy_dnn_data_patch_local_var = OpenAPI_sm_policy_dnn_data_patch_create (
         ogs_strdup(dnn->valuestring),
+        bdt_ref_ids && cJSON_IsNull(bdt_ref_ids) ? true : false,
         bdt_ref_ids ? bdt_ref_idsList : NULL
     );
 

--- a/lib/sbi/openapi/model/sm_policy_dnn_data_patch.h
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data_patch.h
@@ -20,11 +20,13 @@ extern "C" {
 typedef struct OpenAPI_sm_policy_dnn_data_patch_s OpenAPI_sm_policy_dnn_data_patch_t;
 typedef struct OpenAPI_sm_policy_dnn_data_patch_s {
     char *dnn;
+    bool is_bdt_ref_ids_null;
     OpenAPI_list_t* bdt_ref_ids;
 } OpenAPI_sm_policy_dnn_data_patch_t;
 
 OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_create(
     char *dnn,
+    bool is_bdt_ref_ids_null,
     OpenAPI_list_t* bdt_ref_ids
 );
 void OpenAPI_sm_policy_dnn_data_patch_free(OpenAPI_sm_policy_dnn_data_patch_t *sm_policy_dnn_data_patch);

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -47,6 +47,7 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     OpenAPI_qos_flow_usage_e qos_flow_usage,
     OpenAPI_credit_management_status_e credit_manage_status,
     OpenAPI_serving_nf_identity_t *serv_nf_id,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_ma_pdu_indication_e ma_pdu_ind,
     OpenAPI_npcf_atsss_capability_e atsss_capab,
@@ -62,7 +63,9 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     OpenAPI_list_t *types_of_notif,
     OpenAPI_list_t *inter_grp_ids,
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_nwdaf_datas_null,
     OpenAPI_list_t *nwdaf_datas,
     bool is_an_gw_status,
     int an_gw_status
@@ -113,6 +116,7 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     sm_policy_update_context_data_local_var->qos_flow_usage = qos_flow_usage;
     sm_policy_update_context_data_local_var->credit_manage_status = credit_manage_status;
     sm_policy_update_context_data_local_var->serv_nf_id = serv_nf_id;
+    sm_policy_update_context_data_local_var->is_trace_req_null = is_trace_req_null;
     sm_policy_update_context_data_local_var->trace_req = trace_req;
     sm_policy_update_context_data_local_var->ma_pdu_ind = ma_pdu_ind;
     sm_policy_update_context_data_local_var->atsss_capab = atsss_capab;
@@ -128,7 +132,9 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     sm_policy_update_context_data_local_var->types_of_notif = types_of_notif;
     sm_policy_update_context_data_local_var->inter_grp_ids = inter_grp_ids;
     sm_policy_update_context_data_local_var->sat_backhaul_category = sat_backhaul_category;
+    sm_policy_update_context_data_local_var->is_pcf_ue_info_null = is_pcf_ue_info_null;
     sm_policy_update_context_data_local_var->pcf_ue_info = pcf_ue_info;
+    sm_policy_update_context_data_local_var->is_nwdaf_datas_null = is_nwdaf_datas_null;
     sm_policy_update_context_data_local_var->nwdaf_datas = nwdaf_datas;
     sm_policy_update_context_data_local_var->is_an_gw_status = is_an_gw_status;
     sm_policy_update_context_data_local_var->an_gw_status = an_gw_status;
@@ -802,6 +808,11 @@ cJSON *OpenAPI_sm_policy_update_context_data_convertToJSON(OpenAPI_sm_policy_upd
         ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [trace_req]");
         goto end;
     }
+    } else if (sm_policy_update_context_data->is_trace_req_null) {
+        if (cJSON_AddNullToObject(item, "traceReq") == NULL) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [trace_req]");
+            goto end;
+        }
     }
 
     if (sm_policy_update_context_data->ma_pdu_ind != OpenAPI_ma_pdu_indication_NULL) {
@@ -988,6 +999,11 @@ cJSON *OpenAPI_sm_policy_update_context_data_convertToJSON(OpenAPI_sm_policy_upd
         ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [pcf_ue_info]");
         goto end;
     }
+    } else if (sm_policy_update_context_data->is_pcf_ue_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeInfo") == NULL) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [pcf_ue_info]");
+            goto end;
+        }
     }
 
     if (sm_policy_update_context_data->nwdaf_datas) {
@@ -1004,6 +1020,11 @@ cJSON *OpenAPI_sm_policy_update_context_data_convertToJSON(OpenAPI_sm_policy_upd
         }
         cJSON_AddItemToArray(nwdaf_datasList, itemLocal);
     }
+    } else if (sm_policy_update_context_data->is_nwdaf_datas_null) {
+        if (cJSON_AddNullToObject(item, "nwdafDatas") == NULL) {
+            ogs_error("OpenAPI_sm_policy_update_context_data_convertToJSON() failed [nwdaf_datas]");
+            goto end;
+        }
     }
 
     if (sm_policy_update_context_data->is_an_gw_status) {
@@ -1581,10 +1602,12 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
 
     trace_req = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "traceReq");
     if (trace_req) {
+    if (!cJSON_IsNull(trace_req)) {
     trace_req_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_req);
     if (!trace_req_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_req]");
         goto end;
+    }
     }
     }
 
@@ -1819,15 +1842,18 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
 
     pcf_ue_info = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "pcfUeInfo");
     if (pcf_ue_info) {
+    if (!cJSON_IsNull(pcf_ue_info)) {
     pcf_ue_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_info);
     if (!pcf_ue_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_info]");
         goto end;
     }
     }
+    }
 
     nwdaf_datas = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "nwdafDatas");
     if (nwdaf_datas) {
+    if (!cJSON_IsNull(nwdaf_datas)) {
         cJSON *nwdaf_datas_local = NULL;
         if (!cJSON_IsArray(nwdaf_datas)) {
             ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [nwdaf_datas]");
@@ -1848,6 +1874,7 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
             }
             OpenAPI_list_add(nwdaf_datasList, nwdaf_datasItem);
         }
+    }
     }
 
     an_gw_status = cJSON_GetObjectItemCaseSensitive(sm_policy_update_context_dataJSON, "anGwStatus");
@@ -1901,6 +1928,7 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
         qos_flow_usage ? qos_flow_usageVariable : 0,
         credit_manage_status ? credit_manage_statusVariable : 0,
         serv_nf_id ? serv_nf_id_local_nonprim : NULL,
+        trace_req && cJSON_IsNull(trace_req) ? true : false,
         trace_req ? trace_req_local_nonprim : NULL,
         ma_pdu_ind ? ma_pdu_indVariable : 0,
         atsss_capab ? atsss_capabVariable : 0,
@@ -1916,7 +1944,9 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
         types_of_notif ? types_of_notifList : NULL,
         inter_grp_ids ? inter_grp_idsList : NULL,
         sat_backhaul_category ? sat_backhaul_categoryVariable : 0,
+        pcf_ue_info && cJSON_IsNull(pcf_ue_info) ? true : false,
         pcf_ue_info ? pcf_ue_info_local_nonprim : NULL,
+        nwdaf_datas && cJSON_IsNull(nwdaf_datas) ? true : false,
         nwdaf_datas ? nwdaf_datasList : NULL,
         an_gw_status ? true : false,
         an_gw_status ? an_gw_status->valueint : 0

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.h
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.h
@@ -96,6 +96,7 @@ typedef struct OpenAPI_sm_policy_update_context_data_s {
     OpenAPI_qos_flow_usage_e qos_flow_usage;
     OpenAPI_credit_management_status_e credit_manage_status;
     struct OpenAPI_serving_nf_identity_s *serv_nf_id;
+    bool is_trace_req_null;
     struct OpenAPI_trace_data_s *trace_req;
     OpenAPI_ma_pdu_indication_e ma_pdu_ind;
     OpenAPI_npcf_atsss_capability_e atsss_capab;
@@ -111,7 +112,9 @@ typedef struct OpenAPI_sm_policy_update_context_data_s {
     OpenAPI_list_t *types_of_notif;
     OpenAPI_list_t *inter_grp_ids;
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category;
+    bool is_pcf_ue_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_info;
+    bool is_nwdaf_datas_null;
     OpenAPI_list_t *nwdaf_datas;
     bool is_an_gw_status;
     int an_gw_status;
@@ -160,6 +163,7 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     OpenAPI_qos_flow_usage_e qos_flow_usage,
     OpenAPI_credit_management_status_e credit_manage_status,
     OpenAPI_serving_nf_identity_t *serv_nf_id,
+    bool is_trace_req_null,
     OpenAPI_trace_data_t *trace_req,
     OpenAPI_ma_pdu_indication_e ma_pdu_ind,
     OpenAPI_npcf_atsss_capability_e atsss_capab,
@@ -175,7 +179,9 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_c
     OpenAPI_list_t *types_of_notif,
     OpenAPI_list_t *inter_grp_ids,
     OpenAPI_satellite_backhaul_category_e sat_backhaul_category,
+    bool is_pcf_ue_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_info,
+    bool is_nwdaf_datas_null,
     OpenAPI_list_t *nwdaf_datas,
     bool is_an_gw_status,
     int an_gw_status

--- a/lib/sbi/openapi/model/smf_selection_data.h
+++ b/lib/sbi/openapi/model/smf_selection_data.h
@@ -23,6 +23,7 @@ typedef struct OpenAPI_smf_selection_data_s OpenAPI_smf_selection_data_t;
 typedef struct OpenAPI_smf_selection_data_s {
     bool is_unsupp_dnn;
     int unsupp_dnn;
+    bool is_candidates_null;
     OpenAPI_list_t* candidates;
     struct OpenAPI_snssai_s *snssai;
     struct OpenAPI_snssai_s *mapping_snssai;
@@ -32,6 +33,7 @@ typedef struct OpenAPI_smf_selection_data_s {
 OpenAPI_smf_selection_data_t *OpenAPI_smf_selection_data_create(
     bool is_unsupp_dnn,
     int unsupp_dnn,
+    bool is_candidates_null,
     OpenAPI_list_t* candidates,
     OpenAPI_snssai_t *snssai,
     OpenAPI_snssai_t *mapping_snssai,

--- a/lib/sbi/openapi/model/sms_management_subscription_data.c
+++ b/lib/sbi/openapi/model/sms_management_subscription_data.c
@@ -19,6 +19,7 @@ OpenAPI_sms_management_subscription_data_t *OpenAPI_sms_management_subscription_
     bool is_mo_sms_barring_roaming,
     int mo_sms_barring_roaming,
     OpenAPI_list_t *shared_sms_mng_data_ids,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data
 )
 {
@@ -39,6 +40,7 @@ OpenAPI_sms_management_subscription_data_t *OpenAPI_sms_management_subscription_
     sms_management_subscription_data_local_var->is_mo_sms_barring_roaming = is_mo_sms_barring_roaming;
     sms_management_subscription_data_local_var->mo_sms_barring_roaming = mo_sms_barring_roaming;
     sms_management_subscription_data_local_var->shared_sms_mng_data_ids = shared_sms_mng_data_ids;
+    sms_management_subscription_data_local_var->is_trace_data_null = is_trace_data_null;
     sms_management_subscription_data_local_var->trace_data = trace_data;
 
     return sms_management_subscription_data_local_var;
@@ -154,6 +156,11 @@ cJSON *OpenAPI_sms_management_subscription_data_convertToJSON(OpenAPI_sms_manage
         ogs_error("OpenAPI_sms_management_subscription_data_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (sms_management_subscription_data->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_sms_management_subscription_data_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
 end:
@@ -254,10 +261,12 @@ OpenAPI_sms_management_subscription_data_t *OpenAPI_sms_management_subscription_
 
     trace_data = cJSON_GetObjectItemCaseSensitive(sms_management_subscription_dataJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -276,6 +285,7 @@ OpenAPI_sms_management_subscription_data_t *OpenAPI_sms_management_subscription_
         mo_sms_barring_roaming ? true : false,
         mo_sms_barring_roaming ? mo_sms_barring_roaming->valueint : 0,
         shared_sms_mng_data_ids ? shared_sms_mng_data_idsList : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/sms_management_subscription_data.h
+++ b/lib/sbi/openapi/model/sms_management_subscription_data.h
@@ -34,6 +34,7 @@ typedef struct OpenAPI_sms_management_subscription_data_s {
     bool is_mo_sms_barring_roaming;
     int mo_sms_barring_roaming;
     OpenAPI_list_t *shared_sms_mng_data_ids;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
 } OpenAPI_sms_management_subscription_data_t;
 
@@ -52,6 +53,7 @@ OpenAPI_sms_management_subscription_data_t *OpenAPI_sms_management_subscription_
     bool is_mo_sms_barring_roaming,
     int mo_sms_barring_roaming,
     OpenAPI_list_t *shared_sms_mng_data_ids,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data
 );
 void OpenAPI_sms_management_subscription_data_free(OpenAPI_sms_management_subscription_data_t *sms_management_subscription_data);

--- a/lib/sbi/openapi/model/sms_management_subscription_data_1.c
+++ b/lib/sbi/openapi/model/sms_management_subscription_data_1.c
@@ -19,6 +19,7 @@ OpenAPI_sms_management_subscription_data_1_t *OpenAPI_sms_management_subscriptio
     bool is_mo_sms_barring_roaming,
     int mo_sms_barring_roaming,
     OpenAPI_list_t *shared_sms_mng_data_ids,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data
 )
 {
@@ -39,6 +40,7 @@ OpenAPI_sms_management_subscription_data_1_t *OpenAPI_sms_management_subscriptio
     sms_management_subscription_data_1_local_var->is_mo_sms_barring_roaming = is_mo_sms_barring_roaming;
     sms_management_subscription_data_1_local_var->mo_sms_barring_roaming = mo_sms_barring_roaming;
     sms_management_subscription_data_1_local_var->shared_sms_mng_data_ids = shared_sms_mng_data_ids;
+    sms_management_subscription_data_1_local_var->is_trace_data_null = is_trace_data_null;
     sms_management_subscription_data_1_local_var->trace_data = trace_data;
 
     return sms_management_subscription_data_1_local_var;
@@ -154,6 +156,11 @@ cJSON *OpenAPI_sms_management_subscription_data_1_convertToJSON(OpenAPI_sms_mana
         ogs_error("OpenAPI_sms_management_subscription_data_1_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (sms_management_subscription_data_1->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_sms_management_subscription_data_1_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
 end:
@@ -254,10 +261,12 @@ OpenAPI_sms_management_subscription_data_1_t *OpenAPI_sms_management_subscriptio
 
     trace_data = cJSON_GetObjectItemCaseSensitive(sms_management_subscription_data_1JSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -276,6 +285,7 @@ OpenAPI_sms_management_subscription_data_1_t *OpenAPI_sms_management_subscriptio
         mo_sms_barring_roaming ? true : false,
         mo_sms_barring_roaming ? mo_sms_barring_roaming->valueint : 0,
         shared_sms_mng_data_ids ? shared_sms_mng_data_idsList : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL
     );
 

--- a/lib/sbi/openapi/model/sms_management_subscription_data_1.h
+++ b/lib/sbi/openapi/model/sms_management_subscription_data_1.h
@@ -34,6 +34,7 @@ typedef struct OpenAPI_sms_management_subscription_data_1_s {
     bool is_mo_sms_barring_roaming;
     int mo_sms_barring_roaming;
     OpenAPI_list_t *shared_sms_mng_data_ids;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
 } OpenAPI_sms_management_subscription_data_1_t;
 
@@ -52,6 +53,7 @@ OpenAPI_sms_management_subscription_data_1_t *OpenAPI_sms_management_subscriptio
     bool is_mo_sms_barring_roaming,
     int mo_sms_barring_roaming,
     OpenAPI_list_t *shared_sms_mng_data_ids,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data
 );
 void OpenAPI_sms_management_subscription_data_1_free(OpenAPI_sms_management_subscription_data_1_t *sms_management_subscription_data_1);

--- a/lib/sbi/openapi/model/steering_mode.c
+++ b/lib/sbi/openapi/model/steering_mode.c
@@ -11,6 +11,7 @@ OpenAPI_steering_mode_t *OpenAPI_steering_mode_create(
     bool is__3g_load,
     int _3g_load,
     OpenAPI_access_type_e prio_acc,
+    bool is_thres_value_null,
     OpenAPI_threshold_value_t *thres_value,
     OpenAPI_steer_mode_indicator_e steer_mode_ind
 )
@@ -24,6 +25,7 @@ OpenAPI_steering_mode_t *OpenAPI_steering_mode_create(
     steering_mode_local_var->is__3g_load = is__3g_load;
     steering_mode_local_var->_3g_load = _3g_load;
     steering_mode_local_var->prio_acc = prio_acc;
+    steering_mode_local_var->is_thres_value_null = is_thres_value_null;
     steering_mode_local_var->thres_value = thres_value;
     steering_mode_local_var->steer_mode_ind = steer_mode_ind;
 
@@ -113,6 +115,11 @@ cJSON *OpenAPI_steering_mode_convertToJSON(OpenAPI_steering_mode_t *steering_mod
         ogs_error("OpenAPI_steering_mode_convertToJSON() failed [thres_value]");
         goto end;
     }
+    } else if (steering_mode->is_thres_value_null) {
+        if (cJSON_AddNullToObject(item, "thresValue") == NULL) {
+            ogs_error("OpenAPI_steering_mode_convertToJSON() failed [thres_value]");
+            goto end;
+        }
     }
 
     if (steering_mode->steer_mode_ind != OpenAPI_steer_mode_indicator_NULL) {
@@ -191,10 +198,12 @@ OpenAPI_steering_mode_t *OpenAPI_steering_mode_parseFromJSON(cJSON *steering_mod
 
     thres_value = cJSON_GetObjectItemCaseSensitive(steering_modeJSON, "thresValue");
     if (thres_value) {
+    if (!cJSON_IsNull(thres_value)) {
     thres_value_local_nonprim = OpenAPI_threshold_value_parseFromJSON(thres_value);
     if (!thres_value_local_nonprim) {
         ogs_error("OpenAPI_threshold_value_parseFromJSON failed [thres_value]");
         goto end;
+    }
     }
     }
 
@@ -214,6 +223,7 @@ OpenAPI_steering_mode_t *OpenAPI_steering_mode_parseFromJSON(cJSON *steering_mod
         _3g_load ? true : false,
         _3g_load ? _3g_load->valuedouble : 0,
         prio_acc ? prio_accVariable : 0,
+        thres_value && cJSON_IsNull(thres_value) ? true : false,
         thres_value ? thres_value_local_nonprim : NULL,
         steer_mode_ind ? steer_mode_indVariable : 0
     );

--- a/lib/sbi/openapi/model/steering_mode.h
+++ b/lib/sbi/openapi/model/steering_mode.h
@@ -30,6 +30,7 @@ typedef struct OpenAPI_steering_mode_s {
     bool is__3g_load;
     int _3g_load;
     OpenAPI_access_type_e prio_acc;
+    bool is_thres_value_null;
     struct OpenAPI_threshold_value_s *thres_value;
     OpenAPI_steer_mode_indicator_e steer_mode_ind;
 } OpenAPI_steering_mode_t;
@@ -41,6 +42,7 @@ OpenAPI_steering_mode_t *OpenAPI_steering_mode_create(
     bool is__3g_load,
     int _3g_load,
     OpenAPI_access_type_e prio_acc,
+    bool is_thres_value_null,
     OpenAPI_threshold_value_t *thres_value,
     OpenAPI_steer_mode_indicator_e steer_mode_ind
 );

--- a/lib/sbi/openapi/model/subscription_data_sets.c
+++ b/lib/sbi/openapi/model/subscription_data_sets.c
@@ -12,6 +12,7 @@ OpenAPI_subscription_data_sets_t *OpenAPI_subscription_data_sets_create(
     OpenAPI_ue_context_in_smsf_data_t *uec_smsf_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,
@@ -33,6 +34,7 @@ OpenAPI_subscription_data_sets_t *OpenAPI_subscription_data_sets_create(
     subscription_data_sets_local_var->uec_smsf_data = uec_smsf_data;
     subscription_data_sets_local_var->sms_subs_data = sms_subs_data;
     subscription_data_sets_local_var->sm_data = sm_data;
+    subscription_data_sets_local_var->is_trace_data_null = is_trace_data_null;
     subscription_data_sets_local_var->trace_data = trace_data;
     subscription_data_sets_local_var->sms_mng_data = sms_mng_data;
     subscription_data_sets_local_var->lcs_privacy_data = lcs_privacy_data;
@@ -233,6 +235,11 @@ cJSON *OpenAPI_subscription_data_sets_convertToJSON(OpenAPI_subscription_data_se
         ogs_error("OpenAPI_subscription_data_sets_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (subscription_data_sets->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_subscription_data_sets_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (subscription_data_sets->sms_mng_data) {
@@ -444,10 +451,12 @@ OpenAPI_subscription_data_sets_t *OpenAPI_subscription_data_sets_parseFromJSON(c
 
     trace_data = cJSON_GetObjectItemCaseSensitive(subscription_data_setsJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -531,6 +540,7 @@ OpenAPI_subscription_data_sets_t *OpenAPI_subscription_data_sets_parseFromJSON(c
         uec_smsf_data ? uec_smsf_data_local_nonprim : NULL,
         sms_subs_data ? sms_subs_data_local_nonprim : NULL,
         sm_data ? sm_data_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         sms_mng_data ? sms_mng_data_local_nonprim : NULL,
         lcs_privacy_data ? lcs_privacy_data_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/subscription_data_sets.h
+++ b/lib/sbi/openapi/model/subscription_data_sets.h
@@ -42,6 +42,7 @@ typedef struct OpenAPI_subscription_data_sets_s {
     struct OpenAPI_ue_context_in_smsf_data_s *uec_smsf_data;
     struct OpenAPI_sms_subscription_data_s *sms_subs_data;
     struct OpenAPI_sm_subs_data_s *sm_data;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     struct OpenAPI_sms_management_subscription_data_s *sms_mng_data;
     struct OpenAPI_lcs_privacy_data_s *lcs_privacy_data;
@@ -61,6 +62,7 @@ OpenAPI_subscription_data_sets_t *OpenAPI_subscription_data_sets_create(
     OpenAPI_ue_context_in_smsf_data_t *uec_smsf_data,
     OpenAPI_sms_subscription_data_t *sms_subs_data,
     OpenAPI_sm_subs_data_t *sm_data,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     OpenAPI_sms_management_subscription_data_t *sms_mng_data,
     OpenAPI_lcs_privacy_data_t *lcs_privacy_data,

--- a/lib/sbi/openapi/model/threshold_value.c
+++ b/lib/sbi/openapi/model/threshold_value.c
@@ -5,8 +5,10 @@
 #include "threshold_value.h"
 
 OpenAPI_threshold_value_t *OpenAPI_threshold_value_create(
+    bool is_rtt_thres_null,
     bool is_rtt_thres,
     int rtt_thres,
+    bool is_plr_thres_null,
     bool is_plr_thres,
     int plr_thres
 )
@@ -14,8 +16,10 @@ OpenAPI_threshold_value_t *OpenAPI_threshold_value_create(
     OpenAPI_threshold_value_t *threshold_value_local_var = ogs_malloc(sizeof(OpenAPI_threshold_value_t));
     ogs_assert(threshold_value_local_var);
 
+    threshold_value_local_var->is_rtt_thres_null = is_rtt_thres_null;
     threshold_value_local_var->is_rtt_thres = is_rtt_thres;
     threshold_value_local_var->rtt_thres = rtt_thres;
+    threshold_value_local_var->is_plr_thres_null = is_plr_thres_null;
     threshold_value_local_var->is_plr_thres = is_plr_thres;
     threshold_value_local_var->plr_thres = plr_thres;
 
@@ -48,6 +52,11 @@ cJSON *OpenAPI_threshold_value_convertToJSON(OpenAPI_threshold_value_t *threshol
         ogs_error("OpenAPI_threshold_value_convertToJSON() failed [rtt_thres]");
         goto end;
     }
+    } else if (threshold_value->is_rtt_thres_null) {
+        if (cJSON_AddNullToObject(item, "rttThres") == NULL) {
+            ogs_error("OpenAPI_threshold_value_convertToJSON() failed [rtt_thres]");
+            goto end;
+        }
     }
 
     if (threshold_value->is_plr_thres) {
@@ -55,6 +64,11 @@ cJSON *OpenAPI_threshold_value_convertToJSON(OpenAPI_threshold_value_t *threshol
         ogs_error("OpenAPI_threshold_value_convertToJSON() failed [plr_thres]");
         goto end;
     }
+    } else if (threshold_value->is_plr_thres_null) {
+        if (cJSON_AddNullToObject(item, "plrThres") == NULL) {
+            ogs_error("OpenAPI_threshold_value_convertToJSON() failed [plr_thres]");
+            goto end;
+        }
     }
 
 end:
@@ -69,23 +83,29 @@ OpenAPI_threshold_value_t *OpenAPI_threshold_value_parseFromJSON(cJSON *threshol
     cJSON *plr_thres = NULL;
     rtt_thres = cJSON_GetObjectItemCaseSensitive(threshold_valueJSON, "rttThres");
     if (rtt_thres) {
+    if (!cJSON_IsNull(rtt_thres)) {
     if (!cJSON_IsNumber(rtt_thres)) {
         ogs_error("OpenAPI_threshold_value_parseFromJSON() failed [rtt_thres]");
         goto end;
     }
     }
+    }
 
     plr_thres = cJSON_GetObjectItemCaseSensitive(threshold_valueJSON, "plrThres");
     if (plr_thres) {
+    if (!cJSON_IsNull(plr_thres)) {
     if (!cJSON_IsNumber(plr_thres)) {
         ogs_error("OpenAPI_threshold_value_parseFromJSON() failed [plr_thres]");
         goto end;
     }
     }
+    }
 
     threshold_value_local_var = OpenAPI_threshold_value_create (
+        rtt_thres && cJSON_IsNull(rtt_thres) ? true : false,
         rtt_thres ? true : false,
         rtt_thres ? rtt_thres->valuedouble : 0,
+        plr_thres && cJSON_IsNull(plr_thres) ? true : false,
         plr_thres ? true : false,
         plr_thres ? plr_thres->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/threshold_value.h
+++ b/lib/sbi/openapi/model/threshold_value.h
@@ -19,15 +19,19 @@ extern "C" {
 
 typedef struct OpenAPI_threshold_value_s OpenAPI_threshold_value_t;
 typedef struct OpenAPI_threshold_value_s {
+    bool is_rtt_thres_null;
     bool is_rtt_thres;
     int rtt_thres;
+    bool is_plr_thres_null;
     bool is_plr_thres;
     int plr_thres;
 } OpenAPI_threshold_value_t;
 
 OpenAPI_threshold_value_t *OpenAPI_threshold_value_create(
+    bool is_rtt_thres_null,
     bool is_rtt_thres,
     int rtt_thres,
+    bool is_plr_thres_null,
     bool is_plr_thres,
     int plr_thres
 );

--- a/lib/sbi/openapi/model/trace_data_response.h
+++ b/lib/sbi/openapi/model/trace_data_response.h
@@ -20,11 +20,13 @@ extern "C" {
 
 typedef struct OpenAPI_trace_data_response_s OpenAPI_trace_data_response_t;
 typedef struct OpenAPI_trace_data_response_s {
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *shared_trace_data_id;
 } OpenAPI_trace_data_response_t;
 
 OpenAPI_trace_data_response_t *OpenAPI_trace_data_response_create(
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *shared_trace_data_id
 );

--- a/lib/sbi/openapi/model/traffic_control_data.c
+++ b/lib/sbi/openapi/model/traffic_control_data.c
@@ -11,11 +11,16 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     OpenAPI_list_t *add_redirect_info,
     bool is_mute_notif,
     int mute_notif,
+    bool is_traffic_steering_pol_id_dl_null,
     char *traffic_steering_pol_id_dl,
+    bool is_traffic_steering_pol_id_ul_null,
     char *traffic_steering_pol_id_ul,
+    bool is_route_to_locs_null,
     OpenAPI_list_t *route_to_locs,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat,
+    bool is_eas_ip_replace_infos_null,
     OpenAPI_list_t *eas_ip_replace_infos,
     bool is_traff_corre_ind,
     int traff_corre_ind,
@@ -23,6 +28,7 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     int sim_conn_ind,
     bool is_sim_conn_term,
     int sim_conn_term,
+    bool is_up_path_chg_event_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_event,
     OpenAPI_steering_functionality_e steer_fun,
     OpenAPI_steering_mode_t *steer_mode_dl,
@@ -39,11 +45,16 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     traffic_control_data_local_var->add_redirect_info = add_redirect_info;
     traffic_control_data_local_var->is_mute_notif = is_mute_notif;
     traffic_control_data_local_var->mute_notif = mute_notif;
+    traffic_control_data_local_var->is_traffic_steering_pol_id_dl_null = is_traffic_steering_pol_id_dl_null;
     traffic_control_data_local_var->traffic_steering_pol_id_dl = traffic_steering_pol_id_dl;
+    traffic_control_data_local_var->is_traffic_steering_pol_id_ul_null = is_traffic_steering_pol_id_ul_null;
     traffic_control_data_local_var->traffic_steering_pol_id_ul = traffic_steering_pol_id_ul;
+    traffic_control_data_local_var->is_route_to_locs_null = is_route_to_locs_null;
     traffic_control_data_local_var->route_to_locs = route_to_locs;
+    traffic_control_data_local_var->is_max_allowed_up_lat_null = is_max_allowed_up_lat_null;
     traffic_control_data_local_var->is_max_allowed_up_lat = is_max_allowed_up_lat;
     traffic_control_data_local_var->max_allowed_up_lat = max_allowed_up_lat;
+    traffic_control_data_local_var->is_eas_ip_replace_infos_null = is_eas_ip_replace_infos_null;
     traffic_control_data_local_var->eas_ip_replace_infos = eas_ip_replace_infos;
     traffic_control_data_local_var->is_traff_corre_ind = is_traff_corre_ind;
     traffic_control_data_local_var->traff_corre_ind = traff_corre_ind;
@@ -51,6 +62,7 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     traffic_control_data_local_var->sim_conn_ind = sim_conn_ind;
     traffic_control_data_local_var->is_sim_conn_term = is_sim_conn_term;
     traffic_control_data_local_var->sim_conn_term = sim_conn_term;
+    traffic_control_data_local_var->is_up_path_chg_event_null = is_up_path_chg_event_null;
     traffic_control_data_local_var->up_path_chg_event = up_path_chg_event;
     traffic_control_data_local_var->steer_fun = steer_fun;
     traffic_control_data_local_var->steer_mode_dl = steer_mode_dl;
@@ -187,6 +199,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [traffic_steering_pol_id_dl]");
         goto end;
     }
+    } else if (traffic_control_data->is_traffic_steering_pol_id_dl_null) {
+        if (cJSON_AddNullToObject(item, "trafficSteeringPolIdDl") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [traffic_steering_pol_id_dl]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->traffic_steering_pol_id_ul) {
@@ -194,6 +211,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [traffic_steering_pol_id_ul]");
         goto end;
     }
+    } else if (traffic_control_data->is_traffic_steering_pol_id_ul_null) {
+        if (cJSON_AddNullToObject(item, "trafficSteeringPolIdUl") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [traffic_steering_pol_id_ul]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->route_to_locs) {
@@ -210,6 +232,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         }
         cJSON_AddItemToArray(route_to_locsList, itemLocal);
     }
+    } else if (traffic_control_data->is_route_to_locs_null) {
+        if (cJSON_AddNullToObject(item, "routeToLocs") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [route_to_locs]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->is_max_allowed_up_lat) {
@@ -217,6 +244,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [max_allowed_up_lat]");
         goto end;
     }
+    } else if (traffic_control_data->is_max_allowed_up_lat_null) {
+        if (cJSON_AddNullToObject(item, "maxAllowedUpLat") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [max_allowed_up_lat]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->eas_ip_replace_infos) {
@@ -233,6 +265,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         }
         cJSON_AddItemToArray(eas_ip_replace_infosList, itemLocal);
     }
+    } else if (traffic_control_data->is_eas_ip_replace_infos_null) {
+        if (cJSON_AddNullToObject(item, "easIpReplaceInfos") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [eas_ip_replace_infos]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->is_traff_corre_ind) {
@@ -267,6 +304,11 @@ cJSON *OpenAPI_traffic_control_data_convertToJSON(OpenAPI_traffic_control_data_t
         ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [up_path_chg_event]");
         goto end;
     }
+    } else if (traffic_control_data->is_up_path_chg_event_null) {
+        if (cJSON_AddNullToObject(item, "upPathChgEvent") == NULL) {
+            ogs_error("OpenAPI_traffic_control_data_convertToJSON() failed [up_path_chg_event]");
+            goto end;
+        }
     }
 
     if (traffic_control_data->steer_fun != OpenAPI_steering_functionality_NULL) {
@@ -407,22 +449,27 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
 
     traffic_steering_pol_id_dl = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "trafficSteeringPolIdDl");
     if (traffic_steering_pol_id_dl) {
+    if (!cJSON_IsNull(traffic_steering_pol_id_dl)) {
     if (!cJSON_IsString(traffic_steering_pol_id_dl) && !cJSON_IsNull(traffic_steering_pol_id_dl)) {
         ogs_error("OpenAPI_traffic_control_data_parseFromJSON() failed [traffic_steering_pol_id_dl]");
         goto end;
     }
     }
+    }
 
     traffic_steering_pol_id_ul = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "trafficSteeringPolIdUl");
     if (traffic_steering_pol_id_ul) {
+    if (!cJSON_IsNull(traffic_steering_pol_id_ul)) {
     if (!cJSON_IsString(traffic_steering_pol_id_ul) && !cJSON_IsNull(traffic_steering_pol_id_ul)) {
         ogs_error("OpenAPI_traffic_control_data_parseFromJSON() failed [traffic_steering_pol_id_ul]");
         goto end;
     }
     }
+    }
 
     route_to_locs = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "routeToLocs");
     if (route_to_locs) {
+    if (!cJSON_IsNull(route_to_locs)) {
         cJSON *route_to_locs_local = NULL;
         if (!cJSON_IsArray(route_to_locs)) {
             ogs_error("OpenAPI_traffic_control_data_parseFromJSON() failed [route_to_locs]");
@@ -444,17 +491,21 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
             OpenAPI_list_add(route_to_locsList, route_to_locsItem);
         }
     }
+    }
 
     max_allowed_up_lat = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "maxAllowedUpLat");
     if (max_allowed_up_lat) {
+    if (!cJSON_IsNull(max_allowed_up_lat)) {
     if (!cJSON_IsNumber(max_allowed_up_lat)) {
         ogs_error("OpenAPI_traffic_control_data_parseFromJSON() failed [max_allowed_up_lat]");
         goto end;
     }
     }
+    }
 
     eas_ip_replace_infos = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "easIpReplaceInfos");
     if (eas_ip_replace_infos) {
+    if (!cJSON_IsNull(eas_ip_replace_infos)) {
         cJSON *eas_ip_replace_infos_local = NULL;
         if (!cJSON_IsArray(eas_ip_replace_infos)) {
             ogs_error("OpenAPI_traffic_control_data_parseFromJSON() failed [eas_ip_replace_infos]");
@@ -475,6 +526,7 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
             }
             OpenAPI_list_add(eas_ip_replace_infosList, eas_ip_replace_infosItem);
         }
+    }
     }
 
     traff_corre_ind = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "traffCorreInd");
@@ -503,10 +555,12 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
 
     up_path_chg_event = cJSON_GetObjectItemCaseSensitive(traffic_control_dataJSON, "upPathChgEvent");
     if (up_path_chg_event) {
+    if (!cJSON_IsNull(up_path_chg_event)) {
     up_path_chg_event_local_nonprim = OpenAPI_up_path_chg_event_parseFromJSON(up_path_chg_event);
     if (!up_path_chg_event_local_nonprim) {
         ogs_error("OpenAPI_up_path_chg_event_parseFromJSON failed [up_path_chg_event]");
         goto end;
+    }
     }
     }
 
@@ -553,11 +607,16 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
         add_redirect_info ? add_redirect_infoList : NULL,
         mute_notif ? true : false,
         mute_notif ? mute_notif->valueint : 0,
+        traffic_steering_pol_id_dl && cJSON_IsNull(traffic_steering_pol_id_dl) ? true : false,
         traffic_steering_pol_id_dl && !cJSON_IsNull(traffic_steering_pol_id_dl) ? ogs_strdup(traffic_steering_pol_id_dl->valuestring) : NULL,
+        traffic_steering_pol_id_ul && cJSON_IsNull(traffic_steering_pol_id_ul) ? true : false,
         traffic_steering_pol_id_ul && !cJSON_IsNull(traffic_steering_pol_id_ul) ? ogs_strdup(traffic_steering_pol_id_ul->valuestring) : NULL,
+        route_to_locs && cJSON_IsNull(route_to_locs) ? true : false,
         route_to_locs ? route_to_locsList : NULL,
+        max_allowed_up_lat && cJSON_IsNull(max_allowed_up_lat) ? true : false,
         max_allowed_up_lat ? true : false,
         max_allowed_up_lat ? max_allowed_up_lat->valuedouble : 0,
+        eas_ip_replace_infos && cJSON_IsNull(eas_ip_replace_infos) ? true : false,
         eas_ip_replace_infos ? eas_ip_replace_infosList : NULL,
         traff_corre_ind ? true : false,
         traff_corre_ind ? traff_corre_ind->valueint : 0,
@@ -565,6 +624,7 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_parseFromJSON(cJSON
         sim_conn_ind ? sim_conn_ind->valueint : 0,
         sim_conn_term ? true : false,
         sim_conn_term ? sim_conn_term->valuedouble : 0,
+        up_path_chg_event && cJSON_IsNull(up_path_chg_event) ? true : false,
         up_path_chg_event ? up_path_chg_event_local_nonprim : NULL,
         steer_fun ? steer_funVariable : 0,
         steer_mode_dl ? steer_mode_dl_local_nonprim : NULL,

--- a/lib/sbi/openapi/model/traffic_control_data.h
+++ b/lib/sbi/openapi/model/traffic_control_data.h
@@ -33,11 +33,16 @@ typedef struct OpenAPI_traffic_control_data_s {
     OpenAPI_list_t *add_redirect_info;
     bool is_mute_notif;
     int mute_notif;
+    bool is_traffic_steering_pol_id_dl_null;
     char *traffic_steering_pol_id_dl;
+    bool is_traffic_steering_pol_id_ul_null;
     char *traffic_steering_pol_id_ul;
+    bool is_route_to_locs_null;
     OpenAPI_list_t *route_to_locs;
+    bool is_max_allowed_up_lat_null;
     bool is_max_allowed_up_lat;
     int max_allowed_up_lat;
+    bool is_eas_ip_replace_infos_null;
     OpenAPI_list_t *eas_ip_replace_infos;
     bool is_traff_corre_ind;
     int traff_corre_ind;
@@ -45,6 +50,7 @@ typedef struct OpenAPI_traffic_control_data_s {
     int sim_conn_ind;
     bool is_sim_conn_term;
     int sim_conn_term;
+    bool is_up_path_chg_event_null;
     struct OpenAPI_up_path_chg_event_s *up_path_chg_event;
     OpenAPI_steering_functionality_e steer_fun;
     struct OpenAPI_steering_mode_s *steer_mode_dl;
@@ -59,11 +65,16 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     OpenAPI_list_t *add_redirect_info,
     bool is_mute_notif,
     int mute_notif,
+    bool is_traffic_steering_pol_id_dl_null,
     char *traffic_steering_pol_id_dl,
+    bool is_traffic_steering_pol_id_ul_null,
     char *traffic_steering_pol_id_ul,
+    bool is_route_to_locs_null,
     OpenAPI_list_t *route_to_locs,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat,
+    bool is_eas_ip_replace_infos_null,
     OpenAPI_list_t *eas_ip_replace_infos,
     bool is_traff_corre_ind,
     int traff_corre_ind,
@@ -71,6 +82,7 @@ OpenAPI_traffic_control_data_t *OpenAPI_traffic_control_data_create(
     int sim_conn_ind,
     bool is_sim_conn_term,
     int sim_conn_term,
+    bool is_up_path_chg_event_null,
     OpenAPI_up_path_chg_event_t *up_path_chg_event,
     OpenAPI_steering_functionality_e steer_fun,
     OpenAPI_steering_mode_t *steer_mode_dl,

--- a/lib/sbi/openapi/model/traffic_influ_data_patch.c
+++ b/lib/sbi/openapi/model/traffic_influ_data_patch.c
@@ -15,6 +15,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     int traff_corre_ind,
     char *valid_start_time,
     char *valid_end_time,
+    bool is_temp_validities_null,
     OpenAPI_list_t *temp_validities,
     OpenAPI_network_area_info_2_t *nw_area_info,
     char *up_path_chg_notif_uri,
@@ -23,10 +24,12 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     int af_ack_ind,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat,
     bool is_sim_conn_ind,
     int sim_conn_ind,
+    bool is_sim_conn_term_null,
     bool is_sim_conn_term,
     int sim_conn_term
 )
@@ -44,6 +47,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     traffic_influ_data_patch_local_var->traff_corre_ind = traff_corre_ind;
     traffic_influ_data_patch_local_var->valid_start_time = valid_start_time;
     traffic_influ_data_patch_local_var->valid_end_time = valid_end_time;
+    traffic_influ_data_patch_local_var->is_temp_validities_null = is_temp_validities_null;
     traffic_influ_data_patch_local_var->temp_validities = temp_validities;
     traffic_influ_data_patch_local_var->nw_area_info = nw_area_info;
     traffic_influ_data_patch_local_var->up_path_chg_notif_uri = up_path_chg_notif_uri;
@@ -52,10 +56,12 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     traffic_influ_data_patch_local_var->af_ack_ind = af_ack_ind;
     traffic_influ_data_patch_local_var->is_addr_preser_ind = is_addr_preser_ind;
     traffic_influ_data_patch_local_var->addr_preser_ind = addr_preser_ind;
+    traffic_influ_data_patch_local_var->is_max_allowed_up_lat_null = is_max_allowed_up_lat_null;
     traffic_influ_data_patch_local_var->is_max_allowed_up_lat = is_max_allowed_up_lat;
     traffic_influ_data_patch_local_var->max_allowed_up_lat = max_allowed_up_lat;
     traffic_influ_data_patch_local_var->is_sim_conn_ind = is_sim_conn_ind;
     traffic_influ_data_patch_local_var->sim_conn_ind = sim_conn_ind;
+    traffic_influ_data_patch_local_var->is_sim_conn_term_null = is_sim_conn_term_null;
     traffic_influ_data_patch_local_var->is_sim_conn_term = is_sim_conn_term;
     traffic_influ_data_patch_local_var->sim_conn_term = sim_conn_term;
 
@@ -235,6 +241,11 @@ cJSON *OpenAPI_traffic_influ_data_patch_convertToJSON(OpenAPI_traffic_influ_data
         }
         cJSON_AddItemToArray(temp_validitiesList, itemLocal);
     }
+    } else if (traffic_influ_data_patch->is_temp_validities_null) {
+        if (cJSON_AddNullToObject(item, "tempValidities") == NULL) {
+            ogs_error("OpenAPI_traffic_influ_data_patch_convertToJSON() failed [temp_validities]");
+            goto end;
+        }
     }
 
     if (traffic_influ_data_patch->nw_area_info) {
@@ -290,6 +301,11 @@ cJSON *OpenAPI_traffic_influ_data_patch_convertToJSON(OpenAPI_traffic_influ_data
         ogs_error("OpenAPI_traffic_influ_data_patch_convertToJSON() failed [max_allowed_up_lat]");
         goto end;
     }
+    } else if (traffic_influ_data_patch->is_max_allowed_up_lat_null) {
+        if (cJSON_AddNullToObject(item, "maxAllowedUpLat") == NULL) {
+            ogs_error("OpenAPI_traffic_influ_data_patch_convertToJSON() failed [max_allowed_up_lat]");
+            goto end;
+        }
     }
 
     if (traffic_influ_data_patch->is_sim_conn_ind) {
@@ -304,6 +320,11 @@ cJSON *OpenAPI_traffic_influ_data_patch_convertToJSON(OpenAPI_traffic_influ_data
         ogs_error("OpenAPI_traffic_influ_data_patch_convertToJSON() failed [sim_conn_term]");
         goto end;
     }
+    } else if (traffic_influ_data_patch->is_sim_conn_term_null) {
+        if (cJSON_AddNullToObject(item, "simConnTerm") == NULL) {
+            ogs_error("OpenAPI_traffic_influ_data_patch_convertToJSON() failed [sim_conn_term]");
+            goto end;
+        }
     }
 
 end:
@@ -451,6 +472,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
 
     temp_validities = cJSON_GetObjectItemCaseSensitive(traffic_influ_data_patchJSON, "tempValidities");
     if (temp_validities) {
+    if (!cJSON_IsNull(temp_validities)) {
         cJSON *temp_validities_local = NULL;
         if (!cJSON_IsArray(temp_validities)) {
             ogs_error("OpenAPI_traffic_influ_data_patch_parseFromJSON() failed [temp_validities]");
@@ -471,6 +493,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
             }
             OpenAPI_list_add(temp_validitiesList, temp_validitiesItem);
         }
+    }
     }
 
     nw_area_info = cJSON_GetObjectItemCaseSensitive(traffic_influ_data_patchJSON, "nwAreaInfo");
@@ -529,9 +552,11 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
 
     max_allowed_up_lat = cJSON_GetObjectItemCaseSensitive(traffic_influ_data_patchJSON, "maxAllowedUpLat");
     if (max_allowed_up_lat) {
+    if (!cJSON_IsNull(max_allowed_up_lat)) {
     if (!cJSON_IsNumber(max_allowed_up_lat)) {
         ogs_error("OpenAPI_traffic_influ_data_patch_parseFromJSON() failed [max_allowed_up_lat]");
         goto end;
+    }
     }
     }
 
@@ -545,9 +570,11 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
 
     sim_conn_term = cJSON_GetObjectItemCaseSensitive(traffic_influ_data_patchJSON, "simConnTerm");
     if (sim_conn_term) {
+    if (!cJSON_IsNull(sim_conn_term)) {
     if (!cJSON_IsNumber(sim_conn_term)) {
         ogs_error("OpenAPI_traffic_influ_data_patch_parseFromJSON() failed [sim_conn_term]");
         goto end;
+    }
     }
     }
 
@@ -562,6 +589,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
         traff_corre_ind ? traff_corre_ind->valueint : 0,
         valid_start_time && !cJSON_IsNull(valid_start_time) ? ogs_strdup(valid_start_time->valuestring) : NULL,
         valid_end_time && !cJSON_IsNull(valid_end_time) ? ogs_strdup(valid_end_time->valuestring) : NULL,
+        temp_validities && cJSON_IsNull(temp_validities) ? true : false,
         temp_validities ? temp_validitiesList : NULL,
         nw_area_info ? nw_area_info_local_nonprim : NULL,
         up_path_chg_notif_uri && !cJSON_IsNull(up_path_chg_notif_uri) ? ogs_strdup(up_path_chg_notif_uri->valuestring) : NULL,
@@ -570,10 +598,12 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
         af_ack_ind ? af_ack_ind->valueint : 0,
         addr_preser_ind ? true : false,
         addr_preser_ind ? addr_preser_ind->valueint : 0,
+        max_allowed_up_lat && cJSON_IsNull(max_allowed_up_lat) ? true : false,
         max_allowed_up_lat ? true : false,
         max_allowed_up_lat ? max_allowed_up_lat->valuedouble : 0,
         sim_conn_ind ? true : false,
         sim_conn_ind ? sim_conn_ind->valueint : 0,
+        sim_conn_term && cJSON_IsNull(sim_conn_term) ? true : false,
         sim_conn_term ? true : false,
         sim_conn_term ? sim_conn_term->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/traffic_influ_data_patch.h
+++ b/lib/sbi/openapi/model/traffic_influ_data_patch.h
@@ -34,6 +34,7 @@ typedef struct OpenAPI_traffic_influ_data_patch_s {
     int traff_corre_ind;
     char *valid_start_time;
     char *valid_end_time;
+    bool is_temp_validities_null;
     OpenAPI_list_t *temp_validities;
     struct OpenAPI_network_area_info_2_s *nw_area_info;
     char *up_path_chg_notif_uri;
@@ -42,10 +43,12 @@ typedef struct OpenAPI_traffic_influ_data_patch_s {
     int af_ack_ind;
     bool is_addr_preser_ind;
     int addr_preser_ind;
+    bool is_max_allowed_up_lat_null;
     bool is_max_allowed_up_lat;
     int max_allowed_up_lat;
     bool is_sim_conn_ind;
     int sim_conn_ind;
+    bool is_sim_conn_term_null;
     bool is_sim_conn_term;
     int sim_conn_term;
 } OpenAPI_traffic_influ_data_patch_t;
@@ -61,6 +64,7 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     int traff_corre_ind,
     char *valid_start_time,
     char *valid_end_time,
+    bool is_temp_validities_null,
     OpenAPI_list_t *temp_validities,
     OpenAPI_network_area_info_2_t *nw_area_info,
     char *up_path_chg_notif_uri,
@@ -69,10 +73,12 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_create(
     int af_ack_ind,
     bool is_addr_preser_ind,
     int addr_preser_ind,
+    bool is_max_allowed_up_lat_null,
     bool is_max_allowed_up_lat,
     int max_allowed_up_lat,
     bool is_sim_conn_ind,
     int sim_conn_ind,
+    bool is_sim_conn_term_null,
     bool is_sim_conn_term,
     int sim_conn_term
 );

--- a/lib/sbi/openapi/model/tsn_qos_container_rm.c
+++ b/lib/sbi/openapi/model/tsn_qos_container_rm.c
@@ -5,10 +5,13 @@
 #include "tsn_qos_container_rm.h"
 
 OpenAPI_tsn_qos_container_rm_t *OpenAPI_tsn_qos_container_rm_create(
+    bool is_max_tsc_burst_size_null,
     bool is_max_tsc_burst_size,
     int max_tsc_burst_size,
+    bool is_tsc_pack_delay_null,
     bool is_tsc_pack_delay,
     int tsc_pack_delay,
+    bool is_tsc_prio_level_null,
     bool is_tsc_prio_level,
     int tsc_prio_level
 )
@@ -16,10 +19,13 @@ OpenAPI_tsn_qos_container_rm_t *OpenAPI_tsn_qos_container_rm_create(
     OpenAPI_tsn_qos_container_rm_t *tsn_qos_container_rm_local_var = ogs_malloc(sizeof(OpenAPI_tsn_qos_container_rm_t));
     ogs_assert(tsn_qos_container_rm_local_var);
 
+    tsn_qos_container_rm_local_var->is_max_tsc_burst_size_null = is_max_tsc_burst_size_null;
     tsn_qos_container_rm_local_var->is_max_tsc_burst_size = is_max_tsc_burst_size;
     tsn_qos_container_rm_local_var->max_tsc_burst_size = max_tsc_burst_size;
+    tsn_qos_container_rm_local_var->is_tsc_pack_delay_null = is_tsc_pack_delay_null;
     tsn_qos_container_rm_local_var->is_tsc_pack_delay = is_tsc_pack_delay;
     tsn_qos_container_rm_local_var->tsc_pack_delay = tsc_pack_delay;
+    tsn_qos_container_rm_local_var->is_tsc_prio_level_null = is_tsc_prio_level_null;
     tsn_qos_container_rm_local_var->is_tsc_prio_level = is_tsc_prio_level;
     tsn_qos_container_rm_local_var->tsc_prio_level = tsc_prio_level;
 
@@ -52,6 +58,11 @@ cJSON *OpenAPI_tsn_qos_container_rm_convertToJSON(OpenAPI_tsn_qos_container_rm_t
         ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [max_tsc_burst_size]");
         goto end;
     }
+    } else if (tsn_qos_container_rm->is_max_tsc_burst_size_null) {
+        if (cJSON_AddNullToObject(item, "maxTscBurstSize") == NULL) {
+            ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [max_tsc_burst_size]");
+            goto end;
+        }
     }
 
     if (tsn_qos_container_rm->is_tsc_pack_delay) {
@@ -59,6 +70,11 @@ cJSON *OpenAPI_tsn_qos_container_rm_convertToJSON(OpenAPI_tsn_qos_container_rm_t
         ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [tsc_pack_delay]");
         goto end;
     }
+    } else if (tsn_qos_container_rm->is_tsc_pack_delay_null) {
+        if (cJSON_AddNullToObject(item, "tscPackDelay") == NULL) {
+            ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [tsc_pack_delay]");
+            goto end;
+        }
     }
 
     if (tsn_qos_container_rm->is_tsc_prio_level) {
@@ -66,6 +82,11 @@ cJSON *OpenAPI_tsn_qos_container_rm_convertToJSON(OpenAPI_tsn_qos_container_rm_t
         ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [tsc_prio_level]");
         goto end;
     }
+    } else if (tsn_qos_container_rm->is_tsc_prio_level_null) {
+        if (cJSON_AddNullToObject(item, "tscPrioLevel") == NULL) {
+            ogs_error("OpenAPI_tsn_qos_container_rm_convertToJSON() failed [tsc_prio_level]");
+            goto end;
+        }
     }
 
 end:
@@ -81,33 +102,42 @@ OpenAPI_tsn_qos_container_rm_t *OpenAPI_tsn_qos_container_rm_parseFromJSON(cJSON
     cJSON *tsc_prio_level = NULL;
     max_tsc_burst_size = cJSON_GetObjectItemCaseSensitive(tsn_qos_container_rmJSON, "maxTscBurstSize");
     if (max_tsc_burst_size) {
+    if (!cJSON_IsNull(max_tsc_burst_size)) {
     if (!cJSON_IsNumber(max_tsc_burst_size)) {
         ogs_error("OpenAPI_tsn_qos_container_rm_parseFromJSON() failed [max_tsc_burst_size]");
         goto end;
     }
     }
+    }
 
     tsc_pack_delay = cJSON_GetObjectItemCaseSensitive(tsn_qos_container_rmJSON, "tscPackDelay");
     if (tsc_pack_delay) {
+    if (!cJSON_IsNull(tsc_pack_delay)) {
     if (!cJSON_IsNumber(tsc_pack_delay)) {
         ogs_error("OpenAPI_tsn_qos_container_rm_parseFromJSON() failed [tsc_pack_delay]");
         goto end;
     }
     }
+    }
 
     tsc_prio_level = cJSON_GetObjectItemCaseSensitive(tsn_qos_container_rmJSON, "tscPrioLevel");
     if (tsc_prio_level) {
+    if (!cJSON_IsNull(tsc_prio_level)) {
     if (!cJSON_IsNumber(tsc_prio_level)) {
         ogs_error("OpenAPI_tsn_qos_container_rm_parseFromJSON() failed [tsc_prio_level]");
         goto end;
     }
     }
+    }
 
     tsn_qos_container_rm_local_var = OpenAPI_tsn_qos_container_rm_create (
+        max_tsc_burst_size && cJSON_IsNull(max_tsc_burst_size) ? true : false,
         max_tsc_burst_size ? true : false,
         max_tsc_burst_size ? max_tsc_burst_size->valuedouble : 0,
+        tsc_pack_delay && cJSON_IsNull(tsc_pack_delay) ? true : false,
         tsc_pack_delay ? true : false,
         tsc_pack_delay ? tsc_pack_delay->valuedouble : 0,
+        tsc_prio_level && cJSON_IsNull(tsc_prio_level) ? true : false,
         tsc_prio_level ? true : false,
         tsc_prio_level ? tsc_prio_level->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/tsn_qos_container_rm.h
+++ b/lib/sbi/openapi/model/tsn_qos_container_rm.h
@@ -19,19 +19,25 @@ extern "C" {
 
 typedef struct OpenAPI_tsn_qos_container_rm_s OpenAPI_tsn_qos_container_rm_t;
 typedef struct OpenAPI_tsn_qos_container_rm_s {
+    bool is_max_tsc_burst_size_null;
     bool is_max_tsc_burst_size;
     int max_tsc_burst_size;
+    bool is_tsc_pack_delay_null;
     bool is_tsc_pack_delay;
     int tsc_pack_delay;
+    bool is_tsc_prio_level_null;
     bool is_tsc_prio_level;
     int tsc_prio_level;
 } OpenAPI_tsn_qos_container_rm_t;
 
 OpenAPI_tsn_qos_container_rm_t *OpenAPI_tsn_qos_container_rm_create(
+    bool is_max_tsc_burst_size_null,
     bool is_max_tsc_burst_size,
     int max_tsc_burst_size,
+    bool is_tsc_pack_delay_null,
     bool is_tsc_pack_delay,
     int tsc_pack_delay,
+    bool is_tsc_prio_level_null,
     bool is_tsc_prio_level,
     int tsc_prio_level
 );

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -46,6 +46,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     OpenAPI_list_t *mm_context_list,
     OpenAPI_list_t *session_context_list,
     OpenAPI_eps_interworking_info_t *eps_interworking_info,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *service_gap_expiry_time,
     char *stn_sr,
@@ -79,6 +80,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     OpenAPI_list_t* pra_in_ue_policy,
     OpenAPI_updp_subscription_data_t *updp_subscription_data,
     OpenAPI_list_t *sm_policy_notify_pdu_list,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     char *ue_positioning_cap,
     bool is_asti_distribution_indication,
@@ -87,6 +89,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     int ts_error_budget,
     bool is_snpn_onboard_ind,
     int snpn_onboard_ind,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_list_t* pcf_ue_slice_mbr_list,
     char *smsf_set_id,
@@ -141,6 +144,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     ue_context_local_var->mm_context_list = mm_context_list;
     ue_context_local_var->session_context_list = session_context_list;
     ue_context_local_var->eps_interworking_info = eps_interworking_info;
+    ue_context_local_var->is_trace_data_null = is_trace_data_null;
     ue_context_local_var->trace_data = trace_data;
     ue_context_local_var->service_gap_expiry_time = service_gap_expiry_time;
     ue_context_local_var->stn_sr = stn_sr;
@@ -174,6 +178,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     ue_context_local_var->pra_in_ue_policy = pra_in_ue_policy;
     ue_context_local_var->updp_subscription_data = updp_subscription_data;
     ue_context_local_var->sm_policy_notify_pdu_list = sm_policy_notify_pdu_list;
+    ue_context_local_var->is_pcf_ue_callback_info_null = is_pcf_ue_callback_info_null;
     ue_context_local_var->pcf_ue_callback_info = pcf_ue_callback_info;
     ue_context_local_var->ue_positioning_cap = ue_positioning_cap;
     ue_context_local_var->is_asti_distribution_indication = is_asti_distribution_indication;
@@ -182,6 +187,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     ue_context_local_var->ts_error_budget = ts_error_budget;
     ue_context_local_var->is_snpn_onboard_ind = is_snpn_onboard_ind;
     ue_context_local_var->snpn_onboard_ind = snpn_onboard_ind;
+    ue_context_local_var->is_smf_sel_info_null = is_smf_sel_info_null;
     ue_context_local_var->smf_sel_info = smf_sel_info;
     ue_context_local_var->pcf_ue_slice_mbr_list = pcf_ue_slice_mbr_list;
     ue_context_local_var->smsf_set_id = smsf_set_id;
@@ -916,6 +922,11 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
         ogs_error("OpenAPI_ue_context_convertToJSON() failed [trace_data]");
         goto end;
     }
+    } else if (ue_context->is_trace_data_null) {
+        if (cJSON_AddNullToObject(item, "traceData") == NULL) {
+            ogs_error("OpenAPI_ue_context_convertToJSON() failed [trace_data]");
+            goto end;
+        }
     }
 
     if (ue_context->service_gap_expiry_time) {
@@ -1260,6 +1271,11 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
         ogs_error("OpenAPI_ue_context_convertToJSON() failed [pcf_ue_callback_info]");
         goto end;
     }
+    } else if (ue_context->is_pcf_ue_callback_info_null) {
+        if (cJSON_AddNullToObject(item, "pcfUeCallbackInfo") == NULL) {
+            ogs_error("OpenAPI_ue_context_convertToJSON() failed [pcf_ue_callback_info]");
+            goto end;
+        }
     }
 
     if (ue_context->ue_positioning_cap) {
@@ -1301,6 +1317,11 @@ cJSON *OpenAPI_ue_context_convertToJSON(OpenAPI_ue_context_t *ue_context)
         ogs_error("OpenAPI_ue_context_convertToJSON() failed [smf_sel_info]");
         goto end;
     }
+    } else if (ue_context->is_smf_sel_info_null) {
+        if (cJSON_AddNullToObject(item, "smfSelInfo") == NULL) {
+            ogs_error("OpenAPI_ue_context_convertToJSON() failed [smf_sel_info]");
+            goto end;
+        }
     }
 
     if (ue_context->pcf_ue_slice_mbr_list) {
@@ -1975,10 +1996,12 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
 
     trace_data = cJSON_GetObjectItemCaseSensitive(ue_contextJSON, "traceData");
     if (trace_data) {
+    if (!cJSON_IsNull(trace_data)) {
     trace_data_local_nonprim = OpenAPI_trace_data_parseFromJSON(trace_data);
     if (!trace_data_local_nonprim) {
         ogs_error("OpenAPI_trace_data_parseFromJSON failed [trace_data]");
         goto end;
+    }
     }
     }
 
@@ -2339,10 +2362,12 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
 
     pcf_ue_callback_info = cJSON_GetObjectItemCaseSensitive(ue_contextJSON, "pcfUeCallbackInfo");
     if (pcf_ue_callback_info) {
+    if (!cJSON_IsNull(pcf_ue_callback_info)) {
     pcf_ue_callback_info_local_nonprim = OpenAPI_pcf_ue_callback_info_parseFromJSON(pcf_ue_callback_info);
     if (!pcf_ue_callback_info_local_nonprim) {
         ogs_error("OpenAPI_pcf_ue_callback_info_parseFromJSON failed [pcf_ue_callback_info]");
         goto end;
+    }
     }
     }
 
@@ -2380,10 +2405,12 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
 
     smf_sel_info = cJSON_GetObjectItemCaseSensitive(ue_contextJSON, "smfSelInfo");
     if (smf_sel_info) {
+    if (!cJSON_IsNull(smf_sel_info)) {
     smf_sel_info_local_nonprim = OpenAPI_smf_selection_data_parseFromJSON(smf_sel_info);
     if (!smf_sel_info_local_nonprim) {
         ogs_error("OpenAPI_smf_selection_data_parseFromJSON failed [smf_sel_info]");
         goto end;
+    }
     }
     }
 
@@ -2496,6 +2523,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         mm_context_list ? mm_context_listList : NULL,
         session_context_list ? session_context_listList : NULL,
         eps_interworking_info ? eps_interworking_info_local_nonprim : NULL,
+        trace_data && cJSON_IsNull(trace_data) ? true : false,
         trace_data ? trace_data_local_nonprim : NULL,
         service_gap_expiry_time && !cJSON_IsNull(service_gap_expiry_time) ? ogs_strdup(service_gap_expiry_time->valuestring) : NULL,
         stn_sr && !cJSON_IsNull(stn_sr) ? ogs_strdup(stn_sr->valuestring) : NULL,
@@ -2529,6 +2557,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         pra_in_ue_policy ? pra_in_ue_policyList : NULL,
         updp_subscription_data ? updp_subscription_data_local_nonprim : NULL,
         sm_policy_notify_pdu_list ? sm_policy_notify_pdu_listList : NULL,
+        pcf_ue_callback_info && cJSON_IsNull(pcf_ue_callback_info) ? true : false,
         pcf_ue_callback_info ? pcf_ue_callback_info_local_nonprim : NULL,
         ue_positioning_cap && !cJSON_IsNull(ue_positioning_cap) ? ogs_strdup(ue_positioning_cap->valuestring) : NULL,
         asti_distribution_indication ? true : false,
@@ -2537,6 +2566,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
         ts_error_budget ? ts_error_budget->valuedouble : 0,
         snpn_onboard_ind ? true : false,
         snpn_onboard_ind ? snpn_onboard_ind->valueint : 0,
+        smf_sel_info && cJSON_IsNull(smf_sel_info) ? true : false,
         smf_sel_info ? smf_sel_info_local_nonprim : NULL,
         pcf_ue_slice_mbr_list ? pcf_ue_slice_mbr_listList : NULL,
         smsf_set_id && !cJSON_IsNull(smsf_set_id) ? ogs_strdup(smsf_set_id->valuestring) : NULL,

--- a/lib/sbi/openapi/model/ue_context.h
+++ b/lib/sbi/openapi/model/ue_context.h
@@ -88,6 +88,7 @@ typedef struct OpenAPI_ue_context_s {
     OpenAPI_list_t *mm_context_list;
     OpenAPI_list_t *session_context_list;
     struct OpenAPI_eps_interworking_info_s *eps_interworking_info;
+    bool is_trace_data_null;
     struct OpenAPI_trace_data_s *trace_data;
     char *service_gap_expiry_time;
     char *stn_sr;
@@ -121,6 +122,7 @@ typedef struct OpenAPI_ue_context_s {
     OpenAPI_list_t* pra_in_ue_policy;
     struct OpenAPI_updp_subscription_data_s *updp_subscription_data;
     OpenAPI_list_t *sm_policy_notify_pdu_list;
+    bool is_pcf_ue_callback_info_null;
     struct OpenAPI_pcf_ue_callback_info_s *pcf_ue_callback_info;
     char *ue_positioning_cap;
     bool is_asti_distribution_indication;
@@ -129,6 +131,7 @@ typedef struct OpenAPI_ue_context_s {
     int ts_error_budget;
     bool is_snpn_onboard_ind;
     int snpn_onboard_ind;
+    bool is_smf_sel_info_null;
     struct OpenAPI_smf_selection_data_s *smf_sel_info;
     OpenAPI_list_t* pcf_ue_slice_mbr_list;
     char *smsf_set_id;
@@ -181,6 +184,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     OpenAPI_list_t *mm_context_list,
     OpenAPI_list_t *session_context_list,
     OpenAPI_eps_interworking_info_t *eps_interworking_info,
+    bool is_trace_data_null,
     OpenAPI_trace_data_t *trace_data,
     char *service_gap_expiry_time,
     char *stn_sr,
@@ -214,6 +218,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     OpenAPI_list_t* pra_in_ue_policy,
     OpenAPI_updp_subscription_data_t *updp_subscription_data,
     OpenAPI_list_t *sm_policy_notify_pdu_list,
+    bool is_pcf_ue_callback_info_null,
     OpenAPI_pcf_ue_callback_info_t *pcf_ue_callback_info,
     char *ue_positioning_cap,
     bool is_asti_distribution_indication,
@@ -222,6 +227,7 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_create(
     int ts_error_budget,
     bool is_snpn_onboard_ind,
     int snpn_onboard_ind,
+    bool is_smf_sel_info_null,
     OpenAPI_smf_selection_data_t *smf_sel_info,
     OpenAPI_list_t* pcf_ue_slice_mbr_list,
     char *smsf_set_id,

--- a/lib/sbi/openapi/model/updated_item.c
+++ b/lib/sbi/openapi/model/updated_item.c
@@ -6,6 +6,7 @@
 
 OpenAPI_updated_item_t *OpenAPI_updated_item_create(
     char *item,
+    bool is_value_null,
     OpenAPI_any_type_t *value
 )
 {
@@ -13,6 +14,7 @@ OpenAPI_updated_item_t *OpenAPI_updated_item_create(
     ogs_assert(updated_item_local_var);
 
     updated_item_local_var->item = item;
+    updated_item_local_var->is_value_null = is_value_null;
     updated_item_local_var->value = value;
 
     return updated_item_local_var;
@@ -101,6 +103,7 @@ OpenAPI_updated_item_t *OpenAPI_updated_item_parseFromJSON(cJSON *updated_itemJS
 
     updated_item_local_var = OpenAPI_updated_item_create (
         ogs_strdup(item->valuestring),
+        value && cJSON_IsNull(value) ? true : false,
         value_local_object
     );
 

--- a/lib/sbi/openapi/model/updated_item.h
+++ b/lib/sbi/openapi/model/updated_item.h
@@ -21,11 +21,13 @@ extern "C" {
 typedef struct OpenAPI_updated_item_s OpenAPI_updated_item_t;
 typedef struct OpenAPI_updated_item_s {
     char *item;
+    bool is_value_null;
     OpenAPI_any_type_t *value;
 } OpenAPI_updated_item_t;
 
 OpenAPI_updated_item_t *OpenAPI_updated_item_create(
     char *item,
+    bool is_value_null,
     OpenAPI_any_type_t *value
 );
 void OpenAPI_updated_item_free(OpenAPI_updated_item_t *updated_item);

--- a/lib/sbi/openapi/model/usage_monitoring_data.c
+++ b/lib/sbi/openapi/model/usage_monitoring_data.c
@@ -6,25 +6,36 @@
 
 OpenAPI_usage_monitoring_data_t *OpenAPI_usage_monitoring_data_create(
     char *um_id,
+    bool is_volume_threshold_null,
     bool is_volume_threshold,
     long volume_threshold,
+    bool is_volume_threshold_uplink_null,
     bool is_volume_threshold_uplink,
     long volume_threshold_uplink,
+    bool is_volume_threshold_downlink_null,
     bool is_volume_threshold_downlink,
     long volume_threshold_downlink,
+    bool is_time_threshold_null,
     bool is_time_threshold,
     int time_threshold,
+    bool is_monitoring_time_null,
     char *monitoring_time,
+    bool is_next_vol_threshold_null,
     bool is_next_vol_threshold,
     long next_vol_threshold,
+    bool is_next_vol_threshold_uplink_null,
     bool is_next_vol_threshold_uplink,
     long next_vol_threshold_uplink,
+    bool is_next_vol_threshold_downlink_null,
     bool is_next_vol_threshold_downlink,
     long next_vol_threshold_downlink,
+    bool is_next_time_threshold_null,
     bool is_next_time_threshold,
     int next_time_threshold,
+    bool is_inactivity_time_null,
     bool is_inactivity_time,
     int inactivity_time,
+    bool is_ex_usage_pcc_rule_ids_null,
     OpenAPI_list_t *ex_usage_pcc_rule_ids
 )
 {
@@ -32,25 +43,36 @@ OpenAPI_usage_monitoring_data_t *OpenAPI_usage_monitoring_data_create(
     ogs_assert(usage_monitoring_data_local_var);
 
     usage_monitoring_data_local_var->um_id = um_id;
+    usage_monitoring_data_local_var->is_volume_threshold_null = is_volume_threshold_null;
     usage_monitoring_data_local_var->is_volume_threshold = is_volume_threshold;
     usage_monitoring_data_local_var->volume_threshold = volume_threshold;
+    usage_monitoring_data_local_var->is_volume_threshold_uplink_null = is_volume_threshold_uplink_null;
     usage_monitoring_data_local_var->is_volume_threshold_uplink = is_volume_threshold_uplink;
     usage_monitoring_data_local_var->volume_threshold_uplink = volume_threshold_uplink;
+    usage_monitoring_data_local_var->is_volume_threshold_downlink_null = is_volume_threshold_downlink_null;
     usage_monitoring_data_local_var->is_volume_threshold_downlink = is_volume_threshold_downlink;
     usage_monitoring_data_local_var->volume_threshold_downlink = volume_threshold_downlink;
+    usage_monitoring_data_local_var->is_time_threshold_null = is_time_threshold_null;
     usage_monitoring_data_local_var->is_time_threshold = is_time_threshold;
     usage_monitoring_data_local_var->time_threshold = time_threshold;
+    usage_monitoring_data_local_var->is_monitoring_time_null = is_monitoring_time_null;
     usage_monitoring_data_local_var->monitoring_time = monitoring_time;
+    usage_monitoring_data_local_var->is_next_vol_threshold_null = is_next_vol_threshold_null;
     usage_monitoring_data_local_var->is_next_vol_threshold = is_next_vol_threshold;
     usage_monitoring_data_local_var->next_vol_threshold = next_vol_threshold;
+    usage_monitoring_data_local_var->is_next_vol_threshold_uplink_null = is_next_vol_threshold_uplink_null;
     usage_monitoring_data_local_var->is_next_vol_threshold_uplink = is_next_vol_threshold_uplink;
     usage_monitoring_data_local_var->next_vol_threshold_uplink = next_vol_threshold_uplink;
+    usage_monitoring_data_local_var->is_next_vol_threshold_downlink_null = is_next_vol_threshold_downlink_null;
     usage_monitoring_data_local_var->is_next_vol_threshold_downlink = is_next_vol_threshold_downlink;
     usage_monitoring_data_local_var->next_vol_threshold_downlink = next_vol_threshold_downlink;
+    usage_monitoring_data_local_var->is_next_time_threshold_null = is_next_time_threshold_null;
     usage_monitoring_data_local_var->is_next_time_threshold = is_next_time_threshold;
     usage_monitoring_data_local_var->next_time_threshold = next_time_threshold;
+    usage_monitoring_data_local_var->is_inactivity_time_null = is_inactivity_time_null;
     usage_monitoring_data_local_var->is_inactivity_time = is_inactivity_time;
     usage_monitoring_data_local_var->inactivity_time = inactivity_time;
+    usage_monitoring_data_local_var->is_ex_usage_pcc_rule_ids_null = is_ex_usage_pcc_rule_ids_null;
     usage_monitoring_data_local_var->ex_usage_pcc_rule_ids = ex_usage_pcc_rule_ids;
 
     return usage_monitoring_data_local_var;
@@ -106,6 +128,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_volume_threshold_null) {
+        if (cJSON_AddNullToObject(item, "volumeThreshold") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_volume_threshold_uplink) {
@@ -113,6 +140,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold_uplink]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_volume_threshold_uplink_null) {
+        if (cJSON_AddNullToObject(item, "volumeThresholdUplink") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold_uplink]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_volume_threshold_downlink) {
@@ -120,6 +152,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold_downlink]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_volume_threshold_downlink_null) {
+        if (cJSON_AddNullToObject(item, "volumeThresholdDownlink") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [volume_threshold_downlink]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_time_threshold) {
@@ -127,6 +164,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [time_threshold]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_time_threshold_null) {
+        if (cJSON_AddNullToObject(item, "timeThreshold") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [time_threshold]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->monitoring_time) {
@@ -134,6 +176,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [monitoring_time]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_monitoring_time_null) {
+        if (cJSON_AddNullToObject(item, "monitoringTime") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [monitoring_time]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_next_vol_threshold) {
@@ -141,6 +188,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_next_vol_threshold_null) {
+        if (cJSON_AddNullToObject(item, "nextVolThreshold") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_next_vol_threshold_uplink) {
@@ -148,6 +200,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold_uplink]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_next_vol_threshold_uplink_null) {
+        if (cJSON_AddNullToObject(item, "nextVolThresholdUplink") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold_uplink]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_next_vol_threshold_downlink) {
@@ -155,6 +212,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold_downlink]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_next_vol_threshold_downlink_null) {
+        if (cJSON_AddNullToObject(item, "nextVolThresholdDownlink") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_vol_threshold_downlink]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_next_time_threshold) {
@@ -162,6 +224,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_time_threshold]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_next_time_threshold_null) {
+        if (cJSON_AddNullToObject(item, "nextTimeThreshold") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [next_time_threshold]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->is_inactivity_time) {
@@ -169,6 +236,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
         ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [inactivity_time]");
         goto end;
     }
+    } else if (usage_monitoring_data->is_inactivity_time_null) {
+        if (cJSON_AddNullToObject(item, "inactivityTime") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [inactivity_time]");
+            goto end;
+        }
     }
 
     if (usage_monitoring_data->ex_usage_pcc_rule_ids) {
@@ -183,6 +255,11 @@ cJSON *OpenAPI_usage_monitoring_data_convertToJSON(OpenAPI_usage_monitoring_data
             goto end;
         }
     }
+    } else if (usage_monitoring_data->is_ex_usage_pcc_rule_ids_null) {
+        if (cJSON_AddNullToObject(item, "exUsagePccRuleIds") == NULL) {
+            ogs_error("OpenAPI_usage_monitoring_data_convertToJSON() failed [ex_usage_pcc_rule_ids]");
+            goto end;
+        }
     }
 
 end:
@@ -218,86 +295,107 @@ OpenAPI_usage_monitoring_data_t *OpenAPI_usage_monitoring_data_parseFromJSON(cJS
 
     volume_threshold = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "volumeThreshold");
     if (volume_threshold) {
+    if (!cJSON_IsNull(volume_threshold)) {
     if (!cJSON_IsNumber(volume_threshold)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [volume_threshold]");
         goto end;
     }
     }
+    }
 
     volume_threshold_uplink = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "volumeThresholdUplink");
     if (volume_threshold_uplink) {
+    if (!cJSON_IsNull(volume_threshold_uplink)) {
     if (!cJSON_IsNumber(volume_threshold_uplink)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [volume_threshold_uplink]");
         goto end;
     }
     }
+    }
 
     volume_threshold_downlink = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "volumeThresholdDownlink");
     if (volume_threshold_downlink) {
+    if (!cJSON_IsNull(volume_threshold_downlink)) {
     if (!cJSON_IsNumber(volume_threshold_downlink)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [volume_threshold_downlink]");
         goto end;
     }
     }
+    }
 
     time_threshold = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "timeThreshold");
     if (time_threshold) {
+    if (!cJSON_IsNull(time_threshold)) {
     if (!cJSON_IsNumber(time_threshold)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [time_threshold]");
         goto end;
     }
     }
+    }
 
     monitoring_time = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "monitoringTime");
     if (monitoring_time) {
+    if (!cJSON_IsNull(monitoring_time)) {
     if (!cJSON_IsString(monitoring_time) && !cJSON_IsNull(monitoring_time)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [monitoring_time]");
         goto end;
     }
     }
+    }
 
     next_vol_threshold = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "nextVolThreshold");
     if (next_vol_threshold) {
+    if (!cJSON_IsNull(next_vol_threshold)) {
     if (!cJSON_IsNumber(next_vol_threshold)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [next_vol_threshold]");
         goto end;
     }
     }
+    }
 
     next_vol_threshold_uplink = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "nextVolThresholdUplink");
     if (next_vol_threshold_uplink) {
+    if (!cJSON_IsNull(next_vol_threshold_uplink)) {
     if (!cJSON_IsNumber(next_vol_threshold_uplink)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [next_vol_threshold_uplink]");
         goto end;
     }
     }
+    }
 
     next_vol_threshold_downlink = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "nextVolThresholdDownlink");
     if (next_vol_threshold_downlink) {
+    if (!cJSON_IsNull(next_vol_threshold_downlink)) {
     if (!cJSON_IsNumber(next_vol_threshold_downlink)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [next_vol_threshold_downlink]");
         goto end;
     }
     }
+    }
 
     next_time_threshold = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "nextTimeThreshold");
     if (next_time_threshold) {
+    if (!cJSON_IsNull(next_time_threshold)) {
     if (!cJSON_IsNumber(next_time_threshold)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [next_time_threshold]");
         goto end;
     }
     }
+    }
 
     inactivity_time = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "inactivityTime");
     if (inactivity_time) {
+    if (!cJSON_IsNull(inactivity_time)) {
     if (!cJSON_IsNumber(inactivity_time)) {
         ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [inactivity_time]");
         goto end;
     }
     }
+    }
 
     ex_usage_pcc_rule_ids = cJSON_GetObjectItemCaseSensitive(usage_monitoring_dataJSON, "exUsagePccRuleIds");
     if (ex_usage_pcc_rule_ids) {
+    if (!cJSON_IsNull(ex_usage_pcc_rule_ids)) {
         cJSON *ex_usage_pcc_rule_ids_local = NULL;
         if (!cJSON_IsArray(ex_usage_pcc_rule_ids)) {
             ogs_error("OpenAPI_usage_monitoring_data_parseFromJSON() failed [ex_usage_pcc_rule_ids]");
@@ -316,28 +414,40 @@ OpenAPI_usage_monitoring_data_t *OpenAPI_usage_monitoring_data_parseFromJSON(cJS
             OpenAPI_list_add(ex_usage_pcc_rule_idsList, ogs_strdup(ex_usage_pcc_rule_ids_local->valuestring));
         }
     }
+    }
 
     usage_monitoring_data_local_var = OpenAPI_usage_monitoring_data_create (
         ogs_strdup(um_id->valuestring),
+        volume_threshold && cJSON_IsNull(volume_threshold) ? true : false,
         volume_threshold ? true : false,
         volume_threshold ? volume_threshold->valuedouble : 0,
+        volume_threshold_uplink && cJSON_IsNull(volume_threshold_uplink) ? true : false,
         volume_threshold_uplink ? true : false,
         volume_threshold_uplink ? volume_threshold_uplink->valuedouble : 0,
+        volume_threshold_downlink && cJSON_IsNull(volume_threshold_downlink) ? true : false,
         volume_threshold_downlink ? true : false,
         volume_threshold_downlink ? volume_threshold_downlink->valuedouble : 0,
+        time_threshold && cJSON_IsNull(time_threshold) ? true : false,
         time_threshold ? true : false,
         time_threshold ? time_threshold->valuedouble : 0,
+        monitoring_time && cJSON_IsNull(monitoring_time) ? true : false,
         monitoring_time && !cJSON_IsNull(monitoring_time) ? ogs_strdup(monitoring_time->valuestring) : NULL,
+        next_vol_threshold && cJSON_IsNull(next_vol_threshold) ? true : false,
         next_vol_threshold ? true : false,
         next_vol_threshold ? next_vol_threshold->valuedouble : 0,
+        next_vol_threshold_uplink && cJSON_IsNull(next_vol_threshold_uplink) ? true : false,
         next_vol_threshold_uplink ? true : false,
         next_vol_threshold_uplink ? next_vol_threshold_uplink->valuedouble : 0,
+        next_vol_threshold_downlink && cJSON_IsNull(next_vol_threshold_downlink) ? true : false,
         next_vol_threshold_downlink ? true : false,
         next_vol_threshold_downlink ? next_vol_threshold_downlink->valuedouble : 0,
+        next_time_threshold && cJSON_IsNull(next_time_threshold) ? true : false,
         next_time_threshold ? true : false,
         next_time_threshold ? next_time_threshold->valuedouble : 0,
+        inactivity_time && cJSON_IsNull(inactivity_time) ? true : false,
         inactivity_time ? true : false,
         inactivity_time ? inactivity_time->valuedouble : 0,
+        ex_usage_pcc_rule_ids && cJSON_IsNull(ex_usage_pcc_rule_ids) ? true : false,
         ex_usage_pcc_rule_ids ? ex_usage_pcc_rule_idsList : NULL
     );
 

--- a/lib/sbi/openapi/model/usage_monitoring_data.h
+++ b/lib/sbi/openapi/model/usage_monitoring_data.h
@@ -20,49 +20,71 @@ extern "C" {
 typedef struct OpenAPI_usage_monitoring_data_s OpenAPI_usage_monitoring_data_t;
 typedef struct OpenAPI_usage_monitoring_data_s {
     char *um_id;
+    bool is_volume_threshold_null;
     bool is_volume_threshold;
     long volume_threshold;
+    bool is_volume_threshold_uplink_null;
     bool is_volume_threshold_uplink;
     long volume_threshold_uplink;
+    bool is_volume_threshold_downlink_null;
     bool is_volume_threshold_downlink;
     long volume_threshold_downlink;
+    bool is_time_threshold_null;
     bool is_time_threshold;
     int time_threshold;
+    bool is_monitoring_time_null;
     char *monitoring_time;
+    bool is_next_vol_threshold_null;
     bool is_next_vol_threshold;
     long next_vol_threshold;
+    bool is_next_vol_threshold_uplink_null;
     bool is_next_vol_threshold_uplink;
     long next_vol_threshold_uplink;
+    bool is_next_vol_threshold_downlink_null;
     bool is_next_vol_threshold_downlink;
     long next_vol_threshold_downlink;
+    bool is_next_time_threshold_null;
     bool is_next_time_threshold;
     int next_time_threshold;
+    bool is_inactivity_time_null;
     bool is_inactivity_time;
     int inactivity_time;
+    bool is_ex_usage_pcc_rule_ids_null;
     OpenAPI_list_t *ex_usage_pcc_rule_ids;
 } OpenAPI_usage_monitoring_data_t;
 
 OpenAPI_usage_monitoring_data_t *OpenAPI_usage_monitoring_data_create(
     char *um_id,
+    bool is_volume_threshold_null,
     bool is_volume_threshold,
     long volume_threshold,
+    bool is_volume_threshold_uplink_null,
     bool is_volume_threshold_uplink,
     long volume_threshold_uplink,
+    bool is_volume_threshold_downlink_null,
     bool is_volume_threshold_downlink,
     long volume_threshold_downlink,
+    bool is_time_threshold_null,
     bool is_time_threshold,
     int time_threshold,
+    bool is_monitoring_time_null,
     char *monitoring_time,
+    bool is_next_vol_threshold_null,
     bool is_next_vol_threshold,
     long next_vol_threshold,
+    bool is_next_vol_threshold_uplink_null,
     bool is_next_vol_threshold_uplink,
     long next_vol_threshold_uplink,
+    bool is_next_vol_threshold_downlink_null,
     bool is_next_vol_threshold_downlink,
     long next_vol_threshold_downlink,
+    bool is_next_time_threshold_null,
     bool is_next_time_threshold,
     int next_time_threshold,
+    bool is_inactivity_time_null,
     bool is_inactivity_time,
     int inactivity_time,
+    bool is_ex_usage_pcc_rule_ids_null,
     OpenAPI_list_t *ex_usage_pcc_rule_ids
 );
 void OpenAPI_usage_monitoring_data_free(OpenAPI_usage_monitoring_data_t *usage_monitoring_data);

--- a/lib/sbi/openapi/model/usage_threshold_rm.c
+++ b/lib/sbi/openapi/model/usage_threshold_rm.c
@@ -5,12 +5,16 @@
 #include "usage_threshold_rm.h"
 
 OpenAPI_usage_threshold_rm_t *OpenAPI_usage_threshold_rm_create(
+    bool is_duration_null,
     bool is_duration,
     int duration,
+    bool is_total_volume_null,
     bool is_total_volume,
     long total_volume,
+    bool is_downlink_volume_null,
     bool is_downlink_volume,
     long downlink_volume,
+    bool is_uplink_volume_null,
     bool is_uplink_volume,
     long uplink_volume
 )
@@ -18,12 +22,16 @@ OpenAPI_usage_threshold_rm_t *OpenAPI_usage_threshold_rm_create(
     OpenAPI_usage_threshold_rm_t *usage_threshold_rm_local_var = ogs_malloc(sizeof(OpenAPI_usage_threshold_rm_t));
     ogs_assert(usage_threshold_rm_local_var);
 
+    usage_threshold_rm_local_var->is_duration_null = is_duration_null;
     usage_threshold_rm_local_var->is_duration = is_duration;
     usage_threshold_rm_local_var->duration = duration;
+    usage_threshold_rm_local_var->is_total_volume_null = is_total_volume_null;
     usage_threshold_rm_local_var->is_total_volume = is_total_volume;
     usage_threshold_rm_local_var->total_volume = total_volume;
+    usage_threshold_rm_local_var->is_downlink_volume_null = is_downlink_volume_null;
     usage_threshold_rm_local_var->is_downlink_volume = is_downlink_volume;
     usage_threshold_rm_local_var->downlink_volume = downlink_volume;
+    usage_threshold_rm_local_var->is_uplink_volume_null = is_uplink_volume_null;
     usage_threshold_rm_local_var->is_uplink_volume = is_uplink_volume;
     usage_threshold_rm_local_var->uplink_volume = uplink_volume;
 
@@ -56,6 +64,11 @@ cJSON *OpenAPI_usage_threshold_rm_convertToJSON(OpenAPI_usage_threshold_rm_t *us
         ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [duration]");
         goto end;
     }
+    } else if (usage_threshold_rm->is_duration_null) {
+        if (cJSON_AddNullToObject(item, "duration") == NULL) {
+            ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [duration]");
+            goto end;
+        }
     }
 
     if (usage_threshold_rm->is_total_volume) {
@@ -63,6 +76,11 @@ cJSON *OpenAPI_usage_threshold_rm_convertToJSON(OpenAPI_usage_threshold_rm_t *us
         ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [total_volume]");
         goto end;
     }
+    } else if (usage_threshold_rm->is_total_volume_null) {
+        if (cJSON_AddNullToObject(item, "totalVolume") == NULL) {
+            ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [total_volume]");
+            goto end;
+        }
     }
 
     if (usage_threshold_rm->is_downlink_volume) {
@@ -70,6 +88,11 @@ cJSON *OpenAPI_usage_threshold_rm_convertToJSON(OpenAPI_usage_threshold_rm_t *us
         ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [downlink_volume]");
         goto end;
     }
+    } else if (usage_threshold_rm->is_downlink_volume_null) {
+        if (cJSON_AddNullToObject(item, "downlinkVolume") == NULL) {
+            ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [downlink_volume]");
+            goto end;
+        }
     }
 
     if (usage_threshold_rm->is_uplink_volume) {
@@ -77,6 +100,11 @@ cJSON *OpenAPI_usage_threshold_rm_convertToJSON(OpenAPI_usage_threshold_rm_t *us
         ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [uplink_volume]");
         goto end;
     }
+    } else if (usage_threshold_rm->is_uplink_volume_null) {
+        if (cJSON_AddNullToObject(item, "uplinkVolume") == NULL) {
+            ogs_error("OpenAPI_usage_threshold_rm_convertToJSON() failed [uplink_volume]");
+            goto end;
+        }
     }
 
 end:
@@ -93,43 +121,55 @@ OpenAPI_usage_threshold_rm_t *OpenAPI_usage_threshold_rm_parseFromJSON(cJSON *us
     cJSON *uplink_volume = NULL;
     duration = cJSON_GetObjectItemCaseSensitive(usage_threshold_rmJSON, "duration");
     if (duration) {
+    if (!cJSON_IsNull(duration)) {
     if (!cJSON_IsNumber(duration)) {
         ogs_error("OpenAPI_usage_threshold_rm_parseFromJSON() failed [duration]");
         goto end;
     }
     }
+    }
 
     total_volume = cJSON_GetObjectItemCaseSensitive(usage_threshold_rmJSON, "totalVolume");
     if (total_volume) {
+    if (!cJSON_IsNull(total_volume)) {
     if (!cJSON_IsNumber(total_volume)) {
         ogs_error("OpenAPI_usage_threshold_rm_parseFromJSON() failed [total_volume]");
         goto end;
     }
     }
+    }
 
     downlink_volume = cJSON_GetObjectItemCaseSensitive(usage_threshold_rmJSON, "downlinkVolume");
     if (downlink_volume) {
+    if (!cJSON_IsNull(downlink_volume)) {
     if (!cJSON_IsNumber(downlink_volume)) {
         ogs_error("OpenAPI_usage_threshold_rm_parseFromJSON() failed [downlink_volume]");
         goto end;
     }
     }
+    }
 
     uplink_volume = cJSON_GetObjectItemCaseSensitive(usage_threshold_rmJSON, "uplinkVolume");
     if (uplink_volume) {
+    if (!cJSON_IsNull(uplink_volume)) {
     if (!cJSON_IsNumber(uplink_volume)) {
         ogs_error("OpenAPI_usage_threshold_rm_parseFromJSON() failed [uplink_volume]");
         goto end;
     }
     }
+    }
 
     usage_threshold_rm_local_var = OpenAPI_usage_threshold_rm_create (
+        duration && cJSON_IsNull(duration) ? true : false,
         duration ? true : false,
         duration ? duration->valuedouble : 0,
+        total_volume && cJSON_IsNull(total_volume) ? true : false,
         total_volume ? true : false,
         total_volume ? total_volume->valuedouble : 0,
+        downlink_volume && cJSON_IsNull(downlink_volume) ? true : false,
         downlink_volume ? true : false,
         downlink_volume ? downlink_volume->valuedouble : 0,
+        uplink_volume && cJSON_IsNull(uplink_volume) ? true : false,
         uplink_volume ? true : false,
         uplink_volume ? uplink_volume->valuedouble : 0
     );

--- a/lib/sbi/openapi/model/usage_threshold_rm.h
+++ b/lib/sbi/openapi/model/usage_threshold_rm.h
@@ -19,23 +19,31 @@ extern "C" {
 
 typedef struct OpenAPI_usage_threshold_rm_s OpenAPI_usage_threshold_rm_t;
 typedef struct OpenAPI_usage_threshold_rm_s {
+    bool is_duration_null;
     bool is_duration;
     int duration;
+    bool is_total_volume_null;
     bool is_total_volume;
     long total_volume;
+    bool is_downlink_volume_null;
     bool is_downlink_volume;
     long downlink_volume;
+    bool is_uplink_volume_null;
     bool is_uplink_volume;
     long uplink_volume;
 } OpenAPI_usage_threshold_rm_t;
 
 OpenAPI_usage_threshold_rm_t *OpenAPI_usage_threshold_rm_create(
+    bool is_duration_null,
     bool is_duration,
     int duration,
+    bool is_total_volume_null,
     bool is_total_volume,
     long total_volume,
+    bool is_downlink_volume_null,
     bool is_downlink_volume,
     long downlink_volume,
+    bool is_uplink_volume_null,
     bool is_uplink_volume,
     long uplink_volume
 );

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-body.mustache
@@ -63,6 +63,9 @@ OpenAPI_{{classVarName}}_{{name}}_e OpenAPI_{{name}}{{classname}}_FromString(cha
 {{/vars}}
 OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_create(
 {{#vars}}
+    {{#isNullable}}
+    bool is_{{name}}_null,
+    {{/isNullable}}
     {{^isContainer}}
         {{^isPrimitiveType}}
             {{#isEnum}}
@@ -137,6 +140,9 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_create(
     ogs_assert({{classname}}_local_var);
 
 {{#vars}}
+    {{#isNullable}}
+    {{classname}}_local_var->is_{{{name}}}_null = is_{{{name}}}_null;
+    {{/isNullable}}
     {{^isContainer}}
         {{#isPrimitiveType}}
             {{^isEnum}}
@@ -588,6 +594,13 @@ cJSON *OpenAPI_{{classname}}_convertToJSON(OpenAPI_{{classname}}_t *{{classname}
         {{/isMap}}
     {{/isContainer}}
     {{^required}}
+    {{#isNullable}}
+    } else if ({{{classname}}}->is_{{{name}}}_null) {
+        if (cJSON_AddNullToObject(item, "{{{baseName}}}") == NULL) {
+            ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+            goto end;
+        }
+    {{/isNullable}}
     }
     {{/required}}
 
@@ -649,6 +662,9 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
     {{/required}}
     {{^required}}
     if ({{{name}}}) {
+        {{#isNullable}}
+    if (!cJSON_IsNull({{{name}}})) {
+        {{/isNullable}}
     {{/required}}
     {{^isContainer}}
         {{#isPrimitiveType}}
@@ -928,11 +944,17 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
     {{/isContainer}}
     {{^required}}
     }
+        {{#isNullable}}
+    }
+        {{/isNullable}}
     {{/required}}
 
 {{/vars}}
     {{classname}}_local_var = OpenAPI_{{classname}}_create (
 {{#vars}}
+    {{#isNullable}}
+        {{{name}}} && cJSON_IsNull({{{name}}}) ? true : false,
+    {{/isNullable}}
     {{^isContainer}}
         {{^isPrimitiveType}}
             {{#isEnum}}

--- a/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-header.mustache
+++ b/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator/templates/model-header.mustache
@@ -48,6 +48,9 @@ OpenAPI_{{classVarName}}_{{name}}_e OpenAPI_{{classVarName}}_{{name}}_FromString
 {{/vars}}
 typedef struct OpenAPI_{{classname}}_s {
 {{#vars}}
+    {{#isNullable}}
+    bool is_{{name}}_null;
+    {{/isNullable}}
     {{^isContainer}}
         {{^isPrimitiveType}}
             {{#isEnum}}
@@ -121,6 +124,9 @@ typedef struct OpenAPI_{{classname}}_s {
 
 OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_create(
 {{#vars}}
+    {{#isNullable}}
+    bool is_{{name}}_null,
+    {{/isNullable}}
     {{^isContainer}}
         {{^isPrimitiveType}}
             {{#isEnum}}

--- a/tests/af/npcf-build.c
+++ b/tests/af/npcf-build.c
@@ -367,7 +367,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_update(
 
     OpenAPI_list_t *SubComponentList = NULL;
     OpenAPI_map_t *SubComponentMap = NULL;
-    OpenAPI_media_sub_component_t *SubComponent = NULL;
+    OpenAPI_media_sub_component_rm_t *SubComponent = NULL;
 
     OpenAPI_list_t *fDescList = NULL;
     OpenAPI_list_t *codecList = NULL;


### PR DESCRIPTION
- Some fields in OpenAPI yaml files are marked as "nullable". Meaning that these fields can be either present, not present, or null.
This feature is important for example in SmContextUpdateData structure, where many fields are described similar as the following:
This IE shall be included for the modification .... For deleting the field, it shall contain the Null value.

- unittests: Use correct structure when sending modification request from AF



  
