### PR TITLE
[SMF] Gy: Check Multiple-Services-Credit-Control Result-Code in CCA-I

### DIFF
--- a/src/smf/gy-handler.c
+++ b/src/smf/gy-handler.c
@@ -113,24 +113,41 @@ static void urr_update_time(smf_sess_t *sess, ogs_pfcp_urr_t *urr, ogs_diam_gy_m
     }
 }
 
-/* Returns ER_DIAMETER_SUCCESS on success, Diameter error code on failue. */
+/* Returns ER_DIAMETER_SUCCESS on success, Diameter error code on failue.
+ * Upon failure, CCR-Terminate is needed based on "need_termination" value (this
+ * may happen eg. if messaged RC is successful but MSCC RC is rejected). */
 uint32_t smf_gy_handle_cca_initial_request(
         smf_sess_t *sess, ogs_diam_gy_message_t *gy_message,
-        ogs_gtp_xact_t *gtp_xact)
+        ogs_gtp_xact_t *gtp_xact,
+        bool *need_termination)
 {
     smf_bearer_t *bearer;
 
     ogs_assert(sess);
     ogs_assert(gy_message);
     ogs_assert(gtp_xact);
+    ogs_assert(need_termination);
 
     ogs_debug("[Gy CCA Initial]");
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-    if (gy_message->result_code != ER_DIAMETER_SUCCESS)
+    *need_termination = false;
+    if (gy_message->result_code != ER_DIAMETER_SUCCESS) {
+        ogs_warn("Gy CCA Initial Diameter failure: res=%u",
+            gy_message->result_code);
         return gy_message->err ? *gy_message->err :
                                  ER_DIAMETER_AUTHENTICATION_REJECTED;
+    }
+    if (gy_message->cca.result_code != ER_DIAMETER_SUCCESS) {
+        ogs_warn("Gy CCA Initial Diameter Multiple-Services-Credit-Control Result-Code=%u",
+            gy_message->cca.result_code);
+        /* Message RC was successful but MSCC was rejected. The session needs to
+         * be tear down through CCR-T: */
+        *need_termination = true;
+        return gy_message->cca.err ? *gy_message->cca.err :
+                                     ER_DIAMETER_AUTHENTICATION_REJECTED;
+    }
 
     bearer = smf_default_bearer_in_sess(sess);
     ogs_assert(bearer);
@@ -173,8 +190,8 @@ uint32_t smf_gy_handle_cca_update_request(
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
     if (gy_message->result_code != ER_DIAMETER_SUCCESS) {
-        ogs_warn("Gy CCA Update Diameter failure: res=%u err=%u",
-            gy_message->result_code, *gy_message->err);
+        ogs_warn("Gy CCA Update Diameter failure: Result-Code=%u",
+            gy_message->result_code);
         return gy_message->err ? *gy_message->err :
                                  ER_DIAMETER_AUTHENTICATION_REJECTED;
     }

--- a/src/smf/gy-handler.h
+++ b/src/smf/gy-handler.h
@@ -29,7 +29,8 @@ extern "C" {
 
 uint32_t smf_gy_handle_cca_initial_request(
         smf_sess_t *sess, ogs_diam_gy_message_t *gy_message,
-        ogs_gtp_xact_t *gtp_xact);
+        ogs_gtp_xact_t *gtp_xact,
+        bool *need_termination);
 uint32_t smf_gy_handle_cca_update_request(
         smf_sess_t *sess, ogs_diam_gy_message_t *gy_message,
         ogs_pfcp_xact_t *pfcp_xact);


### PR DESCRIPTION
This is the continuation of commit
12158eebb8ab0c6ea7b52291bce6cc4d3d38186c, which only checked the code in CCA[Update], but not in CCA[Initial].

The handling in CCA[Initial] is a bit more complex since depending on the outcome, we may end up with a Result-Code != SUCCESS in MSCC but the session may still be created at the OCS because the message Result-Code = SUCCESS. In that scenario, we want to abort setting up the PDN session but we still need to make sure we terminate the Gy session that was just created.