### PR TITLE
[SMF] Build URR at bearer modification

### DIFF
--- a/src/smf/n4-build.c
+++ b/src/smf/n4-build.c
@@ -326,12 +326,15 @@ ogs_pkbuf_t *smf_n4_build_qos_flow_to_modify_list(
     int num_of_remove_pdr = 0;
     int num_of_remove_far = 0;
     int num_of_remove_qer = 0;
+    int num_of_remove_urr = 0;
     int num_of_create_pdr = 0;
     int num_of_create_far = 0;
     int num_of_create_qer = 0;
+    int num_of_create_urr = 0;
     int num_of_update_pdr = 0;
     int num_of_update_far = 0;
     int num_of_update_qer = 0;
+    int num_of_update_urr = 0;
 
     uint64_t modify_flags = 0;
 
@@ -413,6 +416,17 @@ ogs_pkbuf_t *smf_n4_build_qos_flow_to_modify_list(
                 num_of_remove_qer++;
             }
 
+            /* Remove URR */
+            if (qos_flow->urr) {
+                ogs_pfcp_tlv_remove_urr_t *message =
+                    &req->remove_urr[num_of_remove_urr];
+
+                message->presence = 1;
+                message->urr_id.presence = 1;
+                message->urr_id.u32 = qos_flow->urr->id;
+                num_of_remove_urr++;
+            }
+
         } else {
             if (modify_flags & OGS_PFCP_MODIFY_CREATE) {
 
@@ -457,6 +471,14 @@ ogs_pkbuf_t *smf_n4_build_qos_flow_to_modify_list(
                             num_of_create_qer, qos_flow->qer);
                     num_of_create_qer++;
                 }
+
+                /* Create URR */
+                if (qos_flow->urr) {
+                    ogs_pfcp_build_create_urr(
+                            &req->create_urr[num_of_create_urr],
+                            num_of_create_urr, qos_flow->urr);
+                    num_of_create_urr++;
+                }
             }
             if (modify_flags &
                     (OGS_PFCP_MODIFY_TFT_NEW|OGS_PFCP_MODIFY_TFT_ADD|
@@ -475,6 +497,12 @@ ogs_pkbuf_t *smf_n4_build_qos_flow_to_modify_list(
                             &req->update_pdr[num_of_update_pdr],
                             num_of_update_pdr, qos_flow->ul_pdr);
                     num_of_update_pdr++;
+                }
+                if (qos_flow->urr) {
+                    ogs_pfcp_build_update_urr(
+                            &req->update_urr[num_of_update_urr],
+                            num_of_update_urr, qos_flow->urr, modify_flags);
+                    num_of_update_urr++;
                 }
             }
             if (modify_flags & OGS_PFCP_MODIFY_ACTIVATE) {


### PR DESCRIPTION
Bug:

PFCP Session Modification Request is sent with URR associated in PDRs, but no Create URR IE.

Example:
[testVoNR_NoURR.zip](https://github.com/open5gs/open5gs/files/13974584/testVoNR_NoURR.zip)
Packet No. 10: both PDRs associate URR which is not present.

Fix:

URR building is added for Bearer Modification Request.