### PR TITLE
Delete authentication data on UE deregistration

### DIFF
--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -322,6 +322,9 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             if (OGS_FSM_CHECK(&ausf_ue->sm, ausf_ue_state_exception)) {
                 ogs_error("[%s] State machine exception", ausf_ue->suci);
                 ausf_ue_remove(ausf_ue);
+            } else if (OGS_FSM_CHECK(&ausf_ue->sm, ausf_ue_state_deleted)) {
+                ogs_debug("[%s] AUSF-UE removed", ausf_ue->supi);
+                ausf_ue_remove(ausf_ue);
             }
             break;
 

--- a/src/ausf/ausf-sm.h
+++ b/src/ausf/ausf-sm.h
@@ -33,6 +33,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e);
 void ausf_ue_state_initial(ogs_fsm_t *s, ausf_event_t *e);
 void ausf_ue_state_final(ogs_fsm_t *s, ausf_event_t *e);
 void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e);
+void ausf_ue_state_deleted(ogs_fsm_t *s, ausf_event_t *e);
 void ausf_ue_state_exception(ogs_fsm_t *s, ausf_event_t *e);
 
 #define ausf_sm_debug(__pe) \

--- a/src/ausf/nudm-handler.c
+++ b/src/ausf/nudm-handler.c
@@ -243,7 +243,7 @@ bool ausf_nudm_ueau_handle_auth_removal_ind(ausf_ue_t *ausf_ue,
     ogs_assert(ausf_ue);
     ogs_assert(stream);
 
-    ausf_ue_remove(ausf_ue);
+    OGS_FSM_TRAN(&ausf_ue->sm, &ausf_ue_state_deleted);
 
     memset(&sendmsg, 0, sizeof(sendmsg));
     response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -150,7 +150,8 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_UEAU)
             if (message->res_status != OGS_SBI_HTTP_STATUS_OK &&
-                message->res_status != OGS_SBI_HTTP_STATUS_CREATED) {
+                message->res_status != OGS_SBI_HTTP_STATUS_CREATED &&
+                message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT) {
                 if (message->res_status == OGS_SBI_HTTP_STATUS_NOT_FOUND) {
                     ogs_warn("[%s] Cannot find SUPI [%d]",
                         ausf_ue->suci, message->res_status);
@@ -209,6 +210,30 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     default:
         ogs_error("[%s] Unknown event %s",
                 ausf_ue->suci, ausf_event_get_name(e));
+        break;
+    }
+}
+
+void ausf_ue_state_deleted(ogs_fsm_t *s, ausf_event_t *e)
+{
+    ausf_ue_t *ausf_ue = NULL;
+    ogs_assert(s);
+    ogs_assert(e);
+
+    ausf_sm_debug(e);
+
+    ausf_ue = e->ausf_ue;
+    ogs_assert(ausf_ue);
+
+    switch (e->h.id) {
+    case OGS_FSM_ENTRY_SIG:
+        break;
+
+    case OGS_FSM_EXIT_SIG:
+        break;
+
+    default:
+        ogs_error("[%s] Unknown event %s", ausf_ue->supi, ausf_event_get_name(e));
         break;
     }
 }


### PR DESCRIPTION
- Fix AUSF crashing when removing ausf_ue context
- Delete authentication data from AUSF on UE deregistration

Based on TS 29.509 - 5.2.2.2.5 Authentication Result Removal with 5G method:
In the case that the Purge of subscriber data in AMF after the UE
deregisters from the network or the NAS SMC fails following the
successful authentication in the registration procedure, the NF Service
Consumer (AMF) requests the AUSF to inform the UDM to remove the
authentication result.
