### PR TITLE
[SBI] Allow Specific Source Interface or Address

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -96,6 +96,13 @@ amf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.5
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -59,6 +59,13 @@ ausf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.11
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -59,6 +59,13 @@ bsf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.15
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -85,6 +85,13 @@ nssf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.14
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -185,6 +185,13 @@ pcf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.13
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -84,6 +84,13 @@ scp:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.200
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -221,6 +221,13 @@ smf:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.4
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -119,6 +119,13 @@ udm:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.12
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -60,6 +60,13 @@ udr:
 #  discovery:
 #    delegated: no
 #
+#  o Specify source address or interface for SBI client
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#          source_interface: 127.0.0.20
+#
 ################################################################################
 # HTTPS scheme with TLS
 ################################################################################

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -213,6 +213,9 @@ void ogs_sbi_client_remove(ogs_sbi_client_t *client)
     if (client->cert)
         ogs_free(client->cert);
 
+    if (client->source_interface)
+        ogs_free(client->source_interface);
+
     if (client->fqdn)
         ogs_free(client->fqdn);
     if (client->resolve)
@@ -452,6 +455,11 @@ static connection_t *connection_add(
     }
 
     curl_easy_setopt(conn->easy, CURLOPT_BUFFERSIZE, OGS_MAX_SDU_LEN);
+
+    if (client->source_interface) {
+        curl_easy_setopt(conn->easy, CURLOPT_INTERFACE, 
+            client->source_interface);
+    }
 
     if (client->scheme == OpenAPI_uri_scheme_https) {
         if (client->insecure_skip_verify) {

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -119,6 +119,9 @@ ogs_sbi_client_t *ogs_sbi_client_add(
 
     client->scheme = scheme;
 
+    if (ogs_sbi_self()->source_interface)
+        client->source_interface = ogs_strdup(ogs_sbi_self()->source_interface);
+
     client->insecure_skip_verify =
         ogs_sbi_self()->tls.client.insecure_skip_verify;
     if (ogs_sbi_self()->tls.client.cacert)

--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -69,6 +69,8 @@ typedef struct ogs_sbi_client_s {
     bool insecure_skip_verify;
     char *cacert, *private_key, *cert;
 
+    char *source_interface;
+
     char *fqdn;
     uint16_t fqdn_port;
     ogs_sockaddr_t  *addr;

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -339,6 +339,9 @@ int ogs_sbi_context_parse_config(
                                     }
                                 }
                             }
+                        } else if (!strcmp(default_key, "source_interface")) {
+                            self.source_interface = 
+                                ogs_yaml_iter_value(&default_iter);
                         }
                     }
                 }

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -933,6 +933,8 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
     const char *client_private_key = NULL;
     const char *client_cert = NULL;
 
+    const char *client_source_interface = NULL;
+
     bool rc;
 
     OpenAPI_uri_scheme_e scheme =
@@ -973,6 +975,8 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
             client_private_key = ogs_yaml_iter_value(iter);
         } else if (!strcmp(key, "client_cert")) {
             client_cert = ogs_yaml_iter_value(iter);
+        } else if (!strcmp(key, "source_interface")) {
+            client_source_interface = ogs_yaml_iter_value(iter);
         }
     }
 
@@ -1047,6 +1051,13 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
         ogs_error("Either the private key or certificate is missing.");
         ogs_sbi_client_remove(client);
         return NULL;
+    }
+
+    if (client_source_interface) {
+        if (client->source_interface)
+            ogs_free(client->source_interface);
+        client->source_interface = ogs_strdup(client_source_interface);
+        ogs_assert(client->source_interface);
     }
 
     ogs_free(fqdn);

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -80,6 +80,8 @@ typedef struct ogs_sbi_context_s {
         } client;
     } tls;
 
+    const char *source_interface;
+
     ogs_list_t server_list;
     ogs_list_t client_list;
 


### PR DESCRIPTION
I noticed myself, as well as noted others mentioning this in the discord.  The source address for any of the SBI NFs is selected without consistency.  By adding this _source_interface_ configuration key to any of the SBI client definitions, it is possible for the source address to be predictable.  When using a system with multiple IP addresses, it is currently difficult to know which NF is sending the packet based on the source address.  This will allow that consistency.