### PR TITLE
[AMF] Reject registration if no security context

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -448,6 +448,15 @@ struct amf_ue_s {
         bool sbi_done;
     } explict_de_registered;
 
+    /* CM_IDLE
+     * namf-callback DeregNotify
+     * Paging
+     * Service request
+     * Service accept
+     * De-Registration Request
+     */
+    OpenAPI_deregistration_reason_e do_deregister;
+
     ogs_list_t      sess_list;
 };
 

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -191,6 +191,7 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
                     amf_ue, pdu_session_resource_setup_request);
             AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
             CLEAR_AMF_UE_TIMER(amf_ue->t3513);
+            amf_ue->do_deregister = OpenAPI_deregistration_reason_NULL;
 
             ogs_timer_start(amf_ue->implicit_deregistration.timer,
                     ogs_time_from_sec(amf_self()->time.t3512.value + 240));
@@ -627,6 +628,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
                         amf_ue, pdu_session_resource_setup_request);
                 AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
                 CLEAR_AMF_UE_TIMER(amf_ue->t3513);
+                amf_ue->do_deregister = OpenAPI_deregistration_reason_NULL;
 
             } else {
                 amf_ue->t3513.retry_count++;
@@ -2372,6 +2374,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         AMF_UE_CLEAR_N2_TRANSFER(amf_ue, pdu_session_resource_setup_request);
         AMF_UE_CLEAR_5GSM_MESSAGE(amf_ue);
         CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
+        amf_ue->do_deregister = OpenAPI_deregistration_reason_NULL;
 
         xact_count = amf_sess_xact_count(amf_ue);
 


### PR DESCRIPTION
Bug:

On 'No Security Context' AMF doesn't reject NAS message and gets stuck in gmm_state_security_mode.
Some real UEs block (even SIM card removal doesn't help). Explicit deregistration doesn't work either (UE is not in CM_CONNECTED).

Fix:

Such a registration is rejected and the UE enters a proper DEREGISTERED state.