### PR TITLE
[DBI] mongoc version not checked correctly (#3086)

### DIFF
--- a/lib/dbi/ims.c
+++ b/lib/dbi/ims.c
@@ -42,7 +42,7 @@ int ogs_dbi_msisdn_data(
                 "{", "imsi", BCON_UTF8(imsi_or_msisdn_bcd), "}",
                 "{", "msisdn", BCON_UTF8(imsi_or_msisdn_bcd), "}",
             "]");
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 5
+#if MONGOC_CHECK_VERSION(1, 5, 0)
     cursor = mongoc_collection_find_with_opts(
             ogs_mongoc()->collection.subscriber, query, NULL, NULL);
 #else
@@ -138,7 +138,7 @@ int ogs_dbi_ims_data(char *supi, ogs_ims_data_t *ims_data)
     ogs_assert(supi_id);
 
     query = BCON_NEW(supi_type, BCON_UTF8(supi_id));
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 5
+#if MONGOC_CHECK_VERSION(1, 5, 0)
     cursor = mongoc_collection_find_with_opts(
             ogs_mongoc()->collection.subscriber, query, NULL, NULL);
 #else

--- a/lib/dbi/ogs-mongoc.c
+++ b/lib/dbi/ogs-mongoc.c
@@ -104,7 +104,7 @@ int ogs_mongoc_init(const char *db_uri)
         return OGS_ERROR;
     }
 
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 4
+#if MONGOC_CHECK_VERSION(1, 4, 0)
     mongoc_client_set_error_api(self.client, 2);
 #endif
 
@@ -182,7 +182,7 @@ void ogs_dbi_final(void)
         mongoc_collection_destroy(self.collection.subscriber);
     }
 
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
     if (self.stream) {
         mongoc_change_stream_destroy(self.stream);
     }
@@ -193,7 +193,7 @@ void ogs_dbi_final(void)
 
 int ogs_dbi_collection_watch_init(void)
 {
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
     bson_t empty = BSON_INITIALIZER;    
     const bson_t *err_doc;
     bson_error_t error;

--- a/lib/dbi/ogs-mongoc.h
+++ b/lib/dbi/ogs-mongoc.h
@@ -37,7 +37,7 @@ typedef struct ogs_mongoc_s {
     void *client;
     void *database;
 
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
     mongoc_change_stream_t *stream;
 #endif
 

--- a/lib/dbi/session.c
+++ b/lib/dbi/session.c
@@ -50,7 +50,7 @@ int ogs_dbi_session_data(char *supi, ogs_s_nssai_t *s_nssai, char *dnn,
     ogs_assert(supi_id);
 
     query = BCON_NEW(supi_type, BCON_UTF8(supi_id));
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 5
+#if MONGOC_CHECK_VERSION(1, 5, 0)
     cursor = mongoc_collection_find_with_opts(
             ogs_mongoc()->collection.subscriber, query, NULL, NULL);
 #else

--- a/lib/dbi/subscription.c
+++ b/lib/dbi/subscription.c
@@ -44,7 +44,7 @@ int ogs_dbi_auth_info(char *supi, ogs_dbi_auth_info_t *auth_info)
     ogs_assert(supi_id);
 
     query = BCON_NEW(supi_type, BCON_UTF8(supi_id));
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 5
+#if MONGOC_CHECK_VERSION(1, 5, 0)
     cursor = mongoc_collection_find_with_opts(
             ogs_mongoc()->collection.subscriber, query, NULL, NULL);
 #else
@@ -326,7 +326,7 @@ int ogs_dbi_subscription_data(char *supi,
     ogs_assert(supi_id);
 
     query = BCON_NEW(supi_type, BCON_UTF8(supi_id));
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 5
+#if MONGOC_CHECK_VERSION(1, 5, 0)
     cursor = mongoc_collection_find_with_opts(
             ogs_mongoc()->collection.subscriber, query, NULL, NULL);
 #else

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -331,7 +331,7 @@ int hss_context_parse_config(void)
                             self.sms_over_ims =
                                 ogs_yaml_iter_value(&hss_iter);
                 } else if (!strcmp(hss_key, "use_mongodb_change_stream")) {
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
                     self.use_mongodb_change_stream =
                         ogs_yaml_iter_bool(&hss_iter);
 #else
@@ -1201,7 +1201,7 @@ int hss_db_poll_change_stream(void)
 
 static int poll_change_stream(void)
 {
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
     int rv;
 
     const bson_t *document;

--- a/src/hss/hss-sm.c
+++ b/src/hss/hss-sm.c
@@ -32,7 +32,7 @@ void hss_state_initial(ogs_fsm_t *s, hss_event_t *e)
 
     ogs_assert(s);
 
-#if MONGOC_MAJOR_VERSION >= 1 && MONGOC_MINOR_VERSION >= 9
+#if MONGOC_CHECK_VERSION(1, 9, 0)
     if (hss_self()->use_mongodb_change_stream) {
         ogs_dbi_collection_watch_init();
 


### PR DESCRIPTION
checks mongoc version with

which can unexpectedly return false in case of mongoc versions such as 2.3.4.

So, I've fixed it as below.