### PR TITLE
[SBI] Change discovery option TAI from array to single item

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1686,9 +1686,9 @@ bool ogs_sbi_discovery_option_is_matched(
                     &discovery_option->snssais[0],
                     discovery_option->dnn) == false)
                 return false;
-            if (discovery_option->num_of_tai &&
+            if (discovery_option->tai_presence &&
                 ogs_sbi_check_smf_info_tai(&nf_info->smf,
-                    &discovery_option->tai[0]) == false)
+                    &discovery_option->tai) == false)
                 return false;
             break;
         default:

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -441,17 +441,16 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
             ogs_sbi_header_set(request->http.params,
                     OGS_SBI_PARAM_DNN, discovery_option->dnn);
         }
-        if (discovery_option->num_of_tai) {
+        if (discovery_option->tai_presence) {
             char *v = ogs_sbi_discovery_option_build_tai(discovery_option);
             if (v) {
                 ogs_sbi_header_set(request->http.params, OGS_SBI_PARAM_TAI, v);
                 ogs_free(v);
             } else {
-                ogs_error("build failed: tai(%d)[PLMN_ID:%06x,TAC:%d]",
-                            discovery_option->num_of_tai,
+                ogs_error("build failed: tai[PLMN_ID:%06x,TAC:%d]",
                             ogs_plmn_id_hexdump(
-                                &discovery_option->tai[0].plmn_id),
-                            discovery_option->tai[0].tac.v);
+                                &discovery_option->tai.plmn_id),
+                            discovery_option->tai.tac.v);
             }
         }
         if (discovery_option->requester_features) {
@@ -3008,62 +3007,49 @@ void ogs_sbi_discovery_option_parse_snssais(
     ogs_free(v);
 }
 
-void ogs_sbi_discovery_option_add_tai(
+void ogs_sbi_discovery_option_set_tai(
         ogs_sbi_discovery_option_t *discovery_option, ogs_5gs_tai_t *tai)
 {
     ogs_assert(discovery_option);
     ogs_assert(tai);
 
-    ogs_assert(discovery_option->num_of_tai < OGS_MAX_NUM_OF_TAI);
+    ogs_assert(discovery_option->tai_presence == false);
 
-    memcpy(&discovery_option->tai[discovery_option->num_of_tai],
-            tai, sizeof(ogs_5gs_tai_t));
-    discovery_option->num_of_tai++;
+    memcpy(&discovery_option->tai, tai, sizeof(ogs_5gs_tai_t));
+    discovery_option->tai_presence = true;
 }
 char *ogs_sbi_discovery_option_build_tai(
         ogs_sbi_discovery_option_t *discovery_option)
 {
-    cJSON *item = NULL;
+    OpenAPI_tai_t Tai;
+    cJSON *taiItem = NULL;
     char *v = NULL;
-    int i;
 
     ogs_assert(discovery_option);
+    ogs_assert(discovery_option->tai_presence);
 
-    item = cJSON_CreateArray();
-    if (!item) {
-        ogs_error("cJSON_CreateArray() failed");
-        return NULL;
-    }
+    memset(&Tai, 0, sizeof(Tai));
 
-    for (i = 0; i < discovery_option->num_of_tai; i++) {
-        OpenAPI_tai_t Tai;
-        cJSON *taiItem = NULL;
+    Tai.plmn_id = ogs_sbi_build_plmn_id(&discovery_option->tai.plmn_id);
+    ogs_assert(Tai.plmn_id);
+    Tai.tac = ogs_uint24_to_0string(discovery_option->tai.tac);
+    ogs_assert(Tai.tac);
 
-        memset(&Tai, 0, sizeof(Tai));
+    taiItem = OpenAPI_tai_convertToJSON(&Tai);
+    ogs_assert(taiItem);
 
-        Tai.plmn_id = ogs_sbi_build_plmn_id(&discovery_option->tai[i].plmn_id);
-        ogs_assert(Tai.plmn_id);
-        Tai.tac = ogs_uint24_to_0string(discovery_option->tai[i].tac);
-        ogs_assert(Tai.tac);
+    ogs_sbi_free_plmn_id(Tai.plmn_id);
+    ogs_free(Tai.tac);
 
-        taiItem = OpenAPI_tai_convertToJSON(&Tai);
-        ogs_assert(taiItem);
-        cJSON_AddItemToArray(item, taiItem);
-
-        ogs_sbi_free_plmn_id(Tai.plmn_id);
-        ogs_free(Tai.tac);
-    }
-
-    v = cJSON_PrintUnformatted(item);
+    v = cJSON_PrintUnformatted(taiItem);
     ogs_expect(v);
-    cJSON_Delete(item);
+    cJSON_Delete(taiItem);
 
     return v;
 }
 void ogs_sbi_discovery_option_parse_tai(
         ogs_sbi_discovery_option_t *discovery_option, char *tai)
 {
-    cJSON *item = NULL;
     cJSON *taiItem = NULL;
     char *v = NULL;
 
@@ -3076,39 +3062,37 @@ void ogs_sbi_discovery_option_parse_tai(
         return;
     }
 
-    item = cJSON_Parse(v);
-    if (!item) {
+    taiItem = cJSON_Parse(v);
+    if (!taiItem) {
         ogs_error("Cannot parse tai[%s]", tai);
         ogs_free(v);
         return;
     }
 
-    cJSON_ArrayForEach(taiItem, item) {
-        if (cJSON_IsObject(taiItem)) {
-            OpenAPI_tai_t *Tai = OpenAPI_tai_parseFromJSON(taiItem);
+    if (cJSON_IsObject(taiItem)) {
+        OpenAPI_tai_t *Tai = OpenAPI_tai_parseFromJSON(taiItem);
 
-            if (Tai) {
-                ogs_5gs_tai_t tai;
+        if (Tai) {
+            ogs_5gs_tai_t tai;
 
-                memset(&tai, 0, sizeof(tai));
+            memset(&tai, 0, sizeof(tai));
 
-                if (Tai->plmn_id)
-                    ogs_sbi_parse_plmn_id(&tai.plmn_id, Tai->plmn_id);
-                if (Tai->tac)
-                    tai.tac = ogs_uint24_from_string(Tai->tac);
+            if (Tai->plmn_id)
+                ogs_sbi_parse_plmn_id(&tai.plmn_id, Tai->plmn_id);
+            if (Tai->tac)
+                tai.tac = ogs_uint24_from_string(Tai->tac);
 
-                ogs_sbi_discovery_option_add_tai(discovery_option, &tai);
+            ogs_sbi_discovery_option_set_tai(discovery_option, &tai);
 
-                OpenAPI_tai_free(Tai);
-            } else {
-                ogs_error("OpenAPI_snssai_parseFromJSON() failed : tai[%s]",
-                        tai);
-            }
+            OpenAPI_tai_free(Tai);
         } else {
-            ogs_error("Invalid cJSON Type in snssias[%s]", tai);
+            ogs_error("OpenAPI_snssai_parseFromJSON() failed : tai[%s]",
+                    tai);
         }
+    } else {
+        ogs_error("Invalid cJSON Type in snssias[%s]", tai);
     }
-    cJSON_Delete(item);
+    cJSON_Delete(taiItem);
 
     ogs_free(v);
 }

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -418,8 +418,8 @@ typedef struct ogs_sbi_discovery_option_s {
     int num_of_snssais;
     ogs_s_nssai_t snssais[OGS_MAX_NUM_OF_SLICE];
     char *dnn;
-    int num_of_tai;
-    ogs_5gs_tai_t tai[OGS_MAX_NUM_OF_TAI];
+    bool tai_presence;
+    ogs_5gs_tai_t tai;
 
     uint64_t requester_features;
 } ogs_sbi_discovery_option_t;
@@ -624,7 +624,7 @@ char *ogs_sbi_discovery_option_build_snssais(
 void ogs_sbi_discovery_option_parse_snssais(
         ogs_sbi_discovery_option_t *discovery_option, char *snssais);
 
-void ogs_sbi_discovery_option_add_tai(
+void ogs_sbi_discovery_option_set_tai(
         ogs_sbi_discovery_option_t *discovery_option, ogs_5gs_tai_t *tai);
 char *ogs_sbi_discovery_option_build_tai(
         ogs_sbi_discovery_option_t *discovery_option);

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -328,7 +328,7 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
                         OGS_SBI_CUSTOM_DISCOVERY_DNN, discovery_option->dnn);
             }
 
-            if (discovery_option && discovery_option->num_of_tai) {
+            if (discovery_option && discovery_option->tai_presence) {
                 bool rc = false;
                 char *v = ogs_sbi_discovery_option_build_tai(discovery_option);
                 ogs_expect(v);
@@ -348,11 +348,10 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
                 }
 
                 if (rc == false)
-                    ogs_error("build failed: tai(%d)[PLMN_ID:%06x,TAC:%d]",
-                                discovery_option->num_of_tai,
+                    ogs_error("build failed: tai[PLMN_ID:%06x,TAC:%d]",
                                 ogs_plmn_id_hexdump(
-                                    &discovery_option->tai[0].plmn_id),
-                                discovery_option->tai[0].tac.v);
+                                    &discovery_option->tai.plmn_id),
+                                discovery_option->tai.tac.v);
             }
 
             if (discovery_option &&

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1262,7 +1262,7 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
                 ogs_sbi_discovery_option_add_snssais(
                         discovery_option, &sess->s_nssai);
                 ogs_sbi_discovery_option_set_dnn(discovery_option, sess->dnn);
-                ogs_sbi_discovery_option_add_tai(
+                ogs_sbi_discovery_option_set_tai(
                         discovery_option, &amf_ue->nr_tai);
 
                 nf_instance = sess->sbi.

--- a/src/amf/nnssf-handler.c
+++ b/src/amf/nnssf-handler.c
@@ -93,7 +93,7 @@ int amf_nnssf_nsselection_handle_get(
 
     ogs_sbi_discovery_option_add_snssais(discovery_option, &sess->s_nssai);
     ogs_sbi_discovery_option_set_dnn(discovery_option, sess->dnn);
-    ogs_sbi_discovery_option_add_tai(discovery_option, &amf_ue->nr_tai);
+    ogs_sbi_discovery_option_set_tai(discovery_option, &amf_ue->nr_tai);
 
     if (sess->nssf.nrf.id)
         ogs_free(sess->nssf.nrf.id);

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -766,12 +766,11 @@ bool nrf_nnrf_handle_nf_discover(
         if (discovery_option->dnn) {
             ogs_debug("dnn[%s]", discovery_option->dnn);
         }
-        if (discovery_option->num_of_tai) {
-            for (i = 0; i < discovery_option->num_of_tai; i++)
-                ogs_debug("[%d] tai[PLMN_ID:%06x,TAC:%d]", i,
-                            ogs_plmn_id_hexdump(
-                                &discovery_option->tai[0].plmn_id),
-                            discovery_option->tai[0].tac.v);
+        if (discovery_option->tai_presence) {
+            ogs_debug("tai[PLMN_ID:%06x,TAC:%d]",
+                        ogs_plmn_id_hexdump(
+                            &discovery_option->tai.plmn_id),
+                        discovery_option->tai.tac.v);
         }
         if (discovery_option->requester_features) {
             ogs_debug("requester-features[0x%llx]",


### PR DESCRIPTION
According to 3GPP TS 29.510, the search parameter "tai" should be a single item, not an array of items.

TS 29.510: Table 6.2.3.2.3.1-1:
URI query parameters supported by the GET method on this resource