### PR TITLE
[core] Fix a couple of warnings when using C++ compiler or more stric…

### DIFF
--- a/lib/core/ogs-list.h
+++ b/lib/core/ogs-list.h
@@ -59,13 +59,13 @@ static ogs_inline void *ogs_list_last(const ogs_list_t *list)
 
 static ogs_inline void *ogs_list_next(void *lnode)
 {
-    ogs_list_t *node = lnode;
+    ogs_list_t *node = (ogs_list_t *)lnode;
     return node->next;
 }
 
 static ogs_inline void *ogs_list_prev(void *lnode)
 {
-    ogs_list_t *node = lnode;
+    ogs_list_t *node = (ogs_list_t *)lnode;
     return node->prev;
 }
 
@@ -100,7 +100,7 @@ static ogs_inline void *ogs_list_prev(void *lnode)
 
 static ogs_inline void ogs_list_prepend(ogs_list_t *list, void *lnode)
 {
-    ogs_list_t *node = lnode;
+    ogs_list_t *node = (ogs_list_t *)lnode;
 
     node->prev = NULL;
     node->next = list->next;
@@ -113,7 +113,7 @@ static ogs_inline void ogs_list_prepend(ogs_list_t *list, void *lnode)
 
 static ogs_inline void ogs_list_add(ogs_list_t *list, void *lnode)
 {
-    ogs_list_t *node = lnode;
+    ogs_list_t *node = (ogs_list_t *)lnode;
 
     node->prev = list->prev;
     node->next = NULL;
@@ -126,7 +126,7 @@ static ogs_inline void ogs_list_add(ogs_list_t *list, void *lnode)
 
 static ogs_inline void ogs_list_remove(ogs_list_t *list, void *lnode)
 {
-    ogs_list_t *node = lnode;
+    ogs_list_t *node = (ogs_list_t *)lnode;
     ogs_list_t *prev = node->prev;
     ogs_list_t *next = node->next;
 
@@ -144,8 +144,8 @@ static ogs_inline void ogs_list_remove(ogs_list_t *list, void *lnode)
 static ogs_inline void ogs_list_insert_prev(
         ogs_list_t *list, void *lnext, void *lnode)
 {
-    ogs_list_t *node = lnode;
-    ogs_list_t *next = lnext;
+    ogs_list_t *node = (ogs_list_t *)lnode;
+    ogs_list_t *next = (ogs_list_t *)lnext;
 
     node->prev = next->prev;
     node->next = next;
@@ -159,8 +159,8 @@ static ogs_inline void ogs_list_insert_prev(
 static ogs_inline void ogs_list_insert_next(
         ogs_list_t *list, void *lprev, void *lnode)
 {
-    ogs_list_t *node = lnode;
-    ogs_list_t *prev = lprev;
+    ogs_list_t *node = (ogs_list_t *)lnode;
+    ogs_list_t *prev = (ogs_list_t *)lprev;
 
     node->prev = prev;
     node->next = prev->next;
@@ -178,11 +178,11 @@ typedef int (*ogs_list_compare_f)(ogs_lnode_t *n1, ogs_lnode_t *n2);
 static ogs_inline void __ogs_list_insert_sorted(
     ogs_list_t *list, void *lnode, ogs_list_compare_f compare)
 {
-    ogs_list_t *node = lnode;
-    ogs_list_t *iter = NULL;
+    ogs_list_t *node = (ogs_list_t *)lnode;
+    void *iter = NULL;
 
     ogs_list_for_each(list, iter) {
-        if ((*compare)(node, iter) < 0) {
+        if ((*compare)(node, (ogs_list_t *)iter) < 0) {
             ogs_list_insert_prev(list, iter, node);
             break;
         }
@@ -199,7 +199,7 @@ static ogs_inline bool ogs_list_empty(const ogs_list_t *list)
 
 static ogs_inline int ogs_list_count(const ogs_list_t *list)
 {
-    ogs_list_t *node;
+    void *node;
     int i = 0;
     ogs_list_for_each(list, node)
         i++;

--- a/lib/core/ogs-pkbuf.h
+++ b/lib/core/ogs-pkbuf.h
@@ -131,14 +131,14 @@ static ogs_inline void ogs_pkbuf_put_u8(ogs_pkbuf_t *pkbuf, uint8_t val)
 
 static ogs_inline void ogs_pkbuf_put_u16(ogs_pkbuf_t *pkbuf, uint16_t val)
 {
-    uint8_t *p = ogs_pkbuf_put(pkbuf, 2);
+    void *p = ogs_pkbuf_put(pkbuf, 2);
     uint16_t tmp = htobe16(val);
     memcpy(p, &tmp, 2);
 }
 
 static ogs_inline void ogs_pkbuf_put_u32(ogs_pkbuf_t *pkbuf, uint32_t val)
 {
-    uint8_t *p = ogs_pkbuf_put(pkbuf, 4);
+    void *p = ogs_pkbuf_put(pkbuf, 4);
     uint32_t tmp = htobe32(val);
     memcpy(p, &tmp, 4);
 }

--- a/lib/core/ogs-rbtree.h
+++ b/lib/core/ogs-rbtree.h
@@ -52,7 +52,7 @@ typedef struct ogs_rbtree_s {
 static ogs_inline void ogs_rbtree_link_node(
         void *rb_node, ogs_rbnode_t *parent, ogs_rbnode_t **rb_link)
 {
-    ogs_rbnode_t *node = rb_node;
+    ogs_rbnode_t *node = (ogs_rbnode_t *)rb_node;
     node->parent = parent;
     node->left = node->right = NULL;
     node->color = OGS_RBTREE_RED;
@@ -76,7 +76,7 @@ static ogs_inline void *ogs_rbtree_min(const ogs_rbnode_t *rb_node)
 
 static ogs_inline void *ogs_rbtree_max(const void *rb_node)
 {
-    const ogs_rbnode_t *node = rb_node;
+    const ogs_rbnode_t *node = (const ogs_rbnode_t *)rb_node;
     ogs_assert(node);
 
     while (node->right)
@@ -105,7 +105,7 @@ static ogs_inline bool ogs_rbtree_empty(const ogs_rbtree_t *tree)
 
 static ogs_inline int ogs_rbtree_count(const ogs_rbtree_t *tree)
 {
-    ogs_rbnode_t *node;
+    void *node;
     int i = 0;
     ogs_rbtree_for_each(tree, node)
         i++;

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -608,6 +608,8 @@ static void handle_sepp_info(
     ogs_assert(nf_instance);
     ogs_assert(SeppInfo);
 
+    http.port = 0;
+    https.port = 0;
     http.presence = false;
     https.presence = false;
 

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -246,11 +246,8 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
             if (val)
                 discovery_option->requester_features =
                     ogs_uint64_from_string(val);
-        } else if (!strcasecmp(key, OGS_SBI_SCHEME)) {
-            /* ':scheme' will be automatically filled in later */
-        } else if (!strcasecmp(key, OGS_SBI_AUTHORITY)) {
-            /* ':authority' will be automatically filled in later */
         } else {
+            /* ':scheme' and ':authority' will be automatically filled in later */
         }
     }
 

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -632,7 +632,8 @@ sgwc_tunnel_t *sgwc_tunnel_add(
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
 
-    uint8_t src_if, dst_if;
+    uint8_t src_if = OGS_PFCP_INTERFACE_UNKNOWN;
+    uint8_t dst_if = OGS_PFCP_INTERFACE_UNKNOWN;
 
     ogs_assert(bearer);
     sess = bearer->sess;

--- a/tests/common/s1ap-handler.c
+++ b/tests/common/s1ap-handler.c
@@ -266,7 +266,8 @@ void tests1ap_handle_e_rab_modify_request(
     S1AP_E_RABModifyRequestIEs_t *ie = NULL;
     S1AP_MME_UE_S1AP_ID_t *MME_UE_S1AP_ID = NULL;
     S1AP_NAS_PDU_t *NAS_PDU = NULL;
-    S1AP_E_RABToBeModifiedListBearerModReq_t *E_RABToBeModifiedListBearerModReq;
+    S1AP_E_RABToBeModifiedListBearerModReq_t *E_RABToBeModifiedListBearerModReq
+        = NULL;
 
     ogs_assert(test_ue);
     ogs_assert(message);
@@ -294,6 +295,7 @@ void tests1ap_handle_e_rab_modify_request(
     if (MME_UE_S1AP_ID)
         test_ue->mme_ue_s1ap_id = *MME_UE_S1AP_ID;
 
+    ogs_assert(E_RABToBeModifiedListBearerModReq);
     for (i = 0; i < E_RABToBeModifiedListBearerModReq->list.count; i++) {
         S1AP_E_RABToBeModifiedItemBearerModReqIEs_t *ie2 = NULL;
         S1AP_E_RABToBeModifiedItemBearerModReq_t *e_rab = NULL;


### PR DESCRIPTION
…t settings

../lib/core/ogs-list.h:62:24: warning: invalid conversion from 'void*' to 'ogs_list_t*' {aka 'ogs_list_s*'} [-fpermissive]
../lib/core/ogs-rbtree.h:79:32: warning: invalid conversion from 'const void*' to 'const ogs_rbnode_t*' {aka 'const ogs_rbnode_s*'} [-fpermissive]

[SBI] Fix compiler error - possible uninitialized variable

[SCP] Fix compiler error - Error: this condition has identical branches

In case of additional compiler warnings turned on, the compiler warns about potentially unused variables. Fix those issues.