### PR TITLE
[NRF] crash after sending invalid message (#2808)

### DIFF
--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -927,7 +927,8 @@ bool nrf_nnrf_handle_nf_discover(
 
         goto cleanup;
 
-    } else if (discovery_option->num_of_target_plmn_list &&
+    } else if (discovery_option &&
+            discovery_option->num_of_target_plmn_list &&
             discovery_option->num_of_requester_plmn_list) {
 
         /* No Discovery, Try to find different PLMN */
@@ -940,6 +941,9 @@ bool nrf_nnrf_handle_nf_discover(
         nrf_assoc_t *assoc = NULL;
 
         ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance) {
+            if (NF_INSTANCE_ID_IS_SELF(nf_instance->id))
+                continue;
+
             if (nf_instance->nf_type != OpenAPI_nf_type_NRF)
                 continue;
 


### PR DESCRIPTION
NRF crash after receiving
curl --http2-prior-knowledge http://127.0.0.10:7777/nnrf-disc/v1/nf-instances?target-nf-type=AUSF&requester-plmn-list=[{"mcc":"999","mnc":"70"}]&requester-nf-type=AMF&service-names=nausf-auth&target-plmn-list=[{"mcc":"999","mnc":"70"}] curl --http2-prior-knowledge http://127.0.0.10:7777/nnrf-disc/v1/nf-instances\?target-nf-type=AUSF\&requester-plmn-list=%5B%7B%22mcc%22%3A%22999%22%2C%22mnc%22%3A%2270%22%7D%5D\&requester-nf-type\=AMF\&service-names=nausf-auth\&target-plmn-list=%5B%7B%22mcc%22%3A%22999%22%2C%22mnc%22%3A%2210%22%7D%5D