### PR TITLE
logrotate: fix reload failures

### DIFF
--- a/configs/logrotate/open5gs.in
+++ b/configs/logrotate/open5gs.in
@@ -8,7 +8,9 @@
 
     postrotate
         for i in nrfd scpd seppd pcrfd hssd ausfd udmd udrd upfd sgwcd sgwud smfd mmed amfd; do
-            systemctl reload open5gs-$i
+            if systemctl --quiet is-active open5gs-$i; then
+                 systemctl reload open5gs-$i
+            fi
         done
     endscript
 }


### PR DESCRIPTION
Do not attempt to run "systemctl reload" on the open5gs services, unless they are running. This fixes the logrotate service failing on this postrotate script, if units are not running or not installed.