### PR TITLE
[AMF] Fixed crash in ogs_fsm_tran(!tmp) (#2719)

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -818,7 +818,9 @@ ogs_sbi_nf_instance_t *ogs_sbi_nf_instance_add(void)
 
     ogs_list_add(&ogs_sbi_self()->nf_instance_list, nf_instance);
 
-    ogs_debug("[%s:%d] NFInstance added with Ref",
+    ogs_debug("[%s] NFInstance added with Ref [%s:%d]",
+            nf_instance->nf_type ?
+                OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
             nf_instance->id, nf_instance->reference_count);
 
     return nf_instance;
@@ -916,7 +918,9 @@ void ogs_sbi_nf_instance_remove(ogs_sbi_nf_instance_t *nf_instance)
 {
     ogs_assert(nf_instance);
 
-    ogs_debug("[%s:%d] NFInstance UnRef",
+    ogs_debug("[%s] NFInstance UnRef [%s:%d]",
+            nf_instance->nf_type ?
+                OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
             nf_instance->id, nf_instance->reference_count);
 
     if (OGS_OBJECT_IS_REF(nf_instance)) {
@@ -924,7 +928,9 @@ void ogs_sbi_nf_instance_remove(ogs_sbi_nf_instance_t *nf_instance)
         return;
     }
 
-    ogs_debug("[%s:%d] NFInstance removed",
+    ogs_debug("[%s] NFInstance removed [%s:%d]",
+            nf_instance->nf_type ?
+                OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
             nf_instance->id, nf_instance->reference_count);
 
     ogs_list_remove(&ogs_sbi_self()->nf_instance_list, nf_instance);
@@ -1728,6 +1734,11 @@ void ogs_sbi_client_associate(ogs_sbi_nf_instance_t *nf_instance)
 
     client = nf_instance_find_client(nf_instance);
     ogs_assert(client);
+
+    ogs_debug("[%s] NFInstance associated [%s:%d]",
+            nf_instance->nf_type ?
+                OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+            nf_instance->id, nf_instance->reference_count);
 
     OGS_SBI_SETUP_CLIENT(nf_instance, client);
 

--- a/lib/sbi/nf-sm.c
+++ b/lib/sbi/nf-sm.c
@@ -37,6 +37,7 @@ void ogs_sbi_nf_fsm_tran(ogs_sbi_nf_instance_t *nf_instance, void *state)
     ogs_event_t e;
 
     ogs_assert(nf_instance);
+    ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
 
     memset(&e, 0, sizeof(e));
     e.sbi.data = nf_instance;

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -722,17 +722,24 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
                     nf_instance, message.h.resource.component[1]);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("[%s] (NRF-notify) NF registered", nf_instance->id);
+            ogs_info("(NRF-notify) NF registered [%s:%d]",
+                    nf_instance->id, nf_instance->reference_count);
         } else {
-            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
+            ogs_warn("[%s] (NRF-notify) NF has already been added [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
 
-            ogs_warn("[%s] (NRF-notify) NF has already been added",
-                    message.h.resource.component[1]);
+            ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
+            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
         }
 
         ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
 
-        ogs_info("[%s] (NRF-notify) NF Profile updated", nf_instance->id);
+        ogs_info("[%s] (NRF-notify) NF Profile updated [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
 
         ogs_sbi_client_associate(nf_instance);
 
@@ -742,12 +749,21 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
         if (nf_instance) {
             if (OGS_OBJECT_IS_REF(nf_instance)) {
                 /* There are references to other contexts. */
-                ogs_warn("[%s:%d] NF was referenced in other contexts",
+                ogs_warn("[%s] (NRF-notify) NF was referenced "
+                        "in other contexts [%s:%d]",
+                        nf_instance->nf_type ?
+                            OpenAPI_nf_type_ToString(nf_instance->nf_type) :
+                            "NULL",
                         nf_instance->id, nf_instance->reference_count);
+
+                ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
                 ogs_sbi_nf_fsm_tran(
                         nf_instance, ogs_sbi_nf_state_de_registered);
             } else {
-                ogs_info("[%s:%d] (NRF-notify) NF_DEREGISTERED event",
+                ogs_info("[%s] (NRF-notify) NF_DEREGISTERED event [%s:%d]",
+                        nf_instance->nf_type ?
+                            OpenAPI_nf_type_ToString(nf_instance->nf_type) :
+                            "NULL",
                         nf_instance->id, nf_instance->reference_count);
                 ogs_sbi_nf_fsm_fini((nf_instance));
                 ogs_sbi_nf_instance_remove(nf_instance);
@@ -826,12 +842,18 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
             ogs_sbi_nf_instance_set_id(nf_instance, NFProfile->nf_instance_id);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("[%s] (NF-discover) NF registered", nf_instance->id);
+            ogs_info("[%s] (NRF-discover) NF registered [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
         } else {
-            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
+            ogs_warn("[%s] (NRF-discover) NF has already been added [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
 
-            ogs_warn("[%s] (NF-discover) NF has already been added",
-                    NFProfile->nf_instance_id);
+            ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
+            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
         }
 
         if (NF_INSTANCE_ID_IS_OTHERS(nf_instance->id)) {
@@ -850,10 +872,15 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
                     ogs_time_from_sec(nf_instance->time.validity_duration));
 
             } else
-                ogs_warn("[%s] NF Instance validity-time should not 0",
-                        nf_instance->id);
+                ogs_warn("[%s] NF Instance validity-time should not 0 [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
 
-            ogs_info("[%s] (NF-discover) NF Profile updated", nf_instance->id);
+            ogs_info("[%s] (NF-discover) NF Profile updated [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
         }
     }
 }

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -143,6 +143,21 @@ static int client_discover_cb(
 
             ogs_sbi_nf_instance_set_id(nf_instance, producer_id);
             ogs_sbi_nf_instance_set_type(nf_instance, target_nf_type);
+
+            ogs_sbi_nf_fsm_init(nf_instance);
+
+            ogs_info("[%s] (SCP-discover) NF registered [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
+        } else {
+            ogs_warn("[%s] (SCP-discover) NF has already been added [%s:%d]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
+                    nf_instance->id, nf_instance->reference_count);
+
+            ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
+            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
         }
 
         OGS_SBI_SETUP_NF_INSTANCE(


### PR DESCRIPTION
This problem can be occurred in the following scenarios.

1. Run NFs(NRF/SCP/SMF/UPF/AUSF/UDM/PCF/BSF/NSSF/UDR) except AMF.
2. Run AMF
3. Run gNB/UE and try to register
4. STOP PCF
5. AMF Crashed

AMF discovered the PCF through SCP during the UE registration process.

At this time, ogs_sbi_nf_fsm_init() is not called, so AMF does not have state information about PCF.
In other words, AMF state is NULL.

In such a situation, when PCF is terminated at this time, a crash occurs as AMF attempts to change the PCF state.

So, I've fixed that state information is initialized to solve this problem.