### PR TITLE
[MME] Fix potential null ptr dereference

### DIFF
--- a/lib/core/ogs-sockaddr.c
+++ b/lib/core/ogs-sockaddr.c
@@ -419,9 +419,9 @@ socklen_t ogs_sockaddr_len(const void *sa)
     }
 }
 
-bool ogs_sockaddr_is_equal(void *p, void *q)
+bool ogs_sockaddr_is_equal(const void *p, const void *q)
 {
-    ogs_sockaddr_t *a, *b;
+    const ogs_sockaddr_t *a, *b;
 
     a = p;
     ogs_assert(a);

--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -118,7 +118,7 @@ const char *ogs_inet_ntop(void *sa, char *buf, int buflen);
 int ogs_inet_pton(int family, const char *src, void *sa);
 
 socklen_t ogs_sockaddr_len(const void *sa);
-bool ogs_sockaddr_is_equal(void *p, void *q);
+bool ogs_sockaddr_is_equal(const void *p, const void *q);
 
 int ogs_ipsubnet(ogs_ipsubnet_t *ipsub,
         const char *ipstr, const char *mask_or_numbits);

--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -48,7 +48,7 @@ struct ogs_sockaddr_s {
     /* Reserved Area
      *   - Should not add any atrribute in this area.
      *
-     *   e.g) 
+     *   e.g)
      *   struct sockaddr addr;
      *   ...
      *   sockaddr_len((ogs_sockaddr_t *)&addr);
@@ -92,11 +92,11 @@ typedef struct ogs_ipsubnet_s {
     uint32_t mask[4];
 } ogs_ipsubnet_t;
 
-int ogs_getaddrinfo(ogs_sockaddr_t **sa_list, 
+int ogs_getaddrinfo(ogs_sockaddr_t **sa_list,
         int family, const char *hostname, uint16_t port, int flags);
 int ogs_freeaddrinfo(ogs_sockaddr_t *sa_list);
 
-int ogs_addaddrinfo(ogs_sockaddr_t **sa_list, 
+int ogs_addaddrinfo(ogs_sockaddr_t **sa_list,
         int family, const char *hostname, uint16_t port, int flags);
 int ogs_copyaddrinfo(
         ogs_sockaddr_t **dst, const ogs_sockaddr_t *src);
@@ -106,7 +106,7 @@ int ogs_sortaddrinfo(ogs_sockaddr_t **sa_list, int family);
 ogs_sockaddr_t *ogs_link_local_addr(const char *dev, const ogs_sockaddr_t *sa);
 ogs_sockaddr_t *ogs_link_local_addr_by_dev(const char *dev);
 ogs_sockaddr_t *ogs_link_local_addr_by_sa(const ogs_sockaddr_t *sa);
-int ogs_filter_ip_version(ogs_sockaddr_t **addr, 
+int ogs_filter_ip_version(ogs_sockaddr_t **addr,
         int no_ipv4, int no_ipv6, int prefer_ipv4);
 
 #define OGS_ADDRSTRLEN INET6_ADDRSTRLEN

--- a/lib/nas/eps/conv.c
+++ b/lib/nas/eps/conv.c
@@ -20,7 +20,7 @@
 #include "ogs-nas-eps.h"
 
 void ogs_nas_eps_imsi_to_bcd(
-    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, char *bcd)
+    const ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, char *bcd)
 {
     int bcd_len;
 
@@ -54,7 +54,7 @@ void ogs_nas_eps_imsi_to_bcd(
 }
 
 void ogs_nas_imsi_to_buffer(
-    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len,
+    const ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len,
     uint8_t *buf, uint8_t *buf_len)
 {
     buf[0] = ((('0' + imsi->digit2) << 4) & 0xf0) |

--- a/lib/nas/eps/conv.c
+++ b/lib/nas/eps/conv.c
@@ -54,22 +54,22 @@ void ogs_nas_eps_imsi_to_bcd(
 }
 
 void ogs_nas_imsi_to_buffer(
-    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, 
+    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len,
     uint8_t *buf, uint8_t *buf_len)
 {
-    buf[0] = ((('0' + imsi->digit2) << 4) & 0xf0) | 
+    buf[0] = ((('0' + imsi->digit2) << 4) & 0xf0) |
                 (('0' + imsi->digit1) & 0x0f);
-    buf[1] = ((('0' + imsi->digit4) << 4) & 0xf0) | 
+    buf[1] = ((('0' + imsi->digit4) << 4) & 0xf0) |
                 (('0' + imsi->digit3) & 0x0f);
-    buf[2] = ((('0' + imsi->digit6) << 4) & 0xf0) | 
+    buf[2] = ((('0' + imsi->digit6) << 4) & 0xf0) |
                 (('0' + imsi->digit5) & 0x0f);
-    buf[3] = ((('0' + imsi->digit8) << 4) & 0xf0) | 
+    buf[3] = ((('0' + imsi->digit8) << 4) & 0xf0) |
                 (('0' + imsi->digit7) & 0x0f);
     buf[4] = ((('0' + imsi->digit10) << 4) & 0xf0) |
                 (('0' + imsi->digit9) & 0x0f);
-    buf[5] = ((('0' + imsi->digit12) << 4) & 0xf0) | 
+    buf[5] = ((('0' + imsi->digit12) << 4) & 0xf0) |
                 (('0' + imsi->digit11) & 0x0f);
-    buf[6] = ((('0' + imsi->digit14) << 4) & 0xf0) | 
+    buf[6] = ((('0' + imsi->digit14) << 4) & 0xf0) |
                 (('0' + imsi->digit13) & 0x0f);
     buf[7] = ((('0' + imsi->digit15)) & 0x0f);
 

--- a/lib/nas/eps/conv.h
+++ b/lib/nas/eps/conv.h
@@ -31,11 +31,11 @@ extern "C" {
 #endif
 
 void ogs_nas_imsi_to_buffer(
-    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, 
+    const ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len,
     uint8_t *buf, uint8_t *buf_len);
 
 void ogs_nas_eps_imsi_to_bcd(
-    ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, char *bcd);
+    const ogs_nas_mobile_identity_imsi_t *imsi, uint8_t imsi_len, char *bcd);
 
 #ifdef __cplusplus
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2460,7 +2460,7 @@ void mme_sgsn_remove_all(void)
         mme_sgsn_remove(sgsn);
 }
 
-mme_sgsn_t *mme_sgsn_find_by_addr(ogs_sockaddr_t *addr)
+mme_sgsn_t *mme_sgsn_find_by_addr(const ogs_sockaddr_t *addr)
 {
     mme_sgsn_t *sgsn = NULL;
 
@@ -2545,7 +2545,7 @@ void mme_sgw_remove_all(void)
         mme_sgw_remove(sgw);
 }
 
-mme_sgw_t *mme_sgw_find_by_addr(ogs_sockaddr_t *addr)
+mme_sgw_t *mme_sgw_find_by_addr(const ogs_sockaddr_t *addr)
 {
     mme_sgw_t *sgw = NULL;
 
@@ -2595,7 +2595,7 @@ void mme_pgw_remove_all(void)
 }
 
 static bool compare_apn_enb_info(
-    mme_pgw_t *pgw, mme_sess_t *sess)
+    const mme_pgw_t *pgw, const mme_sess_t *sess)
 {
     mme_ue_t *mme_ue = NULL;
     int i;
@@ -2620,7 +2620,7 @@ static bool compare_apn_enb_info(
 }
 
 ogs_sockaddr_t *mme_pgw_addr_find_by_apn_enb(
-    ogs_list_t *list, int family, mme_sess_t *sess)
+    ogs_list_t *list, int family, const mme_sess_t *sess)
 {
     mme_pgw_t *pgw = NULL;
     ogs_assert(list);
@@ -2698,7 +2698,7 @@ void mme_vlr_close(mme_vlr_t *vlr)
         ogs_sctp_destroy(vlr->sock);
 }
 
-mme_vlr_t *mme_vlr_find_by_addr(ogs_sockaddr_t *addr)
+mme_vlr_t *mme_vlr_find_by_addr(const ogs_sockaddr_t *addr)
 {
     mme_vlr_t *vlr = NULL;
     ogs_assert(addr);
@@ -2745,7 +2745,7 @@ void mme_csmap_remove_all(void)
         mme_csmap_remove(csmap);
 }
 
-mme_csmap_t *mme_csmap_find_by_tai(ogs_eps_tai_t *tai)
+mme_csmap_t *mme_csmap_find_by_tai(const ogs_eps_tai_t *tai)
 {
     mme_csmap_t *csmap = NULL;
     ogs_assert(tai);
@@ -2761,7 +2761,7 @@ mme_csmap_t *mme_csmap_find_by_tai(ogs_eps_tai_t *tai)
     return NULL;
 }
 
-mme_csmap_t *mme_csmap_find_by_nas_lai(ogs_nas_lai_t *lai)
+mme_csmap_t *mme_csmap_find_by_nas_lai(const ogs_nas_lai_t *lai)
 {
     mme_csmap_t *csmap = NULL;
     ogs_assert(lai);
@@ -2863,7 +2863,7 @@ int mme_enb_remove_all(void)
     return OGS_OK;
 }
 
-mme_enb_t *mme_enb_find_by_addr(ogs_sockaddr_t *addr)
+mme_enb_t *mme_enb_find_by_addr(const ogs_sockaddr_t *addr)
 {
     ogs_assert(addr);
     return (mme_enb_t *)ogs_hash_get(self.enb_addr_hash,
@@ -2992,7 +2992,7 @@ void enb_ue_switch_to_enb(enb_ue_t *enb_ue, mme_enb_t *new_enb)
 }
 
 enb_ue_t *enb_ue_find_by_enb_ue_s1ap_id(
-        mme_enb_t *enb, uint32_t enb_ue_s1ap_id)
+        const mme_enb_t *enb, uint32_t enb_ue_s1ap_id)
 {
     enb_ue_t *enb_ue = NULL;
 
@@ -3471,7 +3471,7 @@ void mme_ue_fsm_fini(mme_ue_t *mme_ue)
     ogs_fsm_fini(&mme_ue->sm, &e);
 }
 
-mme_ue_t *mme_ue_find_by_imsi_bcd(char *imsi_bcd)
+mme_ue_t *mme_ue_find_by_imsi_bcd(const char *imsi_bcd)
 {
     uint8_t imsi[OGS_MAX_IMSI_LEN];
     int imsi_len = 0;
@@ -3483,14 +3483,14 @@ mme_ue_t *mme_ue_find_by_imsi_bcd(char *imsi_bcd)
     return mme_ue_find_by_imsi(imsi, imsi_len);
 }
 
-mme_ue_t *mme_ue_find_by_imsi(uint8_t *imsi, int imsi_len)
+mme_ue_t *mme_ue_find_by_imsi(const uint8_t *imsi, int imsi_len)
 {
     ogs_assert(imsi && imsi_len);
 
     return (mme_ue_t *)ogs_hash_get(self.imsi_ue_hash, imsi, imsi_len);
 }
 
-mme_ue_t *mme_ue_find_by_guti(ogs_nas_eps_guti_t *guti)
+mme_ue_t *mme_ue_find_by_guti(const ogs_nas_eps_guti_t *guti)
 {
     ogs_assert(guti);
 
@@ -3508,20 +3508,20 @@ mme_ue_t *mme_ue_find_by_gn_local_teid(uint32_t teid)
     return ogs_hash_get(self.mme_gn_teid_hash, &teid, sizeof(teid));
 }
 
-mme_ue_t *mme_ue_find_by_message(ogs_nas_eps_message_t *message)
+mme_ue_t *mme_ue_find_by_message(const ogs_nas_eps_message_t *message)
 {
     mme_ue_t *mme_ue = NULL;
-    ogs_nas_eps_attach_request_t *attach_request = NULL;
-    ogs_nas_eps_detach_request_from_ue_t *detach_request = NULL;
-    ogs_nas_eps_tracking_area_update_request_t *tau_request = NULL;
-    ogs_nas_eps_extended_service_request_t *extended_service_request = NULL;
-    ogs_nas_eps_mobile_identity_t *eps_mobile_identity = NULL;
-    ogs_nas_mobile_identity_t *mobile_identity = NULL;
+    const ogs_nas_eps_attach_request_t *attach_request = NULL;
+    const ogs_nas_eps_detach_request_from_ue_t *detach_request = NULL;
+    const ogs_nas_eps_tracking_area_update_request_t *tau_request = NULL;
+    const ogs_nas_eps_extended_service_request_t *extended_service_request = NULL;
+    const ogs_nas_eps_mobile_identity_t *eps_mobile_identity = NULL;
+    const ogs_nas_mobile_identity_t *mobile_identity = NULL;
 
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
-    ogs_nas_eps_mobile_identity_guti_t *eps_mobile_identity_guti = NULL;
-    ogs_nas_mobile_identity_tmsi_t *mobile_identity_tmsi = NULL;
-    served_gummei_t *served_gummei = NULL;
+    const ogs_nas_eps_mobile_identity_guti_t *eps_mobile_identity_guti = NULL;
+    const ogs_nas_mobile_identity_tmsi_t *mobile_identity_tmsi = NULL;
+    const served_gummei_t *served_gummei = NULL;
     ogs_nas_eps_guti_t ogs_nas_guti;
 
     switch (message->emm.h.message_type) {
@@ -4050,7 +4050,7 @@ void mme_sess_remove_all(mme_ue_t *mme_ue)
     }
 }
 
-mme_sess_t *mme_sess_find_by_pti(mme_ue_t *mme_ue, uint8_t pti)
+mme_sess_t *mme_sess_find_by_pti(const mme_ue_t *mme_ue, uint8_t pti)
 {
     mme_sess_t *sess = NULL;
 
@@ -4065,7 +4065,7 @@ mme_sess_t *mme_sess_find_by_pti(mme_ue_t *mme_ue, uint8_t pti)
     return NULL;
 }
 
-mme_sess_t *mme_sess_find_by_ebi(mme_ue_t *mme_ue, uint8_t ebi)
+mme_sess_t *mme_sess_find_by_ebi(const mme_ue_t *mme_ue, uint8_t ebi)
 {
     mme_bearer_t *bearer = NULL;
 
@@ -4076,7 +4076,7 @@ mme_sess_t *mme_sess_find_by_ebi(mme_ue_t *mme_ue, uint8_t ebi)
     return NULL;
 }
 
-mme_sess_t *mme_sess_find_by_apn(mme_ue_t *mme_ue, char *apn)
+mme_sess_t *mme_sess_find_by_apn(const mme_ue_t *mme_ue, const char *apn)
 {
     mme_sess_t *sess = NULL;
 
@@ -4093,7 +4093,7 @@ mme_sess_t *mme_sess_find_by_apn(mme_ue_t *mme_ue, char *apn)
     return NULL;
 }
 
-mme_sess_t *mme_sess_first(mme_ue_t *mme_ue)
+mme_sess_t *mme_sess_first(const mme_ue_t *mme_ue)
 {
     return ogs_list_first(&mme_ue->sess_list);
 }
@@ -4103,7 +4103,7 @@ mme_sess_t *mme_sess_next(mme_sess_t *sess)
     return ogs_list_next(sess);
 }
 
-unsigned int mme_sess_count(mme_ue_t *mme_ue)
+unsigned int mme_sess_count(const mme_ue_t *mme_ue)
 {
     unsigned int count = 0;
     mme_sess_t *sess = NULL;
@@ -4195,7 +4195,7 @@ void mme_bearer_remove_all(mme_sess_t *sess)
     }
 }
 
-mme_bearer_t *mme_bearer_find_by_sess_ebi(mme_sess_t *sess, uint8_t ebi)
+mme_bearer_t *mme_bearer_find_by_sess_ebi(const mme_sess_t *sess, uint8_t ebi)
 {
     mme_bearer_t *bearer = NULL;
 
@@ -4212,7 +4212,7 @@ mme_bearer_t *mme_bearer_find_by_sess_ebi(mme_sess_t *sess, uint8_t ebi)
     return NULL;
 }
 
-mme_bearer_t *mme_bearer_find_by_ue_ebi(mme_ue_t *mme_ue, uint8_t ebi)
+mme_bearer_t *mme_bearer_find_by_ue_ebi(const mme_ue_t *mme_ue, uint8_t ebi)
 {
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
@@ -4443,7 +4443,7 @@ mme_bearer_t *mme_linked_bearer(mme_bearer_t *bearer)
     return mme_default_bearer_in_sess(sess);
 }
 
-mme_bearer_t *mme_bearer_first(mme_sess_t *sess)
+mme_bearer_t *mme_bearer_first(const mme_sess_t *sess)
 {
     ogs_assert(sess);
 
@@ -4476,7 +4476,7 @@ void mme_session_remove_all(mme_ue_t *mme_ue)
     mme_ue->num_of_session = 0;
 }
 
-ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, char *apn)
+ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, const char *apn)
 {
     ogs_session_t *session = NULL;
     int i = 0;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -4082,10 +4082,11 @@ mme_sess_t *mme_sess_find_by_apn(mme_ue_t *mme_ue, char *apn)
 
     sess = mme_sess_first(mme_ue);
     while (sess) {
-        ogs_assert(sess->session->name);
-        if (sess->session && ogs_strcasecmp(sess->session->name, apn) == 0)
-            return sess;
-
+        if (sess->session) {
+            ogs_assert(sess->session->name);
+            if (ogs_strcasecmp(sess->session->name, apn) == 0)
+                return sess;
+        }
         sess = mme_sess_next(sess);
     }
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -881,38 +881,38 @@ int mme_context_parse_config(void);
 mme_sgsn_t *mme_sgsn_add(ogs_sockaddr_t *addr);
 void mme_sgsn_remove(mme_sgsn_t *sgsn);
 void mme_sgsn_remove_all(void);
-mme_sgsn_t *mme_sgsn_find_by_addr(ogs_sockaddr_t *addr);
+mme_sgsn_t *mme_sgsn_find_by_addr(const ogs_sockaddr_t *addr);
 mme_sgsn_t *mme_sgsn_find_by_routing_address(const ogs_nas_rai_t *rai, uint16_t cell_id);
 mme_sgsn_t *mme_sgsn_find_by_default_routing_address(void);
 
 mme_sgw_t *mme_sgw_add(ogs_sockaddr_t *addr);
 void mme_sgw_remove(mme_sgw_t *sgw);
 void mme_sgw_remove_all(void);
-mme_sgw_t *mme_sgw_find_by_addr(ogs_sockaddr_t *addr);
+mme_sgw_t *mme_sgw_find_by_addr(const ogs_sockaddr_t *addr);
 
 mme_pgw_t *mme_pgw_add(ogs_sockaddr_t *addr);
 void mme_pgw_remove(mme_pgw_t *pgw);
 void mme_pgw_remove_all(void);
 ogs_sockaddr_t *mme_pgw_addr_find_by_apn_enb(
-        ogs_list_t *list, int family, mme_sess_t *sess);
+        ogs_list_t *list, int family, const mme_sess_t *sess);
 
 mme_vlr_t *mme_vlr_add(ogs_sockaddr_t *sa_list, ogs_sockopt_t *option);
 void mme_vlr_remove(mme_vlr_t *vlr);
 void mme_vlr_remove_all(void);
 void mme_vlr_close(mme_vlr_t *vlr);
-mme_vlr_t *mme_vlr_find_by_addr(ogs_sockaddr_t *addr);
+mme_vlr_t *mme_vlr_find_by_addr(const ogs_sockaddr_t *addr);
 
 mme_csmap_t *mme_csmap_add(mme_vlr_t *vlr);
 void mme_csmap_remove(mme_csmap_t *csmap);
 void mme_csmap_remove_all(void);
 
-mme_csmap_t *mme_csmap_find_by_tai(ogs_eps_tai_t *tai);
-mme_csmap_t *mme_csmap_find_by_nas_lai(ogs_nas_lai_t *lai);
+mme_csmap_t *mme_csmap_find_by_tai(const ogs_eps_tai_t *tai);
+mme_csmap_t *mme_csmap_find_by_nas_lai(const ogs_nas_lai_t *lai);
 
 mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr);
 int mme_enb_remove(mme_enb_t *enb);
 int mme_enb_remove_all(void);
-mme_enb_t *mme_enb_find_by_addr(ogs_sockaddr_t *addr);
+mme_enb_t *mme_enb_find_by_addr(const ogs_sockaddr_t *addr);
 mme_enb_t *mme_enb_find_by_enb_id(uint32_t enb_id);
 int mme_enb_set_enb_id(mme_enb_t *enb, uint32_t enb_id);
 int mme_enb_sock_type(ogs_sock_t *sock);
@@ -922,7 +922,7 @@ enb_ue_t *enb_ue_add(mme_enb_t *enb, uint32_t enb_ue_s1ap_id);
 void enb_ue_remove(enb_ue_t *enb_ue);
 void enb_ue_switch_to_enb(enb_ue_t *enb_ue, mme_enb_t *new_enb);
 enb_ue_t *enb_ue_find_by_enb_ue_s1ap_id(
-        mme_enb_t *enb, uint32_t enb_ue_s1ap_id);
+        const mme_enb_t *enb, uint32_t enb_ue_s1ap_id);
 enb_ue_t *enb_ue_find(uint32_t index);
 enb_ue_t *enb_ue_find_by_mme_ue_s1ap_id(uint32_t mme_ue_s1ap_id);
 enb_ue_t *enb_ue_cycle(enb_ue_t *enb_ue);
@@ -950,13 +950,13 @@ mme_ue_t *mme_ue_cycle(mme_ue_t *mme_ue);
 void mme_ue_fsm_init(mme_ue_t *mme_ue);
 void mme_ue_fsm_fini(mme_ue_t *mme_ue);
 
-mme_ue_t *mme_ue_find_by_imsi(uint8_t *imsi, int imsi_len);
-mme_ue_t *mme_ue_find_by_imsi_bcd(char *imsi_bcd);
-mme_ue_t *mme_ue_find_by_guti(ogs_nas_eps_guti_t *nas_guti);
+mme_ue_t *mme_ue_find_by_imsi(const uint8_t *imsi, int imsi_len);
+mme_ue_t *mme_ue_find_by_imsi_bcd(const char *imsi_bcd);
+mme_ue_t *mme_ue_find_by_guti(const ogs_nas_eps_guti_t *nas_guti);
 mme_ue_t *mme_ue_find_by_s11_local_teid(uint32_t teid);
 mme_ue_t *mme_ue_find_by_gn_local_teid(uint32_t teid);
 
-mme_ue_t *mme_ue_find_by_message(ogs_nas_eps_message_t *message);
+mme_ue_t *mme_ue_find_by_message(const ogs_nas_eps_message_t *message);
 int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd);
 
 bool mme_ue_have_indirect_tunnel(mme_ue_t *mme_ue);
@@ -1032,29 +1032,29 @@ void sgw_ue_source_deassociate_target(sgw_ue_t *sgw_ue);
 mme_sess_t *mme_sess_add(mme_ue_t *mme_ue, uint8_t pti);
 void mme_sess_remove(mme_sess_t *sess);
 void mme_sess_remove_all(mme_ue_t *mme_ue);
-mme_sess_t *mme_sess_find_by_pti(mme_ue_t *mme_ue, uint8_t pti);
-mme_sess_t *mme_sess_find_by_ebi(mme_ue_t *mme_ue, uint8_t ebi);
-mme_sess_t *mme_sess_find_by_apn(mme_ue_t *mme_ue, char *apn);
+mme_sess_t *mme_sess_find_by_pti(const mme_ue_t *mme_ue, uint8_t pti);
+mme_sess_t *mme_sess_find_by_ebi(const mme_ue_t *mme_ue, uint8_t ebi);
+mme_sess_t *mme_sess_find_by_apn(const mme_ue_t *mme_ue, const char *apn);
 
-mme_sess_t *mme_sess_first(mme_ue_t *mme_ue);
+mme_sess_t *mme_sess_first(const mme_ue_t *mme_ue);
 mme_sess_t *mme_sess_next(mme_sess_t *sess);
-unsigned int mme_sess_count(mme_ue_t *mme_ue);
+unsigned int mme_sess_count(const mme_ue_t *mme_ue);
 
 mme_bearer_t *mme_bearer_add(mme_sess_t *sess);
 void mme_bearer_remove(mme_bearer_t *bearer);
 void mme_bearer_remove_all(mme_sess_t *sess);
-mme_bearer_t *mme_bearer_find_by_sess_ebi(mme_sess_t *sess, uint8_t ebi);
-mme_bearer_t *mme_bearer_find_by_ue_ebi(mme_ue_t *mme_ue, uint8_t ebi);
+mme_bearer_t *mme_bearer_find_by_sess_ebi(const mme_sess_t *sess, uint8_t ebi);
+mme_bearer_t *mme_bearer_find_by_ue_ebi(const mme_ue_t *mme_ue, uint8_t ebi);
 mme_bearer_t *mme_bearer_find_or_add_by_message(
         mme_ue_t *mme_ue, ogs_nas_eps_message_t *message, int create_action);
 mme_bearer_t *mme_default_bearer_in_sess(mme_sess_t *sess);
 mme_bearer_t *mme_linked_bearer(mme_bearer_t *bearer);
-mme_bearer_t *mme_bearer_first(mme_sess_t *sess);
+mme_bearer_t *mme_bearer_first(const mme_sess_t *sess);
 mme_bearer_t *mme_bearer_next(mme_bearer_t *bearer);
 mme_bearer_t *mme_bearer_cycle(mme_bearer_t *bearer);
 
 void mme_session_remove_all(mme_ue_t *mme_ue);
-ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, char *apn);
+ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, const char *apn);
 ogs_session_t *mme_default_session(mme_ue_t *mme_ue);
 
 int mme_find_served_tai(ogs_eps_tai_t *tai);


### PR DESCRIPTION
The assert is checking for sess->session->name, but afterwards there's a check to skip ses->session not being null, which means the assert can crash while dereferencing sess->session.