### PR TITLE
[AMF] Fix deregistration request De-registration type

### DIFF
--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -318,7 +318,6 @@ ogs_pkbuf_t *gmm_build_de_registration_request(
         OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GMM;
     message.gmm.h.message_type = OGS_NAS_5GS_DEREGISTRATION_REQUEST_TO_UE;
 
-    dereg_req->de_registration_type.switch_off = 1;
     dereg_req->de_registration_type.re_registration_required =
         dereg_reason == OpenAPI_deregistration_reason_REREGISTRATION_REQUIRED;
     dereg_req->de_registration_type.access_type = OGS_ACCESS_TYPE_3GPP;


### PR DESCRIPTION
[ETSI TS 124 501 V16.5.1](https://www.etsi.org/deliver/etsi_ts/124500_124599/124501/16.05.01_60/ts_124501v160501p.pdf), 9.11.3.20 De-registration type
Switch off (octet 1, bit 4)
In the network to UE direction bit 4 is spare. The network shall set this bit to zero. 