### PR TITLE
[UPF] Report after Session was Deleted (#2936)

### DIFF
--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -242,12 +242,6 @@ OpenAPI_nf_profile_t *ogs_nnrf_nfm_build_nf_profile(
         return NULL;
     }
 
-    if (service_map == true) {
-        NFProfile->nf_service_list = NFServiceList;
-    } else {
-        NFProfile->nf_services = NFServiceList;
-    }
-
     ogs_list_for_each(&nf_instance->nf_service_list, nf_service) {
         OpenAPI_nf_service_t *NFService = NULL;
 
@@ -289,6 +283,16 @@ OpenAPI_nf_profile_t *ogs_nnrf_nfm_build_nf_profile(
             OpenAPI_list_add(NFServiceList, NFService);
         }
     }
+
+    if (NFServiceList->count) {
+        if (service_map == true) {
+            NFProfile->nf_service_list = NFServiceList;
+        } else {
+            NFProfile->nf_services = NFServiceList;
+        }
+    }
+    else
+        OpenAPI_list_free(NFServiceList);
 
     InfoList = OpenAPI_list_create();
     ogs_assert(InfoList);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -857,12 +857,16 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
     unsigned int i;
     for (i = 0; i < OGS_ARRAY_SIZE(sess->urr_acc); i++) {
         if (sess->urr_acc[i].t_time_threshold) {
-            ogs_timer_delete(sess->urr_acc[i].t_validity_time);
-            sess->urr_acc[i].t_validity_time = NULL;
-            ogs_timer_delete(sess->urr_acc[i].t_time_quota);
-            sess->urr_acc[i].t_time_quota = NULL;
             ogs_timer_delete(sess->urr_acc[i].t_time_threshold);
             sess->urr_acc[i].t_time_threshold = NULL;
+        }
+        if (sess->urr_acc[i].t_validity_time) {
+            ogs_timer_delete(sess->urr_acc[i].t_validity_time);
+            sess->urr_acc[i].t_validity_time = NULL;
+        }
+        if (sess->urr_acc[i].t_time_quota) {
+            ogs_timer_delete(sess->urr_acc[i].t_time_quota);
+            sess->urr_acc[i].t_time_quota = NULL;
         }
     }
 }


### PR DESCRIPTION
The UPF is sending Session Report Request after the Session was Deleted, when the Gy interface is active.

UPF is sending PFCP session report request after the session has been deleted when the Gy interface is active. This is because some of the timers related to the report are not deleted when the session is deleted.

We have fixed it to delete all the timers in the session when the SESSION is deleted.