### PR TITLE
systemd: network: Avoid assigning IP addr from UE IP pool to ogstun interface

### DIFF
--- a/configs/systemd/99-open5gs.network
+++ b/configs/systemd/99-open5gs.network
@@ -5,6 +5,14 @@ Name=ogstun
 Address=10.45.0.1/16
 Address=2001:db8:cafe::1/48
 
+[Route]
+Gateway=0.0.0.0
+Destination=10.45.0.0/16
+
+[Route]
+Gateway=::
+Destination=2001:db8:cafe::0/48
+
 [Link]
 MTUBytes=1400
 RequiredForOnline=false


### PR DESCRIPTION
When running the open5gs package with systemd network config, the 1st IP address of the UE pool configured in open5gs-upfd config file for ogstun was being assigned to the interface. This causes routing problems when traffic from the UE which was assigned that same IP address is routed to/from the ogstun interface.

As a result, every time that open5gs-upfd systemd service was restarted, the following changed had to be applied:
ip addr del 10.45.0.1/16 dev ogstun
ip route add 10.45.0.0/16 dev ogstun

The IP address was set in order to get the routing entry for free. Instead, it should only add the routing entry.

Related: https://osmocom.org/issues/6361