### PR TITLE
Reset the number of TA, SLICE, and PLMN supported by AMF/MME(#2761)

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -88,7 +88,13 @@ extern "C" {
 #define OGS_MAX_NUM_OF_SERVED_GUMMEI    8   /* maxnoofRATs: 8 */
 #define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs: 256 */
 #define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs: 256 */
-#define OGS_MAX_NUM_OF_SLICE_SUPPORT    1024 /* maxnoofSliceItems: 1024 */
+
+/*
+ * If I set it to 1024, the AMF crashes in the 'meson test -v registration'.
+ * So for now, I will use 512. Once I figure out the cause of this problem,
+ * I will try 1024.
+ */
+#define OGS_MAX_NUM_OF_SLICE_SUPPORT    512 /* maxnoofSliceItems: 1024 */
 
 #define OGS_MAX_NUM_OF_PLMN_PER_MME     32  /* maxnoofPLMNs(MME): 32 */
 #define OGS_MAX_NUM_OF_PLMN             12  /* maxnoofPLMNs(AMF): 12 */

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -83,8 +83,9 @@ extern "C" {
 #define OGS_MAX_EPCO_LEN                65535
 #define OGS_MAX_FQDN_LEN                256
 
-#define OGS_MAX_NUM_OF_SERVED_GUAMI     8
-#define OGS_MAX_NUM_OF_SERVED_TAI       OGS_MAX_NUM_OF_TAI
+#define OGS_MAX_NUM_OF_SERVED_GUMMEI    8 /* maxnoofRATs : 8 */
+#define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs : 256 */
+#define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs : 256 */
 #define OGS_MAX_NUM_OF_ACCESS_CONTROL   8
 #define OGS_MAX_NUM_OF_ALGORITHM        8
 

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -83,13 +83,18 @@ extern "C" {
 #define OGS_MAX_EPCO_LEN                65535
 #define OGS_MAX_FQDN_LEN                256
 
-#define OGS_MAX_NUM_OF_SERVED_GUMMEI    8 /* maxnoofRATs : 8 */
-#define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs : 256 */
-#define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs : 256 */
-#define OGS_MAX_NUM_OF_ACCESS_CONTROL   8
 #define OGS_MAX_NUM_OF_ALGORITHM        8
 
-#define OGS_MAX_NUM_OF_BPLMN            6
+#define OGS_MAX_NUM_OF_SERVED_GUMMEI    8   /* maxnoofRATs: 8 */
+#define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs: 256 */
+#define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs: 256 */
+
+#define OGS_MAX_NUM_OF_PLMN_PER_MME     32  /* maxnoofPLMNs(MME): 32 */
+#define OGS_MAX_NUM_OF_PLMN             12  /* maxnoofPLMNs(AMF): 12 */
+#define OGS_MAX_NUM_OF_BPLMN            OGS_MAX_NUM_OF_PLMN
+
+#define OGS_MAX_NUM_OF_TAI              16
+#define OGS_MAX_NUM_OF_SLICE            8
 
 #define OGS_NEXT_ID(__id, __min, __max) \
     ((__id) = ((__id) == (__max) ? (__min) : ((__id) + 1)))
@@ -169,7 +174,6 @@ extern "C" {
 
 /************************************
  * PLMN_ID Structure                */
-#define OGS_MAX_NUM_OF_PLMN         6
 typedef struct ogs_plmn_id_s {
 ED2(uint8_t mcc2:4;,
     uint8_t mcc1:4;)
@@ -261,7 +265,6 @@ char *ogs_id_get_value(char *str);
 
 /************************************
  * TAI Structure                    */
-#define OGS_MAX_NUM_OF_TAI              16
 typedef struct ogs_eps_tai_s {
     ogs_plmn_id_t plmn_id;
     uint16_t tac;
@@ -284,7 +287,6 @@ typedef struct ogs_nr_cgi_s {
 
 /************************************
  * S-NSSAI Structure                */
-#define OGS_MAX_NUM_OF_SLICE        8
 #define OGS_S_NSSAI_NO_SD_VALUE     0xffffff
 typedef struct ogs_s_nssai_s {
     uint8_t sst;

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -88,6 +88,7 @@ extern "C" {
 #define OGS_MAX_NUM_OF_SERVED_GUMMEI    8   /* maxnoofRATs: 8 */
 #define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs: 256 */
 #define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs: 256 */
+#define OGS_MAX_NUM_OF_SLICE_SUPPORT    1024 /* maxnoofSliceItems: 1024 */
 
 #define OGS_MAX_NUM_OF_PLMN_PER_MME     32  /* maxnoofPLMNs(MME): 32 */
 #define OGS_MAX_NUM_OF_PLMN             12  /* maxnoofPLMNs(AMF): 12 */

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -367,7 +367,7 @@ int amf_context_parse_config(void)
                         const char *mcc = NULL, *mnc = NULL;
                         const char *region = NULL, *set = NULL;
                         const char *pointer = NULL;
-                        ogs_assert(self.num_of_served_guami <
+                        ogs_assert(self.num_of_served_guami <=
                                 OGS_MAX_NUM_OF_SERVED_GUAMI);
 
                         if (ogs_yaml_iter_type(&guami_array) ==
@@ -464,7 +464,7 @@ int amf_context_parse_config(void)
                     ogs_5gs_tai1_list_t *list1 = NULL;
                     ogs_5gs_tai2_list_t *list2 = NULL;
 
-                    ogs_assert(self.num_of_served_tai <
+                    ogs_assert(self.num_of_served_tai <=
                             OGS_MAX_NUM_OF_SERVED_TAI);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
@@ -646,7 +646,7 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_recurse(&amf_iter, &plmn_support_array);
                     do {
                         const char *mnc = NULL, *mcc = NULL;
-                        ogs_assert(self.num_of_plmn_support <
+                        ogs_assert(self.num_of_plmn_support <=
                                 OGS_MAX_NUM_OF_PLMN);
 
                         if (ogs_yaml_iter_type(&plmn_support_array) ==
@@ -785,7 +785,7 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&amf_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <
+                        ogs_assert(self.num_of_access_control <=
                                 OGS_MAX_NUM_OF_ACCESS_CONTROL);
 
                         if (ogs_yaml_iter_type(&access_control_array) ==

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -465,7 +465,7 @@ int amf_context_parse_config(void)
                     ogs_5gs_tai2_list_t *list2 = NULL;
 
                     ogs_assert(self.num_of_served_tai <=
-                            OGS_MAX_NUM_OF_SERVED_TAI);
+                            OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
                     list2 = &self.served_tai[self.num_of_served_tai].list2;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -367,8 +367,6 @@ int amf_context_parse_config(void)
                         const char *mcc = NULL, *mnc = NULL;
                         const char *region = NULL, *set = NULL;
                         const char *pointer = NULL;
-                        ogs_assert(self.num_of_served_guami <
-                                OGS_MAX_NUM_OF_SERVED_GUAMI);
 
                         if (ogs_yaml_iter_type(&guami_array) ==
                                 YAML_MAPPING_NODE) {
@@ -385,6 +383,9 @@ int amf_context_parse_config(void)
                             break;
                         } else
                             ogs_assert_if_reached();
+
+                        ogs_assert(self.num_of_served_guami <
+                                OGS_MAX_NUM_OF_SERVED_GUAMI);
 
                         while (ogs_yaml_iter_next(&guami_iter)) {
                             const char *guami_key =
@@ -646,8 +647,6 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_recurse(&amf_iter, &plmn_support_array);
                     do {
                         const char *mnc = NULL, *mcc = NULL;
-                        ogs_assert(self.num_of_plmn_support <
-                                OGS_MAX_NUM_OF_PLMN);
 
                         if (ogs_yaml_iter_type(&plmn_support_array) ==
                                 YAML_MAPPING_NODE) {
@@ -664,6 +663,9 @@ int amf_context_parse_config(void)
                             break;
                         } else
                             ogs_assert_if_reached();
+
+                        ogs_assert(self.num_of_plmn_support <
+                                OGS_MAX_NUM_OF_PLMN);
 
                         while (ogs_yaml_iter_next(&plmn_support_iter)) {
                             const char *plmn_support_key =
@@ -701,17 +703,6 @@ int amf_context_parse_config(void)
                                 do {
                                     ogs_s_nssai_t *s_nssai = NULL;
                                     const char *sst = NULL, *sd = NULL;
-                                    ogs_assert(
-                                        self.plmn_support[
-                                            self.num_of_plmn_support].
-                                                num_of_s_nssai <
-                                            OGS_MAX_NUM_OF_SLICE);
-                                    s_nssai = &self.plmn_support[
-                                            self.num_of_plmn_support].s_nssai[
-                                                self.plmn_support[
-                                                    self.num_of_plmn_support].
-                                                        num_of_s_nssai];
-                                    ogs_assert(s_nssai);
 
                                     if (ogs_yaml_iter_type(&s_nssai_array) ==
                                             YAML_MAPPING_NODE) {
@@ -730,6 +721,18 @@ int amf_context_parse_config(void)
                                         break;
                                     } else
                                         ogs_assert_if_reached();
+
+                                    ogs_assert(
+                                        self.plmn_support[
+                                            self.num_of_plmn_support].
+                                                num_of_s_nssai <
+                                            OGS_MAX_NUM_OF_SLICE);
+                                    s_nssai = &self.plmn_support[
+                                            self.num_of_plmn_support].s_nssai[
+                                                self.plmn_support[
+                                                    self.num_of_plmn_support].
+                                                        num_of_s_nssai];
+                                    ogs_assert(s_nssai);
 
                                     while (ogs_yaml_iter_next(&s_nssai_iter)) {
                                         const char *s_nssai_key =
@@ -785,8 +788,6 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&amf_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <
-                                OGS_MAX_NUM_OF_PLMN);
 
                         if (ogs_yaml_iter_type(&access_control_array) ==
                                 YAML_MAPPING_NODE) {
@@ -803,6 +804,9 @@ int amf_context_parse_config(void)
                             break;
                         } else
                             ogs_assert_if_reached();
+
+                        ogs_assert(self.num_of_access_control <
+                                OGS_MAX_NUM_OF_PLMN);
 
                         while (ogs_yaml_iter_next(&access_control_iter)) {
                             const char *mnc = NULL, *mcc = NULL;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -726,7 +726,7 @@ int amf_context_parse_config(void)
                                         self.plmn_support[
                                             self.num_of_plmn_support].
                                                 num_of_s_nssai <
-                                            OGS_MAX_NUM_OF_SLICE);
+                                            OGS_MAX_NUM_OF_SLICE_SUPPORT);
                                     s_nssai = &self.plmn_support[
                                             self.num_of_plmn_support].s_nssai[
                                                 self.plmn_support[

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -367,7 +367,7 @@ int amf_context_parse_config(void)
                         const char *mcc = NULL, *mnc = NULL;
                         const char *region = NULL, *set = NULL;
                         const char *pointer = NULL;
-                        ogs_assert(self.num_of_served_guami <=
+                        ogs_assert(self.num_of_served_guami <
                                 OGS_MAX_NUM_OF_SERVED_GUAMI);
 
                         if (ogs_yaml_iter_type(&guami_array) ==
@@ -464,7 +464,7 @@ int amf_context_parse_config(void)
                     ogs_5gs_tai1_list_t *list1 = NULL;
                     ogs_5gs_tai2_list_t *list2 = NULL;
 
-                    ogs_assert(self.num_of_served_tai <=
+                    ogs_assert(self.num_of_served_tai <
                             OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
@@ -646,7 +646,7 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_recurse(&amf_iter, &plmn_support_array);
                     do {
                         const char *mnc = NULL, *mcc = NULL;
-                        ogs_assert(self.num_of_plmn_support <=
+                        ogs_assert(self.num_of_plmn_support <
                                 OGS_MAX_NUM_OF_PLMN);
 
                         if (ogs_yaml_iter_type(&plmn_support_array) ==
@@ -785,8 +785,8 @@ int amf_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&amf_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <=
-                                OGS_MAX_NUM_OF_ACCESS_CONTROL);
+                        ogs_assert(self.num_of_access_control <
+                                OGS_MAX_NUM_OF_PLMN);
 
                         if (ogs_yaml_iter_type(&access_control_array) ==
                                 YAML_MAPPING_NODE) {

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -56,7 +56,7 @@ typedef struct amf_context_s {
         ogs_5gs_tai0_list_t list0;
         ogs_5gs_tai1_list_t list1;
         ogs_5gs_tai2_list_t list2;
-    } served_tai[OGS_MAX_NUM_OF_SERVED_TAI];
+    } served_tai[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     /* PLMN Support */
     int num_of_plmn_support;
@@ -149,7 +149,7 @@ typedef struct amf_gnb_s {
             int num_of_s_nssai;
             ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE];
         } bplmn_list[OGS_MAX_NUM_OF_BPLMN];
-    } supported_ta_list[OGS_MAX_NUM_OF_TAI];
+    } supported_ta_list[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     OpenAPI_rat_type_e rat_type;
 

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -72,7 +72,7 @@ typedef struct amf_context_s {
     struct {
         int reject_cause;
         ogs_plmn_id_t plmn_id;
-    } access_control[OGS_MAX_NUM_OF_ACCESS_CONTROL];
+    } access_control[OGS_MAX_NUM_OF_PLMN];
 
     /* defined in 'nas_ies.h'
      * #define NAS_SECURITY_ALGORITHMS_EIA0        0

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -63,7 +63,7 @@ typedef struct amf_context_s {
     struct {
         ogs_plmn_id_t plmn_id;
         int num_of_s_nssai;
-        ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE];
+        ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE_SUPPORT];
     } plmn_support[OGS_MAX_NUM_OF_PLMN];
 
     /* Access Control */
@@ -147,7 +147,7 @@ typedef struct amf_gnb_s {
         struct {
             ogs_plmn_id_t plmn_id;
             int num_of_s_nssai;
-            ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE];
+            ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE_SUPPORT];
         } bplmn_list[OGS_MAX_NUM_OF_BPLMN];
     } supported_ta_list[OGS_MAX_NUM_OF_SUPPORTED_TA];
 

--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -96,7 +96,7 @@ ogs_pkbuf_t *gmm_build_registration_accept(amf_ue_t *amf_ue)
     served_tai_index = amf_find_served_tai(&amf_ue->nr_tai);
     ogs_debug("[%s]    SERVED_TAI_INDEX[%d]", amf_ue->supi, served_tai_index);
     ogs_assert(served_tai_index >= 0 &&
-            served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI);
+            served_tai_index < OGS_MAX_NUM_OF_SUPPORTED_TA);
 
     ogs_assert(OGS_OK ==
         ogs_nas_5gs_tai_list_build(&registration_accept->tai_list,

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -263,7 +263,7 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
                             bplmn_list[j].num_of_s_nssai = 0;
                     k < BroadcastPLMNItem->tAISliceSupportList.list.count &&
                     gnb->supported_ta_list[i].bplmn_list[j].num_of_s_nssai <
-                        OGS_MAX_NUM_OF_SLICE_SUPORT;
+                        OGS_MAX_NUM_OF_SLICE_SUPPORT;
                             k++) {
                 NGAP_SliceSupportItem_t *SliceSupportItem = NULL;
                 NGAP_S_NSSAI_t *s_NSSAI = NULL;
@@ -4256,7 +4256,7 @@ void ngap_handle_ran_configuration_update(
                                 bplmn_list[j].num_of_s_nssai = 0;
                         k < BroadcastPLMNItem->tAISliceSupportList.list.count &&
                         gnb->supported_ta_list[i].bplmn_list[j].num_of_s_nssai <
-                            OGS_MAX_NUM_OF_SLICE_SUPORT;
+                            OGS_MAX_NUM_OF_SLICE_SUPPORT;
                                 k++) {
                     NGAP_SliceSupportItem_t *SliceSupportItem = NULL;
                     NGAP_S_NSSAI_t *s_NSSAI = NULL;

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -66,7 +66,7 @@ static bool served_tai_is_found(amf_gnb_t *gnb)
             tai.tac.v = gnb->supported_ta_list[i].tac.v;
             served_tai_index = amf_find_served_tai(&tai);
             if (served_tai_index >= 0 &&
-                    served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI) {
+                    served_tai_index < OGS_MAX_NUM_OF_SUPPORTED_TA) {
                 ogs_debug("    TAC[%d]", gnb->supported_ta_list[i].tac.v);
                 ogs_debug("    PLMN_ID[MCC:%d MNC:%d]",
                     ogs_plmn_id_mcc(&gnb->supported_ta_list[i].
@@ -205,8 +205,8 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     /* Parse Supported TA */
     for (i = 0, gnb->num_of_supported_ta_list = 0;
             i < SupportedTAList->list.count &&
-            gnb->num_of_supported_ta_list < OGS_MAX_NUM_OF_TAI;
-                i++) {
+            gnb->num_of_supported_ta_list < OGS_MAX_NUM_OF_SUPPORTED_TA;
+            i++) {
         NGAP_SupportedTAItem_t *SupportedTAItem = NULL;
 
         SupportedTAItem = (NGAP_SupportedTAItem_t *)

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -263,7 +263,7 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
                             bplmn_list[j].num_of_s_nssai = 0;
                     k < BroadcastPLMNItem->tAISliceSupportList.list.count &&
                     gnb->supported_ta_list[i].bplmn_list[j].num_of_s_nssai <
-                        OGS_MAX_NUM_OF_SLICE;
+                        OGS_MAX_NUM_OF_SLICE_SUPORT;
                             k++) {
                 NGAP_SliceSupportItem_t *SliceSupportItem = NULL;
                 NGAP_S_NSSAI_t *s_NSSAI = NULL;
@@ -4256,7 +4256,7 @@ void ngap_handle_ran_configuration_update(
                                 bplmn_list[j].num_of_s_nssai = 0;
                         k < BroadcastPLMNItem->tAISliceSupportList.list.count &&
                         gnb->supported_ta_list[i].bplmn_list[j].num_of_s_nssai <
-                            OGS_MAX_NUM_OF_SLICE;
+                            OGS_MAX_NUM_OF_SLICE_SUPORT;
                                 k++) {
                     NGAP_SliceSupportItem_t *SliceSupportItem = NULL;
                     NGAP_S_NSSAI_t *s_NSSAI = NULL;

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -153,7 +153,7 @@ ogs_pkbuf_t *emm_build_attach_accept(
     served_tai_index = mme_find_served_tai(&mme_ue->tai);
     ogs_debug("    SERVED_TAI_INDEX[%d]", served_tai_index);
     ogs_assert(served_tai_index >= 0 &&
-            served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI);
+            served_tai_index < OGS_MAX_NUM_OF_SUPPORTED_TA);
     ogs_assert(OGS_OK ==
         ogs_nas_tai_list_build(&attach_accept->tai_list,
             &mme_self()->served_tai[served_tai_index].list0,
@@ -555,7 +555,7 @@ ogs_pkbuf_t *emm_build_tau_accept(mme_ue_t *mme_ue)
     served_tai_index = mme_find_served_tai(&mme_ue->tai);
     ogs_debug("    SERVED_TAI_INDEX[%d]", served_tai_index);
     ogs_assert(served_tai_index >= 0 &&
-            served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI);
+            served_tai_index < OGS_MAX_NUM_OF_SUPPORTED_TA);
     ogs_assert(OGS_OK ==
         ogs_nas_tai_list_build(&tau_accept->tai_list,
             &mme_self()->served_tai[served_tai_index].list0,

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1388,7 +1388,7 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_recurse(&mme_iter, &gummei_array);
                     do {
                         served_gummei_t *gummei = NULL;
-                        ogs_assert(self.num_of_served_gummei <=
+                        ogs_assert(self.num_of_served_gummei <
                                 OGS_MAX_NUM_OF_SERVED_GUMMEI);
                         gummei = &self.served_gummei[
                             self.num_of_served_gummei];
@@ -1422,7 +1422,7 @@ int mme_context_parse_config(void)
                                     ogs_plmn_id_t *plmn_id = NULL;
                                     const char *mcc = NULL, *mnc = NULL;
                                     ogs_assert(gummei->num_of_plmn_id <
-                                            OGS_MAX_NUM_OF_PLMN);
+                                            OGS_MAX_NUM_OF_PLMN_PER_MME);
                                     plmn_id = &gummei->plmn_id[
                                         gummei->num_of_plmn_id];
                                     ogs_assert(plmn_id);
@@ -1555,7 +1555,7 @@ int mme_context_parse_config(void)
                     ogs_eps_tai1_list_t *list1 = NULL;
                     ogs_eps_tai2_list_t *list2 = NULL;
 
-                    ogs_assert(self.num_of_served_tai <=
+                    ogs_assert(self.num_of_served_tai <
                             OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
@@ -1736,8 +1736,8 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&mme_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <=
-                                OGS_MAX_NUM_OF_ACCESS_CONTROL);
+                        ogs_assert(self.num_of_access_control <
+                                OGS_MAX_NUM_OF_PLMN_PER_MME);
 
                         if (ogs_yaml_iter_type(&access_control_array) ==
                                 YAML_MAPPING_NODE) {

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -233,7 +233,7 @@ static int mme_context_validation(void)
         return OGS_ERROR;
     }
 
-    if (self.max_num_of_served_gummei == 0) {
+    if (self.num_of_served_gummei == 0) {
         ogs_error("No mme.gummei in '%s'", ogs_app()->file);
         return OGS_ERROR;
     }
@@ -1388,10 +1388,10 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_recurse(&mme_iter, &gummei_array);
                     do {
                         served_gummei_t *gummei = NULL;
-                        ogs_assert(self.max_num_of_served_gummei <
+                        ogs_assert(self.num_of_served_gummei <=
                                 MAX_NUM_OF_SERVED_GUMMEI);
                         gummei = &self.served_gummei[
-                            self.max_num_of_served_gummei];
+                            self.num_of_served_gummei];
                         ogs_assert(gummei);
 
                         if (ogs_yaml_iter_type(&gummei_array) ==
@@ -1535,7 +1535,7 @@ int mme_context_parse_config(void)
 
                         if (gummei->num_of_plmn_id &&
                             gummei->num_of_mme_gid && gummei->num_of_mme_code) {
-                            self.max_num_of_served_gummei++;
+                            self.num_of_served_gummei++;
                         } else {
                             ogs_warn("Ignore gummei : "
                                     "plmn_id(%d), mme_gid(%d), mme_code(%d)",
@@ -1555,7 +1555,7 @@ int mme_context_parse_config(void)
                     ogs_eps_tai1_list_t *list1 = NULL;
                     ogs_eps_tai2_list_t *list2 = NULL;
 
-                    ogs_assert(self.num_of_served_tai <
+                    ogs_assert(self.num_of_served_tai <=
                             OGS_MAX_NUM_OF_SERVED_TAI);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
@@ -1736,7 +1736,7 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&mme_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <
+                        ogs_assert(self.num_of_access_control <=
                                 OGS_MAX_NUM_OF_ACCESS_CONTROL);
 
                         if (ogs_yaml_iter_type(&access_control_array) ==
@@ -3116,7 +3116,7 @@ void mme_ue_new_guti(mme_ue_t *mme_ue)
     served_gummei_t *served_gummei = NULL;
 
     ogs_assert(mme_ue);
-    ogs_assert(mme_self()->max_num_of_served_gummei > 0);
+    ogs_assert(mme_self()->num_of_served_gummei > 0);
 
     served_gummei = &mme_self()->served_gummei[0];
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -812,8 +812,6 @@ int mme_context_parse_config(void)
                                                 do {
                                                     const char *v = NULL;
 
-                                                    ogs_assert(num_of_tac <
-                                                            OGS_MAX_NUM_OF_TAI);
                                                     if (ogs_yaml_iter_type(
                                                             &tac_iter) ==
                                                         YAML_SEQUENCE_NODE) {
@@ -822,6 +820,8 @@ int mme_context_parse_config(void)
                                                             break;
                                                     }
 
+                                                    ogs_assert(num_of_tac <
+                                                            OGS_MAX_NUM_OF_TAI);
                                                     v = ogs_yaml_iter_value(
                                                             &tac_iter);
                                                     if (v) {
@@ -846,9 +846,6 @@ int mme_context_parse_config(void)
                                                 do {
                                                     const char *v = NULL;
 
-                                                    ogs_assert(
-                                                            num_of_e_cell_id <
-                                                        OGS_MAX_NUM_OF_CELL_ID);
                                                     if (ogs_yaml_iter_type(
                                                             &e_cell_id_iter) ==
                                                         YAML_SEQUENCE_NODE) {
@@ -856,6 +853,9 @@ int mme_context_parse_config(void)
                                                             &e_cell_id_iter))
                                                             break;
                                                     }
+                                                    ogs_assert(
+                                                            num_of_e_cell_id <
+                                                        OGS_MAX_NUM_OF_CELL_ID);
                                                     v = ogs_yaml_iter_value(
                                                             &e_cell_id_iter);
                                                     if (v) {
@@ -1012,8 +1012,6 @@ int mme_context_parse_config(void)
                                                 do {
                                                     const char *v = NULL;
 
-                                                    ogs_assert(num_of_apn <
-                                                            OGS_MAX_NUM_OF_APN);
                                                     if (ogs_yaml_iter_type(
                                                                 &apn_iter) ==
                                                         YAML_SEQUENCE_NODE) {
@@ -1022,6 +1020,8 @@ int mme_context_parse_config(void)
                                                             break;
                                                     }
 
+                                                    ogs_assert(num_of_apn <
+                                                            OGS_MAX_NUM_OF_APN);
                                                     v = ogs_yaml_iter_value(
                                                             &apn_iter);
                                                     if (v) {
@@ -1043,8 +1043,6 @@ int mme_context_parse_config(void)
                                                 do {
                                                     const char *v = NULL;
 
-                                                    ogs_assert(num_of_tac <
-                                                            OGS_MAX_NUM_OF_TAI);
                                                     if (ogs_yaml_iter_type(
                                                                 &tac_iter) ==
                                                         YAML_SEQUENCE_NODE) {
@@ -1053,6 +1051,8 @@ int mme_context_parse_config(void)
                                                             break;
                                                     }
 
+                                                    ogs_assert(num_of_tac <
+                                                            OGS_MAX_NUM_OF_TAI);
                                                     v = ogs_yaml_iter_value(
                                                             &tac_iter);
                                                     if (v) {
@@ -1075,9 +1075,6 @@ int mme_context_parse_config(void)
                                                 do {
                                                     const char *v = NULL;
 
-                                                    ogs_assert(
-                                                            num_of_e_cell_id <
-                                                        OGS_MAX_NUM_OF_CELL_ID);
                                                     if (ogs_yaml_iter_type(
                                                             &e_cell_id_iter) ==
                                                         YAML_SEQUENCE_NODE) {
@@ -1085,6 +1082,9 @@ int mme_context_parse_config(void)
                                                             &e_cell_id_iter))
                                                             break;
                                                     }
+                                                    ogs_assert(
+                                                            num_of_e_cell_id <
+                                                        OGS_MAX_NUM_OF_CELL_ID);
                                                     v = ogs_yaml_iter_value(
                                                             &e_cell_id_iter);
                                                     if (v) {
@@ -1388,11 +1388,6 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_recurse(&mme_iter, &gummei_array);
                     do {
                         served_gummei_t *gummei = NULL;
-                        ogs_assert(self.num_of_served_gummei <
-                                OGS_MAX_NUM_OF_SERVED_GUMMEI);
-                        gummei = &self.served_gummei[
-                            self.num_of_served_gummei];
-                        ogs_assert(gummei);
 
                         if (ogs_yaml_iter_type(&gummei_array) ==
                                 YAML_MAPPING_NODE) {
@@ -1410,6 +1405,12 @@ int mme_context_parse_config(void)
                         } else
                             ogs_assert_if_reached();
 
+                        ogs_assert(self.num_of_served_gummei <
+                                OGS_MAX_NUM_OF_SERVED_GUMMEI);
+                        gummei = &self.served_gummei[
+                            self.num_of_served_gummei];
+                        ogs_assert(gummei);
+
                         while (ogs_yaml_iter_next(&gummei_iter)) {
                             const char *gummei_key =
                                 ogs_yaml_iter_key(&gummei_iter);
@@ -1421,11 +1422,6 @@ int mme_context_parse_config(void)
                                 do {
                                     ogs_plmn_id_t *plmn_id = NULL;
                                     const char *mcc = NULL, *mnc = NULL;
-                                    ogs_assert(gummei->num_of_plmn_id <
-                                            OGS_MAX_NUM_OF_PLMN_PER_MME);
-                                    plmn_id = &gummei->plmn_id[
-                                        gummei->num_of_plmn_id];
-                                    ogs_assert(plmn_id);
 
                                     if (ogs_yaml_iter_type(&plmn_id_array) ==
                                             YAML_MAPPING_NODE) {
@@ -1444,6 +1440,12 @@ int mme_context_parse_config(void)
                                         break;
                                     } else
                                         ogs_assert_if_reached();
+
+                                    ogs_assert(gummei->num_of_plmn_id <
+                                            OGS_MAX_NUM_OF_PLMN_PER_MME);
+                                    plmn_id = &gummei->plmn_id[
+                                        gummei->num_of_plmn_id];
+                                    ogs_assert(plmn_id);
 
                                     while (ogs_yaml_iter_next(&plmn_id_iter)) {
                                         const char *plmn_id_key =
@@ -1478,17 +1480,17 @@ int mme_context_parse_config(void)
                                     uint16_t *mme_gid = NULL;
                                     const char *v = NULL;
 
-                                    ogs_assert(gummei->num_of_mme_gid <
-                                            GRP_PER_MME);
-                                    mme_gid = &gummei->mme_gid[
-                                        gummei->num_of_mme_gid];
-                                    ogs_assert(mme_gid);
-
                                     if (ogs_yaml_iter_type(&mme_gid_iter) ==
                                             YAML_SEQUENCE_NODE) {
                                         if (!ogs_yaml_iter_next(&mme_gid_iter))
                                             break;
                                     }
+
+                                    ogs_assert(gummei->num_of_mme_gid <
+                                            GRP_PER_MME);
+                                    mme_gid = &gummei->mme_gid[
+                                        gummei->num_of_mme_gid];
+                                    ogs_assert(mme_gid);
 
                                     v = ogs_yaml_iter_value(&mme_gid_iter);
                                     if (v) {
@@ -1736,9 +1738,6 @@ int mme_context_parse_config(void)
                     ogs_yaml_iter_t access_control_array, access_control_iter;
                     ogs_yaml_iter_recurse(&mme_iter, &access_control_array);
                     do {
-                        ogs_assert(self.num_of_access_control <
-                                OGS_MAX_NUM_OF_PLMN_PER_MME);
-
                         if (ogs_yaml_iter_type(&access_control_array) ==
                                 YAML_MAPPING_NODE) {
                             memcpy(&access_control_iter, &access_control_array,
@@ -1754,6 +1753,9 @@ int mme_context_parse_config(void)
                             break;
                         } else
                             ogs_assert_if_reached();
+
+                        ogs_assert(self.num_of_access_control <
+                                OGS_MAX_NUM_OF_PLMN_PER_MME);
 
                         while (ogs_yaml_iter_next(&access_control_iter)) {
                             const char *mnc = NULL, *mcc = NULL;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1389,7 +1389,7 @@ int mme_context_parse_config(void)
                     do {
                         served_gummei_t *gummei = NULL;
                         ogs_assert(self.num_of_served_gummei <=
-                                MAX_NUM_OF_SERVED_GUMMEI);
+                                OGS_MAX_NUM_OF_SERVED_GUMMEI);
                         gummei = &self.served_gummei[
                             self.num_of_served_gummei];
                         ogs_assert(gummei);
@@ -1556,7 +1556,7 @@ int mme_context_parse_config(void)
                     ogs_eps_tai2_list_t *list2 = NULL;
 
                     ogs_assert(self.num_of_served_tai <=
-                            OGS_MAX_NUM_OF_SERVED_TAI);
+                            OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 = &self.served_tai[self.num_of_served_tai].list0;
                     list1 = &self.served_tai[self.num_of_served_tai].list1;
                     list2 = &self.served_tai[self.num_of_served_tai].list2;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -66,7 +66,7 @@ typedef uint32_t mme_p_tmsi_t;
 
 typedef struct served_gummei_s {
     int             num_of_plmn_id;
-    ogs_plmn_id_t   plmn_id[OGS_MAX_NUM_OF_PLMN];
+    ogs_plmn_id_t   plmn_id[OGS_MAX_NUM_OF_PLMN_PER_MME];
 
     int             num_of_mme_gid;
     uint16_t        mme_gid[GRP_PER_MME];
@@ -116,7 +116,7 @@ typedef struct mme_context_s {
     struct {
         int reject_cause;
         ogs_plmn_id_t plmn_id;
-    } access_control[OGS_MAX_NUM_OF_ACCESS_CONTROL];
+    } access_control[OGS_MAX_NUM_OF_PLMN_PER_MME];
 
     /* defined in 'nas_ies.h'
      * #define NAS_SECURITY_ALGORITHMS_EIA0        0

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -101,7 +101,7 @@ typedef struct mme_context_s {
     ogs_list_t      csmap_list;     /* TAI-LAI Map List */
 
     /* Served GUMME */
-    int             max_num_of_served_gummei;
+    int             num_of_served_gummei;
     served_gummei_t served_gummei[MAX_NUM_OF_SERVED_GUMMEI];
 
     /* Served TAI */

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -40,8 +40,6 @@ extern "C" {
 #define GRP_PER_MME                 256    /* According to spec it is 65535 */
 #define CODE_PER_MME                256    /* According to spec it is 256 */
 
-#define MAX_NUM_OF_SERVED_GUMMEI    8
-
 extern int __mme_log_domain;
 extern int __emm_log_domain;
 extern int __esm_log_domain;
@@ -102,7 +100,7 @@ typedef struct mme_context_s {
 
     /* Served GUMME */
     int             num_of_served_gummei;
-    served_gummei_t served_gummei[MAX_NUM_OF_SERVED_GUMMEI];
+    served_gummei_t served_gummei[OGS_MAX_NUM_OF_SERVED_GUMMEI];
 
     /* Served TAI */
     int             num_of_served_tai;
@@ -110,7 +108,7 @@ typedef struct mme_context_s {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai1_list_t list1;
         ogs_eps_tai2_list_t list2;
-    } served_tai[OGS_MAX_NUM_OF_SERVED_TAI];
+    } served_tai[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     /* Access Control */
     int             default_reject_cause;
@@ -288,7 +286,7 @@ typedef struct mme_enb_s {
     uint16_t        ostream_id;         /* enb_ostream_id generator */
 
     int             num_of_supported_ta_list;
-    ogs_eps_tai_t   supported_ta_list[OGS_MAX_NUM_OF_TAI*OGS_MAX_NUM_OF_BPLMN];
+    ogs_eps_tai_t   supported_ta_list[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     ogs_pkbuf_t     *s1_reset_ack; /* Reset message */
 

--- a/src/mme/s1ap-build.c
+++ b/src/mme/s1ap-build.c
@@ -83,7 +83,7 @@ ogs_pkbuf_t *s1ap_build_setup_rsp(void)
                 strlen(mme_self()->mme_name), MMEname);
     }
 
-    for (i = 0; i < mme_self()->max_num_of_served_gummei; i++) {
+    for (i = 0; i < mme_self()->num_of_served_gummei; i++) {
         S1AP_ServedGUMMEIsItem_t *ServedGUMMEIsItem = NULL;
         ServedGUMMEIsItem = (S1AP_ServedGUMMEIsItem_t *)
             CALLOC(1, sizeof(S1AP_ServedGUMMEIsItem_t));

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -69,7 +69,7 @@ static bool served_tai_is_found(mme_enb_t *enb)
     for (i = 0; i < enb->num_of_supported_ta_list; i++) {
         served_tai_index = mme_find_served_tai(&enb->supported_ta_list[i]);
         if (served_tai_index >= 0 &&
-                served_tai_index < OGS_MAX_NUM_OF_SERVED_TAI) {
+                served_tai_index < OGS_MAX_NUM_OF_SUPPORTED_TA) {
             ogs_debug("    SERVED_TAI_INDEX[%d]", served_tai_index);
             return true;
         }
@@ -159,8 +159,10 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         ogs_debug("    PagingDRX[%ld]", *PagingDRX);
 
     /* Parse Supported TA */
-    enb->num_of_supported_ta_list = 0;
-    for (i = 0; i < SupportedTAs->list.count; i++) {
+    for (i = 0, enb->num_of_supported_ta_list = 0;
+            i < SupportedTAs->list.count &&
+            enb->num_of_supported_ta_list < OGS_MAX_NUM_OF_SUPPORTED_TA;
+            i++) {
         S1AP_SupportedTAs_Item_t *SupportedTAs_Item = NULL;
         S1AP_TAC_t *tAC = NULL;
 
@@ -289,8 +291,10 @@ void s1ap_handle_enb_configuration_update(
         S1AP_Cause_PR group = S1AP_Cause_PR_NOTHING;
         long cause = 0;
 
-        enb->num_of_supported_ta_list = 0;
-        for (i = 0; i < SupportedTAs->list.count; i++) {
+        for (i = 0, enb->num_of_supported_ta_list = 0;
+                i < SupportedTAs->list.count &&
+                enb->num_of_supported_ta_list < OGS_MAX_NUM_OF_SUPPORTED_TA;
+                i++) {
             S1AP_SupportedTAs_Item_t *SupportedTAs_Item = NULL;
             S1AP_TAC_t *tAC = NULL;
 

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -571,7 +571,7 @@ int test_context_parse_config(void)
                                         self.plmn_support[
                                             self.num_of_plmn_support].
                                                 num_of_s_nssai <=
-                                            OGS_MAX_NUM_OF_SLICE_SUPORT);
+                                            OGS_MAX_NUM_OF_SLICE_SUPPORT);
                                     s_nssai = &self.plmn_support[
                                             self.num_of_plmn_support].s_nssai[
                                                 self.plmn_support[

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -328,7 +328,7 @@ int test_context_parse_config(void)
                     ogs_5gs_tai2_list_t *list2 = NULL;
 
                     ogs_assert(self.num_of_nr_served_tai <=
-                            OGS_MAX_NUM_OF_SERVED_TAI);
+                            OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 =
                         &self.nr_served_tai[self.num_of_nr_served_tai].list0;
                     list1 =
@@ -808,7 +808,7 @@ int test_context_parse_config(void)
                     ogs_eps_tai2_list_t *list2 = NULL;
 
                     ogs_assert(self.num_of_e_served_tai <=
-                            OGS_MAX_NUM_OF_SERVED_TAI);
+                            OGS_MAX_NUM_OF_SUPPORTED_TA);
                     list0 = &self.e_served_tai[self.num_of_e_served_tai].list0;
                     list1 = &self.e_served_tai[self.num_of_e_served_tai].list1;
                     list2 = &self.e_served_tai[self.num_of_e_served_tai].list2;

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -571,7 +571,7 @@ int test_context_parse_config(void)
                                         self.plmn_support[
                                             self.num_of_plmn_support].
                                                 num_of_s_nssai <=
-                                            OGS_MAX_NUM_OF_SLICE);
+                                            OGS_MAX_NUM_OF_SLICE_SUPORT);
                                     s_nssai = &self.plmn_support[
                                             self.num_of_plmn_support].s_nssai[
                                                 self.plmn_support[

--- a/tests/common/context.h
+++ b/tests/common/context.h
@@ -78,7 +78,7 @@ typedef struct test_context_s {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai1_list_t list1;
         ogs_eps_tai2_list_t list2;
-    } e_served_tai[OGS_MAX_NUM_OF_SERVED_TAI];
+    } e_served_tai[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     ogs_eps_tai_t e_tai;
 
@@ -88,7 +88,7 @@ typedef struct test_context_s {
         ogs_5gs_tai0_list_t list0;
         ogs_5gs_tai1_list_t list1;
         ogs_5gs_tai2_list_t list2;
-    } nr_served_tai[OGS_MAX_NUM_OF_SERVED_TAI];
+    } nr_served_tai[OGS_MAX_NUM_OF_SUPPORTED_TA];
 
     ogs_5gs_tai_t nr_tai;
     ogs_nr_cgi_t nr_cgi;

--- a/tests/common/context.h
+++ b/tests/common/context.h
@@ -69,7 +69,7 @@ typedef struct test_context_s {
     struct {
         ogs_plmn_id_t plmn_id;
         int num_of_s_nssai;
-        ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE];
+        ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE_SUPPORT];
     } plmn_support[OGS_MAX_NUM_OF_PLMN];
 
     /* Served EPC TAI */


### PR DESCRIPTION
I have reset the number of TA, SLICE, and PLMN supported by AMF/MME as follows.

- From lib/proto/types.h
```
define OGS_MAX_NUM_OF_SERVED_GUMMEI    8   /* maxnoofRATs: 8 */
#define OGS_MAX_NUM_OF_SERVED_GUAMI     256 /* maxnoofServedGUAMIs: 256 */
#define OGS_MAX_NUM_OF_SUPPORTED_TA     256 /* maxnoofTACs: 256 */

/*
 * If I set it to 1024, the AMF crashes in the 'meson test -v registration'.
 * So for now, I will use 512. Once I figure out the cause of this problem,
 * I will try 1024.
 */
#define OGS_MAX_NUM_OF_SLICE_SUPPORT    512 /* maxnoofSliceItems: 1024 */

#define OGS_MAX_NUM_OF_PLMN_PER_MME     32  /* maxnoofPLMNs(MME): 32 */
#define OGS_MAX_NUM_OF_PLMN             12  /* maxnoofPLMNs(AMF): 12 */
#define OGS_MAX_NUM_OF_BPLMN            OGS_MAX_NUM_OF_PLMN

#define OGS_MAX_NUM_OF_TAI              16
#define OGS_MAX_NUM_OF_SLICE            8
```