### PR TITLE
Ue context transfer

### DIFF
--- a/lib/nas/5gs/types.c
+++ b/lib/nas/5gs/types.c
@@ -968,3 +968,22 @@ int ogs_nas_parse_qos_rules(
 
     return (int)(rule-first);
 }
+
+bool ogs_nas_guti_is_valid(ogs_nas_5gs_guti_t *guti)
+{
+    if ((guti->amf_id.region !=0) &&
+        (guti->amf_id.set2 !=0) &&
+        (guti->amf_id.pointer !=0) &&
+        (guti->m_tmsi != 0) &&
+        ((guti->nas_plmn_id.mcc1) !=0 ||
+            (guti->nas_plmn_id.mcc2) !=0 ||
+            (guti->nas_plmn_id.mcc3) !=0) &&
+        ((guti->nas_plmn_id.mnc1) !=0 ||
+            (guti->nas_plmn_id.mnc2) !=0 ||
+            (guti->nas_plmn_id.mnc3) !=0)) {
+
+        return true;
+    }
+
+    return false;
+}

--- a/lib/nas/5gs/types.h
+++ b/lib/nas/5gs/types.h
@@ -1192,6 +1192,8 @@ typedef struct ogs_nas_rsn_s {
     uint8_t value;
 } __attribute__ ((packed)) ogs_nas_rsn_t;
 
+bool ogs_nas_guti_is_valid(ogs_nas_5gs_guti_t *guti);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -88,6 +88,8 @@ extern "C" {
 #define OGS_MAX_NUM_OF_ACCESS_CONTROL   8
 #define OGS_MAX_NUM_OF_ALGORITHM        8
 
+#define OGS_MAX_GUTI_LEN                28
+
 #define OGS_MAX_NUM_OF_BPLMN            6
 
 #define OGS_NEXT_ID(__id, __min, __max) \
@@ -186,10 +188,11 @@ ogs_amf_id_t *ogs_amf_id_build(ogs_amf_id_t *amf_id,
 #define OGS_PROTECTION_SCHEME_PROFILE_B 2
 
 /************************************
- * SUPI/GPSI                       */
+ * SUPI/GPSI/GUTI                   */
 #define OGS_ID_SUPI_TYPE_IMSI "imsi"
 #define OGS_ID_GPSI_TYPE_MSISDN "msisdn"
 #define OGS_ID_SUPI_TYPE_IMEISV "imeisv"
+#define OGS_ID_5G_GUTI_TYPE "5g-guti"
 char *ogs_id_get_type(char *str);
 char *ogs_id_get_value(char *str);
 

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1547,6 +1547,9 @@ bool ogs_sbi_discovery_option_is_matched(
         OpenAPI_nf_type_e requester_nf_type,
         ogs_sbi_discovery_option_t *discovery_option)
 {
+    ogs_sbi_nf_info_t *node = NULL;
+    ogs_guami_t *nf_instance_guami = NULL;
+
     ogs_assert(nf_instance);
     ogs_assert(requester_nf_type);
     ogs_assert(discovery_option);
@@ -1554,6 +1557,31 @@ bool ogs_sbi_discovery_option_is_matched(
     if (discovery_option->target_nf_instance_id &&
         nf_instance->id && strcmp(nf_instance->id,
             discovery_option->target_nf_instance_id) != 0) {
+        return false;
+    }
+
+    if (discovery_option->target_guami &&
+        (requester_nf_type == OpenAPI_nf_type_AMF)) {
+        /* AMF is searching for AMF */
+
+        ogs_list_for_each(&nf_instance->nf_info_list, node) {
+            int i;
+            for (i = 0; i < node->amf.num_of_guami; i++) {
+                nf_instance_guami = &node->amf.guami[i];
+
+                if ((memcmp(&nf_instance_guami->amf_id,
+                        &discovery_option->target_guami->amf_id,
+                        sizeof(ogs_amf_id_t)) == 0) &&
+                    (memcmp(&nf_instance_guami->plmn_id,
+                        &discovery_option->target_guami->plmn_id,
+                        OGS_PLMN_ID_LEN) == 0)) {
+                    return true;
+                }
+            }
+        }
+
+        /* TODO - backup_info_amf_removal and backup_info_amf_failure */
+
         return false;
     }
 

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -29,6 +29,7 @@ static OGS_POOL(xact_pool, ogs_sbi_xact_t);
 static OGS_POOL(subscription_spec_pool, ogs_sbi_subscription_spec_t);
 static OGS_POOL(subscription_data_pool, ogs_sbi_subscription_data_t);
 static OGS_POOL(smf_info_pool, ogs_sbi_smf_info_t);
+static OGS_POOL(amf_info_pool, ogs_sbi_amf_info_t);
 static OGS_POOL(nf_info_pool, ogs_sbi_nf_info_t);
 
 void ogs_sbi_context_init(OpenAPI_nf_type_e nf_type)
@@ -61,6 +62,8 @@ void ogs_sbi_context_init(OpenAPI_nf_type_e nf_type)
     ogs_pool_init(&subscription_data_pool, ogs_app()->pool.subscription);
 
     ogs_pool_init(&smf_info_pool, ogs_app()->pool.nf);
+
+    ogs_pool_init(&amf_info_pool, ogs_app()->pool.nf);
 
     ogs_pool_init(&nf_info_pool, ogs_app()->pool.nf * OGS_MAX_NUM_OF_NF_INFO);
 
@@ -105,6 +108,7 @@ void ogs_sbi_context_final(void)
     ogs_pool_final(&nf_instance_pool);
     ogs_pool_final(&nf_service_pool);
     ogs_pool_final(&smf_info_pool);
+    ogs_pool_final(&amf_info_pool);
 
     ogs_pool_final(&nf_info_pool);
 
@@ -1239,7 +1243,13 @@ ogs_sbi_nf_info_t *ogs_sbi_nf_info_add(
 
 static void amf_info_free(ogs_sbi_amf_info_t *amf_info)
 {
-    /* Nothing */
+    ogs_assert(amf_info);
+
+    amf_info->num_of_guami = 0;
+    amf_info->num_of_nr_tai = 0;
+    amf_info->num_of_nr_tai_range = 0;
+
+    ogs_pool_free(&amf_info_pool, amf_info);
 }
 
 static void smf_info_free(ogs_sbi_smf_info_t *smf_info)

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -185,6 +185,10 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_sdm_subscription_free(message->SDMSubscription);
     if (message->ModificationNotification)
         OpenAPI_modification_notification_free(message->ModificationNotification);
+    if (message->UeContextTransferReqData)
+        OpenAPI_ue_context_transfer_req_data_free(message->UeContextTransferReqData);
+    if (message->UeContextTransferRspData)
+        OpenAPI_ue_context_transfer_rsp_data_free(message->UeContextTransferRspData);
 
     /* HTTP Part */
     for (i = 0; i < message->num_of_part; i++) {
@@ -1219,6 +1223,14 @@ static char *build_json(ogs_sbi_message_t *message)
         item = OpenAPI_modification_notification_convertToJSON(
             message->ModificationNotification);
         ogs_assert(item);
+    } else if (message->UeContextTransferReqData) {
+        item = OpenAPI_ue_context_transfer_req_data_convertToJSON(
+                message->UeContextTransferReqData);
+        ogs_assert(item);
+    } else if (message->UeContextTransferRspData) {
+        item = OpenAPI_ue_context_transfer_rsp_data_convertToJSON(
+                message->UeContextTransferRspData);
+        ogs_assert(item);
     }
 
     if (item) {
@@ -1943,6 +1955,27 @@ static int parse_json(ogs_sbi_message_t *message,
                             rv = OGS_ERROR;
                             ogs_error("JSON parse error");
                         }
+                    }
+                    break;
+
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER)
+                    if (message->res_status == 0) {
+                        message->UeContextTransferReqData =
+                            OpenAPI_ue_context_transfer_req_data_parseFromJSON(item);
+                        if (!message->UeContextTransferReqData) {
+                            rv = OGS_ERROR;
+                            ogs_error("JSON parse error");
+                        }
+                    } else if (message->res_status == OGS_SBI_HTTP_STATUS_OK) {
+                        message->UeContextTransferRspData =
+                            OpenAPI_ue_context_transfer_rsp_data_parseFromJSON(item);
+                        if (!message->UeContextTransferRspData) {
+                            rv = OGS_ERROR;
+                            ogs_error("JSON parse error");
+                        }
+                    } else {
+                        ogs_error("HTTP ERROR Status : %d",
+                            message->res_status);
                     }
                     break;
 

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -124,6 +124,7 @@ extern "C" {
 
 #define OGS_SBI_RESOURCE_NAME_UE_CONTEXTS           "ue-contexts"
 #define OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES        "n1-n2-messages"
+#define OGS_SBI_RESOURCE_NAME_TRANSFER              "transfer"
 
 #define OGS_SBI_RESOURCE_NAME_SM_CONTEXT_STATUS     "sm-context-status"
 #define OGS_SBI_RESOURCE_NAME_AM_POLICY_NOTIFY      "am-policy-notify"
@@ -514,6 +515,8 @@ typedef struct ogs_sbi_message_s {
     OpenAPI_sdm_subscription_t *SDMSubscription;
     OpenAPI_modification_notification_t *ModificationNotification;
     OpenAPI_smf_registration_t *SmfRegistration;
+    OpenAPI_ue_context_transfer_req_data_t *UeContextTransferReqData;
+    OpenAPI_ue_context_transfer_rsp_data_t *UeContextTransferRspData;
 
     ogs_sbi_links_t *links;
 

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -314,6 +314,7 @@ extern "C" {
 #define OGS_SBI_PARAM_PLMN_ID                       "plmn-id"
 #define OGS_SBI_PARAM_SINGLE_NSSAI                  "single-nssai"
 #define OGS_SBI_PARAM_SNSSAI                        "snssai"
+#define OGS_SBI_PARAM_GUAMI                         "guami"
 #define OGS_SBI_PARAM_SLICE_INFO_REQUEST_FOR_PDU_SESSION \
         "slice-info-request-for-pdu-session"
 #define OGS_SBI_PARAM_IPV4ADDR                      "ipv4Addr"
@@ -403,6 +404,8 @@ typedef struct ogs_sbi_part_s {
 typedef struct ogs_sbi_discovery_option_s {
     char *target_nf_instance_id;
     char *requester_nf_instance_id;
+
+    ogs_guami_t *target_guami;
 
     int num_of_service_names;
     char *service_names[OGS_SBI_MAX_NUM_OF_SERVICE_TYPE];

--- a/lib/sbi/ogs-sbi.h
+++ b/lib/sbi/ogs-sbi.h
@@ -82,6 +82,8 @@
 #include "model/modification_notification.h"
 #include "model/patch_item.h"
 #include "model/ue_authentication_ctx.h"
+#include "model/ue_context_transfer_req_data.h"
+#include "model/ue_context_transfer_rsp_data.h"
 
 #include "custom/links.h"
 

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -179,6 +179,21 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                                 "Invalid HTTP method", sbi_message.h.method));
                     END
                     break;
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER)
+                    SWITCH(sbi_message.h.method)
+                    CASE(OGS_SBI_HTTP_METHOD_POST)
+                        amf_namf_comm_handle_ue_context_transfer_request(
+                                stream, &sbi_message);
+                        break;
+                    DEFAULT
+                        ogs_error("Invalid HTTP method [%s]",
+                                sbi_message.h.method);
+                        ogs_assert(true ==
+                            ogs_sbi_server_send_error(stream,
+                                OGS_SBI_HTTP_STATUS_FORBIDDEN, &sbi_message,
+                                "Invalid HTTP method", sbi_message.h.method));
+                    END
+                    break;
 
                 DEFAULT
                     ogs_error("Invalid resource name [%s]",
@@ -375,6 +390,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_UECM)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_SDM)
         CASE(OGS_SBI_SERVICE_NAME_NPCF_AM_POLICY_CONTROL)
+        CASE(OGS_SBI_SERVICE_NAME_NAMF_COMM)
             sbi_xact = e->h.sbi.data;
             ogs_assert(sbi_xact);
 

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -689,6 +689,7 @@ void amf_ue_fsm_fini(amf_ue_t *amf_ue);
 amf_ue_t *amf_ue_find_by_guti(ogs_nas_5gs_guti_t *nas_guti);
 amf_ue_t *amf_ue_find_by_suci(char *suci);
 amf_ue_t *amf_ue_find_by_supi(char *supi);
+amf_ue_t *amf_ue_find_by_ue_context_id(char *ue_context_id);
 
 amf_ue_t *amf_ue_find_by_message(ogs_nas_5gs_message_t *message);
 void amf_ue_set_suci(amf_ue_t *amf_ue,

--- a/src/amf/gmm-handler.h
+++ b/src/amf/gmm-handler.h
@@ -21,6 +21,7 @@
 #define GMM_HANDLER_H
 
 #include "context.h"
+#include "namf-handler.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -27,8 +27,10 @@
 #include "nsmf-handler.h"
 #include "nudm-handler.h"
 #include "npcf-handler.h"
+#include "namf-handler.h"
 #include "sbi-path.h"
 #include "amf-sm.h"
+#include "namf-build.h"
 
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __gmm_log_domain
@@ -64,6 +66,9 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
     amf_sess_t *sess = NULL;
 
     ogs_sbi_message_t *sbi_message = NULL;
+    ogs_nas_5gs_message_t *nas_message = NULL;
+    ogs_nas_5gmm_cause_t gmm_cause;
+    ogs_nas_security_header_type_t h;
 
     int r, state = 0;
 
@@ -489,6 +494,112 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
                     ogs_assert_if_reached();
                 END
                 break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[0]);
+                ogs_assert_if_reached();
+            END
+            break;
+
+        CASE(OGS_SBI_SERVICE_NAME_NAMF_COMM)
+            SWITCH(sbi_message->h.resource.component[0])
+            CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)
+                SWITCH(sbi_message->h.resource.component[2])
+                    CASE(OGS_SBI_RESOURCE_NAME_TRANSFER)
+
+                        h.type = e->nas.type;
+                        nas_message = e->nas.message;
+
+                        if (sbi_message->res_status == OGS_SBI_HTTP_STATUS_OK) {
+                            r = amf_namf_comm_handle_ue_context_transfer_response(sbi_message, amf_ue);
+                            ogs_expect(r == OGS_OK);
+                        }
+
+                        int xact_count = amf_sess_xact_count(amf_ue);
+
+                        if (!AMF_UE_HAVE_SUCI(amf_ue)) {
+                            CLEAR_AMF_UE_TIMER(amf_ue->t3570);
+                            r = nas_5gs_send_identity_request(amf_ue);
+                            ogs_expect(r == OGS_OK);
+                            ogs_assert(r != OGS_ERROR);
+                            break;
+                        }
+
+                        if (h.integrity_protected && SECURITY_CONTEXT_IS_VALID(amf_ue)) {
+                            gmm_cause = gmm_handle_registration_update(
+                                    amf_ue, &nas_message->gmm.registration_request);
+                            if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
+                                ogs_error("[%s] gmm_handle_registration_update() "
+                                            "failed [%d]", amf_ue->suci, gmm_cause);
+                                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                                ogs_expect(r == OGS_OK);
+                                ogs_assert(r != OGS_ERROR);
+                                OGS_FSM_TRAN(s, gmm_state_exception);
+                                break;
+                            }
+
+                            if (amf_sess_xact_count(amf_ue) == xact_count) {
+
+                                if (amf_update_allowed_nssai(amf_ue) == false) {
+                                    ogs_error("No Allowed-NSSAI");
+                                    r = nas_5gs_send_gmm_reject(
+                                        amf_ue,
+                                        OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
+                                    ogs_expect(r == OGS_OK);
+                                    ogs_assert(r != OGS_ERROR);
+                                    OGS_FSM_TRAN(s, gmm_state_exception);
+                                    break;
+                                }
+
+                                if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
+                                    r = amf_ue_sbi_discover_and_send(
+                                            OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
+                                            NULL,
+                                            amf_npcf_am_policy_control_build_create,
+                                            amf_ue, 0, NULL);
+                                    ogs_expect(r == OGS_OK);
+                                    ogs_assert(r != OGS_ERROR);
+                                    OGS_FSM_TRAN(s, &gmm_state_initial_context_setup);
+                                    break;
+                                }
+
+                                CLEAR_AMF_UE_TIMER(amf_ue->t3550);
+                                r = nas_5gs_send_registration_accept(amf_ue);
+                                ogs_expect(r == OGS_OK);
+                                ogs_assert(r != OGS_ERROR);
+                            }
+
+                            if (amf_ue->next.m_tmsi)
+                                OGS_FSM_TRAN(s, &gmm_state_initial_context_setup);
+                            else
+                                OGS_FSM_TRAN(s, &gmm_state_registered);
+
+                        } else {
+
+                            amf_sbi_send_release_all_sessions(
+                                    amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
+
+                            if (!AMF_SESSION_RELEASE_PENDING(amf_ue) &&
+                                amf_sess_xact_count(amf_ue) == xact_count) {
+                                r = amf_ue_sbi_discover_and_send(
+                                        OGS_SBI_SERVICE_TYPE_NAUSF_AUTH, NULL,
+                                        amf_nausf_auth_build_authenticate,
+                                        amf_ue, 0, NULL);
+                                ogs_expect(r == OGS_OK);
+                                ogs_assert(r != OGS_ERROR);
+                            }
+
+                            OGS_FSM_TRAN(s, &gmm_state_authentication);
+                        }
+                        break;
+
+                    DEFAULT
+                        ogs_error("Invalid resource name [%s]",
+                                sbi_message->h.resource.component[2]);
+                        ogs_assert_if_reached();
+                    END
+                    break;
 
             DEFAULT
                 ogs_error("Invalid resource name [%s]",
@@ -1032,6 +1143,10 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
     ran_ue_t *ran_ue = NULL;
     ogs_nas_5gs_message_t *nas_message = NULL;
     ogs_nas_security_header_type_t h;
+    ogs_nas_5gs_registration_request_t *registration_request = NULL;
+    ogs_nas_5gs_mobile_identity_header_t *mobile_identity_header = NULL;
+    ogs_nas_5gs_mobile_identity_t *mobile_identity = NULL;
+
 
     ogs_assert(e);
 
@@ -1088,6 +1203,65 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
                 break;
+            }
+
+            registration_request = &nas_message->gmm.registration_request;
+            mobile_identity = &registration_request->mobile_identity;
+            mobile_identity_header =
+                    (ogs_nas_5gs_mobile_identity_header_t *)mobile_identity->buffer;
+
+            /* Check if registration is done with GUTI  */
+            if (mobile_identity_header && mobile_identity_header->type ==
+                    OGS_NAS_5GS_MOBILE_IDENTITY_GUTI &&
+                    ogs_nas_guti_is_valid(&amf_ue->current.guti)) {
+
+               /*
+                * TS 23.502
+                * 4.2.2.2.2 General Registration
+                * (Without UDSF Deployment): If the UE's 5G-GUTI was included in the
+                * Registration Request and the serving AMF has changed since last
+                * Registration procedure, the new AMF may invoke the
+                * Namf_Communication_UEContextTransfer service operation on the
+                * old AMF including the complete Registration Request NAS message,
+                * which may be integrity protected, as well as the Access Type,
+                * to request the UE's SUPI and UE Context. See clause 5.2.2.2.2
+                * for details of this service operation.
+                */
+
+                int state = e->h.sbi.state;
+                bool serving_guami = false;
+                int i;
+
+                /* Compare all serving guami-s with guami from UE's GUTI */
+                for (i = 0; i < amf_self()->num_of_served_guami; i++) {
+                    if ((memcmp(&amf_self()->served_guami[i].amf_id,
+                                &amf_ue->current.guti.amf_id,
+                                sizeof(ogs_amf_id_t)) == 0) &&
+                        (memcmp(&amf_self()->served_guami[i].plmn_id,
+                                &amf_ue->current.guti.nas_plmn_id,
+                                OGS_PLMN_ID_LEN) == 0)) {
+                        serving_guami = true;
+                        break;
+                    }
+                }
+                if (!serving_guami) {
+                    /* Guami from UE is not this AMF's serving guami - send UEContextTransfer */
+                    ogs_sbi_discovery_option_t *discovery_option = NULL;
+
+                    discovery_option = ogs_sbi_discovery_option_new();
+                    ogs_assert(discovery_option);
+
+                    memcpy(discovery_option->target_guami,
+                            amf_ue->guami, sizeof(ogs_guami_t));
+
+                    int r = amf_ue_sbi_discover_and_send(
+                            OGS_SBI_SERVICE_TYPE_NAMF_COMM, discovery_option,
+                            amf_namf_comm_build_ue_context_transfer,
+                            amf_ue, state, nas_message);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+                    break;
+                }
             }
 
             if (!AMF_UE_HAVE_SUCI(amf_ue)) {

--- a/src/amf/meson.build
+++ b/src/amf/meson.build
@@ -40,6 +40,7 @@ libamf_sources = files('''
     nnrf-build.c
     nnrf-handler.c
 
+    namf-build.c
     namf-handler.c
     sbi-path.c
 

--- a/src/amf/namf-build.c
+++ b/src/amf/namf-build.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "namf-build.h"
+
+static char* ogs_guti_to_string(amf_ue_t *amf_ue)
+{
+    ogs_plmn_id_t plmn_id;
+    char plmn_id_buff[OGS_PLMNIDSTRLEN];
+    char *amf_id = NULL;
+    char *tmsi = NULL;
+    char *guti = NULL;
+
+    memset(&plmn_id, 0, sizeof(plmn_id));
+    ogs_nas_to_plmn_id(&plmn_id, &amf_ue->current.guti.nas_plmn_id);
+
+    amf_id = ogs_amf_id_to_string(&amf_ue->current.guti.amf_id);
+    tmsi = ogs_uint32_to_0string(*(amf_ue->current.m_tmsi));
+
+    guti = ogs_msprintf("5g-guti-%s%s%s",
+            ogs_plmn_id_to_string(&plmn_id, plmn_id_buff),
+            amf_id,
+            tmsi);
+
+    /* TS29.518 6.1.3.2.2 Guti pattern (27 or 28 characters):
+    "5g-guti-[0-9]{5,6}[0-9a-fA-F]{14}" */
+    ogs_assert(strlen(guti) == (OGS_MAX_GUTI_LEN - 1) ||
+            (strlen(guti)) == OGS_MAX_GUTI_LEN);
+
+    ogs_free(amf_id);
+    ogs_free(tmsi);
+
+    return guti;
+}
+
+static char* amf_ue_to_context_id(amf_ue_t *amf_ue)
+{
+    char *ue_context_id = NULL;
+
+    if (amf_ue->supi) {
+        ue_context_id = ogs_strdup(amf_ue->supi);
+    } else {
+        ue_context_id = ogs_guti_to_string(amf_ue);
+    }
+
+    return ue_context_id;
+}
+
+ogs_sbi_request_t *amf_namf_comm_build_ue_context_transfer(
+        amf_ue_t *amf_ue, void *data)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+    OpenAPI_ue_context_transfer_req_data_t UeContextTransferReqData;
+    char *ue_context_id = NULL;
+
+    ogs_assert(amf_ue);
+
+    ue_context_id = amf_ue_to_context_id(amf_ue);
+    ogs_assert(ue_context_id);
+
+    memset(&UeContextTransferReqData, 0, sizeof(UeContextTransferReqData));
+    UeContextTransferReqData.access_type = amf_ue->nas.access_type;
+    UeContextTransferReqData.reason = amf_ue->nas.registration.value;
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
+    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NAMF_COMM;
+    message.h.api.version = (char *)OGS_SBI_API_V1;
+    message.h.resource.component[0] =
+            (char *)OGS_SBI_RESOURCE_NAME_UE_CONTEXTS;
+    message.h.resource.component[1] = ue_context_id;
+    message.h.resource.component[2] =
+            (char *)OGS_SBI_RESOURCE_NAME_TRANSFER;
+    message.UeContextTransferReqData = &UeContextTransferReqData;
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+    if (ue_context_id)
+        ogs_free(ue_context_id);
+
+    return request;
+}

--- a/src/amf/namf-build.h
+++ b/src/amf/namf-build.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef AMF_NAMF_BUILD_H
+#define AMF_NAMF_BUILD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "context.h"
+
+ogs_sbi_request_t *amf_namf_comm_build_ue_context_transfer(
+        amf_ue_t *amf_ue, void *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AMF_NAMF_BUILD_H */

--- a/src/amf/namf-handler.h
+++ b/src/amf/namf-handler.h
@@ -34,6 +34,10 @@ int amf_namf_callback_handle_dereg_notify(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 int amf_namf_callback_handle_sdm_data_change_notify(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_comm_handle_ue_context_transfer_request(
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+int amf_namf_comm_handle_ue_context_transfer_response(
+        ogs_sbi_message_t *recvmsg, amf_ue_t *amf_ue);
 
 #ifdef __cplusplus
 }

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -36,6 +36,7 @@ int amf_sbi_open(void)
     ogs_sbi_nf_instance_build_default(nf_instance);
     ogs_sbi_nf_instance_add_allowed_nf_type(nf_instance, OpenAPI_nf_type_SMF);
     ogs_sbi_nf_instance_add_allowed_nf_type(nf_instance, OpenAPI_nf_type_SCP);
+    ogs_sbi_nf_instance_add_allowed_nf_type(nf_instance, OpenAPI_nf_type_AMF);
 
     /* Build NF service information. It will be transmitted to NRF. */
     if (ogs_sbi_nf_service_is_available(OGS_SBI_SERVICE_NAME_NAMF_COMM)) {
@@ -45,6 +46,7 @@ int amf_sbi_open(void)
         ogs_sbi_nf_service_add_version(
                     service, OGS_SBI_API_V1, OGS_SBI_API_V1_0_0, NULL);
         ogs_sbi_nf_service_add_allowed_nf_type(service, OpenAPI_nf_type_SMF);
+        ogs_sbi_nf_service_add_allowed_nf_type(service, OpenAPI_nf_type_AMF);
     }
 
     /* Initialize NRF NF Instance */


### PR DESCRIPTION
Support for:
 - UEContextTransfer request from new AMF to old AMF and
 -  UEContextTransfer response from old AMF to new AMF
 
AMF info had to be stored in the (new) AMF to find the suitable (old) AMF and target_guami is added in discovery_option as a parameter to find the suitable AMF.