### PR TITLE
[SMF] Handle APCO IE in S2b GTPv2C CreateSessionRequest/Response

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -333,6 +333,7 @@ typedef struct smf_sess_s {
     struct {
         uint8_t version; /* GTPC version */
         ogs_tlv_octet_t ue_pco;
+        ogs_tlv_octet_t ue_apco;
         ogs_tlv_octet_t ue_epco;
         ogs_tlv_octet_t user_location_information;
         ogs_tlv_octet_t ue_timezone;

--- a/src/smf/s5c-build.c
+++ b/src/smf/s5c-build.c
@@ -47,6 +47,8 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
     int len;
     uint8_t pco_buf[OGS_MAX_PCO_LEN];
     int16_t pco_len;
+    uint8_t apco_buf[OGS_MAX_PCO_LEN];
+    int16_t apco_len;
     uint8_t *epco_buf = NULL;
     int16_t epco_len;
 
@@ -143,6 +145,17 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;
+    }
+
+    /* APCO */
+    if (sess->gtp.ue_apco.presence &&
+            sess->gtp.ue_apco.len && sess->gtp.ue_apco.data) {
+        apco_len = smf_pco_build(
+                apco_buf, sess->gtp.ue_apco.data, sess->gtp.ue_apco.len);
+        ogs_assert(apco_len > 0);
+        rsp->additional_protocol_configuration_options.presence = 1;
+        rsp->additional_protocol_configuration_options.data = apco_buf;
+        rsp->additional_protocol_configuration_options.len = apco_len;
     }
 
     /* ePCO */

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -378,6 +378,12 @@ uint8_t smf_s5c_handle_create_session_request(
                 &req->protocol_configuration_options);
     }
 
+    /* APCO */
+    if (req->additional_protocol_configuration_options.presence) {
+        OGS_TLV_STORE_DATA(&sess->gtp.ue_apco,
+                &req->additional_protocol_configuration_options);
+    }
+
     /* Set User Location Information */
     if (req->user_location_information.presence) {
         OGS_TLV_STORE_DATA(&sess->gtp.user_location_information,
@@ -451,6 +457,8 @@ uint8_t smf_s5c_handle_delete_session_request(
          */
         OGS_TLV_CLEAR_DATA(&sess->gtp.ue_pco);
     }
+
+    /* APCO not present in Session deletion procedure, hence no need to clear it here. */
 
     if (req->extended_protocol_configuration_options.presence) {
         OGS_TLV_STORE_DATA(&sess->gtp.ue_epco,


### PR DESCRIPTION
This IE is used by UEs registering through S2b interface (ePDG) to obtain DNS and P-CSCF server address information.