### PR TITLE
[IPv6] Fixed to include MTU in SLAAC RA (#2754)

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2988,7 +2988,7 @@ int smf_pco_build(uint8_t *pco_buf, uint8_t *buffer, int length)
             break;
         case OGS_PCO_ID_IPV4_LINK_MTU_REQUEST:
             if (smf_self()->mtu) {
-                mtu = htons(smf_self()->mtu);
+                mtu = htobe16(smf_self()->mtu);
                 smf.ids[smf.num_of_id].id = ue.ids[i].id;
                 smf.ids[smf.num_of_id].len = sizeof(uint16_t);
                 smf.ids[smf.num_of_id].data = &mtu;


### PR DESCRIPTION
SLAAC RA sent by the network should contain ICMPv6 option type 5 (MTU) field.