### PR TITLE
[MME] Store decoded PAA into session->ue_ip and session_type

### DIFF
--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -372,6 +372,9 @@ void mme_s11_handle_create_session_response(
     if (rsp->pdn_address_allocation.presence) {
         memcpy(&session->paa, rsp->pdn_address_allocation.data,
                 rsp->pdn_address_allocation.len);
+        session->session_type = session->paa.session_type;
+        ogs_assert(OGS_OK ==
+                ogs_gtp2_paa_to_ip(&session->paa, &session->ue_ip));
     }
 
     /* ePCO */


### PR DESCRIPTION
This will be used by the Gn interface to obtain the UE IP and provide it to new SGSN when transmitting SGSN Context Response.