### PR TITLE
[AMF] Fix Nudm_SDM_Get for re-registration

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1229,7 +1229,15 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                         break;
                     }
 
-                    if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
+                    if (!UDM_SDM_SUBSCRIBED(amf_ue)) {
+                        r = amf_ue_sbi_discover_and_send(
+                                OGS_SBI_SERVICE_TYPE_NUDM_UECM, NULL,
+                                amf_nudm_uecm_build_registration, amf_ue, 0, NULL);
+                        ogs_expect(r == OGS_OK);
+                        ogs_assert(r != OGS_ERROR);
+                        OGS_FSM_TRAN(s, &gmm_state_initial_context_setup);
+                        break;
+                    } else if (!PCF_AM_POLICY_ASSOCIATED(amf_ue)) {
                         r = amf_ue_sbi_discover_and_send(
                                 OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL,
                                 NULL,


### PR DESCRIPTION
Bug:

In case that AMF does not have subscription data for the UE, PDU session remains unreleased after implicit de-registeration.

The exact test case:
- UE registered (integrity protection applied)
- UE deregistered (Nudm_SDM_Unsubscribe, Nudm_UECM_Registration (purgeFlag))
- UE registered, PDU session activated

    UE data are still stored in AMF. So if integrity protected applies,
    the steps 4 - 14 [ETSI TS 123 502 V16.7.0](https://www.etsi.org/deliver/etsi_ts/123500_123599/123502/16.07.00_60/ts_123502v160700p.pdf) are skipped.
    Only AM Policy Association Establishment is performed.
- UE is moved out of radio coverage, 2 x (4 min + Timer t3512) expires

Result: UE is implicitly de-registered, PDU session is not released

The steps of implicit de-registeration:
  1. Implicit Timer Expiration
  2. UDM_SDM_Unsubscribe
  3. UDM_UECM_Deregistration
  4. PDU session release request
  5. PDUSessionResourceReleaseCommand + PDU session release command
  6. PDUSessionResourceReleaseResponse
  7. AM_Policy_Association_Termination

So PDU session release is performed after the confirmation of UDM_UECM_Deregistration.
Since there is no UDM_SDM subscription, the UDM steps are skipped and PDU session is not released.

Fix:

If the AMF does not have subscription data for the UE which registers, the AMF registers with the UDM using Nudm_UECM_Registration and retrieves subscription data with Nudm_SDM_Get.

[ETSI TS 123 502 V16.7.0](https://www.etsi.org/deliver/etsi_ts/123500_123599/123502/16.07.00_60/ts_123502v160700p.pdf), 4.2.2.2.2 General Registration, 14a-c:
> If the AMF does not have subscription data for the UE, the AMF retrieves the Access and Mobility Subscription data, SMF
> Selection Subscription data, UE context in SMF data and LCS mobile origination using Nudm_SDM_Get.