### PR TITLE
[SMF] Crash SMF when no GTP-C config (#3094)

### DIFF
--- a/lib/gtp/path.h
+++ b/lib/gtp/path.h
@@ -35,16 +35,12 @@ extern "C" {
         ogs_gtp_self()->gtpc_sock6 = \
             ogs_socknode_sock_first(&ogs_gtp_self()->gtpc_list6); \
         \
-        ogs_assert(ogs_gtp_self()->gtpc_sock || ogs_gtp_self()->gtpc_sock6); \
-        \
         if (ogs_gtp_self()->gtpc_sock) \
             ogs_gtp_self()->gtpc_addr = \
                 &ogs_gtp_self()->gtpc_sock->local_addr; \
         if (ogs_gtp_self()->gtpc_sock6) \
             ogs_gtp_self()->gtpc_addr6 = \
                 &ogs_gtp_self()->gtpc_sock6->local_addr; \
-        \
-        ogs_assert(ogs_gtp_self()->gtpc_addr || ogs_gtp_self()->gtpc_addr6); \
         \
     } while(0)
 

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -203,6 +203,8 @@ int mme_gtp_open(void)
     }
 
     OGS_SETUP_GTPC_SERVER;
+    ogs_assert(ogs_gtp_self()->gtpc_sock || ogs_gtp_self()->gtpc_sock6);
+    ogs_assert(ogs_gtp_self()->gtpc_addr || ogs_gtp_self()->gtpc_addr6);
 
     mme_self()->pgw_addr = mme_pgw_addr_find_by_apn_enb(
             &mme_self()->pgw_list, AF_INET, NULL);

--- a/src/sgwc/gtp-path.c
+++ b/src/sgwc/gtp-path.c
@@ -129,6 +129,8 @@ int sgwc_gtp_open(void)
     }
 
     OGS_SETUP_GTPC_SERVER;
+    ogs_assert(ogs_gtp_self()->gtpc_sock || ogs_gtp_self()->gtpc_sock6);
+    ogs_assert(ogs_gtp_self()->gtpc_addr || ogs_gtp_self()->gtpc_addr6);
 
     return OGS_OK;
 }

--- a/src/smf/gtp-path.c
+++ b/src/smf/gtp-path.c
@@ -251,6 +251,9 @@ int smf_gtp_open(void)
     }
 
     OGS_SETUP_GTPC_SERVER;
+    /* If we only use 5G, we don't need GTP-C, so there is no check routine. */
+    if (!ogs_gtp_self()->gtpc_sock  && !ogs_gtp_self()->gtpc_sock6)
+        ogs_warn("No GTP-C configuration");
 
     ogs_list_for_each(&ogs_gtp_self()->gtpu_list, node) {
         sock = ogs_gtp_server(node);


### PR DESCRIPTION
When GTP-C secition of smf.yaml is deleted as follows to run smf as 5G, it crashed.

```diff
--- smf.yaml.orig       2024-03-26 14:13:12.000000000 +0900
+++ smf.yaml    2024-03-26 14:29:40.701508424 +0900
@@ -23,9 +23,6 @@
     client:
       upf:
         - address: 127.0.0.7
-  gtpc:
-    server:
-      - address: 127.0.0.4
   gtpu:
     server:
       - address: 127.0.0.4
@@ -47,7 +44,7 @@
 #    - ::1
 #  ctf:
 #    enabled: auto   # auto(default)|yes|no
-  freeDiameter: /root/open5gs/install/etc/freeDiameter/smf.conf
+#  freeDiameter: /root/open5gs/install/etc/freeDiameter/smf.conf

 ################################################################################
 # SMF Info
Open5GS daemon v2.7.0-119-g581d255

03/26 14:39:42.844: [app] INFO: Configuration: 'install/etc/open5gs/smf.yaml' (../lib/app/ogs-init.c:130)
03/26 14:39:42.845: [app] INFO: File Logging: '/root/open5gs/install/var/log/open5gs/smf.log' (../lib/app/ogs-init.c:133)
03/26 14:39:42.913: [metrics] INFO: metrics_server() [http://127.0.0.4]:9090 (../lib/metrics/prometheus/context.c:299)
03/26 14:39:42.913: [smf] WARNING: No diameter configuration (../src/smf/fd-path.c:30)
03/26 14:39:42.913: [smf] FATAL: smf_gtp_open: Assertion `ogs_gtp_self()->gtpc_sock || ogs_gtp_self()->gtpc_sock6' failed. (../src/smf/gtp-path.c:253)
03/26 14:39:42.913: [core] FATAL: backtrace() returned 8 addresses (../lib/core/ogs-abort.c:37)
./install/bin/open5gs-smfd(+0x391ab) [0x55d28319b1ab]
./install/bin/open5gs-smfd(+0x10046) [0x55d283172046]
./install/bin/open5gs-smfd(+0xf3de) [0x55d2831713de]
./install/bin/open5gs-smfd(+0xfcf9) [0x55d283171cf9]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f0a145f9d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7f0a145f9e40]
./install/bin/open5gs-smfd(+0xf305) [0x55d283171305]
Aborted (core dumped)
```

So, Fixed to run SMF with GTP-C disabled for 5G.