### PR TITLE
[SMF] Fix no. of QoS flows metric

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2479,8 +2479,12 @@ void smf_bearer_remove_all(smf_sess_t *sess)
     smf_bearer_t *bearer = NULL, *next_bearer = NULL;
 
     ogs_assert(sess);
-    ogs_list_for_each_safe(&sess->bearer_list, next_bearer, bearer)
+    ogs_list_for_each_safe(&sess->bearer_list, next_bearer, bearer) {
+        smf_metrics_inst_by_5qi_add(&sess->serving_plmn_id,
+                &sess->s_nssai, sess->session.qos.index,
+                SMF_METR_GAUGE_SM_QOSFLOWNBR, -1);
         smf_bearer_remove(bearer);
+    }
 }
 
 smf_bearer_t *smf_bearer_find_by_pgw_s5u_teid(


### PR DESCRIPTION
Since commit [[METRICS] Fixed a core dump in SMF/UPF/PCF (#1985)](https://github.com/open5gs/open5gs/commit/8553c77733f50f82bfa6a9a4ee57f7ca0133a815) the `fivegs_smffunction_sm_qos_flow_nbr` metric does not decrement on session release.
Originally the decrement had been done in smf_bearer_remove().

The decrement is added into `smf_bearer_remove_all()` for each existing bearer.