### PR TITLE
[MME] Match any SGSN in same RAI if none with specific RAI+CI found

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2488,6 +2488,15 @@ mme_sgsn_t *mme_sgsn_find_by_routing_address(const ogs_nas_rai_t *rai, uint16_t 
         }
     }
 
+    /* If no exact match found, try using any with same RAI: */
+    ogs_list_for_each(&self.sgsn_list, sgsn) {
+        mme_sgsn_route_t *rt = NULL;
+        ogs_list_for_each(&sgsn->route_list, rt) {
+            if (memcmp(&rt->rai, rai, sizeof(ogs_nas_rai_t)) == 0)
+                return sgsn;
+        }
+    }
+
     /* No route found, return default route if available: */
     return mme_sgsn_find_by_default_routing_address();
 }


### PR DESCRIPTION
This will be useful for other procedures where only the RAI is known, but not the specific CI. This is the case of idle mobility from Gb or Iu to EUTRAN, where MME needs to request contexts based on the RAI mapped in the GUTI obtained from the UE during TAU.
This also makes the config more resilient in RIM scenario, where an SGSN can be picked now even if CI doesn't match, instead of failing or faling back to the default route SGSN.