### PR TITLE
[WebUI] Fix launch problem in docker (#2767)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - mongodb
     ports:
-      - "3000:3000"
+      - "9999:9999"
     environment:
       - DB_URI=mongodb://mongodb/open5gs
       - WAIT_HOSTS=mongodb:27017

--- a/docker/webui/Dockerfile
+++ b/docker/webui/Dockerfile
@@ -13,4 +13,4 @@ RUN chmod +x /wait
 
 CMD /wait && npm run start
 
-EXPOSE 3000
+EXPOSE 9999

--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -224,7 +224,7 @@ Okay - you have installed the software, now what to do with it? Well, there are 
 Out of the box, the default configurations see all of the Open5GS components fully configured for use on a single computer. They are set to communicate with each other using the local loopback address space (`127.0.0.X`). The default addresses for each of the bind interfaces for these components and functions are as follows:
 
 ```
-MongoDB   = 127.0.0.1 (subscriber data) - http://localhost:3000
+MongoDB   = 127.0.0.1 (subscriber data) - http://localhost:9999
 
 MME-s1ap  = 127.0.0.2 :36412 for S1-MME
 MME-gtpc  = 127.0.0.2 :2123 for S11


### PR DESCRIPTION
I have changed the WebUI Port number from 3000 to 9999. As a result, Docker/WebUI did not function properly because the necessary modifications were not made accordingly.

I have made modifications to run the WebUI in a Docker environment with the port number 9999.