### PR TITLE
[AMF,SMF,PCF,UPF,MME] cleanup code for metrics

### DIFF
--- a/src/amf/metrics.h
+++ b/src/amf/metrics.h
@@ -30,9 +30,6 @@ typedef enum amf_metric_type_global_s {
 } amf_metric_type_global_t;
 extern ogs_metrics_inst_t *amf_metrics_inst_global[_AMF_METR_GLOB_MAX];
 
-int amf_metrics_init_inst_global(void);
-int amf_metrics_free_inst_global(void);
-
 static inline void amf_metrics_inst_global_set(amf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(amf_metrics_inst_global[t], val); }
 static inline void amf_metrics_inst_global_add(amf_metric_type_global_t t, int val)

--- a/src/mme/metrics.c
+++ b/src/mme/metrics.c
@@ -22,16 +22,6 @@ static int mme_metrics_init_inst(ogs_metrics_inst_t **inst, ogs_metrics_spec_t *
     return OGS_OK;
 }
 
-static int mme_metrics_free_inst(ogs_metrics_inst_t **inst,
-        unsigned int len)
-{
-    unsigned int i;
-    for (i = 0; i < len; i++)
-        ogs_metrics_inst_free(inst[i]);
-    memset(inst, 0, sizeof(inst[0]) * len);
-    return OGS_OK;
-}
-
 static int mme_metrics_init_spec(ogs_metrics_context_t *ctx,
         ogs_metrics_spec_t **dst, mme_metrics_spec_def_t *src, unsigned int len)
 {
@@ -46,9 +36,9 @@ static int mme_metrics_init_spec(ogs_metrics_context_t *ctx,
 }
 
 /* GLOBAL */
-ogs_metrics_spec_t *mme_metrics_spec_global[_MME_METR_GLOB_MAX];
+static ogs_metrics_spec_t *mme_metrics_spec_global[_MME_METR_GLOB_MAX];
 ogs_metrics_inst_t *mme_metrics_inst_global[_MME_METR_GLOB_MAX];
-mme_metrics_spec_def_t mme_metrics_spec_def_global[_MME_METR_GLOB_MAX] = {
+static mme_metrics_spec_def_t mme_metrics_spec_def_global[_MME_METR_GLOB_MAX] = {
 /* Global Gauges: */
 [MME_METR_GLOB_GAUGE_ENB_UE] = {
     .type = OGS_METRICS_METRIC_TYPE_GAUGE,
@@ -70,10 +60,6 @@ int mme_metrics_init_inst_global(void)
 {
     return mme_metrics_init_inst(mme_metrics_inst_global, mme_metrics_spec_global,
                 _MME_METR_GLOB_MAX, 0, NULL);
-}
-int mme_metrics_free_inst_global(void)
-{
-    return mme_metrics_free_inst(mme_metrics_inst_global, _MME_METR_GLOB_MAX);
 }
 
 void mme_metrics_init(void)

--- a/src/mme/metrics.h
+++ b/src/mme/metrics.h
@@ -17,7 +17,6 @@ typedef enum mme_metric_type_global_s {
 extern ogs_metrics_inst_t *mme_metrics_inst_global[_MME_METR_GLOB_MAX];
 
 int mme_metrics_init_inst_global(void);
-int mme_metrics_free_inst_global(void);
 
 static inline void mme_metrics_inst_global_set(mme_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(mme_metrics_inst_global[t], val); }

--- a/src/pcf/metrics.c
+++ b/src/pcf/metrics.c
@@ -23,16 +23,6 @@ static int pcf_metrics_init_inst(ogs_metrics_inst_t **inst,
     return OGS_OK;
 }
 
-static int pcf_metrics_free_inst(ogs_metrics_inst_t **inst,
-        unsigned int len)
-{
-    unsigned int i;
-    for (i = 0; i < len; i++)
-        ogs_metrics_inst_free(inst[i]);
-    memset(inst, 0, sizeof(inst[0]) * len);
-    return OGS_OK;
-}
-
 static int pcf_metrics_init_spec(ogs_metrics_context_t *ctx,
         ogs_metrics_spec_t **dst, pcf_metrics_spec_def_t *src, unsigned int len)
 {
@@ -47,24 +37,21 @@ static int pcf_metrics_init_spec(ogs_metrics_context_t *ctx,
 }
 
 /* GLOBAL */
-ogs_metrics_spec_t *pcf_metrics_spec_global[_PCF_METR_GLOB_MAX];
+static ogs_metrics_spec_t *pcf_metrics_spec_global[_PCF_METR_GLOB_MAX];
 ogs_metrics_inst_t *pcf_metrics_inst_global[_PCF_METR_GLOB_MAX];
-pcf_metrics_spec_def_t pcf_metrics_spec_def_global[_PCF_METR_GLOB_MAX] = {
+static pcf_metrics_spec_def_t pcf_metrics_spec_def_global[_PCF_METR_GLOB_MAX] = {
 /* Global Counters: */
 /* Global Gauges: */
 };
-int pcf_metrics_init_inst_global(void)
+
+static int pcf_metrics_init_inst_global(void)
 {
     return pcf_metrics_init_inst(pcf_metrics_inst_global,
             pcf_metrics_spec_global, _PCF_METR_GLOB_MAX, 0, NULL);
 }
-int pcf_metrics_free_inst_global(void)
-{
-    return pcf_metrics_free_inst(pcf_metrics_inst_global, _PCF_METR_GLOB_MAX);
-}
 
 /* BY_SLICE */
-const char *labels_slice[] = {
+static const char *labels_slice[] = {
     "plmnid",
     "snssai"
 };
@@ -85,9 +72,9 @@ const char *labels_slice[] = {
         .num_labels = OGS_ARRAY_SIZE(labels_slice), \
         .labels = labels_slice, \
     },
-ogs_metrics_spec_t *pcf_metrics_spec_by_slice[_PCF_METR_BY_SLICE_MAX];
-ogs_hash_t *metrics_hash_by_slice = NULL;   /* hash table for SLICE labels */
-pcf_metrics_spec_def_t pcf_metrics_spec_def_by_slice[_PCF_METR_BY_SLICE_MAX] = {
+static ogs_metrics_spec_t *pcf_metrics_spec_by_slice[_PCF_METR_BY_SLICE_MAX];
+static ogs_hash_t *metrics_hash_by_slice = NULL;
+static pcf_metrics_spec_def_t pcf_metrics_spec_def_by_slice[_PCF_METR_BY_SLICE_MAX] = {
 /* Counters: */
 PCF_METR_BY_SLICE_CTR_ENTRY(
     PCF_METR_CTR_PA_POLICYAMASSOREQ,
@@ -111,64 +98,49 @@ PCF_METR_BY_SLICE_GAUGE_ENTRY(
     "fivegs_pcffunction_pa_sessionnbr",
     "Active Sessions")
 };
-void pcf_metrics_init_by_slice(void);
-int pcf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst);
 typedef struct pcf_metric_key_by_slice_s {
     ogs_plmn_id_t               plmn_id;
     ogs_s_nssai_t               snssai;
     pcf_metric_type_by_slice_t  t;
 } pcf_metric_key_by_slice_t;
 
-void pcf_metrics_init_by_slice(void)
+static void pcf_metrics_init_by_slice(void)
 {
     metrics_hash_by_slice = ogs_hash_make();
     ogs_assert(metrics_hash_by_slice);
 }
 
-void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
-        ogs_s_nssai_t *snssai, pcf_metric_type_by_slice_t t, int val)
+void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+        pcf_metric_type_by_slice_t t, int val)
 {
     ogs_metrics_inst_t *metrics = NULL;
     pcf_metric_key_by_slice_t *slice_key;
 
+    ogs_assert(plmn);
+    ogs_assert(snssai);
+
     slice_key = ogs_calloc(1, sizeof(*slice_key));
     ogs_assert(slice_key);
 
-    if (plmn) {
-        slice_key->plmn_id = *plmn;
-    }
-
-    if (snssai) {
-        slice_key->snssai = *snssai;
-    } else {
-        slice_key->snssai.sst = 0;
-        slice_key->snssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
-    }
-
+    slice_key->plmn_id = *plmn;
+    slice_key->snssai = *snssai;
     slice_key->t = t;
 
     metrics = ogs_hash_get(metrics_hash_by_slice,
             slice_key, sizeof(*slice_key));
 
     if (!metrics) {
-        char plmn_id[OGS_PLMNIDSTRLEN] = "";
-        char *s_nssai = NULL;
+        char plmn_id[OGS_PLMNIDSTRLEN];
+        char *s_nssai;
 
-        if (plmn) {
-            ogs_plmn_id_to_string(plmn, plmn_id);
-        }
-
-        if (snssai) {
-            s_nssai = ogs_sbi_s_nssai_to_string(snssai);
-        } else {
-            s_nssai = ogs_strdup("");
-        }
+        ogs_plmn_id_to_string(plmn, plmn_id);
+        s_nssai = ogs_sbi_s_nssai_to_string(snssai);
 
         metrics = ogs_metrics_inst_new(pcf_metrics_spec_by_slice[t],
                 pcf_metrics_spec_def_by_slice->num_labels,
                 (const char *[]){ plmn_id, s_nssai });
-
         ogs_assert(metrics);
+
         ogs_hash_set(metrics_hash_by_slice,
                 slice_key, sizeof(*slice_key), metrics);
 
@@ -179,11 +151,6 @@ void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn,
     }
 
     ogs_metrics_inst_add(metrics, val);
-}
-
-int pcf_metrics_free_inst_by_slice(ogs_metrics_inst_t **inst)
-{
-    return pcf_metrics_free_inst(inst, _PCF_METR_BY_SLICE_MAX);
 }
 
 void pcf_metrics_init(void)

--- a/src/pcf/metrics.h
+++ b/src/pcf/metrics.h
@@ -12,9 +12,6 @@ typedef enum pcf_metric_type_global_s {
 } pcf_metric_type_global_t;
 extern ogs_metrics_inst_t *pcf_metrics_inst_global[_PCF_METR_GLOB_MAX];
 
-int pcf_metrics_init_inst_global(void);
-int pcf_metrics_free_inst_global(void);
-
 static inline void pcf_metrics_inst_global_set(pcf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(pcf_metrics_inst_global[t], val); }
 static inline void pcf_metrics_inst_global_add(pcf_metric_type_global_t t, int val)
@@ -34,9 +31,8 @@ typedef enum pcf_metric_type_by_slice_s {
     _PCF_METR_BY_SLICE_MAX,
 } pcf_metric_type_by_slice_t;
 
-void pcf_metrics_inst_by_slice_add(
-    ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
-    pcf_metric_type_by_slice_t t, int val);
+void pcf_metrics_inst_by_slice_add(ogs_plmn_id_t *plmn, ogs_s_nssai_t *snssai,
+        pcf_metric_type_by_slice_t t, int val);
 
 void pcf_metrics_init(void);
 void pcf_metrics_final(void);

--- a/src/smf/metrics.h
+++ b/src/smf/metrics.h
@@ -27,8 +27,6 @@ typedef enum smf_metric_type_global_s {
     _SMF_METR_GLOB_MAX,
 } smf_metric_type_global_t;
 extern ogs_metrics_inst_t *smf_metrics_inst_global[_SMF_METR_GLOB_MAX];
-int smf_metrics_init_inst_global(void);
-int smf_metrics_free_inst_global(void);
 
 static inline void smf_metrics_inst_global_set(smf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(smf_metrics_inst_global[t], val); }

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -537,9 +537,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                                     NULL, NULL);
                             break;
                         }
-
-                        smf_metrics_inst_by_slice_add(NULL, NULL,
-                                SMF_METR_CTR_SM_PDUSESSIONCREATIONREQ, 1);
                     END
                     break;
 

--- a/src/upf/metrics.c
+++ b/src/upf/metrics.c
@@ -23,16 +23,6 @@ static int upf_metrics_init_inst(ogs_metrics_inst_t **inst,
     return OGS_OK;
 }
 
-static int upf_metrics_free_inst(ogs_metrics_inst_t **inst,
-        unsigned int len)
-{
-    unsigned int i;
-    for (i = 0; i < len; i++)
-        ogs_metrics_inst_free(inst[i]);
-    memset(inst, 0, sizeof(inst[0]) * len);
-    return OGS_OK;
-}
-
 static int upf_metrics_init_spec(ogs_metrics_context_t *ctx,
         ogs_metrics_spec_t **dst, upf_metrics_spec_def_t *src, unsigned int len)
 {
@@ -47,9 +37,9 @@ static int upf_metrics_init_spec(ogs_metrics_context_t *ctx,
 }
 
 /* GLOBAL */
-ogs_metrics_spec_t *upf_metrics_spec_global[_UPF_METR_GLOB_MAX];
+static ogs_metrics_spec_t *upf_metrics_spec_global[_UPF_METR_GLOB_MAX];
 ogs_metrics_inst_t *upf_metrics_inst_global[_UPF_METR_GLOB_MAX];
-upf_metrics_spec_def_t upf_metrics_spec_def_global[_UPF_METR_GLOB_MAX] = {
+static upf_metrics_spec_def_t upf_metrics_spec_def_global[_UPF_METR_GLOB_MAX] = {
 /* Global Counters: */
 [UPF_METR_GLOB_CTR_GTP_INDATAPKTN3UPF] = {
     .type = OGS_METRICS_METRIC_TYPE_COUNTER,
@@ -83,18 +73,15 @@ upf_metrics_spec_def_t upf_metrics_spec_def_global[_UPF_METR_GLOB_MAX] = {
     .description = "Active Sessions",
 },
 };
-int upf_metrics_init_inst_global(void)
+
+static int upf_metrics_init_inst_global(void)
 {
     return upf_metrics_init_inst(upf_metrics_inst_global, upf_metrics_spec_global,
                 _UPF_METR_GLOB_MAX, 0, NULL);
 }
-int upf_metrics_free_inst_global(void)
-{
-    return upf_metrics_free_inst(upf_metrics_inst_global, _UPF_METR_GLOB_MAX);
-}
 
 /* BY_QFI */
-const char *labels_qfi[] = {
+static const char *labels_qfi[] = {
     "qfi"
 };
 #define UPF_METR_BY_QFI_CTR_ENTRY(_id, _name, _desc) \
@@ -105,9 +92,9 @@ const char *labels_qfi[] = {
         .num_labels = OGS_ARRAY_SIZE(labels_qfi), \
         .labels = labels_qfi, \
     },
-ogs_metrics_spec_t *upf_metrics_spec_by_qfi[_UPF_METR_BY_QFI_MAX];
-ogs_hash_t *metrics_hash_by_qfi = NULL;   /* hash table for QFI label */
-upf_metrics_spec_def_t upf_metrics_spec_def_by_qfi[_UPF_METR_BY_QFI_MAX] = {
+static ogs_metrics_spec_t *upf_metrics_spec_by_qfi[_UPF_METR_BY_QFI_MAX];
+static ogs_hash_t *metrics_hash_by_qfi = NULL;   /* hash table for QFI label */
+static upf_metrics_spec_def_t upf_metrics_spec_def_by_qfi[_UPF_METR_BY_QFI_MAX] = {
 /* Counters: */
 UPF_METR_BY_QFI_CTR_ENTRY(
     UPF_METR_CTR_GTP_INDATAVOLUMEQOSLEVELN3UPF,
@@ -118,14 +105,13 @@ UPF_METR_BY_QFI_CTR_ENTRY(
     "fivegs_ep_n3_gtp_outdatavolumeqosleveln3upf",
     "Data volume of outgoing GTP data packets per QoS level on the N3 interface")
 };
-void upf_metrics_init_by_qfi(void);
-int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst);
+
 typedef struct upf_metric_key_by_qfi_s {
     uint8_t                     qfi;
     upf_metric_type_by_qfi_t    t;
 } upf_metric_key_by_qfi_t;
 
-void upf_metrics_init_by_qfi(void)
+static void upf_metrics_init_by_qfi(void)
 {
     metrics_hash_by_qfi = ogs_hash_make();
     ogs_assert(metrics_hash_by_qfi);
@@ -163,13 +149,8 @@ void upf_metrics_inst_by_qfi_add(uint8_t qfi,
     ogs_metrics_inst_add(metrics, val);
 }
 
-int upf_metrics_free_inst_by_qfi(ogs_metrics_inst_t **inst)
-{
-    return upf_metrics_free_inst(inst, _UPF_METR_BY_QFI_MAX);
-}
-
 /* BY_CAUSE */
-const char *labels_cause[] = {
+static const char *labels_cause[] = {
     "cause"
 };
 
@@ -181,23 +162,22 @@ const char *labels_cause[] = {
         .num_labels = OGS_ARRAY_SIZE(labels_cause), \
         .labels = labels_cause, \
     },
-ogs_metrics_spec_t *upf_metrics_spec_by_cause[_UPF_METR_BY_CAUSE_MAX];
-ogs_hash_t *metrics_hash_by_cause = NULL;   /* hash table for CAUSE labels */
-upf_metrics_spec_def_t upf_metrics_spec_def_by_cause[_UPF_METR_BY_CAUSE_MAX] = {
+static ogs_metrics_spec_t *upf_metrics_spec_by_cause[_UPF_METR_BY_CAUSE_MAX];
+static ogs_hash_t *metrics_hash_by_cause = NULL;
+static upf_metrics_spec_def_t upf_metrics_spec_def_by_cause[_UPF_METR_BY_CAUSE_MAX] = {
 /* Counters: */
 UPF_METR_BY_CAUSE_CTR_ENTRY(
     UPF_METR_CTR_SM_N4SESSIONESTABFAIL,
     "fivegs_upffunction_sm_n4sessionestabfail",
     "Number of failed N4 session establishments")
 };
-void upf_metrics_init_by_cause(void);
-int upf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst);
+
 typedef struct upf_metric_key_by_cause_s {
     uint8_t                     cause;
     upf_metric_type_by_cause_t  t;
 } upf_metric_key_by_cause_t;
 
-void upf_metrics_init_by_cause(void)
+static void upf_metrics_init_by_cause(void)
 {
     metrics_hash_by_cause = ogs_hash_make();
     ogs_assert(metrics_hash_by_cause);
@@ -236,13 +216,8 @@ void upf_metrics_inst_by_cause_add(uint8_t cause,
     ogs_metrics_inst_add(metrics, val);
 }
 
-int upf_metrics_free_inst_by_cause(ogs_metrics_inst_t **inst)
-{
-    return upf_metrics_free_inst(inst, _UPF_METR_BY_CAUSE_MAX);
-}
-
 /* BY_DNN */
-const char *labels_dnn[] = {
+static const char *labels_dnn[] = {
     "dnn"
 };
 
@@ -254,29 +229,28 @@ const char *labels_dnn[] = {
         .num_labels = OGS_ARRAY_SIZE(labels_dnn), \
         .labels = labels_dnn, \
     },
-ogs_metrics_spec_t *upf_metrics_spec_by_dnn[_UPF_METR_BY_DNN_MAX];
-ogs_hash_t *metrics_hash_by_dnn = NULL;   /* hash table for DNN labels */
-upf_metrics_spec_def_t upf_metrics_spec_def_by_dnn[_UPF_METR_BY_DNN_MAX] = {
+static ogs_metrics_spec_t *upf_metrics_spec_by_dnn[_UPF_METR_BY_DNN_MAX];
+static ogs_hash_t *metrics_hash_by_dnn = NULL;
+static upf_metrics_spec_def_t upf_metrics_spec_def_by_dnn[_UPF_METR_BY_DNN_MAX] = {
 /* Gauges: */
 UPF_METR_BY_DNN_GAUGE_ENTRY(
     UPF_METR_GAUGE_UPF_QOSFLOWS,
     "fivegs_upffunction_upf_qosflows",
     "Number of QoS flows of UPF")
 };
-void upf_metrics_init_by_dnn(void);
-int upf_metrics_free_inst_by_dnn(ogs_metrics_inst_t **inst);
+
 typedef struct upf_metric_key_by_dnn_s {
     char                        dnn[OGS_MAX_DNN_LEN+1];
     upf_metric_type_by_dnn_t    t;
 } upf_metric_key_by_dnn_t;
 
-void upf_metrics_init_by_dnn(void)
+static void upf_metrics_init_by_dnn(void)
 {
     metrics_hash_by_dnn = ogs_hash_make();
     ogs_assert(metrics_hash_by_dnn);
 }
 
-void upf_metrics_inst_by_dnn_add(char *dnn,
+void upf_metrics_inst_by_dnn_add(const char *dnn,
         upf_metric_type_by_dnn_t t, int val)
 {
     ogs_metrics_inst_t *metrics = NULL;
@@ -309,11 +283,6 @@ void upf_metrics_inst_by_dnn_add(char *dnn,
     }
 
     ogs_metrics_inst_add(metrics, val);
-}
-
-int upf_metrics_free_inst_by_dnn(ogs_metrics_inst_t **inst)
-{
-    return upf_metrics_free_inst(inst, _UPF_METR_BY_DNN_MAX);
 }
 
 void upf_metrics_init(void)

--- a/src/upf/metrics.h
+++ b/src/upf/metrics.h
@@ -19,9 +19,6 @@ typedef enum upf_metric_type_global_s {
 } upf_metric_type_global_t;
 extern ogs_metrics_inst_t *upf_metrics_inst_global[_UPF_METR_GLOB_MAX];
 
-int upf_metrics_init_inst_global(void);
-int upf_metrics_free_inst_global(void);
-
 static inline void upf_metrics_inst_global_set(upf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(upf_metrics_inst_global[t], val); }
 static inline void upf_metrics_inst_global_add(upf_metric_type_global_t t, int val)
@@ -57,7 +54,7 @@ typedef enum upf_metric_type_by_dnn_s {
 } upf_metric_type_by_dnn_t;
 
 void upf_metrics_inst_by_dnn_add(
-    char *dnn, upf_metric_type_by_dnn_t t, int val);
+    const char *dnn, upf_metric_type_by_dnn_t t, int val);
 
 void upf_metrics_init(void);
 void upf_metrics_final(void);


### PR DESCRIPTION
- remove unused functions
- make some arguments (PLMN & S-NSSAI) as required, not optional, and simplify the code
- used static functions/variables whenever possible