### PR TITLE
[SCTP] Fixed a crash on SIGPIPE (#2734)

### DIFF
--- a/lib/core/ogs-epoll.c
+++ b/lib/core/ogs-epoll.c
@@ -254,6 +254,7 @@ static int epoll_process(ogs_pollset_t *pollset, ogs_time_t timeout)
             }
             if (received & EPOLLRDHUP) {
                 when |= OGS_POLLIN;
+                when &= ~OGS_POLLOUT;
             }
         }
 


### PR DESCRIPTION
If EPOLLIN, EPOLLOUT, and EPOLLRDHUP occur at the same time, Linux generates a SIGPIPE signal as below.

```
11/13 16:55:43.340: [core] INFO: after eopll_process , num_of_poll is 1 (../lib/core/ogs-epoll.c:215)
11/13 16:55:43.340: [core] INFO: received: 2005 (../lib/core/ogs-epoll.c:230)
11/13 16:55:43.340: [core] INFO: EPOLLIN event occurred (../lib/core/ogs-epoll.
11/13 16:55:43.340: [core] INFO: EPOLLOUT event occurred (../lib/core/ogs-epoll.c:259)
11/13 16:55:43.340: [core] INFO: EPOLLRDHUP event occurred (../lib/core/ogs-epoll.c:263)
11/13 16:55:43.340: [amf] DEBUG: SCTP_SHUTDOWN_EVENT:[T:32773, F:0x0, L:12] (../src/amf/ngap-sctp.c:191)
11/13 16:55:43.340: [amf] INFO: ogs_queue_push amf_sctp_event_push (../src/amf/event.c:104)
```

I've made modifications so that when EPOLLRDHUP occurs, only OGS_POLLIN is set and OGS_POLLOUT is unset to prevent SIGPIPE from occurring in such cases.

Thanks a lot!
Sukchan