### PR TITLE
[MME/AMF] Fixed crash following Handover Request (#3014)

### DIFF
--- a/lib/ngap/build.c
+++ b/lib/ngap/build.c
@@ -20,7 +20,7 @@
 #include "ogs-ngap.h"
 
 ogs_pkbuf_t *ogs_ngap_build_error_indication(
-        uint32_t *ran_ue_ngap_id,
+        uint64_t *ran_ue_ngap_id,
         uint64_t *amf_ue_ngap_id,
         NGAP_Cause_PR group, long cause)
 {
@@ -72,7 +72,7 @@ ogs_pkbuf_t *ogs_ngap_build_error_indication(
         RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
         *RAN_UE_NGAP_ID = *ran_ue_ngap_id;
-        ogs_debug("    RAN_UE_NGAP_ID[%d]", (int)*ran_ue_ngap_id);
+        ogs_debug("    RAN_UE_NGAP_ID[%lld]", (long long)*ran_ue_ngap_id);
     }
 
     ie = CALLOC(1, sizeof(NGAP_ErrorIndicationIEs_t));
@@ -155,7 +155,7 @@ ogs_pkbuf_t *ogs_ngap_build_ng_reset(
 
 void ogs_ngap_build_part_of_ng_interface(
     NGAP_UE_associatedLogicalNG_connectionList_t *partOfNG_Interface,
-    uint32_t *ran_ue_ngap_id, uint64_t *amf_ue_ngap_id)
+    uint64_t *ran_ue_ngap_id, uint64_t *amf_ue_ngap_id)
 {
     NGAP_UE_associatedLogicalNG_connectionItem_t *item = NULL;
 
@@ -223,7 +223,7 @@ ogs_pkbuf_t *ogs_ngap_build_ng_reset_ack(
         for (i = 0; i < partOfNG_Interface->list.count; i++) {
             NGAP_UE_associatedLogicalNG_connectionItem_t *item = NULL;
             uint64_t amf_ue_ngap_id = 0;
-            uint32_t ran_ue_ngap_id = 0;
+            uint64_t ran_ue_ngap_id = 0;
 
             item = partOfNG_Interface->list.array[i];
             ogs_assert(item);
@@ -245,8 +245,8 @@ ogs_pkbuf_t *ogs_ngap_build_ng_reset_ack(
                 item->rAN_UE_NGAP_ID ? &ran_ue_ngap_id : NULL,
                 item->aMF_UE_NGAP_ID ? &amf_ue_ngap_id : NULL);
 
-            ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                    item->rAN_UE_NGAP_ID ? ran_ue_ngap_id : -1,
+            ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                    item->rAN_UE_NGAP_ID ? (long long)ran_ue_ngap_id : -1,
                     item->aMF_UE_NGAP_ID ? (long long)amf_ue_ngap_id : -1);
         }
     }

--- a/lib/ngap/build.h
+++ b/lib/ngap/build.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 ogs_pkbuf_t *ogs_ngap_build_error_indication(
-    uint32_t *ran_ue_ngap_id,
+    uint64_t *ran_ue_ngap_id,
     uint64_t *amf_ue_ngap_id,
     NGAP_Cause_PR group, long cause);
 
@@ -39,7 +39,7 @@ ogs_pkbuf_t *ogs_ngap_build_ng_reset(
 
 void ogs_ngap_build_part_of_ng_interface(
     NGAP_UE_associatedLogicalNG_connectionList_t *partOfNG_Interface,
-    uint32_t *ran_ue_ngap_id, uint64_t *amf_ue_ngap_id);
+    uint64_t *ran_ue_ngap_id, uint64_t *amf_ue_ngap_id);
 
 ogs_pkbuf_t *ogs_ngap_build_ng_reset_ack(
     NGAP_UE_associatedLogicalNG_connectionList_t *partOfNG_Interface);

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -847,8 +847,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             break;
         case AMF_TIMER_NG_HOLDING:
             ogs_warn("Implicit NG release");
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                  ran_ue->ran_ue_ngap_id,
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                  (long long)ran_ue->ran_ue_ngap_id,
                   (long long)ran_ue->amf_ue_ngap_id);
             ngap_handle_ue_context_release_action(ran_ue);
             break;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1318,7 +1318,7 @@ amf_gnb_t *amf_gnb_cycle(amf_gnb_t *gnb)
 }
 
 /** ran_ue_context handling function */
-ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint32_t ran_ue_ngap_id)
+ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
 {
     ran_ue_t *ran_ue = NULL;
 
@@ -1397,7 +1397,7 @@ void ran_ue_switch_to_gnb(ran_ue_t *ran_ue, amf_gnb_t *new_gnb)
 }
 
 ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(
-        amf_gnb_t *gnb, uint32_t ran_ue_ngap_id)
+        amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
 {
     ran_ue_t *ran_ue = NULL;
 
@@ -1978,8 +1978,9 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
             if (CM_CONNECTED(old_amf_ue)) {
                 /* Implcit NG release */
                 ogs_warn("[%s] Implicit NG release", suci);
-                ogs_warn("[%s]    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                        old_amf_ue->suci, old_amf_ue->ran_ue->ran_ue_ngap_id,
+                ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                        old_amf_ue->suci,
+                        (long long)old_amf_ue->ran_ue->ran_ue_ngap_id,
                         (long long)old_amf_ue->ran_ue->amf_ue_ngap_id);
                 ran_ue_remove(old_amf_ue->ran_ue);
             }

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -164,8 +164,8 @@ struct ran_ue_s {
     uint32_t        index;
 
     /* UE identity */
-#define INVALID_UE_NGAP_ID      0xffffffff /* Initial value of ran_ue_ngap_id */
-    uint32_t        ran_ue_ngap_id; /* eNB-UE-NGAP-ID received from eNB */
+#define INVALID_UE_NGAP_ID 0xffffffffffffffffULL /* Initial value of ran_ue_ngap_id */
+    uint64_t        ran_ue_ngap_id; /* RAN-UE-NGAP-ID received from RAN */
     uint64_t        amf_ue_ngap_id; /* AMF-UE-NGAP-ID received from AMF */
 
     uint16_t        gnb_ostream_id; /* SCTP output stream id for eNB */
@@ -389,8 +389,9 @@ struct amf_ue_s {
         (__aMF)->ran_ue_holding = ran_ue_cycle((__aMF)->ran_ue); \
         if ((__aMF)->ran_ue_holding) { \
             ogs_warn("[%s] Holding NG Context", (__aMF)->suci); \
-            ogs_warn("[%s]    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]", \
-                    (__aMF)->suci, (__aMF)->ran_ue_holding->ran_ue_ngap_id, \
+            ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]", \
+                    (__aMF)->suci, \
+                    (long long)(__aMF)->ran_ue_holding->ran_ue_ngap_id, \
                     (long long)(__aMF)->ran_ue_holding->amf_ue_ngap_id); \
             \
             (__aMF)->ran_ue_holding->ue_ctx_rel_action = \
@@ -406,8 +407,9 @@ struct amf_ue_s {
         if (ran_ue_cycle((__aMF)->ran_ue_holding)) { \
             int r; \
             ogs_warn("[%s] Clear NG Context", (__aMF)->suci); \
-            ogs_warn("[%s]    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]", \
-                    (__aMF)->suci, (__aMF)->ran_ue_holding->ran_ue_ngap_id, \
+            ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]", \
+                    (__aMF)->suci, \
+                    (long long)(__aMF)->ran_ue_holding->ran_ue_ngap_id, \
                     (long long)(__aMF)->ran_ue_holding->amf_ue_ngap_id); \
             \
             r = ngap_send_ran_ue_context_release_command( \
@@ -723,11 +725,11 @@ int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id);
 int amf_gnb_sock_type(ogs_sock_t *sock);
 amf_gnb_t *amf_gnb_cycle(amf_gnb_t *gnb);
 
-ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint32_t ran_ue_ngap_id);
+ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id);
 void ran_ue_remove(ran_ue_t *ran_ue);
 void ran_ue_switch_to_gnb(ran_ue_t *ran_ue, amf_gnb_t *new_gnb);
 ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(
-        amf_gnb_t *gnb, uint32_t ran_ue_ngap_id);
+        amf_gnb_t *gnb, uint64_t ran_ue_ngap_id);
 ran_ue_t *ran_ue_find(uint32_t index);
 ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(uint64_t amf_ue_ngap_id);
 ran_ue_t *ran_ue_cycle(ran_ue_t *ran_ue);

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -361,8 +361,9 @@ ogs_pkbuf_t *ngap_build_downlink_nas_transport(
 
     NAS_PDU = &ie->value.choice.NAS_PDU;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -623,8 +624,9 @@ ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
 
     SecurityKey = &ie->value.choice.SecurityKey;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -858,8 +860,9 @@ ogs_pkbuf_t *ngap_build_ue_context_modification_request(amf_ue_t *amf_ue)
 
     SecurityKey = &ie->value.choice.SecurityKey;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1091,8 +1094,9 @@ ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
 
     SecurityKey = &ie->value.choice.SecurityKey;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1335,8 +1339,9 @@ ogs_pkbuf_t *ngap_ue_build_pdu_session_resource_setup_request(
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1511,8 +1516,9 @@ ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
 
     PDUSessionList = &ie->value.choice.PDUSessionResourceSetupListSUReq;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1653,8 +1659,9 @@ ogs_pkbuf_t *ngap_build_pdu_session_resource_modify_request(
 
     PDUSessionList = &ie->value.choice.PDUSessionResourceModifyListModReq;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1743,8 +1750,9 @@ ogs_pkbuf_t *ngap_build_pdu_session_resource_release_command(
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -1991,8 +1999,9 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
     ie->criticality = NGAP_Criticality_ignore;
     ie->value.present = NGAP_PathSwitchRequestAcknowledgeIEs__value_PR_PDUSessionResourceSwitchedList;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, ran_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = ran_ue->ran_ue_ngap_id;
@@ -2131,8 +2140,9 @@ ogs_pkbuf_t *ngap_build_handover_request(ran_ue_t *target_ue)
 
     AMF_UE_NGAP_ID = &ie->value.choice.AMF_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)target_ue->ran_ue_ngap_id,
+            (long long)target_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, target_ue->amf_ue_ngap_id);
 
@@ -2443,8 +2453,9 @@ ogs_pkbuf_t *ngap_build_handover_preparation_failure(
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)source_ue->ran_ue_ngap_id,
+            (long long)source_ue->amf_ue_ngap_id);
     asn_uint642INTEGER(AMF_UE_NGAP_ID, source_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = source_ue->ran_ue_ngap_id;
 
@@ -2524,8 +2535,9 @@ ogs_pkbuf_t *ngap_build_handover_command(ran_ue_t *source_ue)
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)source_ue->ran_ue_ngap_id,
+            (long long)source_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, source_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = source_ue->ran_ue_ngap_id;
@@ -2642,8 +2654,9 @@ ogs_pkbuf_t *ngap_build_handover_cancel_ack(ran_ue_t *source_ue)
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)source_ue->ran_ue_ngap_id,
+            (long long)source_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, source_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = source_ue->ran_ue_ngap_id;
@@ -2707,8 +2720,9 @@ ogs_pkbuf_t *ngap_build_downlink_ran_status_transfer(
 
     RAN_UE_NGAP_ID = &ie->value.choice.RAN_UE_NGAP_ID;
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)target_ue->ran_ue_ngap_id,
+            (long long)target_ue->amf_ue_ngap_id);
 
     asn_uint642INTEGER(AMF_UE_NGAP_ID, target_ue->amf_ue_ngap_id);
     *RAN_UE_NGAP_ID = target_ue->ran_ue_ngap_id;

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -559,9 +559,9 @@ void ngap_handle_initial_ue_message(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &ran_ue->saved.nr_tai);
 
-    ogs_info("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] "
+    ogs_info("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] "
             "TAC[%d] CellID[0x%llx]",
-        ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id,
+        (long long)ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id,
         ran_ue->saved.nr_tai.tac.v, (long long)ran_ue->saved.nr_cgi.cell_id);
 
     if (UEContextRequest) {
@@ -633,7 +633,7 @@ void ngap_handle_uplink_nas_transport(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -642,7 +642,7 @@ void ngap_handle_uplink_nas_transport(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -654,7 +654,7 @@ void ngap_handle_uplink_nas_transport(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -729,9 +729,9 @@ void ngap_handle_uplink_nas_transport(
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &ran_ue->saved.nr_tai);
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] "
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] "
             "TAC[%d] CellID[0x%llx]",
-        ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id,
+        (long long)ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id,
         ran_ue->saved.nr_tai.tac.v, (long long)ran_ue->saved.nr_cgi.cell_id);
 
     /* Copy NR-TAI/NR-CGI from ran_ue */
@@ -795,7 +795,7 @@ void ngap_handle_ue_radio_capability_info_indication(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -804,7 +804,7 @@ void ngap_handle_ue_radio_capability_info_indication(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -816,7 +816,7 @@ void ngap_handle_ue_radio_capability_info_indication(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -824,8 +824,9 @@ void ngap_handle_ue_radio_capability_info_indication(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     if (!UERadioCapability) {
         ogs_error("No UERadioCapability");
@@ -899,7 +900,7 @@ void ngap_handle_initial_context_setup_response(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -908,7 +909,7 @@ void ngap_handle_initial_context_setup_response(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -920,7 +921,7 @@ void ngap_handle_initial_context_setup_response(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -928,8 +929,9 @@ void ngap_handle_initial_context_setup_response(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     ran_ue->initial_context_setup_response_received = true;
 
@@ -1177,7 +1179,7 @@ void ngap_handle_initial_context_setup_failure(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1186,7 +1188,7 @@ void ngap_handle_initial_context_setup_failure(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1198,7 +1200,7 @@ void ngap_handle_initial_context_setup_failure(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -1206,8 +1208,9 @@ void ngap_handle_initial_context_setup_failure(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     if (!Cause) {
         ogs_error("No Cause");
@@ -1392,8 +1395,9 @@ void ngap_handle_ue_context_modification_failure(
             ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                     (long long)amf_ue_ngap_id);
         else
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                    ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                    (long long)ran_ue->ran_ue_ngap_id,
+                    (long long)ran_ue->amf_ue_ngap_id);
 
     } else if (RAN_UE_NGAP_ID) {
         ran_ue = ran_ue_find_by_ran_ue_ngap_id(gnb, *RAN_UE_NGAP_ID);
@@ -1401,8 +1405,9 @@ void ngap_handle_ue_context_modification_failure(
             ogs_warn("No RAN UE Context : RAN_UE_NGAP_ID[%d]",
                     (int)*RAN_UE_NGAP_ID);
         else
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                    ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                    (long long)ran_ue->ran_ue_ngap_id,
+                    (long long)ran_ue->amf_ue_ngap_id);
     }
 
     if (Cause) {
@@ -1470,7 +1475,7 @@ void ngap_handle_ue_context_release_request(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1479,7 +1484,7 @@ void ngap_handle_ue_context_release_request(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1491,7 +1496,7 @@ void ngap_handle_ue_context_release_request(
         ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -1499,8 +1504,9 @@ void ngap_handle_ue_context_release_request(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     if (!Cause) {
         ogs_error("No Cause");
@@ -1641,7 +1647,7 @@ void ngap_handle_ue_context_release_complete(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1650,7 +1656,7 @@ void ngap_handle_ue_context_release_complete(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1662,7 +1668,7 @@ void ngap_handle_ue_context_release_complete(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -1688,8 +1694,9 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
     amf_ue = ran_ue->amf_ue;
 
     ogs_info("UE Context Release [Action:%d]", ran_ue->ue_ctx_rel_action);
-    ogs_info("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_info("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
     if (amf_ue) {
         ogs_info("    SUCI[%s]", amf_ue->suci ? amf_ue->suci : "Unknown");
 
@@ -1871,7 +1878,7 @@ void ngap_handle_pdu_session_resource_setup_response(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1880,7 +1887,7 @@ void ngap_handle_pdu_session_resource_setup_response(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1892,7 +1899,7 @@ void ngap_handle_pdu_session_resource_setup_response(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -1900,8 +1907,9 @@ void ngap_handle_pdu_session_resource_setup_response(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     amf_ue = ran_ue->amf_ue;
     if (!amf_ue) {
@@ -2192,7 +2200,7 @@ void ngap_handle_pdu_session_resource_modify_response(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2201,7 +2209,7 @@ void ngap_handle_pdu_session_resource_modify_response(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2213,7 +2221,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -2221,8 +2229,9 @@ void ngap_handle_pdu_session_resource_modify_response(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     amf_ue = ran_ue->amf_ue;
     if (!amf_ue) {
@@ -2378,7 +2387,7 @@ void ngap_handle_pdu_session_resource_release_response(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2387,7 +2396,7 @@ void ngap_handle_pdu_session_resource_release_response(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2399,7 +2408,7 @@ void ngap_handle_pdu_session_resource_release_response(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -2407,8 +2416,9 @@ void ngap_handle_pdu_session_resource_release_response(
         return;
     }
 
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     amf_ue = ran_ue->amf_ue;
     if (!amf_ue) {
@@ -2729,7 +2739,7 @@ void ngap_handle_path_switch_request(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2738,7 +2748,7 @@ void ngap_handle_path_switch_request(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -2750,7 +2760,7 @@ void ngap_handle_path_switch_request(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -2771,8 +2781,8 @@ void ngap_handle_path_switch_request(
         return;
     }
 
-    ogs_info("    [OLD] RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_info("    [OLD] RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
     ogs_info("    [OLD] TAC[%d] CellID[0x%llx]",
         amf_ue->nr_tai.tac.v, (long long)amf_ue->nr_cgi.cell_id);
 
@@ -2829,8 +2839,8 @@ void ngap_handle_path_switch_request(
         return;
     }
 
-    ogs_info("    [NEW] RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_info("    [NEW] RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
 
     UserLocationInformationNR =
             UserLocationInformation->choice.userLocationInformationNR;
@@ -3055,7 +3065,7 @@ void ngap_handle_handover_required(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3064,7 +3074,7 @@ void ngap_handle_handover_required(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3076,7 +3086,7 @@ void ngap_handle_handover_required(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -3084,8 +3094,9 @@ void ngap_handle_handover_required(
         return;
     }
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
 
     amf_ue = source_ue->amf_ue;
     if (!amf_ue) {
@@ -3205,6 +3216,46 @@ void ngap_handle_handover_required(
         return;
     }
 
+    target_ue = ran_ue_cycle(source_ue->target_ue);
+    if (target_ue) {
+    /*
+     * Issue #3014
+     *
+     * 1. HandoverRequired
+     * 2. HandoverRequest
+     * 3. HandoverFailure
+     * 4. UEContextReleaseCommand
+     * 5. HandoverPreparationFailure
+     *
+     * If UEContextReleaseComplete is not received,
+     * the Source-UE will have the Target-UE.
+     *
+     * 6. HandoverRequired
+     *
+     * There may be cases where the Source UE has a Target UE
+     * from a previous HandoverRequired process. In this case,
+     * it is recommended to force the deletion of the Target UE information
+     * when receiving a new HandoverRequired.
+     *
+     * 7. HandoverRequest
+     * 8. HandoverFailure
+     * 9. UEContextReleaseCommand
+     * 10. UEContextReleaseComplete
+     * 11. HandoverPreparationFailure
+     *
+     * ... Crashed ...
+     */
+        ogs_warn("DELETE the previously used TARGET in SOURCE");
+        ogs_warn("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+            (long long)source_ue->ran_ue_ngap_id,
+            (long long)source_ue->amf_ue_ngap_id);
+        ogs_warn("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+            (long long)target_ue->ran_ue_ngap_id,
+            (long long)target_ue->amf_ue_ngap_id);
+        source_ue_deassociate_target_ue(target_ue);
+        ran_ue_remove(target_ue);
+    }
+
     /* Target UE */
     target_ue = ran_ue_add(target_gnb, INVALID_UE_NGAP_ID);
     if (target_ue == NULL) {
@@ -3227,8 +3278,9 @@ void ngap_handle_handover_required(
 
     target_ue->psimask.activated = source_ue->psimask.activated;
 
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
 
     /* Store HandoverType */
     amf_ue->handover.type = *HandoverType;
@@ -3393,7 +3445,7 @@ void ngap_handle_handover_request_ack(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3402,7 +3454,7 @@ void ngap_handle_handover_request_ack(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3414,7 +3466,7 @@ void ngap_handle_handover_request_ack(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -3458,10 +3510,12 @@ void ngap_handle_handover_request_ack(
         return;
     }
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
 
     if (!PDUSessionList) {
         ogs_error("No PDUSessionList");
@@ -3650,10 +3704,12 @@ void ngap_handle_handover_failure(
         return;
     }
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
 
     if (!Cause) {
         ogs_error("No Cause");
@@ -3731,7 +3787,7 @@ void ngap_handle_handover_cancel(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3740,7 +3796,7 @@ void ngap_handle_handover_cancel(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3752,7 +3808,7 @@ void ngap_handle_handover_cancel(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -3785,10 +3841,12 @@ void ngap_handle_handover_cancel(
         return;
     }
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
 
     if (!Cause) {
         ogs_error("No Cause");
@@ -3881,7 +3939,7 @@ void ngap_handle_uplink_ran_status_transfer(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3890,7 +3948,7 @@ void ngap_handle_uplink_ran_status_transfer(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -3902,7 +3960,7 @@ void ngap_handle_uplink_ran_status_transfer(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -3935,10 +3993,12 @@ void ngap_handle_uplink_ran_status_transfer(
         return;
     }
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
 
     r = ngap_send_downlink_ran_status_transfer(
             target_ue, RANStatusTransfer_TransparentContainer);
@@ -4001,7 +4061,7 @@ void ngap_handle_handover_notification(
 
     if (!AMF_UE_NGAP_ID) {
         ogs_error("No AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -4010,7 +4070,7 @@ void ngap_handle_handover_notification(
 
     if (asn_INTEGER2uint64(AMF_UE_NGAP_ID, &amf_ue_ngap_id) != 0) {
         ogs_error("Invalid AMF_UE_NGAP_ID");
-        r = ngap_send_error_indication(gnb, (uint32_t *)RAN_UE_NGAP_ID, NULL,
+        r = ngap_send_error_indication(gnb, (uint64_t *)RAN_UE_NGAP_ID, NULL,
                 NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -4022,7 +4082,7 @@ void ngap_handle_handover_notification(
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
         r = ngap_send_error_indication(
-                gnb, (uint32_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
+                gnb, (uint64_t *)RAN_UE_NGAP_ID, &amf_ue_ngap_id,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_unknown_local_UE_NGAP_ID);
         ogs_expect(r == OGS_OK);
@@ -4085,13 +4145,15 @@ void ngap_handle_handover_notification(
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &target_ue->saved.nr_tai);
 
-    ogs_debug("    Source : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        source_ue->ran_ue_ngap_id, (long long)source_ue->amf_ue_ngap_id);
+    ogs_debug("    Source : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)source_ue->ran_ue_ngap_id,
+        (long long)source_ue->amf_ue_ngap_id);
     ogs_debug("    Source : TAC[%d] CellID[0x%llx]",
         source_ue->saved.nr_tai.tac.v,
         (long long)source_ue->saved.nr_cgi.cell_id);
-    ogs_debug("    Target : RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] ",
-        target_ue->ran_ue_ngap_id, (long long)target_ue->amf_ue_ngap_id);
+    ogs_debug("    Target : RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
+        (long long)target_ue->ran_ue_ngap_id,
+        (long long)target_ue->amf_ue_ngap_id);
     ogs_debug("    Target : TAC[%d] CellID[0x%llx]",
         target_ue->saved.nr_tai.tac.v,
         (long long)target_ue->saved.nr_cgi.cell_id);
@@ -4549,9 +4611,9 @@ void ngap_handle_ng_reset(
                 new_xact_count = amf_sess_xact_count(amf_ue);
             } else {
                 ogs_warn("UE(amf-ue) context has already been removed");
-                ogs_warn("   AMF_UE_NGAP_ID[%lld] RAN_UE_NGAP_ID[%d]",
+                ogs_warn("   AMF_UE_NGAP_ID[%lld] RAN_UE_NGAP_ID[%lld]",
                             (long long)ran_ue->amf_ue_ngap_id,
-                            ran_ue->ran_ue_ngap_id);
+                            (long long)ran_ue->ran_ue_ngap_id);
             }
 
             if (old_xact_count == new_xact_count) ran_ue_remove(ran_ue);
@@ -4641,8 +4703,9 @@ void ngap_handle_error_indication(amf_gnb_t *gnb, ogs_ngap_message_t *message)
             ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                     (long long)amf_ue_ngap_id);
         else
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                    ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                    (long long)ran_ue->ran_ue_ngap_id,
+                    (long long)ran_ue->amf_ue_ngap_id);
 
     } else if (RAN_UE_NGAP_ID) {
         ran_ue = ran_ue_find_by_ran_ue_ngap_id(gnb, *RAN_UE_NGAP_ID);
@@ -4650,8 +4713,9 @@ void ngap_handle_error_indication(amf_gnb_t *gnb, ogs_ngap_message_t *message)
             ogs_warn("No RAN UE Context : RAN_UE_NGAP_ID[%d]",
                     (int)*RAN_UE_NGAP_ID);
         else
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-                    ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                    (long long)ran_ue->ran_ue_ngap_id,
+                    (long long)ran_ue->amf_ue_ngap_id);
     }
 
     if (Cause) {

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -365,8 +365,9 @@ int ngap_send_ran_ue_context_release_command(
     }
 
     ogs_debug("UEContextReleaseCommand");
-    ogs_debug("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld]",
-            ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
+    ogs_debug("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+            (long long)ran_ue->ran_ue_ngap_id,
+            (long long)ran_ue->amf_ue_ngap_id);
 
     ogs_assert(action != NGAP_UE_CTX_REL_INVALID_ACTION);
     ran_ue->ue_ctx_rel_action = action;
@@ -668,7 +669,7 @@ int ngap_send_downlink_ran_status_transfer(
 
 int ngap_send_error_indication(
         amf_gnb_t *gnb,
-        uint32_t *ran_ue_ngap_id,
+        uint64_t *ran_ue_ngap_id,
         uint64_t *amf_ue_ngap_id,
         NGAP_Cause_PR group, long cause)
 {

--- a/src/amf/ngap-path.h
+++ b/src/amf/ngap-path.h
@@ -78,7 +78,7 @@ int ngap_send_downlink_ran_status_transfer(
 
 int ngap_send_error_indication(
         amf_gnb_t *gnb,
-        uint32_t *ran_ue_ngap_id,
+        uint64_t *ran_ue_ngap_id,
         uint64_t *amf_ue_ngap_id,
         NGAP_Cause_PR group, long cause);
 int ngap_send_error_indication2(

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -463,8 +463,9 @@ void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state)
             }
         } else {
             ogs_warn("amf_sbi_send_deactivate_all_ue_in_gnb()");
-            ogs_warn("    RAN_UE_NGAP_ID[%d] AMF_UE_NGAP_ID[%lld] State[%d]",
-                ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id,
+            ogs_warn("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] State[%d]",
+                (long long)ran_ue->ran_ue_ngap_id,
+                (long long)ran_ue->amf_ue_ngap_id,
                 state);
 
             if (state == AMF_REMOVE_S1_CONTEXT_BY_LO_CONNREFUSED ||

--- a/src/mme/s1ap-path.c
+++ b/src/mme/s1ap-path.c
@@ -731,7 +731,43 @@ int s1ap_send_handover_request(
         return OGS_NOTFOUND;
     }
 
-    ogs_assert(source_ue->target_ue == NULL);
+    target_ue = enb_ue_cycle(source_ue->target_ue);
+    if (target_ue) {
+    /*
+     * Issue #3014
+     *
+     * 1. HandoverRequired
+     * 2. HandoverRequest
+     * 3. HandoverFailure
+     * 4. UEContextReleaseCommand
+     * 5. HandoverPreparationFailure
+     *
+     * If UEContextReleaseComplete is not received,
+     * the Source-UE will have the Target-UE.
+     *
+     * 6. HandoverRequired
+     *
+     * There may be cases where the Source UE has a Target UE
+     * from a previous HandoverRequired process. In this case,
+     * it is recommended to force the deletion of the Target UE information
+     * when receiving a new HandoverRequired.
+     *
+     * 7. HandoverRequest
+     * 8. HandoverFailure
+     * 9. UEContextReleaseCommand
+     * 10. UEContextReleaseComplete
+     * 11. HandoverPreparationFailure
+     *
+     * ... Crashed ...
+     */
+        ogs_warn("DELETE the previously used TARGET in SOURCE");
+        ogs_warn("    Source : ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
+                source_ue->enb_ue_s1ap_id, source_ue->mme_ue_s1ap_id);
+        ogs_warn("    Target : ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
+                target_ue->enb_ue_s1ap_id, target_ue->mme_ue_s1ap_id);
+        enb_ue_source_deassociate_target(target_ue);
+        enb_ue_remove(target_ue);
+    }
 
     target_ue = enb_ue_add(target_enb, INVALID_UE_S1AP_ID);
     if (target_ue == NULL) {

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1548,10 +1548,15 @@ uint8_t smf_sess_set_ue_ip(smf_sess_t *sess)
         subnet = ogs_pfcp_find_subnet_by_dnn(AF_INET, sess->session.name);
         subnet6 = ogs_pfcp_find_subnet_by_dnn(AF_INET6, sess->session.name);
 
-        if (subnet != NULL && subnet6 == NULL)
+        if (subnet != NULL && subnet6 == NULL) {
             sess->session.session_type = OGS_PDU_SESSION_TYPE_IPV4;
-        else if (subnet == NULL && subnet6 != NULL)
+            ogs_error("[%s] No IPv6 subnet or set to /63 or /64, "
+                    "only IPv4 assigned", sess->session.name);
+        } else if (subnet == NULL && subnet6 != NULL) {
             sess->session.session_type = OGS_PDU_SESSION_TYPE_IPV6;
+            ogs_error("[%s] No IPv4 subnet or set to /31 or /32, "
+                    "only IPv6 assigned", sess->session.name);
+        }
     }
 
     sess->session.paa.session_type = sess->session.session_type;

--- a/tests/common/context.h
+++ b/tests/common/context.h
@@ -288,7 +288,7 @@ typedef struct test_esm_information_param_s {
 typedef struct test_ue_s {
     ogs_lnode_t     lnode;          /**< A node of list_t */
 
-    uint32_t ran_ue_ngap_id; /* gNB-UE-NGAP-ID received from gNB */
+    uint64_t ran_ue_ngap_id; /* gNB-UE-NGAP-ID received from gNB */
     uint64_t amf_ue_ngap_id; /* AMF-UE-NGAP-ID received from AMF */
     uint32_t enb_ue_s1ap_id; /* eNB-UE-S1AP-ID received from eNB */
     uint32_t mme_ue_s1ap_id; /* MME-UE-S1AP-ID received from MME */

--- a/tests/common/s1ap-path.c
+++ b/tests/common/s1ap-path.c
@@ -126,6 +126,7 @@ void tests1ap_recv(test_ue_t *test_ue, ogs_pkbuf_t *pkbuf)
         case S1AP_ProcedureCode_id_S1Setup:
             break;
         case S1AP_ProcedureCode_id_HandoverPreparation:
+            tests1ap_handle_handover_preparation_failure(test_ue, pdu);
             break;
         default:
             ogs_error("Not implemented(choice:%d, proc:%d)",

--- a/tests/handover/5gc-n2-test.c
+++ b/tests/handover/5gc-n2-test.c
@@ -364,6 +364,39 @@ static void failure_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, recvbuf);
     testngap_recv(test_ue, recvbuf);
 
+    /* Receive HandoverPreparationFailure */
+    recvbuf = testgnb_ngap_read(ngap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send HandoverRequired */
+    sendbuf = testngap_build_handover_required(
+            test_ue, NGAP_HandoverType_intra5gs,
+            0x4001, 28,
+            NGAP_Cause_PR_radioNetwork,
+            NGAP_CauseRadioNetwork_handover_desirable_for_radio_reason,
+            true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive HandoverRequest */
+    recvbuf = testgnb_ngap_read(ngap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send HandoverFailure */
+    sendbuf = testngap_build_handover_failure(test_ue,
+            NGAP_Cause_PR_radioNetwork, NGAP_CauseRadioNetwork_unspecified);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
     /* Send UEContextReleaseComplete */
     sendbuf = testngap_build_ue_context_release_complete(test_ue);
     ABTS_PTR_NOTNULL(tc, sendbuf);
@@ -437,7 +470,7 @@ static void direct_complete_func(abts_case *tc, void *data)
     test_sess_t *sess = NULL;
     test_bearer_t *qos_flow = NULL;
 
-    uint32_t ran_ue_ngap_id;
+    uint64_t ran_ue_ngap_id;
     uint64_t amf_ue_ngap_id;
 
     bson_t *doc = NULL;
@@ -1465,7 +1498,7 @@ static void indirect_complete_func(abts_case *tc, void *data)
     test_sess_t *sess = NULL;
     test_bearer_t *qos_flow = NULL;
 
-    uint32_t ran_ue_ngap_id;
+    uint64_t ran_ue_ngap_id;
     uint64_t amf_ue_ngap_id;
 
     bson_t *doc = NULL;
@@ -2118,7 +2151,7 @@ static void indirect_cancel_func(abts_case *tc, void *data)
     test_sess_t *sess = NULL;
     test_bearer_t *qos_flow = NULL;
 
-    uint32_t ran_ue_ngap_id;
+    uint64_t ran_ue_ngap_id;
     uint64_t amf_ue_ngap_id;
 
     bson_t *doc = NULL;

--- a/tests/handover/epc-s1-test.c
+++ b/tests/handover/epc-s1-test.c
@@ -1218,6 +1218,38 @@ static void test3_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, recvbuf);
     tests1ap_recv(test_ue, recvbuf);
 
+    /* Receive Handover Preparation Failure */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Required */
+    sendbuf = test_s1ap_build_handover_required(
+            test_ue, S1AP_HandoverType_intralte,
+            S1AP_ENB_ID_PR_macroENB_ID, 0x43,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_time_critical_handover);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Request */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Failure */
+    sendbuf = test_s1ap_build_handover_failure(test_ue,
+            S1AP_Cause_PR_radioNetwork, S1AP_CauseRadioNetwork_unspecified);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
     /* Send UE Context Release Complete */
     sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
     ABTS_PTR_NOTNULL(tc, sendbuf);

--- a/tests/registration/guti-test.c
+++ b/tests/registration/guti-test.c
@@ -1233,7 +1233,7 @@ static void test4_issues2839_func(abts_case *tc, void *data)
     ogs_ngap_message_t message;
     int i;
 
-    uint32_t ran_ue_ngap_id; /* gNB-UE-NGAP-ID received from gNB */
+    uint64_t ran_ue_ngap_id; /* gNB-UE-NGAP-ID received from gNB */
     uint64_t amf_ue_ngap_id; /* AMF-UE-NGAP-ID received from AMF */
 
     ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;

--- a/tests/registration/idle-test.c
+++ b/tests/registration/idle-test.c
@@ -1016,7 +1016,7 @@ static void test4_func(abts_case *tc, void *data)
     int i;
 
     /* for backup */
-    uint32_t ran_ue_ngap_id;
+    uint64_t ran_ue_ngap_id;
     uint64_t amf_ue_ngap_id;
 
     ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;

--- a/tests/unit/ngap-message-test.c
+++ b/tests/unit/ngap-message-test.c
@@ -35,7 +35,7 @@ static void ngap_message_test1(abts_case *tc, void *data)
     size_t struct_size;
     asn_dec_rval_t dec_ret = {0};
 
-    uint32_t ran_ue_ngap_id;
+    uint64_t ran_ue_ngap_id;
     uint64_t amf_ue_ngap_id;
 
     memset(&pdu, 0, sizeof (NGAP_NGAP_PDU_t));
@@ -185,7 +185,7 @@ static void ngap_message_test4(abts_case *tc, void *data)
 }
 
 static ogs_pkbuf_t *build_uplink_nas_transport(
-        uint32_t ran_ue_ngap_id, uint64_t amf_ue_ngap_id, ogs_pkbuf_t *gmmbuf)
+        uint64_t ran_ue_ngap_id, uint64_t amf_ue_ngap_id, ogs_pkbuf_t *gmmbuf)
 {
     const char *payload =
         "7e005c00 0d0199f9 07f0ff00 00000020"


### PR DESCRIPTION
1. HandoverRequired
2. HandoverRequest
3. HandoverFailure
4. UEContextReleaseCommand
5. HandoverPreparationFailure

If UEContextReleaseComplete is not received,
the Source-UE will have the Target-UE.

6. HandoverRequired

There may be cases where the Source UE has a Target UE from a previous HandoverRequired process. In this case, it is recommended to force the deletion of the Target UE information when receiving a new HandoverRequired.

7. HandoverRequest
8. HandoverFailure
9. UEContextReleaseCommand
10. UEContextReleaseComplete
11. HandoverPreparationFailure

... Crashed ...