### PR TITLE
[MME] Store received PGW S5C IP address in mme_sess_t

### DIFF
--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -734,6 +734,7 @@ typedef struct mme_sess_s {
     uint8_t         pti;        /* Procedure Trasaction Identity */
 
     uint32_t        pgw_s5c_teid;
+    ogs_ip_t        pgw_s5c_ip;
 
     /* PDN Connectivity Request */
     ogs_nas_request_type_t request_type;

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -366,6 +366,8 @@ void mme_s11_handle_create_session_response(
     if (rsp->pgw_s5_s8__s2a_s2b_f_teid_for_pmip_based_interface_or_for_gtp_based_control_plane_interface.presence) {
         pgw_s5c_teid = rsp->pgw_s5_s8__s2a_s2b_f_teid_for_pmip_based_interface_or_for_gtp_based_control_plane_interface.data;
         sess->pgw_s5c_teid = be32toh(pgw_s5c_teid->teid);
+        ogs_assert(OGS_OK ==
+                ogs_gtp2_f_teid_to_ip(pgw_s5c_teid, &sess->pgw_s5c_ip));
     }
 
     /* PDN Addresss Allocation */


### PR DESCRIPTION
This information will be required by the Gn interface in MME when answering an SGSN with an "SGSN Context Response" message during MS cell reselection EUTRAN->GERAN.