### PR TITLE
[MME] Add no_time_zone_in_emm_information param

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -235,6 +235,10 @@ int ogs_app_parse_global_conf(ogs_yaml_iter_t *parent)
                             "no_pfcp_rr_select")) {
                     global_conf.parameter.no_pfcp_rr_select =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(parameter_key,
+                            "no_time_zone_information")) {
+                    global_conf.parameter.no_time_zone_information =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else
                     ogs_warn("unknown key `%s`", parameter_key);
             }

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -62,6 +62,7 @@ typedef struct ogs_global_conf_s {
         int no_ipv4v6_local_addr_in_packet_filter;
 
         int no_pfcp_rr_select;
+        int no_time_zone_information;
     } parameter;
 
     struct {


### PR DESCRIPTION
Allow network operators to omit the local time zone in the EMM information. This is useful for better compatibility with some UEs.

According to 3GPP TS 124.301 Table 8.2.13.1, the parameter is optional.