### PR TITLE
[MME] incorrect behavior of the SGsAP

### DIFF
--- a/docs/_docs/tutorial/01-your-first-lte.md
+++ b/docs/_docs/tutorial/01-your-first-lte.md
@@ -334,7 +334,7 @@ Change back to the srsRAN source directory and copy the main config example as w
 ```bash
 $ cp srsenb/enb.conf.example srsenb/enb.conf
 $ cp srsenb/rr.conf.example srsenb/rr.conf
-$ cp srsenb/drb.conf.example srsenb/drb.conf
+$ cp srsenb/rb.conf.example srsenb/rb.conf
 $ cp srsenb/sib.conf.example srsenb/sib.conf
 ```
 

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -236,13 +236,17 @@ int esm_handle_information_response(mme_sess_t *sess,
             mme_csmap_t *csmap = mme_csmap_find_by_tai(&mme_ue->tai);
             mme_ue->csmap = csmap;
 
-            if (csmap) {
-                ogs_assert(OGS_OK ==
-                    sgsap_send_location_update_request(mme_ue));
-            } else {
+            if (!csmap ||
+                mme_ue->network_access_mode ==
+                    OGS_NETWORK_ACCESS_MODE_ONLY_PACKET ||
+                mme_ue->nas_eps.attach.value ==
+                    OGS_NAS_ATTACH_TYPE_EPS_ATTACH) {
                 r = nas_eps_send_attach_accept(mme_ue);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
+            } else {
+                ogs_assert(OGS_OK ==
+                    sgsap_send_location_update_request(mme_ue));
             }
         } else {
             ogs_assert(OGS_OK ==

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -427,17 +427,20 @@ void mme_s11_handle_create_session_response(
         mme_csmap_t *csmap = mme_csmap_find_by_tai(&mme_ue->tai);
         mme_ue->csmap = csmap;
 
-        if (csmap) {
-            ogs_assert(OGS_PDU_SESSION_TYPE_IS_VALID(
-                        session->paa.session_type));
-            ogs_assert(OGS_OK ==
-                sgsap_send_location_update_request(mme_ue));
-        } else {
+        if (!csmap ||
+            mme_ue->network_access_mode ==
+                OGS_NETWORK_ACCESS_MODE_ONLY_PACKET ||
+            mme_ue->nas_eps.attach.value ==
+                OGS_NAS_ATTACH_TYPE_EPS_ATTACH) {
             ogs_assert(OGS_PDU_SESSION_TYPE_IS_VALID(
                         session->paa.session_type));
             r = nas_eps_send_attach_accept(mme_ue);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
+        } else {
+            ogs_assert(OGS_PDU_SESSION_TYPE_IS_VALID(
+                        session->paa.session_type));
+            ogs_assert(OGS_OK == sgsap_send_location_update_request(mme_ue));
         }
 
     } else if (create_action == OGS_GTP_CREATE_IN_TRACKING_AREA_UPDATE) {

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -210,11 +210,9 @@ void sgsap_handle_location_update_reject(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
                     ogs_plmn_id_hexdump(&lai->nas_plmn_id), lai->lac);
     }
 
-    r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
-            emm_cause, OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
+    r = nas_eps_send_attach_accept(mme_ue);
     ogs_expect(r == OGS_OK);
     ogs_assert(r != OGS_ERROR);
-    mme_send_delete_session_or_mme_ue_context_release(mme_ue);
 
     return;
 


### PR DESCRIPTION
1. According to ETSI TS 129 118 4.1, if the Network Access Mode (NAM) is set to "Packet only," no SGs association should be established.

2. If the NAM is set to "Packet and Circuit," and the SGs association is rejected by the CS core, this rejection should only impact the SGs association itself and not result in a UE attach rejection for a UE with a valid HSS account.