### PR TITLE
[AMF] Reject Service Req. for ServiceType Data w/o UlDataStatus

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -673,6 +673,30 @@ ogs_nas_5gmm_cause_t gmm_handle_service_update(amf_ue_t *amf_ue,
         return gmm_handle_nas_message_container(
                 amf_ue, OGS_NAS_5GS_SERVICE_REQUEST,
                 &service_request->nas_message_container);
+    } else {
+        /*
+        * 3GPPTS 24.501, 5.6.1 Service request procedure
+        * c) the UE, in 5GMM-IDLE mode over 3GPP access,
+        *    has uplink signalling pending:
+        *    the Uplink data status IE shall not be included,
+        *    the UE shall set the service type IE to "signalling".
+        * d) the UE, in 5GMM-IDLE mode over 3GPP access,
+        *    has uplink user data pending:
+        *    the Uplink data status IE shall be included, the service type IE
+        *    in the SERVICE REQUEST message shall be set to "data".
+        */
+        if (service_request->ngksi.type == OGS_NAS_SERVICE_TYPE_DATA &&
+                !(service_request->presencemask &
+                OGS_NAS_5GS_SERVICE_REQUEST_UPLINK_DATA_STATUS_PRESENT)) {
+            ogs_info("Service type data, but no Uplink user data pending");
+            return OGS_5GMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE;
+        }
+        if (service_request->ngksi.type == OGS_NAS_SERVICE_TYPE_SIGNALLING &&
+                (service_request->presencemask &
+                OGS_NAS_5GS_SERVICE_REQUEST_UPLINK_DATA_STATUS_PRESENT)) {
+            ogs_info("Service type signalling, but Uplink user data pending");
+            return OGS_5GMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE;
+        }
     }
 
     xact_count = amf_sess_xact_count(amf_ue);


### PR DESCRIPTION
Bug:

Service Request for ServiceType Data without UplinkDataStatus causes AMF to misbehave:
- Deregistration accept is not sent on Deregistration request,
- UEContextReleaseCommand is not sent after Deregistration,
- no response is sent from AMF towards gNB on next Registration request,
- PDU session remains forever.

Fix:

Service Request for ServiceType Data without UplinkDataStatus is rejected with #95 (just protection against incorrect message).
Proper fix should address the Service Request without UplinkDataStatus handling (so ServiceType Signalling would be covered).