### PR TITLE
[SBI] Fix handling "dnn" URL parameter

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -856,9 +856,10 @@ int ogs_sbi_parse_request(
                     ogs_uint64_from_string(v);
                 discovery_option_presence = true;
             }
+        }
 
         /* URL Query Parameter */
-        } else if (!strcmp(ogs_hash_this_key(hi), OGS_SBI_PARAM_NF_ID)) {
+        if (!strcmp(ogs_hash_this_key(hi), OGS_SBI_PARAM_NF_ID)) {
             message->param.nf_id = ogs_hash_this_val(hi);
         } else if (!strcmp(ogs_hash_this_key(hi), OGS_SBI_PARAM_NF_TYPE)) {
             message->param.nf_type =


### PR DESCRIPTION
"dnn" URL parameter was handled twice. Once as a NF discovery parameter, and once as normal URL parameter.

This fixes https://github.com/open5gs/open5gs/issues/3054 : DNN parameter was not propagated at UDM to UDR when SMF requested "sm-data".

If you have any other idea how to fix it, please tell.