### PR TITLE
[HSS] Add hss_event_init after change to event system

### DIFF
--- a/src/hss/hss-init.c
+++ b/src/hss/hss-init.c
@@ -36,6 +36,7 @@ int hss_initialize(void)
     if (rv != OGS_OK) return rv;
 
     hss_context_init();
+    hss_event_init();
 
     rv = hss_context_parse_config();
     if (rv != OGS_OK) return rv;

--- a/src/hss/hss-init.c
+++ b/src/hss/hss-init.c
@@ -70,6 +70,7 @@ void hss_terminate(void)
 
     ogs_dbi_final();
     hss_context_final();
+    hss_event_final();
 
     return;
 }


### PR DESCRIPTION
When `use_mongodb_change_stream` is enabled, the HSS is unable to start due to the following error:

```
[app] FATAL: hss_event_new: Assertion `e' failed. (../src/hss/hss-event.c:46)
```

In #2739, the event functions were moved into the hss app, however, `hss_event_init` is never called.  This adds the call to the function to allow the hss to start with change streams enabled.