### PR TITLE
[SMF] Identify Common PCO

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -597,6 +597,9 @@ int ogs_fqdn_parse(char *dst, char *src, int len);
 #define OGS_PCO_ID_IPV4_LINK_MTU_REQUEST                        0x0010
 #define OGS_PCO_ID_MS_SUPPORT_LOCAL_ADDR_TFT_INDICATOR          0x0011
 #define OGS_PCO_ID_P_CSCF_RE_SELECTION_SUPPORT                  0x0012
+#define OGS_PCO_ID_3GPP_PS_DATA_OFF_SUPPORT_INDICATION          0x0017
+#define OGS_PCO_ID_QOS_RULES_WITH_THE_LENGTH_OF_TWO_OCTETS      0x0023
+#define OGS_PCO_ID_QOS_FLOW_DESC_WITH_THE_LENGTH_OF_TWO_OCTETS  0x0024
 
 enum ogs_pco_ipcp_options {
     OGS_IPCP_OPT_IPADDR = 3,

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3007,8 +3007,17 @@ int smf_pco_build(uint8_t *pco_buf, uint8_t *buffer, int length)
         case OGS_PCO_ID_P_CSCF_RE_SELECTION_SUPPORT:
             /* TODO */
             break;
+        case OGS_PCO_ID_3GPP_PS_DATA_OFF_SUPPORT_INDICATION:
+            /* TODO */
+            break;
+        case OGS_PCO_ID_QOS_RULES_WITH_THE_LENGTH_OF_TWO_OCTETS:
+            /* TODO */
+            break;
+        case OGS_PCO_ID_QOS_FLOW_DESC_WITH_THE_LENGTH_OF_TWO_OCTETS:
+            /* TODO */
+            break;
         default:
-            ogs_warn("Unknown PCO ID:(0x%x)", ue.ids[i].id);
+            ogs_warn("Unknown PCO ID:(0x%04x)", ue.ids[i].id);
         }
     }
 


### PR DESCRIPTION
While testing with Commercial Handset, these PCO are included, and causes frequent additional warning logs.  This should cleanup the log entries as well as provide better formatting of the log entry.