### PR TITLE
editorconfig: new file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+; See http://editorconfig.org
+root = true
+
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
Add a file that allows editors to automatically use the right indentation format when working with the open5gs source tree.