### PR TITLE
[AMF] Issue during Concurrent UE Registration (#2839)

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -690,9 +690,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                     break;
                 }
 
-                amf_ue = sess->amf_ue;
-                ogs_assert(amf_ue);
-                amf_ue = amf_ue_cycle(amf_ue);
+                amf_ue = amf_ue_cycle(sess->amf_ue);
                 if (!amf_ue) {
                     ogs_error("UE(amf_ue) Context has already been removed");
                     break;
@@ -701,13 +699,13 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 ogs_error("[%d:%d] Cannot receive SBI message",
                         sess->psi, sess->pti);
                 if (sess->payload_container_type) {
-                    r = nas_5gs_send_back_gsm_message(sess,
+                    r = nas_5gs_send_back_gsm_message(sess->ran_ue, sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                 } else {
-                    r = ngap_send_error_indication2(amf_ue,
+                    r = ngap_send_error_indication2(sess->ran_ue,
                             NGAP_Cause_PR_transport,
                             NGAP_CauseTransport_transport_resource_unavailable);
                     ogs_expect(r == OGS_OK);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -697,6 +697,7 @@ typedef struct amf_sess_s {
 
     /* Related Context */
     amf_ue_t        *amf_ue;
+    ran_ue_t        *ran_ue;
 
     ogs_s_nssai_t s_nssai;
     ogs_s_nssai_t mapped_hplmn;

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1016,7 +1016,7 @@ ogs_nas_5gmm_cause_t gmm_handle_security_mode_complete(amf_ue_t *amf_ue,
     return OGS_5GMM_CAUSE_REQUEST_ACCEPTED;
 }
 
-int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
+int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
         ogs_nas_5gs_ul_nas_transport_t *ul_nas_transport)
 {
     int r;
@@ -1031,7 +1031,8 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
     ogs_nas_dnn_t *dnn = NULL;
     ogs_nas_5gsm_header_t *gsm_header = NULL;
 
-    ogs_assert(amf_ue);
+    ogs_assert(amf_ue_cycle(amf_ue));
+    ogs_assert(ran_ue_cycle(ran_ue));
     ogs_assert(ul_nas_transport);
 
     payload_container_type = &ul_nas_transport->payload_container_type;
@@ -1318,7 +1319,7 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
             if (!SESSION_CONTEXT_IN_SMF(sess)) {
                 ogs_error("[%s:%d] Session Context is not in SMF [%d]",
                     amf_ue->supi, sess->psi, gsm_header->message_type);
-                r = nas_5gs_send_back_gsm_message(sess,
+                r = nas_5gs_send_back_gsm_message(ran_ue, sess,
                         OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE, 0);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);

--- a/src/amf/gmm-handler.h
+++ b/src/amf/gmm-handler.h
@@ -50,7 +50,8 @@ ogs_nas_5gmm_cause_t gmm_handle_identity_response(amf_ue_t *amf_ue,
 ogs_nas_5gmm_cause_t gmm_handle_security_mode_complete(amf_ue_t *amf_ue,
         ogs_nas_5gs_security_mode_complete_t *security_mode_complete);
 
-int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
+int gmm_handle_ul_nas_transport(
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue,
         ogs_nas_5gs_ul_nas_transport_t *ul_nas_transport);
 
 #ifdef __cplusplus

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1132,8 +1132,8 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
     ogs_nas_5gmm_cause_t gmm_cause;
 
     amf_ue_t *amf_ue = NULL;
-    amf_sess_t *sess = NULL;
     ran_ue_t *ran_ue = NULL;
+    amf_sess_t *sess = NULL;
     ogs_nas_5gs_message_t *nas_message = NULL;
     ogs_nas_security_header_type_t h;
 
@@ -1187,7 +1187,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("gmm_handle_registration_request() failed [%d]",
                             gmm_cause);
-                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1216,7 +1216,8 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                 if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                     ogs_error("[%s] gmm_handle_registration_update() "
                                 "failed [%d]", amf_ue->suci, gmm_cause);
-                    r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                    r = nas_5gs_send_registration_reject(
+                            ran_ue, amf_ue, gmm_cause);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                     OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1228,7 +1229,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                     if (amf_update_allowed_nssai(amf_ue) == false) {
                         ogs_error("No Allowed-NSSAI");
                         r = nas_5gs_send_gmm_reject(
-                                amf_ue,
+                                ran_ue, amf_ue,
                                 OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
                         ogs_expect(r == OGS_OK);
                         ogs_assert(r != OGS_ERROR);
@@ -1292,7 +1293,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
             if (state != GMM_COMMON_STATE_REGISTERED) {
                 ogs_info("[%s] Handling service request failed [Not registered]",
                             amf_ue->suci);
-                r = nas_5gs_send_service_reject(amf_ue,
+                r = nas_5gs_send_service_reject(ran_ue, amf_ue,
                     OGS_5GMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
@@ -1305,7 +1306,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("[%s] gmm_handle_service_request() failed [%d]",
                             amf_ue->suci, gmm_cause);
-                r = nas_5gs_send_service_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_service_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1314,7 +1315,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
 
             if (!AMF_UE_HAVE_SUCI(amf_ue)) {
                 ogs_info("Service request : Unknown UE");
-                r = nas_5gs_send_service_reject(amf_ue,
+                r = nas_5gs_send_service_reject(ran_ue, amf_ue,
                     OGS_5GMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
@@ -1324,7 +1325,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
 
             if (!h.integrity_protected || !SECURITY_CONTEXT_IS_VALID(amf_ue)) {
                 ogs_error("No Security Context");
-                r = nas_5gs_send_service_reject(amf_ue,
+                r = nas_5gs_send_service_reject(ran_ue, amf_ue,
                     OGS_5GMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
@@ -1344,7 +1345,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("[%s] gmm_handle_service_update() failed [%d]",
                             amf_ue->suci, gmm_cause);
-                r = nas_5gs_send_service_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_service_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1364,7 +1365,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
                 ogs_error("gmm_handle_identity_response() "
                             "failed [%d] in type [%d]",
                             gmm_cause, amf_ue->nas.message_type);
-                r = nas_5gs_send_gmm_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_gmm_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1373,7 +1374,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
 
             if (!AMF_UE_HAVE_SUCI(amf_ue)) {
                 ogs_error("No SUCI");
-                r = nas_5gs_send_gmm_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_gmm_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1481,7 +1482,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
             }
 
             gmm_handle_ul_nas_transport(
-                    amf_ue, &nas_message->gmm.ul_nas_transport);
+                    ran_ue, amf_ue, &nas_message->gmm.ul_nas_transport);
             break;
 
         case OGS_NAS_5GS_REGISTRATION_COMPLETE:
@@ -1506,6 +1507,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
     ogs_nas_5gmm_cause_t gmm_cause;
 
     amf_ue_t *amf_ue = NULL;
+    ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
 
     ogs_nas_5gs_message_t *nas_message = NULL;
@@ -1539,6 +1541,9 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
     case AMF_EVENT_5GMM_MESSAGE:
         nas_message = e->nas.message;
         ogs_assert(nas_message);
+
+        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ogs_assert(ran_ue);
 
         h.type = e->nas.type;
 
@@ -1626,7 +1631,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("[%s] gmm_handle_registration_request() failed [%d]",
                             amf_ue->suci, gmm_cause);
-                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1801,6 +1806,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
     int r;
     ogs_nas_5gmm_cause_t gmm_cause;
     amf_ue_t *amf_ue = NULL;
+    ran_ue_t *ran_ue = NULL;
     ogs_nas_5gs_message_t *nas_message = NULL;
     ogs_nas_security_header_type_t h;
 
@@ -1824,6 +1830,9 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
     case AMF_EVENT_5GMM_MESSAGE:
         nas_message = e->nas.message;
         ogs_assert(nas_message);
+
+        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ogs_assert(ran_ue);
 
         h.type = e->nas.type;
 
@@ -1873,7 +1882,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
                 ogs_error("[%s] gmm_handle_security_mode_complete() "
                             "failed [%d] in type [%d]",
                             amf_ue->suci, gmm_cause, amf_ue->nas.message_type);
-                r = nas_5gs_send_gmm_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_gmm_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1917,7 +1926,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("[%s] gmm_handle_registration_request() failed [%d]",
                             amf_ue->suci, gmm_cause);
-                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -1935,7 +1944,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
 
         case OGS_NAS_5GS_SERVICE_REQUEST:
             ogs_info("[%s] Service request", amf_ue->supi);
-            r = nas_5gs_send_service_reject(amf_ue,
+            r = nas_5gs_send_service_reject(ran_ue, amf_ue,
                     OGS_5GMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -1967,7 +1976,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
             if (amf_ue->t3560.retry_count >=
                     amf_timer_cfg(AMF_TIMER_T3560)->max_count) {
                 ogs_warn("[%s] Retransmission failed. Stop", amf_ue->supi);
-                r = nas_5gs_send_gmm_reject(amf_ue,
+                r = nas_5gs_send_gmm_reject(amf_ue->ran_ue, amf_ue,
                         OGS_5GMM_CAUSE_SECURITY_MODE_REJECTED_UNSPECIFIED);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
@@ -1997,6 +2006,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
     ogs_nas_5gmm_cause_t gmm_cause;
 
     amf_ue_t *amf_ue = NULL;
+    ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
     ogs_nas_5gs_message_t *nas_message = NULL;
     ogs_nas_security_header_type_t h;
@@ -2041,7 +2051,8 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
                     r = nas_5gs_send_gmm_reject(
-                            amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
+                            amf_ue->ran_ue, amf_ue,
+                            OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -2085,7 +2096,8 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
                     r = nas_5gs_send_gmm_reject(
-                            amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
+                            amf_ue->ran_ue, amf_ue,
+                            OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                     OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
@@ -2170,6 +2182,9 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
     case AMF_EVENT_5GMM_MESSAGE:
         nas_message = e->nas.message;
         ogs_assert(nas_message);
+
+        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ogs_assert(ran_ue);
 
         h.type = e->nas.type;
 
@@ -2266,7 +2281,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("[%s] gmm_handle_registration_request() failed [%d]",
                             amf_ue->suci, gmm_cause);
-                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -2290,7 +2305,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
 
         case OGS_NAS_5GS_SERVICE_REQUEST:
             ogs_info("[%s] Service request", amf_ue->supi);
-            r = nas_5gs_send_service_reject(amf_ue,
+            r = nas_5gs_send_service_reject(ran_ue, amf_ue,
                 OGS_5GMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2444,7 +2459,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
             if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                 ogs_error("gmm_handle_registration_request() failed [%d]",
                             gmm_cause);
-                r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                r = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 OGS_FSM_TRAN(s, gmm_state_exception);
@@ -2475,7 +2490,8 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
                 if (gmm_cause != OGS_5GMM_CAUSE_REQUEST_ACCEPTED) {
                     ogs_error("[%s] gmm_handle_registration_update() "
                                 "failed [%d]", amf_ue->suci, gmm_cause);
-                    r = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+                    r = nas_5gs_send_registration_reject(
+                            ran_ue, amf_ue, gmm_cause);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                     OGS_FSM_TRAN(s, gmm_state_exception);
@@ -2487,7 +2503,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
                     if (amf_update_allowed_nssai(amf_ue) == false) {
                         ogs_error("No Allowed-NSSAI");
                         r = nas_5gs_send_gmm_reject(
-                                amf_ue,
+                                ran_ue, amf_ue,
                                 OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
                         ogs_expect(r == OGS_OK);
                         ogs_assert(r != OGS_ERROR);

--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -27,7 +27,8 @@ int nas_5gs_send_to_gnb(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
     int rv;
     ogs_assert(pkbuf);
 
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         ogs_pkbuf_free(pkbuf);
         return OGS_NOTFOUND;
@@ -39,35 +40,23 @@ int nas_5gs_send_to_gnb(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
     return rv;
 }
 
-int nas_5gs_send_to_downlink_nas_transport(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
+int nas_5gs_send_to_downlink_nas_transport(
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
 {
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
-    ran_ue_t *ran_ue = NULL;
 
+    ogs_assert(ran_ue_cycle(ran_ue));
+    ogs_assert(amf_ue_cycle(amf_ue));
     ogs_assert(pkbuf);
 
-    if (!amf_ue_cycle(amf_ue)) {
-        ogs_error("UE(amf-ue) context has already been removed");
-        ogs_pkbuf_free(pkbuf);
-        return OGS_NOTFOUND;
-    }
-
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
-    if (!ran_ue) {
-        ogs_error("NG context has already been removed");
-        ogs_pkbuf_free(pkbuf);
-        return OGS_NOTFOUND;
-    }
-
-    ngapbuf = ngap_build_downlink_nas_transport(
-            ran_ue, pkbuf, false, false);
+    ngapbuf = ngap_build_downlink_nas_transport(ran_ue, pkbuf, false, false);
     if (!ngapbuf) {
         ogs_error("ngap_build_downlink_nas_transport() failed");
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
+    rv = ngap_send_to_ran_ue(ran_ue, ngapbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -184,15 +173,13 @@ int nas_5gs_send_registration_accept(amf_ue_t *amf_ue)
 }
 
 int nas_5gs_send_registration_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
 {
     int rv;
     ogs_pkbuf_t *gmmbuf = NULL;
 
-    if (!amf_ue_cycle(amf_ue)) {
-        ogs_error("UE(amf-ue) context has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(ran_ue_cycle(ran_ue));
+    ogs_assert(amf_ue_cycle(amf_ue));
 
     switch (amf_ue->nas.registration.value) {
     case OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL:
@@ -224,7 +211,7 @@ int nas_5gs_send_registration_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -303,7 +290,8 @@ int nas_5gs_send_service_accept(amf_ue_t *amf_ue)
             rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
             ogs_expect(rv == OGS_OK);
         } else {
-            rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+            rv = nas_5gs_send_to_downlink_nas_transport(
+                    amf_ue->ran_ue, amf_ue, gmmbuf);
             ogs_expect(rv == OGS_OK);
         }
     }
@@ -312,20 +300,13 @@ int nas_5gs_send_service_accept(amf_ue_t *amf_ue)
 }
 
 int nas_5gs_send_service_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
 {
     int rv;
     ogs_pkbuf_t *gmmbuf = NULL;
 
-    if (!amf_ue_cycle(amf_ue)) {
-        ogs_error("UE(amf-ue) context has already been removed");
-        return OGS_NOTFOUND;
-    }
-
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(ran_ue_cycle(ran_ue));
+    ogs_assert(amf_ue_cycle(amf_ue));
 
     ogs_debug("[%s] Service reject", amf_ue->supi);
 
@@ -335,7 +316,7 @@ int nas_5gs_send_service_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -370,7 +351,8 @@ int nas_5gs_send_de_registration_accept(amf_ue_t *amf_ue)
             return OGS_ERROR;
         }
 
-        rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+        rv = nas_5gs_send_to_downlink_nas_transport(
+                amf_ue->ran_ue, amf_ue, gmmbuf);
         if (rv != OGS_OK) {
             ogs_error("nas_5gs_send_to_downlink_nas_transport() failed");
             return rv;
@@ -428,7 +410,8 @@ int nas_5gs_send_de_registration_request(
     ogs_timer_start(amf_ue->t3522.timer,
             amf_timer_cfg(AMF_TIMER_T3522)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(
+            amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -470,7 +453,8 @@ int nas_5gs_send_identity_request(amf_ue_t *amf_ue)
     ogs_timer_start(amf_ue->t3570.timer,
             amf_timer_cfg(AMF_TIMER_T3570)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(
+            amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -514,7 +498,7 @@ int nas_5gs_send_authentication_request(amf_ue_t *amf_ue)
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_AMF_AUTH_REQ);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -545,7 +529,7 @@ int nas_5gs_send_authentication_reject(amf_ue_t *amf_ue)
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_AMF_AUTH_REJECT);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -587,7 +571,7 @@ int nas_5gs_send_security_mode_command(amf_ue_t *amf_ue)
     ogs_timer_start(amf_ue->t3560.timer,
             amf_timer_cfg(AMF_TIMER_T3560)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -648,7 +632,7 @@ int nas_5gs_send_configuration_update_command(
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_MM_CONF_UPDATE);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -693,25 +677,25 @@ int nas_send_pdu_session_setup_request(amf_sess_t *sess,
     if (ran_ue->ue_context_requested == true &&
         ran_ue->initial_context_setup_request_sent == false) {
         ngapbuf = ngap_sess_build_initial_context_setup_request(
-                sess, gmmbuf, n2smbuf);
+                ran_ue, sess, gmmbuf, n2smbuf);
         if (!ngapbuf) {
             ogs_error("ngap_sess_build_initial_context_setup_request() failed");
             return OGS_ERROR;
         }
 
-        rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
+        rv = ngap_send_to_ran_ue(ran_ue, ngapbuf);
         ogs_expect(rv == OGS_OK);
 
         ran_ue->initial_context_setup_request_sent = true;
     } else {
         ngapbuf = ngap_sess_build_pdu_session_resource_setup_request(
-                sess, gmmbuf, n2smbuf);
+                ran_ue, sess, gmmbuf, n2smbuf);
         if (!ngapbuf) {
             ogs_error("ngap_sess_build_initial_context_setup_request() failed");
             return OGS_ERROR;
         }
 
-        rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
+        rv = ngap_send_to_ran_ue(ran_ue, ngapbuf);
         ogs_expect(rv == OGS_OK);
     }
 
@@ -739,7 +723,7 @@ int nas_send_pdu_session_modification_command(amf_sess_t *sess,
     }
     ran_ue = ran_ue_cycle(amf_ue->ran_ue);
     if (!ran_ue) {
-        ogs_warn("NG context has already been removed");
+        ogs_warn("[%s] NG context has already been removed", amf_ue->supi);
         if (n1smbuf) ogs_pkbuf_free(n1smbuf);
         ogs_pkbuf_free(n2smbuf);
         return OGS_NOTFOUND;
@@ -903,34 +887,36 @@ int nas_5gs_send_gmm_status(amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t cause)
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
 }
 
 int nas_5gs_send_gmm_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause)
 {
     int rv;
 
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
+    ran_ue = ran_ue_cycle(ran_ue);
+    if (!ran_ue) {
+        ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
     }
 
     switch(amf_ue->nas.message_type) {
     case OGS_NAS_5GS_REGISTRATION_REQUEST:
-        rv = nas_5gs_send_registration_reject(amf_ue, gmm_cause);
+        rv = nas_5gs_send_registration_reject(ran_ue, amf_ue, gmm_cause);
         ogs_expect(rv == OGS_OK);
         break;
     case OGS_NAS_5GS_SERVICE_REQUEST:
-        rv = nas_5gs_send_service_reject(amf_ue, gmm_cause);
+        rv = nas_5gs_send_service_reject(ran_ue, amf_ue, gmm_cause);
         ogs_expect(rv == OGS_OK);
         break;
     default:
@@ -970,23 +956,16 @@ int nas_5gs_send_gmm_reject_from_sbi(amf_ue_t *amf_ue, int status)
 {
     int rv;
 
-    if (!amf_ue_cycle(amf_ue)) {
-        ogs_error("UE(amf-ue) context has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(amf_ue);
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
-        return OGS_NOTFOUND;
-    }
-
-    rv = nas_5gs_send_gmm_reject(amf_ue, gmm_cause_from_sbi(status));
+    rv = nas_5gs_send_gmm_reject(
+            amf_ue->ran_ue, amf_ue, gmm_cause_from_sbi(status));
     ogs_expect(rv == OGS_OK);
 
     return rv;
 }
 
-int nas_5gs_send_dl_nas_transport(amf_sess_t *sess,
+int nas_5gs_send_dl_nas_transport(ran_ue_t *ran_ue, amf_sess_t *sess,
         uint8_t payload_container_type, ogs_pkbuf_t *payload_container,
         ogs_nas_5gmm_cause_t cause, uint8_t backoff_time)
 {
@@ -996,15 +975,21 @@ int nas_5gs_send_dl_nas_transport(amf_sess_t *sess,
     amf_ue_t *amf_ue = NULL;
 
     ogs_assert(sess);
+    sess = amf_sess_cycle(sess);
+    if (!sess) {
+        ogs_error("Session has already been removed");
+        return OGS_NOTFOUND;
+    }
 
-    amf_ue = sess->amf_ue;
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(sess->amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
+    ran_ue = ran_ue_cycle(ran_ue);
+    if (!ran_ue) {
+        ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
     }
 
@@ -1019,7 +1004,7 @@ int nas_5gs_send_dl_nas_transport(amf_sess_t *sess,
         ogs_error("gmm_build_dl_nas_transport() failed");
         return OGS_ERROR;
     }
-    rv = nas_5gs_send_to_downlink_nas_transport(amf_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -1038,22 +1023,28 @@ int nas_5gs_send_dl_nas_transport(amf_sess_t *sess,
  * As such, this function 'nas_5gs_send_gsm_reject()' must be used
  * only when an N1 SM message has been forwarded to the SMF.
  */
-int nas_5gs_send_gsm_reject(amf_sess_t *sess,
+int nas_5gs_send_gsm_reject(ran_ue_t *ran_ue, amf_sess_t *sess,
         uint8_t payload_container_type, ogs_pkbuf_t *payload_container)
 {
     int rv;
     amf_ue_t *amf_ue = NULL;
 
     ogs_assert(sess);
+    sess = amf_sess_cycle(sess);
+    if (!sess) {
+        ogs_error("Session has already been removed");
+        return OGS_NOTFOUND;
+    }
 
-    amf_ue = sess->amf_ue;
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(sess->amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
+    ran_ue = ran_ue_cycle(ran_ue);
+    if (!ran_ue) {
+        ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
     }
 
@@ -1061,29 +1052,36 @@ int nas_5gs_send_gsm_reject(amf_sess_t *sess,
     ogs_assert(payload_container);
 
     rv = nas_5gs_send_dl_nas_transport(
-            sess, payload_container_type, payload_container, 0, 0);
+            ran_ue, sess, payload_container_type, payload_container, 0, 0);
     ogs_expect(rv == OGS_OK);
 
     return rv;
 }
 
 int nas_5gs_send_back_gsm_message(
-        amf_sess_t *sess, ogs_nas_5gmm_cause_t cause, uint8_t backoff_time)
+        ran_ue_t *ran_ue, amf_sess_t *sess,
+        ogs_nas_5gmm_cause_t cause, uint8_t backoff_time)
 {
     int rv;
     ogs_pkbuf_t *pbuf = NULL;
     amf_ue_t *amf_ue = NULL;
 
     ogs_assert(sess);
+    sess = amf_sess_cycle(sess);
+    if (!sess) {
+        ogs_error("Session has already been removed");
+        return OGS_NOTFOUND;
+    }
 
-    amf_ue = sess->amf_ue;
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(sess->amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
+    ran_ue = ran_ue_cycle(ran_ue);
+    if (!ran_ue) {
+        ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
     }
 
@@ -1097,7 +1095,8 @@ int nas_5gs_send_back_gsm_message(
     }
 
     rv = nas_5gs_send_dl_nas_transport(
-            sess, sess->payload_container_type, pbuf, cause, backoff_time);
+            ran_ue, sess, sess->payload_container_type, pbuf,
+            cause, backoff_time);
     ogs_expect(rv == OGS_OK);
 
     return rv;

--- a/src/amf/nas-path.h
+++ b/src/amf/nas-path.h
@@ -30,15 +30,15 @@ extern "C" {
 
 int nas_5gs_send_to_gnb(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf);
 int nas_5gs_send_to_downlink_nas_transport(
-        amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf);
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf);
 
 int nas_5gs_send_registration_accept(amf_ue_t *amf_ue);
 int nas_5gs_send_registration_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 
 int nas_5gs_send_service_accept(amf_ue_t *amf_ue);
 int nas_5gs_send_service_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 
 int nas_5gs_send_de_registration_accept(amf_ue_t *amf_ue);
 int nas_5gs_send_de_registration_request(
@@ -66,17 +66,18 @@ int nas_send_pdu_session_release_command(amf_sess_t *sess,
 int nas_5gs_send_gmm_status(amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t cause);
 
 int nas_5gs_send_gmm_reject(
-        amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t gmm_cause);
 int nas_5gs_send_gmm_reject_from_sbi(amf_ue_t *amf_ue, int status);
 
-int nas_5gs_send_dl_nas_transport(amf_sess_t *sess,
+int nas_5gs_send_dl_nas_transport(ran_ue_t *ran_ue, amf_sess_t *sess,
         uint8_t payload_container_type, ogs_pkbuf_t *payload_container,
         ogs_nas_5gmm_cause_t cause, uint8_t backoff_time);
 
-int nas_5gs_send_gsm_reject(amf_sess_t *sess,
+int nas_5gs_send_gsm_reject(ran_ue_t *ran_ue, amf_sess_t *sess,
         uint8_t payload_container_type, ogs_pkbuf_t *payload_container);
 int nas_5gs_send_back_gsm_message(
-        amf_sess_t *sess, ogs_nas_5gmm_cause_t cause, uint8_t backoff_time);
+        ran_ue_t *ran_ue, amf_sess_t *sess,
+        ogs_nas_5gmm_cause_t cause, uint8_t backoff_time);
 
 #ifdef __cplusplus
 }

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -905,11 +905,11 @@ ogs_pkbuf_t *ngap_build_ue_context_modification_request(amf_ue_t *amf_ue)
 }
 
 ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
-            amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf)
+        ran_ue_t *ran_ue, amf_sess_t *sess,
+        ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf)
 {
     int i;
 
-    ran_ue_t *ran_ue = NULL;
     amf_ue_t *amf_ue = NULL;
 
     NGAP_NGAP_PDU_t pdu;
@@ -931,7 +931,7 @@ ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
     ogs_assert(sess);
     amf_ue = amf_ue_cycle(sess->amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
 
     ogs_debug("InitialContextSetupRequest(Session)");
@@ -1436,10 +1436,10 @@ ogs_pkbuf_t *ngap_ue_build_pdu_session_resource_setup_request(
 }
 
 ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
-    amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf)
+        ran_ue_t *ran_ue, amf_sess_t *sess,
+        ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf)
 {
     amf_ue_t *amf_ue = NULL;
-    ran_ue_t *ran_ue = NULL;
 
     NGAP_NGAP_PDU_t pdu;
     NGAP_InitiatingMessage_t *initiatingMessage = NULL;
@@ -1463,7 +1463,7 @@ ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
 
     amf_ue = amf_ue_cycle(sess->amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
 
     ogs_debug("PDUSessionResourceSetupRequest(Session)");

--- a/src/amf/ngap-build.h
+++ b/src/amf/ngap-build.h
@@ -41,14 +41,16 @@ ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
     amf_ue_t *amf_ue, ogs_pkbuf_t *gmmbuf);
 ogs_pkbuf_t *ngap_build_ue_context_modification_request(amf_ue_t *amf_ue);
 ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
-    amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
+    ran_ue_t *ran_ue, amf_sess_t *sess,
+    ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
 ogs_pkbuf_t *ngap_build_ue_context_release_command(
     ran_ue_t *ran_ue, NGAP_Cause_PR group, long cause);
 
 ogs_pkbuf_t *ngap_ue_build_pdu_session_resource_setup_request(
     amf_ue_t *amf_ue, ogs_pkbuf_t *gmmbuf);
 ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
-    amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
+    ran_ue_t *ran_ue, amf_sess_t *sess,
+    ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
 ogs_pkbuf_t *ngap_build_pdu_session_resource_modify_request(
     amf_sess_t *sess, ogs_pkbuf_t *gmmbuf, ogs_pkbuf_t *n2smbuf);
 ogs_pkbuf_t *ngap_build_pdu_session_resource_release_command(

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -955,7 +955,7 @@ void ngap_handle_initial_context_setup_response(
 
         if (!PDUSessionItem) {
             ogs_error("No PDUSessionResourceSetupItemCxtRes");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -965,7 +965,7 @@ void ngap_handle_initial_context_setup_response(
         transfer = &PDUSessionItem->pDUSessionResourceSetupResponseTransfer;
         if (!transfer) {
             ogs_error("No PDUSessionResourceSetupResponseTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -975,7 +975,7 @@ void ngap_handle_initial_context_setup_response(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -986,7 +986,7 @@ void ngap_handle_initial_context_setup_response(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -997,7 +997,7 @@ void ngap_handle_initial_context_setup_response(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -1563,7 +1563,7 @@ void ngap_handle_ue_context_release_request(
                 if (!PDUSessionItem) {
                     ogs_error("No PDUSessionResourceSetupItemSURes");
                     r = ngap_send_error_indication2(
-                            amf_ue, NGAP_Cause_PR_protocol,
+                            ran_ue, NGAP_Cause_PR_protocol,
                             NGAP_CauseProtocol_semantic_error);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
@@ -1574,7 +1574,7 @@ void ngap_handle_ue_context_release_request(
                         OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
                     ogs_error("PDU Session Identity is unassigned");
                     r = ngap_send_error_indication2(
-                            amf_ue, NGAP_Cause_PR_protocol,
+                            ran_ue, NGAP_Cause_PR_protocol,
                             NGAP_CauseProtocol_semantic_error);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
@@ -1934,7 +1934,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!PDUSessionItem) {
                 ogs_error("No PDUSessionResourceSetupItemSURes");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -1946,7 +1946,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!transfer) {
                 ogs_error("No PDUSessionResourceSetupResponseTransfer");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -1958,7 +1958,7 @@ void ngap_handle_pdu_session_resource_setup_response(
                     OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
                 ogs_error("PDU Session Identity is unassigned");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -1970,7 +1970,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!sess) {
                 ogs_error("Cannot find PDU Session ID [%d]",
                         (int)PDUSessionItem->pDUSessionID);
-                r = ngap_send_error_indication2(amf_ue,
+                r = ngap_send_error_indication2(ran_ue,
                         NGAP_Cause_PR_radioNetwork,
                         NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
                 ogs_expect(r == OGS_OK);
@@ -1981,7 +1981,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!SESSION_CONTEXT_IN_SMF(sess)) {
                 ogs_error("Session Context is not in SMF [%d]",
                         (int)PDUSessionItem->pDUSessionID);
-                r = ngap_send_error_indication2(amf_ue,
+                r = ngap_send_error_indication2(ran_ue,
                         NGAP_Cause_PR_radioNetwork,
                         NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
                 ogs_expect(r == OGS_OK);
@@ -2019,7 +2019,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!PDUSessionFailedItem) {
                 ogs_error("No PDUSessionResourceFailedToSetupItemSURes");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -2033,7 +2033,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!transfer) {
                 ogs_error("No PDUSessionResourceSetupUnsuccessfulTransfer");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -2045,7 +2045,7 @@ void ngap_handle_pdu_session_resource_setup_response(
                     OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
                 ogs_error("PDU Session Identity is unassigned");
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_protocol,
                         NGAP_CauseProtocol_semantic_error);
                 ogs_expect(r == OGS_OK);
@@ -2059,7 +2059,7 @@ void ngap_handle_pdu_session_resource_setup_response(
                 ogs_error("Cannot find PDU Session ID [%d]",
                         (int)PDUSessionFailedItem->pDUSessionID);
                 r = ngap_send_error_indication2(
-                        amf_ue,
+                        ran_ue,
                         NGAP_Cause_PR_radioNetwork,
                         NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
                 ogs_expect(r == OGS_OK);
@@ -2070,7 +2070,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             if (!SESSION_CONTEXT_IN_SMF(sess)) {
                 ogs_error("Session Context is not in SMF [%d]",
                         (int)PDUSessionFailedItem->pDUSessionID);
-                r = ngap_send_error_indication2(amf_ue,
+                r = ngap_send_error_indication2(ran_ue,
                         NGAP_Cause_PR_radioNetwork,
                         NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
                 ogs_expect(r == OGS_OK);
@@ -2137,7 +2137,7 @@ void ngap_handle_pdu_session_resource_setup_response(
         }
     } else {
         ogs_error("No PDUSessionResourceList");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2249,7 +2249,7 @@ void ngap_handle_pdu_session_resource_modify_response(
 
     if (!PDUSessionList) {
         ogs_error("No PDUSessionResourceModifyListModRes");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2263,7 +2263,7 @@ void ngap_handle_pdu_session_resource_modify_response(
 
         if (!PDUSessionItem) {
             ogs_error("No PDUSessionResourceModifyItemModRes");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2273,7 +2273,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         transfer = &PDUSessionItem->pDUSessionResourceModifyResponseTransfer;
         if (!transfer) {
             ogs_error("No PDUSessionResourceModifyResponseTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2283,7 +2283,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2294,7 +2294,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -2305,7 +2305,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -2436,7 +2436,7 @@ void ngap_handle_pdu_session_resource_release_response(
 
     if (!PDUSessionList) {
         ogs_error("No PDUSessionResourceReleasedListRelRes");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2450,7 +2450,7 @@ void ngap_handle_pdu_session_resource_release_response(
 
         if (!PDUSessionItem) {
             ogs_error("No PDUSessionResourceReleasedItemRelRes");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2460,7 +2460,7 @@ void ngap_handle_pdu_session_resource_release_response(
         transfer = &PDUSessionItem->pDUSessionResourceReleaseResponseTransfer;
         if (!transfer) {
             ogs_error("No PDUSessionResourceReleaseResponseTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2470,7 +2470,7 @@ void ngap_handle_pdu_session_resource_release_response(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2481,7 +2481,7 @@ void ngap_handle_pdu_session_resource_release_response(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -2492,7 +2492,7 @@ void ngap_handle_pdu_session_resource_release_response(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -2791,7 +2791,7 @@ void ngap_handle_path_switch_request(
 
     if (!UserLocationInformation) {
         ogs_error("No UserLocationInformation");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2802,7 +2802,7 @@ void ngap_handle_path_switch_request(
             NGAP_UserLocationInformation_PR_userLocationInformationNR) {
         ogs_error("Not implemented UserLocationInformation[%d]",
                 UserLocationInformation->present);
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_unspecified);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2811,7 +2811,7 @@ void ngap_handle_path_switch_request(
 
     if (!UESecurityCapabilities) {
         ogs_error("No UESecurityCapabilities");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2820,7 +2820,7 @@ void ngap_handle_path_switch_request(
 
     if (!PDUSessionResourceToBeSwitchedDLList) {
         ogs_error("No PDUSessionResourceToBeSwitchedDLList");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2829,7 +2829,7 @@ void ngap_handle_path_switch_request(
 
     if (!SECURITY_CONTEXT_IS_VALID(amf_ue)) {
         ogs_error("No Security Context");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(ran_ue,
                 NGAP_Cause_PR_nas, NGAP_CauseNas_authentication_failure);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2915,7 +2915,7 @@ void ngap_handle_path_switch_request(
 
         if (!PDUSessionItem) {
             ogs_error("No NGAP_PDUSessionResourceToBeSwitchedDLItem");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2925,7 +2925,7 @@ void ngap_handle_path_switch_request(
         transfer = &PDUSessionItem->pathSwitchRequestTransfer;
         if (!transfer) {
             ogs_error("No PDUSessionResourceSetupResponseTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2935,7 +2935,7 @@ void ngap_handle_path_switch_request(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -2946,7 +2946,7 @@ void ngap_handle_path_switch_request(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -2957,7 +2957,7 @@ void ngap_handle_path_switch_request(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(ran_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -3110,7 +3110,7 @@ void ngap_handle_handover_required(
 
     if (!HandoverType) {
         ogs_error("No HandoverType");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3119,7 +3119,7 @@ void ngap_handle_handover_required(
 
     if (!Cause) {
         ogs_error("No Cause");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3128,7 +3128,7 @@ void ngap_handle_handover_required(
 
     if (!TargetID) {
         ogs_error("No TargetID");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3137,7 +3137,7 @@ void ngap_handle_handover_required(
 
     if (TargetID->present != NGAP_TargetID_PR_targetRANNodeID) {
         ogs_error("Not implemented TargetID[%d]", TargetID->present);
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3146,7 +3146,7 @@ void ngap_handle_handover_required(
     targetRANNodeID = TargetID->choice.targetRANNodeID;
     if (!targetRANNodeID) {
         ogs_error("No targetRANNodeID");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3157,7 +3157,7 @@ void ngap_handle_handover_required(
     if (globalRANNodeID->present != NGAP_GlobalRANNodeID_PR_globalGNB_ID) {
         ogs_error("Not implemented globalRANNodeID[%d]",
                 globalRANNodeID->present);
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3167,7 +3167,7 @@ void ngap_handle_handover_required(
     globalGNB_ID = globalRANNodeID->choice.globalGNB_ID;
     if (!globalGNB_ID) {
         ogs_error("No globalGNB_ID");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3179,7 +3179,7 @@ void ngap_handle_handover_required(
     if (!target_gnb) {
         ogs_error("Handover required : cannot find target gNB-id[0x%x]",
                 target_gnb_id);
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3188,7 +3188,7 @@ void ngap_handle_handover_required(
 
     if (!PDUSessionList) {
         ogs_error("No PDUSessionList");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3197,7 +3197,7 @@ void ngap_handle_handover_required(
 
     if (!SourceToTarget_TransparentContainer) {
         ogs_error("No SourceToTarget_TransparentContainer");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3206,7 +3206,7 @@ void ngap_handle_handover_required(
 
     if (!SECURITY_CONTEXT_IS_VALID(amf_ue)) {
         ogs_error("No Security Context");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_nas, NGAP_CauseNas_authentication_failure);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3216,7 +3216,7 @@ void ngap_handle_handover_required(
     /* Target UE */
     target_ue = ran_ue_add(target_gnb, INVALID_UE_NGAP_ID);
     if (target_ue == NULL) {
-        r = ngap_send_error_indication2(amf_ue, NGAP_Cause_PR_misc,
+        r = ngap_send_error_indication2(source_ue, NGAP_Cause_PR_misc,
                 NGAP_CauseMisc_control_processing_overload);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3260,7 +3260,7 @@ void ngap_handle_handover_required(
 
         if (!PDUSessionItem) {
             ogs_error("No PDUSessionResourceItemHORqd");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(source_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3270,7 +3270,7 @@ void ngap_handle_handover_required(
         transfer = &PDUSessionItem->handoverRequiredTransfer;
         if (!transfer) {
             ogs_error("No handoverRequiredTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(source_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3280,7 +3280,7 @@ void ngap_handle_handover_required(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(source_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3291,7 +3291,7 @@ void ngap_handle_handover_required(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(source_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -3302,7 +3302,7 @@ void ngap_handle_handover_required(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(source_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -3474,7 +3474,7 @@ void ngap_handle_handover_request_ack(
 
     if (!PDUSessionList) {
         ogs_error("No PDUSessionList");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(target_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3483,7 +3483,7 @@ void ngap_handle_handover_request_ack(
 
     if (!TargetToSource_TransparentContainer) {
         ogs_error("No TargetToSource_TransparentContainer");
-        r = ngap_send_error_indication2(amf_ue,
+        r = ngap_send_error_indication2(target_ue,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3501,7 +3501,7 @@ void ngap_handle_handover_request_ack(
 
         if (!PDUSessionItem) {
             ogs_error("No PDUSessionResourceAdmittedItem");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(target_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3511,7 +3511,7 @@ void ngap_handle_handover_request_ack(
         transfer = &PDUSessionItem->handoverRequestAcknowledgeTransfer;
         if (!transfer) {
             ogs_error("No handoverRequestAcknowledgeTransfer");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(target_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3521,7 +3521,7 @@ void ngap_handle_handover_request_ack(
         if (PDUSessionItem->pDUSessionID ==
                 OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
             ogs_error("PDU Session Identity is unassigned");
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(target_ue,
                     NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -3532,7 +3532,7 @@ void ngap_handle_handover_request_ack(
         if (!sess) {
             ogs_error("Cannot find PDU Session ID [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(target_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);
@@ -3543,7 +3543,7 @@ void ngap_handle_handover_request_ack(
         if (!SESSION_CONTEXT_IN_SMF(sess)) {
             ogs_error("Session Context is not in SMF [%d]",
                     (int)PDUSessionItem->pDUSessionID);
-            r = ngap_send_error_indication2(amf_ue,
+            r = ngap_send_error_indication2(target_ue,
                     NGAP_Cause_PR_radioNetwork,
                     NGAP_CauseRadioNetwork_unknown_PDU_session_ID);
             ogs_expect(r == OGS_OK);

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -494,18 +494,25 @@ int ngap_send_path_switch_ack(amf_sess_t *sess)
     int rv;
 
     amf_ue_t *amf_ue = NULL;
+    ran_ue_t *ran_ue = NULL;
     ogs_pkbuf_t *ngapbuf = NULL;
 
     ogs_assert(sess);
+    sess = amf_sess_cycle(sess);
+    if (!sess) {
+        ogs_error("Session has already been removed");
+        return OGS_NOTFOUND;
+    }
 
-    amf_ue = sess->amf_ue;
-    if (!amf_ue_cycle(amf_ue)) {
+    amf_ue = amf_ue_cycle(sess->amf_ue);
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!ran_ue_cycle(amf_ue->ran_ue)) {
-        ogs_error("NG context has already been removed");
+    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    if (!ran_ue) {
+        ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
     }
 
@@ -687,17 +694,11 @@ int ngap_send_error_indication(
 }
 
 int ngap_send_error_indication2(
-        amf_ue_t *amf_ue, NGAP_Cause_PR group, long cause)
+        ran_ue_t *ran_ue, NGAP_Cause_PR group, long cause)
 {
     int rv;
-    ran_ue_t *ran_ue;
 
-    if (!amf_ue_cycle(amf_ue)) {
-        ogs_error("UE(amf-ue) context has already been removed");
-        return OGS_NOTFOUND;
-    }
-
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_cycle(ran_ue);
     if (!ran_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;

--- a/src/amf/ngap-path.h
+++ b/src/amf/ngap-path.h
@@ -82,7 +82,7 @@ int ngap_send_error_indication(
         uint64_t *amf_ue_ngap_id,
         NGAP_Cause_PR group, long cause);
 int ngap_send_error_indication2(
-        amf_ue_t *amf_ue, NGAP_Cause_PR group, long cause);
+        ran_ue_t *ran_ue, NGAP_Cause_PR group, long cause);
 int ngap_send_ng_reset_ack(
         amf_gnb_t *gnb,
         NGAP_UE_associatedLogicalNG_connectionList_t *partOfNG_Interface);

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -79,19 +79,16 @@ void amf_nnrf_handle_nf_discover(
             sess = (amf_sess_t *)sbi_object;
             ogs_assert(sess);
                         
-            amf_ue = sess->amf_ue;
-            ogs_assert(amf_ue);
-                        
             ogs_error("[%d:%d] (NF discover) No [%s]", sess->psi, sess->pti,
                         ogs_sbi_service_type_to_name(service_type));
             if (sess->payload_container_type) {
-                r = nas_5gs_send_back_gsm_message(sess,
+                r = nas_5gs_send_back_gsm_message(sess->ran_ue, sess,
                         OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                         AMF_NAS_BACKOFF_TIME);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
             } else {
-                r = ngap_send_error_indication2(amf_ue,
+                r = ngap_send_error_indication2(sess->ran_ue,
                         NGAP_Cause_PR_transport,
                         NGAP_CauseTransport_transport_resource_unavailable);
                 ogs_expect(r == OGS_OK);

--- a/src/amf/nnssf-handler.c
+++ b/src/amf/nnssf-handler.c
@@ -39,14 +39,22 @@ int amf_nnssf_nsselection_handle_get(
     amf_ue_t *amf_ue = NULL;
     ran_ue_t *ran_ue = NULL;
 
-    ogs_assert(sess);
-    amf_ue = sess->amf_ue;
-    ogs_assert(amf_ue);
     ogs_assert(recvmsg);
-
     ogs_assert(!SESSION_CONTEXT_IN_SMF(sess));
 
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    sess = amf_sess_cycle(sess);
+    if (!sess) {
+        ogs_error("Session has already been removed");
+        return OGS_ERROR;
+    }
+
+    amf_ue = amf_ue_cycle(sess->amf_ue);
+    if (!amf_ue) {
+        ogs_error("UE(amf_ue) Context has already been removed");
+        return OGS_ERROR;
+    }
+
+    ran_ue = ran_ue_cycle(sess->ran_ue);
     if (!ran_ue) {
         ogs_error("NG context has already been removed");
         return OGS_ERROR;

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -26,21 +26,9 @@ int amf_nudm_sdm_handle_provisioned(
         amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg)
 {
     int i, r;
-    ran_ue_t *ran_ue = NULL;
 
     ogs_assert(amf_ue);
     ogs_assert(recvmsg);
-
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
-    if (!ran_ue) {
-        /* ran_ue is required for amf_ue_is_rat_restricted() */
-        ogs_error("NG context has already been removed");
-        r = nas_5gs_send_gmm_reject(
-                amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
-        ogs_expect(r == OGS_OK);
-        ogs_assert(r != OGS_ERROR);
-        return OGS_ERROR;
-    }
 
     SWITCH(recvmsg->h.resource.component[1])
     CASE(OGS_SBI_RESOURCE_NAME_AM_DATA)
@@ -156,7 +144,8 @@ int amf_nudm_sdm_handle_provisioned(
         if (amf_update_allowed_nssai(amf_ue) == false) {
             ogs_error("No Allowed-NSSAI");
             r = nas_5gs_send_gmm_reject(
-                    amf_ue, OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
+                    amf_ue->ran_ue, amf_ue,
+                    OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
             return OGS_ERROR;
@@ -165,7 +154,8 @@ int amf_nudm_sdm_handle_provisioned(
         if (amf_ue_is_rat_restricted(amf_ue)) {
             ogs_error("Registration rejected due to RAT restrictions");
             r = nas_5gs_send_gmm_reject(
-                    amf_ue, OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
+                    amf_ue->ran_ue, amf_ue,
+                    OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
             return OGS_ERROR;

--- a/tests/registration/guti-test.c
+++ b/tests/registration/guti-test.c
@@ -1220,6 +1220,303 @@ static void test3_func(abts_case *tc, void *data)
     test_ue_remove(test_ue);
 }
 
+static void test4_issues2839_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *ngap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *gmmbuf;
+    ogs_pkbuf_t *gsmbuf;
+    ogs_pkbuf_t *nasbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_ngap_message_t message;
+    int i;
+
+    uint32_t ran_ue_ngap_id; /* gNB-UE-NGAP-ID received from gNB */
+    uint64_t amf_ue_ngap_id; /* AMF-UE-NGAP-ID received from AMF */
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "0000203190");
+    ogs_assert(test_ue);
+
+    test_ue->nr_cgi.cell_id = 0x40001;
+
+    test_ue->nas.registration.tsc = 0;
+    test_ue->nas.registration.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.registration.follow_on_request = 1;
+    test_ue->nas.registration.value = OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    /* gNB connects to AMF */
+    ngap = testngap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, ngap);
+
+    /* gNB connects to UPF */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send NG-Setup Reqeust */
+    sendbuf = testngap_build_ng_setup_request(0x4000, 22);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive NG-Setup Response */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Registration request */
+    test_ue->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    test_ue->registration_request_param.gmm_capability = 1;
+    test_ue->registration_request_param.s1_ue_network_capability = 1;
+    test_ue->registration_request_param.requested_nssai = 1;
+    test_ue->registration_request_param.last_visited_registered_tai = 1;
+    test_ue->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Identity request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Identity response */
+    gmmbuf = testgmm_build_identity_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    gmmbuf = testgmm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    gmmbuf = testgmm_build_security_mode_complete(test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send UERadioCapabilityInfoIndication */
+    sendbuf = testngap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send PDU session establishment request */
+    sess = test_sess_add_by_dnn_and_psi(test_ue, "internet", 5);
+    ogs_assert(sess);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 0;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration request
+     * - Update Registration request type
+     * - Uplink Data Status */
+    test_ue->nas.registration.value =
+        OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING;
+
+    test_ue->registration_request_param.uplink_data_status = 1;
+    test_ue->registration_request_param.psimask.uplink_data_status =
+        1 << sess->psi;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
+    test_ue->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(test_ue, nasbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, true, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_DownlinkNASTransport,
+            test_ue->ngap_procedure_code);
+
+    /* OLD Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Backup NGAP-ID */
+    ran_ue_ngap_id = test_ue->ran_ue_ngap_id;
+    amf_ue_ngap_id = test_ue->amf_ue_ngap_id;
+
+    /* Receive PDUSessionResourceSetupRequest +
+     * DL NAS transport +
+     * PDU session establishment accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    ABTS_INT_EQUAL(tc, ran_ue_ngap_id, test_ue->ran_ue_ngap_id + 1);
+    ABTS_INT_EQUAL(tc, amf_ue_ngap_id, test_ue->amf_ue_ngap_id + 1);
+
+    /* Send OLD UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Restore NGAP-ID */
+    test_ue->ran_ue_ngap_id = ran_ue_ngap_id;
+    test_ue->amf_ue_ngap_id = amf_ue_ngap_id;
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send UEContextReleaseRequest */
+    sendbuf = testngap_build_ue_context_release_request(test_ue,
+            NGAP_Cause_PR_radioNetwork, NGAP_CauseRadioNetwork_user_inactivity,
+            true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* gNB disonncect from UPF */
+    testgnb_gtpu_close(gtpu);
+
+    /* gNB disonncect from AMF */
+    testgnb_ngap_close(ngap);
+
+    /* Clear Test UE Context */
+    test_ue_remove(test_ue);
+}
+
 abts_suite *test_guti(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -1227,6 +1524,7 @@ abts_suite *test_guti(abts_suite *suite)
     abts_run_test(suite, test1_func, NULL);
     abts_run_test(suite, test2_func, NULL);
     abts_run_test(suite, test3_func, NULL);
+    abts_run_test(suite, test4_issues2839_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
While they were continuing their fuzzy testing and developing PacketRusher, an unusual issue with the AMF was observed. The problem arises when a single Ethernet frame containing three bundled SCTP chunks is sent. This behavior is reproduced with PacketRusher when attempting to concurrently register two UEs with the same MSIN.

The expected behavior is that the PDU Session Establishment Accept is sent inside a DownlinkNASTransport to RAN UE NGAP ID 1. However, it is actually sent inside an InitialContextSetupRequest to RAN UE NGAP ID 2. The MAC of this NAS message is invalid for the Security Context of RAN UE NGAP ID 2 (probably valid for RAN UE NGAP ID 1)