### PR TITLE
.gitignore: Add install/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+install/
+
 # This directory is fetched during first build and is present in this directory
 subprojects/freeDiameter
 subprojects/libtins


### PR DESCRIPTION
Open5GS documentation instructs to install into open5gs.git/install/ during build [1]:
"""
$ cd open5gs
$ meson build --prefix=`pwd`/install
$ ninja -C build
"""

As a result, this directory appears all the time when using git, since it's not in the .gitignore file. Add it.

[1] https://open5gs.org/open5gs/docs/guide/02-building-open5gs-from-sources/