### PR TITLE
[SBI] Fix conversion of AMBR bitrates from string to integer

### DIFF
--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -717,6 +717,7 @@ uint64_t ogs_sbi_bitrate_from_string(char *str)
     char *unit = NULL;
     uint64_t bitrate = 0;
     ogs_assert(str);
+    uint64_t mul = 1;
 
     unit = strrchr(str, ' ');
     bitrate = atoll(str);
@@ -728,15 +729,25 @@ uint64_t ogs_sbi_bitrate_from_string(char *str)
 
     SWITCH(unit+1)
     CASE("Kbps")
-        return bitrate * 1000;
+        mul = 1000ul;
+        break;
     CASE("Mbps")
-        return bitrate * 1000 * 1000;
+        mul = 1000ul * 1000ul;
+        break;
     CASE("Gbps")
-        return bitrate * 1000 * 1000 * 1000;
+        mul = 1000ul * 1000ul * 1000ul;
+        break;
     CASE("Tbps")
-        return bitrate * 1000 * 1000 * 1000 * 1000;
+        mul = 1000ul * 1000ul * 1000ul * 1000ul;
+        break;
     DEFAULT
     END
+
+    if (bitrate >= (INT64_MAX / mul))
+        bitrate = INT64_MAX;
+    else
+        bitrate *= mul;
+
     return bitrate;
 }
 


### PR DESCRIPTION
When the input string contains a number and a unit too large to be represented by a 64-bit variable, AMF/SMF would crash due to conversion resulting in a negative value and unable to be used in compiling NAS-PDU container.
Now the value gets clipped at int64_t maximum value.

Failed to encode ASN-PDU [-1] (../lib/asn1c/util/message.c:42)