### PR TITLE
[SMF] Provide PDRs and gate status according to flow direction

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -420,6 +420,12 @@ typedef struct ogs_qos_s {
 #define OGS_QOS_INDEX_1                                       1
 #define OGS_QOS_INDEX_2                                       2
 #define OGS_QOS_INDEX_5                                       5
+#define FIVE_QI_IS_GBR(__iNDEX) \
+    (!(((__iNDEX) >= 5 && (__iNDEX) <= 9) || \
+    (__iNDEX) == 69 || \
+    (__iNDEX) == 70 || \
+    (__iNDEX) == 79 || \
+    (__iNDEX) == 80))
     uint8_t         index;
 
     struct {

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -460,8 +460,10 @@ int ogs_check_qos_conf(ogs_qos_t *qos);
 
 /**********************************
  * Flow  Structure               */
+#define OGS_FLOW_UNSPECIFIED      0
 #define OGS_FLOW_DOWNLINK_ONLY    1
 #define OGS_FLOW_UPLINK_ONLY      2
+#define OGS_FLOW_BIDIRECTIONAL    3
 typedef struct ogs_flow_s {
     uint8_t direction;
     char *description;

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2632,8 +2632,10 @@ void smf_bearer_qos_update(smf_bearer_t *bearer, uint8_t direction)
 
     qer->mbr.uplink = bearer->qos.mbr.uplink;
     qer->mbr.downlink = bearer->qos.mbr.downlink;
-    qer->gbr.uplink = bearer->qos.gbr.uplink;
-    qer->gbr.downlink = bearer->qos.gbr.downlink;
+    if (FIVE_QI_IS_GBR(bearer->qos.index)) {
+        qer->gbr.uplink = bearer->qos.gbr.uplink;
+        qer->gbr.downlink = bearer->qos.gbr.downlink;
+    }
 
     if (direction == OGS_FLOW_UPLINK_ONLY)
         qer->gate_status.downlink = OGS_PFCP_GATE_CLOSE;

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -486,7 +486,7 @@ void smf_sess_delete_cp_up_data_forwarding(smf_sess_t *sess);
 
 ogs_pcc_rule_t *smf_pcc_rule_find_by_id(smf_sess_t *sess, char *pcc_rule_id);
 
-smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess);
+smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess, uint8_t direction);
 smf_bearer_t *smf_qos_flow_find_by_qfi(smf_sess_t *sess, uint8_t qfi);
 smf_bearer_t *smf_qos_flow_find_by_pcc_rule_id(
         smf_sess_t *sess, char *pcc_rule_id);
@@ -503,8 +503,8 @@ smf_bearer_t *smf_bearer_find_by_pdr_id(
         smf_sess_t *sess, ogs_pfcp_pdr_id_t pdr_id);
 smf_bearer_t *smf_default_bearer_in_sess(smf_sess_t *sess);
 
-void smf_bearer_tft_update(smf_bearer_t *bearer);
-void smf_bearer_qos_update(smf_bearer_t *bearer);
+void smf_bearer_tft_update(smf_bearer_t *bearer, uint8_t direction);
+void smf_bearer_qos_update(smf_bearer_t *bearer, uint8_t direction);
 
 smf_ue_t *smf_ue_cycle(smf_ue_t *smf_ue);
 smf_sess_t *smf_sess_cycle(smf_sess_t *sess);

--- a/src/smf/gsm-build.c
+++ b/src/smf/gsm-build.c
@@ -318,7 +318,7 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
 {
     ogs_pkbuf_t *pkbuf = NULL;
     smf_bearer_t *qos_flow = NULL;
-    ogs_pfcp_pdr_t *dl_pdr = NULL;
+    ogs_pfcp_pdr_t *pdr = NULL;
     int num_of_param, rv, i;
 
     ogs_nas_5gs_message_t message;
@@ -359,8 +359,11 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
                 &sess->qos_flow_to_modify_list, qos_flow, to_modify_node) {
             ogs_assert(i < OGS_MAX_NUM_OF_BEARER);
 
-            dl_pdr = qos_flow->dl_pdr;
-            ogs_assert(dl_pdr);
+            if (qos_flow->dl_pdr)
+                pdr = qos_flow->dl_pdr;
+            else
+                pdr = qos_flow->ul_pdr;
+            ogs_assert(pdr);
 
             qos_rule[i].identifier = qos_flow->qfi; /* Use QFI in Open5GS */
             qos_rule[i].code = qos_rule_code;
@@ -372,9 +375,9 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
             if (qos_rule_code != OGS_NAS_QOS_CODE_DELETE_EXISTING_QOS_RULE &&
                 qos_rule_code != OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_AND_DELETE_PACKET_FILTERS &&
                 qos_rule_code != OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_WITHOUT_MODIFYING_PACKET_FILTERS) {
-                ogs_assert(dl_pdr->precedence > 0 && dl_pdr->precedence < 255);
+                ogs_assert(pdr->precedence > 0 && pdr->precedence < 255);
                 /* Use PCC Rule Precedence */
-                qos_rule[i].precedence = dl_pdr->precedence;
+                qos_rule[i].precedence = pdr->precedence;
 
                 qos_rule[i].flow.segregation = 0;
                 qos_rule[i].flow.identifier = qos_flow->qfi;

--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -506,10 +506,10 @@ int gsm_handle_pdu_session_modification_request(
         if (pfcp_flags &
                 (OGS_PFCP_MODIFY_TFT_NEW|OGS_PFCP_MODIFY_TFT_ADD|
                 OGS_PFCP_MODIFY_TFT_REPLACE|OGS_PFCP_MODIFY_TFT_DELETE))
-            smf_bearer_tft_update(qos_flow);
+            smf_bearer_tft_update(qos_flow, OGS_FLOW_UNSPECIFIED);
 
         if (pfcp_flags & OGS_PFCP_MODIFY_QOS_MODIFY)
-            smf_bearer_qos_update(qos_flow);
+            smf_bearer_qos_update(qos_flow, OGS_FLOW_UNSPECIFIED);
 
     } else {
         ogs_fatal("Unknown PFCP-Flags : [0x%llx]", (long long)pfcp_flags);

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -447,7 +447,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
     smf_bearer_remove_all(sess);
 
     /* Setup Default QoS flow */
-    qos_flow = smf_qos_flow_add(sess);
+    qos_flow = smf_qos_flow_add(sess, OGS_FLOW_UNSPECIFIED);
     ogs_assert(qos_flow);
 
     /* Setup CP/UP Data Forwarding PDR/FAR */

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -902,12 +902,12 @@ void smf_s5c_handle_update_bearer_response(
 
     if (gtp_flags & OGS_GTP_MODIFY_TFT_UPDATE) {
         pfcp_flags |= OGS_PFCP_MODIFY_EPC_TFT_UPDATE;
-        smf_bearer_tft_update(bearer);
+        smf_bearer_tft_update(bearer, OGS_FLOW_UNSPECIFIED);
     }
 
     if (gtp_flags & OGS_GTP_MODIFY_QOS_UPDATE) {
         pfcp_flags |= OGS_PFCP_MODIFY_EPC_QOS_UPDATE;
-        smf_bearer_qos_update(bearer);
+        smf_bearer_qos_update(bearer, OGS_FLOW_UNSPECIFIED);
     }
 
     if (pfcp_flags)


### PR DESCRIPTION
Bug:

Both UL and DL PDRs & FARs are always added and gates are always OPEN regardless of flow direction.

Fix:

Flow direction is considered when adding PDRs, FARs and setting QER/Gate Status.