### PR TITLE
[MME] Assign valid PTI to sess created by mobility from 2G

### DIFF
--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -225,7 +225,7 @@ static mme_sess_t *mme_ue_session_from_gtp1_pdp_ctx(mme_ue_t *mme_ue, const ogs_
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
     const ogs_gtp1_qos_profile_decoded_t *qos_pdec = &gtp1_pdp_ctx->qos_sub;
-    uint8_t pti = gtp1_pdp_ctx->trans_id;
+    uint8_t pti = 1; /* Default PTI : 1 */
     uint8_t qci = 0;
     ogs_session_t *ogs_sess;
 


### PR DESCRIPTION
Transaction Identity doesn't map 1-to-1 with Procedure Transaction Identity: The value ranges change, and PTI cannot use value 0 8which means unused).
Hence, for now let's simply set the PTI to a valid default value instead of asserting during mme_sess_add:
Assertion `pti != OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED'

Related: https://github.com/open5gs/open5gs/issues/3020