### PR TITLE
[GTP-U] Fixed ogs_pfcp_find_gtpu_resource()(#2923)

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1184,7 +1184,7 @@ void ogs_pfcp_object_teid_hash_set(
             ogs_gtpu_resource_t *resource = NULL;
             resource = ogs_pfcp_find_gtpu_resource(
                     &ogs_gtp_self()->gtpu_resource_list,
-                    pdr->dnn, OGS_PFCP_INTERFACE_ACCESS);
+                    pdr->dnn, pdr->src_if);
             if (resource) {
                 ogs_assert(
                     (resource->info.v4 && pdr->f_teid.ipv4) ||

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -716,7 +716,7 @@ sgwc_tunnel_t *sgwc_tunnel_add(
         ogs_gtpu_resource_t *resource = NULL;
         resource = ogs_pfcp_find_gtpu_resource(
                 &sess->pfcp_node->gtpu_resource_list,
-                sess->session.name, OGS_PFCP_INTERFACE_ACCESS);
+                sess->session.name, pdr->src_if);
         if (resource) {
             ogs_user_plane_ip_resource_info_to_sockaddr(&resource->info,
                 &tunnel->local_addr, &tunnel->local_addr6);

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -190,7 +190,7 @@ void smf_bearer_binding(smf_sess_t *sess)
                     ogs_gtpu_resource_t *resource = NULL;
                     resource = ogs_pfcp_find_gtpu_resource(
                             &sess->pfcp_node->gtpu_resource_list,
-                            sess->session.name, OGS_PFCP_INTERFACE_ACCESS);
+                            sess->session.name, ul_pdr->src_if);
                     if (resource) {
                         ogs_user_plane_ip_resource_info_to_sockaddr(
                                 &resource->info,

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2116,7 +2116,7 @@ void smf_sess_create_indirect_data_forwarding(smf_sess_t *sess)
 
                 resource = ogs_pfcp_find_gtpu_resource(
                         &sess->pfcp_node->gtpu_resource_list,
-                        sess->session.name, OGS_PFCP_INTERFACE_ACCESS);
+                        sess->session.name, pdr->src_if);
 
                 if (resource) {
                     ogs_user_plane_ip_resource_info_to_sockaddr(&resource->info,

--- a/src/smf/gx-handler.c
+++ b/src/smf/gx-handler.c
@@ -196,7 +196,7 @@ uint32_t smf_gx_handle_cca_initial_request(
         ogs_gtpu_resource_t *resource = NULL;
         resource = ogs_pfcp_find_gtpu_resource(
                 &sess->pfcp_node->gtpu_resource_list,
-                sess->session.name, OGS_PFCP_INTERFACE_ACCESS);
+                sess->session.name, ul_pdr->src_if);
         if (resource) {
             ogs_user_plane_ip_resource_info_to_sockaddr(&resource->info,
                 &bearer->pgw_s5u_addr, &bearer->pgw_s5u_addr6);

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -590,7 +590,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
         ogs_gtpu_resource_t *resource = NULL;
         resource = ogs_pfcp_find_gtpu_resource(
                 &sess->pfcp_node->gtpu_resource_list,
-                sess->session.name, OGS_PFCP_INTERFACE_ACCESS);
+                sess->session.name, ul_pdr->src_if);
         if (resource) {
             ogs_user_plane_ip_resource_info_to_sockaddr(&resource->info,
                 &sess->upf_n3_addr, &sess->upf_n3_addr6);


### PR DESCRIPTION
As mentioned in the sgwu.yaml configuration file, it is possible to configure multiple addresses with different source_interface values for the gtpu interface.

Following the this section, I defined two addresses, one with source_interface set to 0 and another with source_interface set to 1. My expectation was to see different addresses for the two PDRs in the Session Establishment Response message during session establishment. However, both addresses were the same, and it was the address I had set for source_interface = 0.

When I looked into the code, I found the reason for the issue. In the lib/pfcp/context.c file, on line 1185, the function that determines the address is called as follows:

...
        } else {
            ogs_gtpu_resource_t *resource = NULL;
            resource = ogs_pfcp_find_gtpu_resource(
                    &ogs_gtp_self()->gtpu_resource_list,
                    pdr->dnn, OGS_PFCP_INTERFACE_ACCESS);
            if (resource) {
...
In the last parameter of this function, a constant value, OGS_PFCP_INTERFACE_ACCESS, is used. This causes every PDR with any source_interface to be considered as "access," and the value 0 is used for its interface.

I replaced the value with pdr->src_if, and the bug was resolved.