### PR TITLE
[APP] Add space to improve readability of error

### DIFF
--- a/lib/app/ogs-init.c
+++ b/lib/app/ogs-init.c
@@ -197,7 +197,7 @@ static int read_config(void)
             break;
         case YAML_SCANNER_ERROR:
             if (parser.context)
-                ogs_error("Scanner error - %s at line %zu, column %zu"
+                ogs_error("Scanner error - %s at line %zu, column %zu "
                         "%s at line %zu, column %zu", parser.context,
                         parser.context_mark.line+1,
                         parser.context_mark.column+1,
@@ -210,7 +210,7 @@ static int read_config(void)
             break;
         case YAML_PARSER_ERROR:
             if (parser.context)
-                ogs_error("Parser error - %s at line %zu, column %zu"
+                ogs_error("Parser error - %s at line %zu, column %zu "
                         "%s at line %zu, column %zu", parser.context,
                         parser.context_mark.line+1,
                         parser.context_mark.column+1,


### PR DESCRIPTION
Error currently shows up like this:

`open5gs-mmed[2195243]: 12/19 18:14:34.260: [app] ERROR: Parser error - while parsing a block mapping at line 1, column 1did not find expected key at line 19, column 4 (../lib/app/ogs-init.c:213)`