### PR TITLE
[SMF,MME] Gn: Set Delivery order QoS field to No

### DIFF
--- a/lib/gtp/v1/types.h
+++ b/lib/gtp/v1/types.h
@@ -218,6 +218,12 @@ typedef struct ogs_gtp1_gsn_addr_s {
 #define OGS_GTP1_APN_RESTRICTION_PRIVATE_1  3
 #define OGS_GTP1_APN_RESTRICTION_PRIVATE_2  4
 
+/* Table 10.5.156/3GPP TS 24.008 Quality of service */
+/* Delivery order, octet 6 (see also 3GPP TS 23.107) */
+#define OGS_GTP1_DELIVERY_ORDER_SUBSCRIBED 0
+#define OGS_GTP1_DELIVERY_ORDER_YES 1
+#define OGS_GTP1_DELIVERY_ORDER_NO 2
+
 /* TS 29.060 7.7.34 Quality of Service (QoS) Profile */
 #define OGS_GTP1_QOS_PROFILE_MAX_LEN 255
 /* TS 24.008 10.5.6.5 Quality of service */

--- a/lib/gtp/v1/types.h
+++ b/lib/gtp/v1/types.h
@@ -224,6 +224,12 @@ typedef struct ogs_gtp1_gsn_addr_s {
 #define OGS_GTP1_DELIVERY_ORDER_YES 1
 #define OGS_GTP1_DELIVERY_ORDER_NO 2
 
+/* Delivery of erroneous SDUs, octet 6 (see also 3GPP TS 23.107) */
+#define OGS_GTP1_DELIVERY_ERR_SDU_SUBSCRIBED 0
+#define OGS_GTP1_DELIVERY_ERR_SDU_NO_DETECT 1
+#define OGS_GTP1_DELIVERY_ERR_SDU_YES 2
+#define OGS_GTP1_DELIVERY_ERR_SDU_NO 3
+
 /* TS 29.060 7.7.34 Quality of Service (QoS) Profile */
 #define OGS_GTP1_QOS_PROFILE_MAX_LEN 255
 /* TS 24.008 10.5.6.5 Quality of service */

--- a/src/mme/mme-gn-build.c
+++ b/src/mme/mme-gn-build.c
@@ -69,6 +69,8 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
      * required" [...] as described in clause "compatibility issues" (4.8.1) */
     qos_pdec->qos_profile.data.delivery_order = OGS_GTP1_DELIVERY_ORDER_NO;
 
+    qos_pdec->qos_profile.data.delivery_erroneous_sdu = OGS_GTP1_DELIVERY_ERR_SDU_NO;
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (session->qos.index) { /* QCI */

--- a/src/mme/mme-gn-build.c
+++ b/src/mme/mme-gn-build.c
@@ -62,6 +62,13 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
 
     qos_pdec->qos_profile.arp = session->qos.arp.priority_level;
 
+    /* 3GPP TS 23.107 "Delivery order should be set to 'no' for PDP Type =
+     * 'IPv4' or 'IPv6'. The SGSN shall ensure that the appropriate value is set."
+     * 3GPP TS 23.401 D.3.5 2b NOTE4: The GTP and PDCP sequence numbers are not
+     * relevant as the network does not configure usage of "delivery order
+     * required" [...] as described in clause "compatibility issues" (4.8.1) */
+    qos_pdec->qos_profile.data.delivery_order = OGS_GTP1_DELIVERY_ORDER_NO;
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (session->qos.index) { /* QCI */

--- a/src/mme/mme-gn-build.c
+++ b/src/mme/mme-gn-build.c
@@ -71,6 +71,9 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
 
     qos_pdec->qos_profile.data.delivery_erroneous_sdu = OGS_GTP1_DELIVERY_ERR_SDU_NO;
 
+    /* Maximum SDU Size: Encode it as 1500, the maximum for IP 3GPP TS 23.107 Table 4, Note 4) */
+    qos_pdec->qos_profile.data.max_sdu_size = 0x96;
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (session->qos.index) { /* QCI */

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -32,6 +32,13 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
 
     qos_pdec->qos_profile.arp = sess->session.qos.arp.priority_level;
 
+    /* 3GPP TS 23.107 "Delivery order should be set to 'no' for PDP Type =
+     * 'IPv4' or 'IPv6'. The SGSN shall ensure that the appropriate value is set."
+     * 3GPP TS 23.401 D.3.5 2b NOTE4: The GTP and PDCP sequence numbers are not
+     * relevant as the network does not configure usage of "delivery order
+     * required" [...] as described in clause "compatibility issues" (4.8.1) */
+    qos_pdec->qos_profile.data.delivery_order = OGS_GTP1_DELIVERY_ORDER_NO;
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (sess->session.qos.index) { /* QCI */

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -39,6 +39,8 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
      * required" [...] as described in clause "compatibility issues" (4.8.1) */
     qos_pdec->qos_profile.data.delivery_order = OGS_GTP1_DELIVERY_ORDER_NO;
 
+    qos_pdec->qos_profile.data.delivery_erroneous_sdu = OGS_GTP1_DELIVERY_ERR_SDU_NO;
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (sess->session.qos.index) { /* QCI */

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -41,6 +41,14 @@ static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_p
 
     qos_pdec->qos_profile.data.delivery_erroneous_sdu = OGS_GTP1_DELIVERY_ERR_SDU_NO;
 
+    /* Maximum SDU Size: If value is set to a valid value, reuse it: */
+    if (sess->gtp.v1.qos_pdec.qos_profile.data.max_sdu_size >= 0x01 &&
+        sess->gtp.v1.qos_pdec.qos_profile.data.max_sdu_size <= 0x99) {
+        qos_pdec->qos_profile.data.max_sdu_size = sess->gtp.v1.qos_pdec.qos_profile.data.max_sdu_size;
+    } else { /* Encode it as 1500, the maximum for IP 3GPP TS 23.107 Table 4, Note 4) */
+        qos_pdec->qos_profile.data.max_sdu_size = 0x96;
+    }
+
      /* 3GPP TS 23.401 Annex E table Table E.3 */
     /* Also take into account table 7 in 3GPP TS 23.107 9.1.2.2 */
     switch (sess->session.qos.index) { /* QCI */


### PR DESCRIPTION
Before this patch, it was set as 0, which is Reserved in Network to MS direction.