### PR TITLE
[GTP/PFCP]] incorrect dst TEI=0/SEID=0 (#3043)

### DIFF
--- a/lib/gtp/path.c
+++ b/lib/gtp/path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -127,17 +127,4 @@ int ogs_gtp_sendto(ogs_gtp_node_t *gnode, ogs_pkbuf_t *pkbuf)
     }
 
     return OGS_OK;
-}
-
-void ogs_gtp_send_error_message(
-        ogs_gtp_xact_t *xact, uint32_t teid, uint8_t type, uint8_t cause_value)
-{
-    switch (xact->gtp_version) {
-    case 1:
-        ogs_gtp1_send_error_message(xact, teid, type, cause_value);
-        break;
-    case 2:
-        ogs_gtp2_send_error_message(xact, teid, type, cause_value);
-        break;
-    }
 }

--- a/lib/gtp/path.h
+++ b/lib/gtp/path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -71,9 +71,6 @@ int ogs_gtp_connect(ogs_sock_t *ipv4, ogs_sock_t *ipv6, ogs_gtp_node_t *gnode);
 
 int ogs_gtp_send(ogs_gtp_node_t *gnode, ogs_pkbuf_t *pkbuf);
 int ogs_gtp_sendto(ogs_gtp_node_t *gnode, ogs_pkbuf_t *pkbuf);
-
-void ogs_gtp_send_error_message(
-        ogs_gtp_xact_t *xact, uint32_t teid, uint8_t type, uint8_t cause_value);
 
 #ifdef __cplusplus
 }

--- a/lib/gtp/v2/message.c
+++ b/lib/gtp/v2/message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2023-08-26 16:35:12.648272 by acetcom
+ * Created on: 2024-03-23 07:21:22.444548 by acetcom
  * from 29274-h70.docx
  ******************************************************************************/
 

--- a/lib/gtp/v2/message.h
+++ b/lib/gtp/v2/message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by gtp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2023-08-26 16:35:12.642445 by acetcom
+ * Created on: 2024-03-23 07:21:22.438775 by acetcom
  * from 29274-h70.docx
  ******************************************************************************/
 
@@ -44,6 +44,9 @@ typedef struct ogs_gtp2_header_s {
         struct {
 #define OGS_GTP2_VERSION_0 0
 #define OGS_GTP2_VERSION_1 1
+
+#define OGS_GTP2_TEID_NO_PRESENCE 0
+#define OGS_GTP2_TEID_PRESENCE 1
         ED4(uint8_t version:3;,
             uint8_t piggybacked:1;,
             uint8_t teid_presence:1;,

--- a/lib/gtp/v2/path.c
+++ b/lib/gtp/v2/path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -160,8 +160,8 @@ ogs_pkbuf_t *ogs_gtp2_handle_echo_req(ogs_pkbuf_t *pkb)
     return pkb_resp;
 }
 
-void ogs_gtp2_send_error_message(
-        ogs_gtp_xact_t *xact, uint32_t teid, uint8_t type, uint8_t cause_value)
+void ogs_gtp2_send_error_message(ogs_gtp_xact_t *xact,
+        int teid_presence, uint32_t teid, uint8_t type, uint8_t cause_value)
 {
     int rv;
     ogs_gtp2_message_t errmsg;
@@ -170,6 +170,7 @@ void ogs_gtp2_send_error_message(
     ogs_pkbuf_t *pkbuf = NULL;
 
     memset(&errmsg, 0, sizeof(ogs_gtp2_message_t));
+    errmsg.h.teid_presence = teid_presence;
     errmsg.h.teid = teid;
     errmsg.h.type = type;
 
@@ -257,7 +258,7 @@ void ogs_gtp2_send_echo_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_ECHO_REQUEST_TYPE;
-    h.teid = 0;
+    h.teid_presence = OGS_GTP2_TEID_NO_PRESENCE;
 
     pkbuf = ogs_gtp2_build_echo_request(h.type, recovery, features);
     if (!pkbuf) {
@@ -284,7 +285,7 @@ void ogs_gtp2_send_echo_response(ogs_gtp_xact_t *xact,
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_ECHO_RESPONSE_TYPE;
-    h.teid = 0;
+    h.teid_presence = OGS_GTP2_TEID_NO_PRESENCE;
 
     pkbuf = ogs_gtp2_build_echo_response(h.type, recovery, features);
     if (!pkbuf) {

--- a/lib/gtp/v2/path.h
+++ b/lib/gtp/v2/path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -36,8 +36,8 @@ int ogs_gtp2_send_user_plane(
         ogs_pkbuf_t *pkbuf);
 
 ogs_pkbuf_t *ogs_gtp2_handle_echo_req(ogs_pkbuf_t *pkb);
-void ogs_gtp2_send_error_message(
-        ogs_gtp_xact_t *xact, uint32_t teid, uint8_t type, uint8_t cause_value);
+void ogs_gtp2_send_error_message(ogs_gtp_xact_t *xact,
+        int teid_presence, uint32_t teid, uint8_t type, uint8_t cause_value);
 
 void ogs_gtp2_send_echo_request(
         ogs_gtp_node_t *gnode, uint8_t recovery, uint8_t features);

--- a/lib/gtp/v2/support/gtp-tlv.py
+++ b/lib/gtp/v2/support/gtp-tlv.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+# Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
 
 # This file is part of Open5GS.
 
@@ -60,7 +60,7 @@ def write_file(f, string):
 def output_header_to_file(f):
     now = datetime.datetime.now()
     f.write("""/*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -461,6 +461,9 @@ typedef struct ogs_gtp2_header_s {
         struct {
 #define OGS_GTP2_VERSION_0 0
 #define OGS_GTP2_VERSION_1 1
+
+#define OGS_GTP2_TEID_NO_PRESENCE 0
+#define OGS_GTP2_TEID_PRESENCE 1
         ED4(uint8_t version:3;,
             uint8_t piggybacked:1;,
             uint8_t teid_presence:1;,

--- a/lib/gtp/xact.c
+++ b/lib/gtp/xact.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
  * Copyright (C) 2022 by sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
+ * Copyright (C) 2023-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -407,7 +408,7 @@ int ogs_gtp_xact_update_tx(ogs_gtp_xact_t *xact,
         return OGS_ERROR;
     }
 
-    if (hdesc->type > OGS_GTP2_VERSION_NOT_SUPPORTED_INDICATION_TYPE) {
+    if (hdesc->teid_presence) {
         gtp_hlen = OGS_GTPV2C_HEADER_LEN;
     } else {
         gtp_hlen = OGS_GTPV2C_HEADER_LEN - OGS_GTP2_TEID_LEN;
@@ -420,12 +421,12 @@ int ogs_gtp_xact_update_tx(ogs_gtp_xact_t *xact,
     h->version = 2;
     h->type = hdesc->type;
 
-    if (hdesc->type > OGS_GTP2_VERSION_NOT_SUPPORTED_INDICATION_TYPE) {
-        h->teid_presence = 1;
+    if (hdesc->teid_presence) {
+        h->teid_presence = OGS_GTP2_TEID_PRESENCE;
         h->teid = htobe32(hdesc->teid);
         h->sqn = OGS_GTP2_XID_TO_SQN(xact->xid);
     } else {
-        h->teid_presence = 0;
+        h->teid_presence = OGS_GTP2_TEID_NO_PRESENCE;
         h->sqn_only = OGS_GTP2_XID_TO_SQN(xact->xid);
     }
     h->length = htobe16(pkbuf->len - 4);

--- a/lib/pfcp/message.c
+++ b/lib/pfcp/message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by pfcp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2024-01-19 23:36:01.346970 by acetcom
+ * Created on: 2024-03-23 07:20:44.691773 by acetcom
  * from 29244-h71-modified.docx
  ******************************************************************************/
 

--- a/lib/pfcp/message.h
+++ b/lib/pfcp/message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by pfcp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2024-01-19 23:36:01.327925 by acetcom
+ * Created on: 2024-03-23 07:20:44.672650 by acetcom
  * from 29244-h71-modified.docx
  ******************************************************************************/
 
@@ -41,6 +41,8 @@ extern "C" {
 typedef struct ogs_pfcp_header_s {
     union {
         struct {
+#define OGS_PFCP_SEID_NO_PRESENCE 0
+#define OGS_PFCP_SEID_PRESENCE 1
         ED4(uint8_t version:3;,
             uint8_t spare1:3;,
             uint8_t mp:1;,

--- a/lib/pfcp/path.c
+++ b/lib/pfcp/path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -140,7 +140,7 @@ int ogs_pfcp_send_heartbeat_request(ogs_pfcp_node_t *node,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_HEARTBEAT_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     xact = ogs_pfcp_xact_local_create(node, cb, node);
     if (!xact) {
@@ -176,7 +176,7 @@ int ogs_pfcp_send_heartbeat_response(ogs_pfcp_xact_t *xact)
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_HEARTBEAT_RESPONSE_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     pkbuf = ogs_pfcp_build_heartbeat_response(h.type);
     if (!pkbuf) {
@@ -217,7 +217,7 @@ int ogs_pfcp_cp_send_association_setup_request(ogs_pfcp_node_t *node,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     xact = ogs_pfcp_xact_local_create(node, cb, node);
     if (!xact) {
@@ -254,7 +254,7 @@ int ogs_pfcp_cp_send_association_setup_response(ogs_pfcp_xact_t *xact,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     pkbuf = ogs_pfcp_cp_build_association_setup_response(h.type, cause);
     if (!pkbuf) {
@@ -286,7 +286,7 @@ int ogs_pfcp_up_send_association_setup_request(ogs_pfcp_node_t *node,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     xact = ogs_pfcp_xact_local_create(node, cb, node);
     if (!xact) {
@@ -323,7 +323,7 @@ int ogs_pfcp_up_send_association_setup_response(ogs_pfcp_xact_t *xact,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE;
-    h.seid = 0;
+    h.seid_presence = OGS_PFCP_SEID_NO_PRESENCE;
 
     pkbuf = ogs_pfcp_up_build_association_setup_response(h.type, cause);
     if (!pkbuf) {
@@ -468,7 +468,7 @@ void ogs_pfcp_send_buffered_packet(ogs_pfcp_pdr_t *pdr)
 }
 
 void ogs_pfcp_send_error_message(
-    ogs_pfcp_xact_t *xact, uint64_t seid, uint8_t type,
+    ogs_pfcp_xact_t *xact, int seid_presence, uint64_t seid, uint8_t type,
     uint8_t cause_value, uint16_t offending_ie_value)
 {
     int rv;
@@ -480,6 +480,7 @@ void ogs_pfcp_send_error_message(
     ogs_assert(xact);
 
     memset(&errmsg, 0, sizeof(ogs_pfcp_message_t));
+    errmsg.h.seid_presence = seid_presence;
     errmsg.h.seid = seid;
     errmsg.h.type = type;
 

--- a/lib/pfcp/path.h
+++ b/lib/pfcp/path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -86,7 +86,7 @@ int ogs_pfcp_send_end_marker(ogs_pfcp_pdr_t *pdr);
 void ogs_pfcp_send_buffered_packet(ogs_pfcp_pdr_t *pdr);
 
 void ogs_pfcp_send_error_message(
-    ogs_pfcp_xact_t *xact, uint64_t seid, uint8_t type,
+    ogs_pfcp_xact_t *xact, int seid_presence, uint64_t seid, uint8_t type,
     uint8_t cause_value, uint16_t offending_ie_value);
 
 #ifdef __cplusplus

--- a/lib/pfcp/support/pfcp-tlv.py
+++ b/lib/pfcp/support/pfcp-tlv.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+# Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
 
 # This file is part of Open5GS.
 
@@ -54,7 +54,7 @@ def write_file(f, string):
 def output_header_to_file(f):
     now = datetime.datetime.now()
     f.write("""/*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -541,6 +541,8 @@ extern "C" {
 typedef struct ogs_pfcp_header_s {
     union {
         struct {
+#define OGS_PFCP_SEID_NO_PRESENCE 0
+#define OGS_PFCP_SEID_PRESENCE 1
         ED4(uint8_t version:3;,
             uint8_t spare1:3;,
             uint8_t mp:1;,

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -251,7 +251,7 @@ int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
         return OGS_ERROR;
     }
 
-    if (hdesc->type >= OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE) {
+    if (hdesc->seid_presence) {
         pfcp_hlen = OGS_PFCP_HEADER_LEN;
     } else {
         pfcp_hlen = OGS_PFCP_HEADER_LEN - OGS_PFCP_SEID_LEN;
@@ -264,7 +264,7 @@ int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
     h->version = OGS_PFCP_VERSION;
     h->type = hdesc->type;
 
-    if (h->type >= OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE) {
+    if (hdesc->seid_presence) {
         h->seid_presence = 1;
         h->seid = htobe64(hdesc->seid);
         h->sqn = OGS_PFCP_XID_TO_SQN(xact->xid);

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -254,6 +254,7 @@ int mme_gtp_send_create_session_request(mme_sess_t *sess, int create_action)
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_session_request(h.type, sess, create_action);
@@ -293,6 +294,7 @@ int mme_gtp_send_modify_bearer_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_modify_bearer_request(h.type, mme_ue, uli_presence);
@@ -332,6 +334,7 @@ int mme_gtp_send_delete_session_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     s11buf = mme_s11_build_delete_session_request(h.type, sess, action);
@@ -400,6 +403,7 @@ int mme_gtp_send_create_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_bearer_response(h.type, bearer, cause_value);
@@ -445,6 +449,7 @@ int mme_gtp_send_update_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_update_bearer_response(h.type, bearer, cause_value);
@@ -490,6 +495,7 @@ int mme_gtp_send_delete_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_delete_bearer_response(h.type, bearer, cause_value);
@@ -525,6 +531,7 @@ int mme_gtp_send_release_access_bearers_request(mme_ue_t *mme_ue, int action)
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_release_access_bearers_request(h.type);
@@ -622,6 +629,7 @@ int mme_gtp_send_downlink_data_notification_ack(
     /* Build Downlink data notification ack */
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     s11buf = mme_s11_build_downlink_data_notification_ack(h.type, cause_value);
@@ -657,6 +665,7 @@ int mme_gtp_send_create_indirect_data_forwarding_tunnel_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_create_indirect_data_forwarding_tunnel_request(
@@ -696,6 +705,7 @@ int mme_gtp_send_delete_indirect_data_forwarding_tunnel_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = ogs_pkbuf_alloc(NULL, OGS_TLV_MAX_HEADROOM);
@@ -738,6 +748,7 @@ int mme_gtp_send_bearer_resource_command(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgw_ue->sgw_s11_teid;
 
     pkbuf = mme_s11_build_bearer_resource_command(h.type, bearer, nas_message);

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -820,7 +820,9 @@ void mme_s11_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgw_ue ? sgw_ue->sgw_s11_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -856,7 +858,9 @@ void mme_s11_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgw_ue ? sgw_ue->sgw_s11_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1012,7 +1016,9 @@ void mme_s11_handle_update_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgw_ue ? sgw_ue->sgw_s11_teid : 0,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1183,7 +1189,9 @@ void mme_s11_handle_delete_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgw_ue ? sgw_ue->sgw_s11_teid : 0,
                 OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
         return;
@@ -1440,7 +1448,9 @@ void mme_s11_handle_downlink_data_notification(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgw_ue ? sgw_ue->sgw_s11_teid : 0,
                 OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE,
                 OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
         return;

--- a/src/sgwc/gtp-path.c
+++ b/src/sgwc/gtp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -182,6 +182,7 @@ int sgwc_gtp_send_create_session_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgwc_ue->mme_s11_teid;
 
     pkbuf = sgwc_s11_build_create_session_response(h.type, sess);
@@ -229,6 +230,7 @@ int sgwc_gtp_send_downlink_data_notification(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sgwc_ue->mme_s11_teid;
 
     pkbuf = sgwc_s11_build_downlink_data_notification(cause_value, bearer);

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -222,6 +222,7 @@ int sgwc_pfcp_send_bearer_to_modify_list(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = sgwc_sxa_build_bearer_to_modify_list(h.type, sess, xact);
@@ -302,6 +303,7 @@ int sgwc_pfcp_send_session_establishment_request(
  *   over N4 towards another SMF or another PFCP entity in the SMF
  *   as specified in clause 5.22.2 and clause 5.22.3.
  */
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = sgwc_sxa_build_session_establishment_request(h.type, sess);
@@ -389,6 +391,7 @@ int sgwc_pfcp_send_bearer_modification_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = sgwc_sxa_build_bearer_to_modify_list(h.type, sess, xact);
@@ -437,6 +440,7 @@ int sgwc_pfcp_send_session_deletion_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_DELETION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = sgwc_sxa_build_session_deletion_request(h.type, sess);
@@ -466,6 +470,7 @@ int sgwc_pfcp_send_session_report_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwu_sxa_seid;
 
     sxabuf = ogs_pfcp_build_session_report_response(h.type, cause);

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -173,8 +173,9 @@ void sgwc_s11_handle_create_session_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -214,8 +215,9 @@ void sgwc_s11_handle_create_session_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -262,8 +264,9 @@ void sgwc_s11_handle_create_session_request(
     /* Check if selected SGW-U is associated with SGW-C */
     ogs_assert(sess->pfcp_node);
     if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING);
         return;
@@ -423,8 +426,9 @@ void sgwc_s11_handle_modify_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -531,8 +535,9 @@ void sgwc_s11_handle_modify_bearer_request(
 
     if (i == 0) {
         ogs_error("No Bearer");
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -609,8 +614,9 @@ void sgwc_s11_handle_delete_session_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -629,8 +635,9 @@ void sgwc_s11_handle_delete_session_request(
         indication->operation_indication == 1 &&
         indication->scope_indication == 1) {
         ogs_error("Invalid Indication");
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT);
         return;
@@ -656,6 +663,7 @@ void sgwc_s11_handle_delete_session_request(
 
     } else {
         message->h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
+        message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         message->h.teid = sess->pgw_s5c_teid;
 
         gtpbuf = ogs_gtp2_build_msg(message);
@@ -762,7 +770,9 @@ void sgwc_s11_handle_create_bearer_response(
             sgwc_pfcp_send_bearer_modification_request(
                 bearer, NULL, NULL,
                 OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_REMOVE));
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -781,7 +791,9 @@ void sgwc_s11_handle_create_bearer_response(
             sgwc_pfcp_send_bearer_modification_request(
                 bearer, NULL, NULL,
                 OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_REMOVE));
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -915,7 +927,9 @@ void sgwc_s11_handle_update_bearer_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -930,7 +944,9 @@ void sgwc_s11_handle_update_bearer_response(
     cause_value = cause->value;
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("GTP Bearer Cause [VALUE:%d]", cause_value);
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -940,7 +956,9 @@ void sgwc_s11_handle_update_bearer_response(
     cause_value = cause->value;
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("GTP Cause [Value:%d]", cause_value);
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -957,6 +975,7 @@ void sgwc_s11_handle_update_bearer_response(
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
 
     message->h.type = OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE;
+    message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     message->h.teid = sess->pgw_s5c_teid;
 
     pkbuf = ogs_gtp2_build_msg(message);
@@ -1128,8 +1147,9 @@ void sgwc_s11_handle_release_access_bearers_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1235,8 +1255,9 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 cause_value);
         return;
@@ -1253,8 +1274,9 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
     for (i = 0; req->bearer_contexts[i].presence; i++) {
         if (req->bearer_contexts[i].eps_bearer_id.presence == 0) {
             ogs_error("No EBI");
-            ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
             return;
@@ -1276,8 +1298,9 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
 
             rv = ogs_gtp2_f_teid_to_ip(req_teid, &tunnel->remote_ip);
             if (rv != OGS_OK) {
-                ogs_gtp_send_error_message(s11_xact,
-                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
                 return;
@@ -1311,8 +1334,9 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
 
             rv = ogs_gtp2_f_teid_to_ip(req_teid, &tunnel->remote_ip);
             if (rv != OGS_OK) {
-                ogs_gtp_send_error_message(s11_xact,
-                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
                 return;
@@ -1366,8 +1390,9 @@ void sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 cause_value);
         return;
@@ -1441,8 +1466,9 @@ void sgwc_s11_handle_bearer_resource_command(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
@@ -1462,8 +1488,9 @@ void sgwc_s11_handle_bearer_resource_command(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
@@ -1483,6 +1510,7 @@ void sgwc_s11_handle_bearer_resource_command(
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
 
     message->h.type = OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE;
+    message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     message->h.teid = sess->pgw_s5c_teid;
 
     pkbuf = ogs_gtp2_build_msg(message);

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024444 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -122,8 +122,9 @@ void sgwc_s5c_handle_create_session_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -160,8 +161,9 @@ void sgwc_s5c_handle_create_session_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -185,8 +187,10 @@ void sgwc_s5c_handle_create_session_response(
         bearer_cause = cause->value;
         if (bearer_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
             ogs_error("GTP Bearer Cause [VALUE:%d]", bearer_cause);
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+            ogs_gtp2_send_error_message(s11_xact,
+                    sgwc_ue ? OGS_GTP2_TEID_PRESENCE :
+                        OGS_GTP2_TEID_NO_PRESENCE,
+                    sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, bearer_cause);
             return;
         }
@@ -199,8 +203,9 @@ void sgwc_s5c_handle_create_session_response(
         session_cause !=
             OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY) {
         ogs_error("GTP Cause [VALUE:%d]", session_cause);
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, session_cause);
         return;
     }
@@ -233,8 +238,10 @@ void sgwc_s5c_handle_create_session_response(
         bearer = sgwc_bearer_find_by_sess_ebi(sess,
                     rsp->bearer_contexts_created[i].eps_bearer_id.u8);
         if (!bearer) {
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+            ogs_gtp2_send_error_message(s11_xact,
+                    sgwc_ue ? OGS_GTP2_TEID_PRESENCE :
+                        OGS_GTP2_TEID_NO_PRESENCE,
+                    sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                     OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
             return;
@@ -253,8 +260,10 @@ void sgwc_s5c_handle_create_session_response(
 
         rv = ogs_gtp2_f_teid_to_ip(pgw_s5u_teid, &ul_tunnel->remote_ip);
         if (rv != OGS_OK) {
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+            ogs_gtp2_send_error_message(s11_xact,
+                    sgwc_ue ? OGS_GTP2_TEID_PRESENCE :
+                        OGS_GTP2_TEID_NO_PRESENCE,
+                    sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                     OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
             return;
@@ -354,13 +363,15 @@ void sgwc_s5c_handle_modify_bearer_response(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (modify_action == OGS_GTP_MODIFY_IN_PATH_SWITCH_REQUEST)
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         else
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -376,13 +387,15 @@ void sgwc_s5c_handle_modify_bearer_response(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (modify_action == OGS_GTP_MODIFY_IN_PATH_SWITCH_REQUEST)
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         else
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
 
@@ -394,13 +407,15 @@ void sgwc_s5c_handle_modify_bearer_response(
     if (session_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("GTP Cause [VALUE:%d]", session_cause);
         if (modify_action == OGS_GTP_MODIFY_IN_PATH_SWITCH_REQUEST)
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, session_cause);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, session_cause);
         else
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, session_cause);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, session_cause);
         return;
     }
 
@@ -420,6 +435,7 @@ void sgwc_s5c_handle_modify_bearer_response(
             sgwc_gtp_send_create_session_response(sess, s11_xact));
     } else {
         message->h.type = OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE;
+        message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         message->h.teid = sgwc_ue->mme_s11_teid;
 
         pkbuf = ogs_gtp2_build_msg(message);
@@ -493,8 +509,9 @@ void sgwc_s5c_handle_delete_session_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -573,7 +590,9 @@ void sgwc_s5c_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -601,7 +620,9 @@ void sgwc_s5c_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -631,7 +652,9 @@ void sgwc_s5c_handle_create_bearer_request(
 
     rv = ogs_gtp2_f_teid_to_ip(pgw_s5u_teid, &ul_tunnel->remote_ip);
     if (rv != OGS_OK) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
         return;
@@ -709,7 +732,9 @@ void sgwc_s5c_handle_update_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -729,6 +754,7 @@ void sgwc_s5c_handle_update_bearer_request(
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
 
     message->h.type = OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE;
+    message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     message->h.teid = sgwc_ue->mme_s11_teid;
 
     pkbuf = ogs_gtp2_build_msg(message);
@@ -850,7 +876,9 @@ void sgwc_s5c_handle_delete_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(s5c_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -870,6 +898,7 @@ void sgwc_s5c_handle_delete_bearer_request(
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
 
     message->h.type = OGS_GTP2_DELETE_BEARER_REQUEST_TYPE;
+    message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     message->h.teid = sgwc_ue->mme_s11_teid;
 
     pkbuf = ogs_gtp2_build_msg(message);
@@ -970,6 +999,8 @@ void sgwc_s5c_handle_bearer_resource_failure_indication(
         cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    ogs_gtp_send_error_message(s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+    ogs_gtp2_send_error_message(s11_xact,
+            sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+            sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
             OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
 }

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -245,8 +245,9 @@ void sgwc_sxa_handle_session_establishment_response(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (sess) sgwc_ue = sess->sgwc_ue;
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+        ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -269,10 +270,11 @@ void sgwc_sxa_handle_session_establishment_response(
 
         if (dl_tunnel->local_addr == NULL && dl_tunnel->local_addr6 == NULL) {
             ogs_error("No UP F-TEID");
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
-                    OGS_GTP2_CAUSE_GRE_KEY_NOT_FOUND);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                OGS_GTP2_CAUSE_GRE_KEY_NOT_FOUND);
             return;
         }
 
@@ -347,6 +349,7 @@ void sgwc_sxa_handle_session_establishment_response(
         memset(&send_message, 0, sizeof(ogs_gtp2_message_t));
 
         send_message.h.type = OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE;
+        send_message.h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         send_message.h.teid = sess->pgw_s5c_teid;
 
         /* Send Control Plane(DL) : SGW-S5C */
@@ -396,6 +399,7 @@ void sgwc_sxa_handle_session_establishment_response(
 
         /* Create Session Request */
         recv_message->h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
+        recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         recv_message->h.teid = sess->pgw_s5c_teid;
 
         /* Send Control Plane(DL) : SGW-S5C */
@@ -581,9 +585,10 @@ void sgwc_sxa_handle_session_modification_response(
             s5c_xact = pfcp_xact->assoc_xact;
 
             if (s5c_xact) {
-                ogs_gtp_send_error_message(
-                        s5c_xact, sess ? sess->pgw_s5c_teid : 0,
-                        OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE, cause_value);
+                ogs_gtp2_send_error_message(s5c_xact,
+                    sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                    sess ? sess->pgw_s5c_teid : 0,
+                    OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE, cause_value);
             }
 
             sgwc_bearer_remove(bearer);
@@ -591,8 +596,9 @@ void sgwc_sxa_handle_session_modification_response(
             s5c_xact = pfcp_xact->assoc_xact;
             ogs_assert(s5c_xact);
 
-            ogs_gtp_send_error_message(
-                    s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+            ogs_gtp2_send_error_message(s5c_xact,
+                    sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                    sess ? sess->pgw_s5c_teid : 0,
                     OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
 
 
@@ -601,16 +607,20 @@ void sgwc_sxa_handle_session_modification_response(
                 s11_xact = pfcp_xact->assoc_xact;
                 ogs_assert(s11_xact);
 
-                ogs_gtp_send_error_message(
-                        s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                ogs_gtp2_send_error_message(s11_xact,
+                        sgwc_ue ? OGS_GTP2_TEID_PRESENCE :
+                            OGS_GTP2_TEID_NO_PRESENCE,
+                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                         OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
 
             } else if (flags & OGS_PFCP_MODIFY_DL_ONLY) {
                 s11_xact = pfcp_xact->assoc_xact;
                 ogs_assert(s11_xact);
 
-                ogs_gtp_send_error_message(
-                        s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                ogs_gtp2_send_error_message(s11_xact,
+                        sgwc_ue ? OGS_GTP2_TEID_PRESENCE :
+                            OGS_GTP2_TEID_NO_PRESENCE,
+                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                         OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
             } else {
                 ogs_fatal("Invalid modify_flags[0x%llx]", (long long)flags);
@@ -620,9 +630,10 @@ void sgwc_sxa_handle_session_modification_response(
             s11_xact = pfcp_xact->assoc_xact;
             ogs_assert(s11_xact);
 
-            ogs_gtp_send_error_message(
-                    s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                    OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
+            ogs_gtp2_send_error_message(s11_xact,
+                sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
         }
 
         ogs_pfcp_xact_commit(pfcp_xact);
@@ -694,6 +705,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 send_message.h.type =
                 OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
+                send_message.h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
                 pkbuf = ogs_gtp2_build_msg(&send_message);
@@ -720,6 +732,7 @@ void sgwc_sxa_handle_session_modification_response(
             if (s5c_xact) {
                 ogs_assert(recv_message);
                 recv_message->h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
+                recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                 recv_message->h.teid = sess->pgw_s5c_teid;
 
                 pkbuf = ogs_gtp2_build_msg(recv_message);
@@ -769,6 +782,7 @@ void sgwc_sxa_handle_session_modification_response(
             gtp_req->bearer_contexts.s1_u_enodeb_f_teid.len = len;
 
             recv_message->h.type = OGS_GTP2_CREATE_BEARER_REQUEST_TYPE;
+            recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
             recv_message->h.teid = sgwc_ue->mme_s11_teid;
 
             pkbuf = ogs_gtp2_build_msg(recv_message);
@@ -836,6 +850,7 @@ void sgwc_sxa_handle_session_modification_response(
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.len = len;
 
             recv_message->h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
+            recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
             recv_message->h.teid = sess->pgw_s5c_teid;
 
             pkbuf = ogs_gtp2_build_msg(recv_message);
@@ -962,6 +977,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 send_message.h.type =
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE;
+                send_message.h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
                 pkbuf = ogs_gtp2_build_msg(&send_message);
@@ -1046,6 +1062,7 @@ void sgwc_sxa_handle_session_modification_response(
             }
 
             recv_message->h.type = OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE;
+            recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
             recv_message->h.teid = sgwc_ue->mme_s11_teid;
 
             pkbuf = ogs_gtp2_build_msg(recv_message);
@@ -1083,6 +1100,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 if (indication && indication->handover_indication) {
                     recv_message->h.type = OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE;
+                    recv_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                     recv_message->h.teid = sess->pgw_s5c_teid;
 
                     pkbuf = ogs_gtp2_build_msg(recv_message);
@@ -1168,6 +1186,7 @@ void sgwc_sxa_handle_session_modification_response(
                     }
 
                     send_message.h.type = OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE;
+                    send_message.h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                     send_message.h.teid = sgwc_ue->mme_s11_teid;
 
                     pkbuf = ogs_gtp2_build_msg(&send_message);
@@ -1233,6 +1252,7 @@ void sgwc_sxa_handle_session_modification_response(
 
                 send_message.h.type =
                     OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE;
+                send_message.h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                 send_message.h.teid = sgwc_ue->mme_s11_teid;
 
                 pkbuf = ogs_gtp2_build_msg(&send_message);
@@ -1264,6 +1284,7 @@ void sgwc_sxa_handle_session_deletion_response(
 {
     int rv;
     uint8_t cause_value = 0;
+    int teid_presence = OGS_GTP2_TEID_NO_PRESENCE;
     uint32_t teid = 0;
 
     sgwc_ue_t *sgwc_ue = NULL;
@@ -1315,6 +1336,8 @@ void sgwc_sxa_handle_session_deletion_response(
          * 2. SMF sends Delete Session Response to SGW/MME.
          */
         if (sess) sgwc_ue = sess->sgwc_ue;
+        teid_presence =
+            sgwc_ue ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE;
         teid = sgwc_ue ? sgwc_ue->mme_s11_teid : 0;
         break;
     case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
@@ -1331,6 +1354,8 @@ void sgwc_sxa_handle_session_deletion_response(
          * - Bearer Resource Command
          * - Delete Bearer Request/Response with DEDICATED BEARER.
          */
+        teid_presence =
+            sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE;
         teid = sess ? sess->pgw_s5c_teid : 0;
         break;
     default:
@@ -1340,8 +1365,8 @@ void sgwc_sxa_handle_session_deletion_response(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (gtp_xact) {
-            ogs_gtp_send_error_message(
-                    gtp_xact, teid, gtp_message->h.type, cause_value);
+            ogs_gtp2_send_error_message(gtp_xact,
+                    teid_presence, teid, gtp_message->h.type, cause_value);
         }
         return;
     }
@@ -1358,6 +1383,7 @@ void sgwc_sxa_handle_session_deletion_response(
          * If gtp_message->h.type == OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE
          * Then gtp_xact is S5C-XACT
          */
+        gtp_message->h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         gtp_message->h.teid = teid;
 
         pkbuf = ogs_gtp2_build_msg(gtp_message);
@@ -1419,7 +1445,8 @@ void sgwc_sxa_handle_session_report_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_pfcp_send_error_message(pfcp_xact, 0,
+        ogs_pfcp_send_error_message(pfcp_xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 cause_value, 0);
         return;
@@ -1431,7 +1458,9 @@ void sgwc_sxa_handle_session_report_request(
 
     if (!sgwc_ue->gnode) {
         ogs_error("No SGWC-UE GTP Node");
-        ogs_pfcp_send_error_message(pfcp_xact, sess ? sess->sgwu_sxa_seid : 0,
+        ogs_pfcp_send_error_message(pfcp_xact,
+                sess ? OGS_PFCP_SEID_PRESENCE : OGS_PFCP_SEID_NO_PRESENCE,
+                sess ? sess->sgwu_sxa_seid : 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;

--- a/src/sgwu/pfcp-path.c
+++ b/src/sgwu/pfcp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -180,6 +180,7 @@ int sgwu_pfcp_send_session_establishment_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwc_sxa_f_seid.seid;
 
     sxabuf = sgwu_sxa_build_session_establishment_response(
@@ -213,6 +214,7 @@ int sgwu_pfcp_send_session_modification_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwc_sxa_f_seid.seid;
 
     sxabuf = sgwu_sxa_build_session_modification_response(
@@ -245,6 +247,7 @@ int sgwu_pfcp_send_session_deletion_response(ogs_pfcp_xact_t *xact,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwc_sxa_f_seid.seid;
 
     sxabuf = sgwu_sxa_build_session_deletion_response(h.type, sess);
@@ -295,6 +298,7 @@ int sgwu_pfcp_send_session_report_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_REPORT_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->sgwc_sxa_f_seid.seid;
 
     xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_timeout, sess);

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -45,7 +45,8 @@ void sgwu_sxa_handle_session_establishment_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_MANDATORY_IE_MISSING, 0);
         return;
@@ -142,7 +143,9 @@ void sgwu_sxa_handle_session_establishment_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->sgwu_sxa_seid : 0,
+    ogs_pfcp_send_error_message(xact,
+            sess ? OGS_PFCP_SEID_PRESENCE : OGS_PFCP_SEID_NO_PRESENCE,
+            sess ? sess->sgwu_sxa_seid : 0,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
@@ -168,7 +171,8 @@ void sgwu_sxa_handle_session_modification_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -309,7 +313,9 @@ void sgwu_sxa_handle_session_modification_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->sgwu_sxa_seid : 0,
+    ogs_pfcp_send_error_message(xact,
+            sess ? OGS_PFCP_SEID_PRESENCE : OGS_PFCP_SEID_NO_PRESENCE,
+            sess ? sess->sgwu_sxa_seid : 0,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
@@ -325,7 +331,8 @@ void sgwu_sxa_handle_session_deletion_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -363,6 +363,7 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 memset(&h, 0, sizeof(ogs_gtp2_header_t));
                 h.type = OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE;
+                h.teid_presence = OGS_GTP2_TEID_PRESENCE;
                 h.teid = sess->sgw_s5c_teid;
 
                 pkbuf = smf_s5c_build_update_bearer_request(
@@ -439,6 +440,7 @@ int smf_gtp2_send_create_bearer_request(smf_bearer_t *bearer)
     ogs_assert(sess);
 
     h.type = OGS_GTP2_CREATE_BEARER_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->sgw_s5c_teid;
 
     memset(&tft, 0, sizeof tft);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
-
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -74,7 +73,9 @@ static void send_gtp_create_err_msg(const smf_sess_t *sess,
         ogs_gtp1_send_error_message(gtp_xact, sess->sgw_s5c_teid,
             OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE, gtp_cause);
     else
-        ogs_gtp2_send_error_message(gtp_xact, sess->sgw_s5c_teid,
+        ogs_gtp2_send_error_message(gtp_xact,
+            sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+            sess->sgw_s5c_teid,
             OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, gtp_cause);
 }
 
@@ -85,7 +86,9 @@ static void send_gtp_delete_err_msg(const smf_sess_t *sess,
         ogs_gtp1_send_error_message(gtp_xact, sess->sgw_s5c_teid,
             OGS_GTP1_DELETE_PDP_CONTEXT_RESPONSE_TYPE, gtp_cause);
     else
-        ogs_gtp2_send_error_message(gtp_xact, sess->sgw_s5c_teid,
+        ogs_gtp2_send_error_message(gtp_xact,
+            sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+            sess->sgw_s5c_teid,
             OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, gtp_cause);
 }
 
@@ -775,8 +778,10 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                             sess, e->gtp_xact,
                             &gtp2_message->delete_session_request);
             if (gtp2_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-                ogs_gtp2_send_error_message(e->gtp_xact, sess->sgw_s5c_teid,
-                        OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, gtp2_cause);
+                ogs_gtp2_send_error_message(e->gtp_xact,
+                    sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                    sess->sgw_s5c_teid,
+                    OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, gtp2_cause);
                 return;
             }
             OGS_FSM_TRAN(s, smf_gsm_state_wait_pfcp_deletion);

--- a/src/smf/gtp-path.c
+++ b/src/smf/gtp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -444,6 +444,7 @@ int smf_gtp2_send_create_session_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->sgw_s5c_teid;
 
     pkbuf = smf_s5c_build_create_session_response(h.type, sess);
@@ -478,6 +479,7 @@ int smf_gtp2_send_modify_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->sgw_s5c_teid;
 
     pkbuf = smf_s5c_build_modify_bearer_response(
@@ -511,6 +513,7 @@ int smf_gtp2_send_delete_session_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->sgw_s5c_teid;
 
     pkbuf = smf_s5c_build_delete_session_response(h.type, sess);
@@ -548,6 +551,7 @@ int smf_gtp2_send_delete_bearer_request(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_BEARER_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->sgw_s5c_teid;
 
     pkbuf = smf_s5c_build_delete_bearer_request(

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -971,6 +971,7 @@ void smf_epc_n4_handle_session_modification_response(
 
             memset(&h, 0, sizeof(ogs_gtp2_header_t));
             h.teid = sess->sgw_s5c_teid;
+            h.teid_presence = OGS_GTP2_TEID_PRESENCE;
             h.type = OGS_GTP2_DELETE_BEARER_REQUEST_TYPE;
 
             pkbuf = smf_s5c_build_delete_bearer_request(
@@ -1182,7 +1183,8 @@ void smf_n4_handle_session_report_request(
     }
 
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_pfcp_send_error_message(pfcp_xact, 0,
+        ogs_pfcp_send_error_message(pfcp_xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 cause_value, 0);
         return;
@@ -1222,7 +1224,8 @@ void smf_n4_handle_session_report_request(
                     if (paging_policy_indication_value) {
                         ogs_warn("Not implement - "
                                 "Paging Policy Indication Value");
-                        ogs_pfcp_send_error_message(pfcp_xact, 0,
+                        ogs_pfcp_send_error_message(pfcp_xact,
+                                OGS_PFCP_SEID_NO_PRESENCE, 0,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED, 0);
                         return;
@@ -1232,7 +1235,8 @@ void smf_n4_handle_session_report_request(
                         qos_flow = smf_qos_flow_find_by_qfi(sess, qfi);
                         if (!qos_flow) {
                             ogs_error("Cannot find the QoS Flow[%d]", qfi);
-                            ogs_pfcp_send_error_message(pfcp_xact, 0,
+                            ogs_pfcp_send_error_message(pfcp_xact,
+                                OGS_PFCP_SEID_NO_PRESENCE, 0,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
                             return;
@@ -1257,7 +1261,8 @@ void smf_n4_handle_session_report_request(
 
         if (!pdr) {
             ogs_error("No Context");
-            ogs_pfcp_send_error_message(pfcp_xact, 0,
+            ogs_pfcp_send_error_message(pfcp_xact,
+                    OGS_PFCP_SEID_NO_PRESENCE, 0,
                     OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                     OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
             return;

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -353,6 +353,7 @@ int smf_pfcp_send_modify_list(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     n4buf = (*modify_list)(h.type, sess, xact);
@@ -430,6 +431,7 @@ int smf_5gc_pfcp_send_session_establishment_request(
  *   over N4 towards another SMF or another PFCP entity in the SMF
  *   as specified in clause 5.22.2 and clause 5.22.3.
  */
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess, xact);
@@ -532,6 +534,7 @@ int smf_5gc_pfcp_send_session_deletion_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_DELETION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_deletion_request(h.type, sess);
@@ -605,6 +608,7 @@ int smf_epc_pfcp_send_session_establishment_request(
  *   over N4 towards another SMF or another PFCP entity in the SMF
  *   as specified in clause 5.22.2 and clause 5.22.3.
  */
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_establishment_request(h.type, sess, xact);
@@ -748,6 +752,7 @@ int smf_epc_pfcp_send_session_deletion_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_DELETION_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     n4buf = smf_n4_build_session_deletion_request(h.type, sess);
@@ -846,6 +851,7 @@ int smf_pfcp_send_session_report_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->upf_n4_seid;
 
     sxabuf = ogs_pfcp_build_session_report_response(h.type, cause);

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -317,7 +317,8 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                         OGS_GTP1_CREATE_PDP_CONTEXT_RESPONSE_TYPE,
                         OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND);
                 else
-                    ogs_gtp2_send_error_message(gtp_xact, 0,
+                    ogs_gtp2_send_error_message(gtp_xact,
+                        OGS_GTP2_TEID_NO_PRESENCE, 0,
                         OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;
@@ -352,7 +353,8 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                         OGS_GTP1_DELETE_PDP_CONTEXT_RESPONSE_TYPE,
                         OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND);
                 else
-                    ogs_gtp2_send_error_message(gtp_xact, 0,
+                    ogs_gtp2_send_error_message(gtp_xact,
+                        OGS_GTP2_TEID_NO_PRESENCE, 0,
                         OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -504,7 +504,9 @@ void smf_s5c_handle_modify_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(gtp_xact, sess ? sess->sgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(gtp_xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1186,7 +1188,9 @@ void smf_s5c_handle_bearer_resource_command(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
@@ -1211,7 +1215,9 @@ void smf_s5c_handle_bearer_resource_command(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
@@ -1240,8 +1246,10 @@ void smf_s5c_handle_bearer_resource_command(
             pf = smf_pf_find_by_id(bearer, tft.pf[i].identifier+1);
             if (pf) {
                 if (reconfigure_packet_filter(pf, &tft, i) < 0) {
-                    ogs_gtp2_send_error_message(
-                        xact, sess ? sess->sgw_s5c_teid : 0,
+                    ogs_gtp2_send_error_message(xact,
+                        sess ? OGS_GTP2_TEID_PRESENCE :
+                            OGS_GTP2_TEID_NO_PRESENCE,
+                        sess ? sess->sgw_s5c_teid : 0,
                         OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
                         OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
                     return;
@@ -1309,8 +1317,9 @@ void smf_s5c_handle_bearer_resource_command(
             ogs_assert(pf);
 
             if (reconfigure_packet_filter(pf, &tft, i) < 0) {
-                ogs_gtp2_send_error_message(
-                    xact, sess ? sess->sgw_s5c_teid : 0,
+                ogs_gtp2_send_error_message(xact,
+                    sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                    sess ? sess->sgw_s5c_teid : 0,
                     OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
                     OGS_GTP2_CAUSE_SEMANTIC_ERRORS_IN_PACKET_FILTER);
                 return;
@@ -1396,7 +1405,9 @@ void smf_s5c_handle_bearer_resource_command(
 
     if (tft_update == 0 && tft_delete == 0 && qos_update == 0) {
         /* No modification */
-        ogs_gtp2_send_error_message(xact, sess ? sess->sgw_s5c_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sess ? OGS_GTP2_TEID_PRESENCE : OGS_GTP2_TEID_NO_PRESENCE,
+                sess ? sess->sgw_s5c_teid : 0,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
                 OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED);
         return;
@@ -1422,6 +1433,7 @@ void smf_s5c_handle_bearer_resource_command(
     } else {
         memset(&h, 0, sizeof(ogs_gtp2_header_t));
         h.teid = sess->sgw_s5c_teid;
+        h.teid_presence = OGS_GTP2_TEID_PRESENCE;
         h.type = OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE;
 
         pkbuf = smf_s5c_build_update_bearer_request(

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -144,7 +144,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             }
             if (!sess) {
                 ogs_error("No Session");
-                ogs_gtp2_send_error_message(gtp_xact, 0,
+                ogs_gtp2_send_error_message(gtp_xact,
+                        OGS_GTP2_TEID_NO_PRESENCE, 0,
                         OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;
@@ -158,7 +159,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             smf_metrics_inst_gtp_node_inc(smf_gnode->metrics, SMF_METR_GTP_NODE_CTR_S5C_RX_DELETESESSIONREQ);
             if (!sess) {
                 ogs_error("No Session");
-                ogs_gtp2_send_error_message(gtp_xact, 0,
+                ogs_gtp2_send_error_message(gtp_xact,
+                        OGS_GTP2_TEID_NO_PRESENCE, 0,
                         OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -69,7 +69,8 @@ void upf_n4_handle_session_establishment_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_MANDATORY_IE_MISSING, 0);
         upf_metrics_inst_by_cause_add(OGS_PFCP_CAUSE_MANDATORY_IE_MISSING,
@@ -214,7 +215,9 @@ cleanup:
     upf_metrics_inst_by_cause_add(cause_value,
             UPF_METR_CTR_SM_N4SESSIONESTABFAIL, 1);
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
+    ogs_pfcp_send_error_message(xact,
+            sess ? OGS_PFCP_SEID_PRESENCE : OGS_PFCP_SEID_NO_PRESENCE,
+            sess ? sess->smf_n4_f_seid.seid : 0,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
@@ -240,7 +243,8 @@ void upf_n4_handle_session_modification_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -413,7 +417,9 @@ void upf_n4_handle_session_modification_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
+    ogs_pfcp_send_error_message(xact,
+            sess ? OGS_PFCP_SEID_PRESENCE : OGS_PFCP_SEID_NO_PRESENCE,
+            sess ? sess->smf_n4_f_seid.seid : 0,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
@@ -431,7 +437,8 @@ void upf_n4_handle_session_deletion_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                OGS_PFCP_SEID_NO_PRESENCE, 0,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;

--- a/src/upf/pfcp-path.c
+++ b/src/upf/pfcp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -183,6 +183,7 @@ int upf_pfcp_send_session_establishment_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->smf_n4_f_seid.seid;
 
     n4buf = upf_n4_build_session_establishment_response(
@@ -216,6 +217,7 @@ int upf_pfcp_send_session_modification_response(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->smf_n4_f_seid.seid;
 
     n4buf = upf_n4_build_session_modification_response(
@@ -248,6 +250,7 @@ int upf_pfcp_send_session_deletion_response(ogs_pfcp_xact_t *xact,
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->smf_n4_f_seid.seid;
 
     n4buf = upf_n4_build_session_deletion_response(h.type, sess);
@@ -300,6 +303,7 @@ int upf_pfcp_send_session_report_request(
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
     h.type = OGS_PFCP_SESSION_REPORT_REQUEST_TYPE;
+    h.seid_presence = OGS_PFCP_SEID_PRESENCE;
     h.seid = sess->smf_n4_f_seid.seid;
 
     xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_timeout, sess);

--- a/tests/non3gpp/gtp-path.c
+++ b/tests/non3gpp/gtp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -135,6 +135,7 @@ int test_s2b_send_create_session_request(test_sess_t *sess, bool handover_ind)
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_SESSION_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_create_session_request(h.type, sess, handover_ind);
@@ -166,6 +167,7 @@ int test_s2b_send_delete_session_request(test_sess_t *sess)
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_delete_session_request(h.type, sess);
@@ -201,6 +203,7 @@ int test_s2b_send_create_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_create_bearer_response(h.type, bearer);
@@ -236,6 +239,7 @@ int test_s2b_send_delete_bearer_response(
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
+    h.teid_presence = OGS_GTP2_TEID_PRESENCE;
     h.teid = sess->smf_s2b_c_teid;
 
     pkbuf = test_s2b_build_delete_bearer_response(h.type, bearer);


### PR DESCRIPTION
If eg. PCRF or AAA diameter link is not yet ready (eg. PCRF crashed), and a client sends a CreateSessionRequest announcing its ow F-TEID, then open5gs-smfd answers with Create Session Response Cause= "Remote peer not responding", but it is not setting the received F-TEID in the header of the response, instead it sends with TEI=0.

As a result, the peer cannot match the CreateSessionResponse, and needs to rely on its own timeout timer to figure out that specific request failed.

This also happens in PFCP, so to solve this problem, I added teid/seid_presence to the interface that sends the error message as shown below.

```
void ogs_gtp2_send_error_message(ogs_gtp_xact_t *xact,
        int teid_presence, uint32_t teid, uint8_t type, uint8_t cause_value);
void ogs_pfcp_send_error_message(
    ogs_pfcp_xact_t *xact, int seid_presence, uint64_t seid, uint8_t type,
    uint8_t cause_value, uint16_t offending_ie_value);
```