### PR TITLE
[PFCP/GTP] Incorrect TEI/SEID=0 (#3043)

### DIFF
--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -233,7 +233,7 @@ MME-frDi  = 127.0.0.2 :3868 for S6a
 SGWC-gtpc = 127.0.0.3 :2123 for S11
 SGWC-pfcp = 127.0.0.3 :8805 for Sxa
 
-SMF-gtpc  = 127.0.0.4 :2123 for S5c, N11
+SMF-gtpc  = 127.0.0.4 :2123 for S5c
 SMF-gtpu  = 127.0.0.4 :2152 for N4u (Sxu)
 SMF-pfcp  = 127.0.0.4 :8805 for N4 (Sxb)
 SMF-frDi  = 127.0.0.4 :3868 for Gx auth

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -60,9 +60,13 @@ static uint8_t esm_cause_from_gtp(uint8_t gtp_cause)
 }
 
 void mme_s11_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req)
+        ogs_gtp_xact_t *xact, ogs_gtp2_message_t *gtp2_message)
 {
+    ogs_gtp2_echo_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(gtp2_message);
+    req = &gtp2_message->echo_request;
     ogs_assert(req);
 
     ogs_debug("Receiving Echo Request");
@@ -72,14 +76,14 @@ void mme_s11_handle_echo_request(
 }
 
 void mme_s11_handle_echo_response(
-        ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *rsp)
+        ogs_gtp_xact_t *xact, ogs_gtp2_message_t *gtp2_message)
 {
     /* Not Implemented */
 }
 
 void mme_s11_handle_create_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_create_session_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int i, r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -100,6 +104,10 @@ void mme_s11_handle_create_session_response(
     uint16_t decoded = 0;
     int create_action = 0;
 
+    ogs_gtp2_create_session_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->create_session_response;
     ogs_assert(rsp);
 
     ogs_debug("Create Session Response");
@@ -472,7 +480,7 @@ void mme_s11_handle_create_session_response(
 
 void mme_s11_handle_modify_bearer_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_modify_bearer_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -482,6 +490,10 @@ void mme_s11_handle_modify_bearer_response(
     mme_ue_t *mme_ue = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
+    ogs_gtp2_modify_bearer_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->modify_bearer_response;
     ogs_assert(rsp);
 
     ogs_debug("Modify Bearer Response");
@@ -586,7 +598,7 @@ void mme_s11_handle_modify_bearer_response(
 
 void mme_s11_handle_delete_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_delete_session_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -595,6 +607,10 @@ void mme_s11_handle_delete_session_response(
     mme_sess_t *sess = NULL;
     mme_ue_t *mme_ue = NULL;
 
+    ogs_gtp2_delete_session_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->delete_session_response;
     ogs_assert(rsp);
 
     ogs_debug("Delete Session Response");
@@ -778,7 +794,7 @@ void mme_s11_handle_delete_session_response(
 
 void mme_s11_handle_create_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_create_bearer_request_t *req)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -790,7 +806,11 @@ void mme_s11_handle_create_bearer_request(
     ogs_gtp2_f_teid_t *pgw_s5u_teid = NULL;
     ogs_gtp2_bearer_qos_t bearer_qos;
 
+    ogs_gtp2_create_bearer_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(gtp2_message);
+    req = &gtp2_message->create_bearer_request;
     ogs_assert(req);
 
     ogs_debug("Create Bearer Request");
@@ -823,7 +843,8 @@ void mme_s11_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? sgw_ue->sgw_s11_teid : gtp2_message->h.teid,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -859,7 +880,8 @@ void mme_s11_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? sgw_ue->sgw_s11_teid : gtp2_message->h.teid,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -982,7 +1004,7 @@ void mme_s11_handle_create_bearer_request(
 
 void mme_s11_handle_update_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_update_bearer_request_t *req)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -991,7 +1013,11 @@ void mme_s11_handle_update_bearer_request(
     sgw_ue_t *sgw_ue = NULL;
     ogs_gtp2_bearer_qos_t bearer_qos;
 
+    ogs_gtp2_update_bearer_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(gtp2_message);
+    req = &gtp2_message->update_bearer_request;
     ogs_assert(req);
 
     ogs_debug("Update Bearer Request");
@@ -1028,7 +1054,8 @@ void mme_s11_handle_update_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? sgw_ue->sgw_s11_teid : gtp2_message->h.teid,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1129,7 +1156,7 @@ void mme_s11_handle_update_bearer_request(
 
 void mme_s11_handle_delete_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_delete_bearer_request_t *req)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -1138,7 +1165,11 @@ void mme_s11_handle_delete_bearer_request(
     mme_sess_t *sess = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
+    ogs_gtp2_delete_bearer_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(gtp2_message);
+    req = &gtp2_message->delete_bearer_request;
     ogs_assert(req);
 
     ogs_debug("Delete Bearer Request");
@@ -1199,7 +1230,8 @@ void mme_s11_handle_delete_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? sgw_ue->sgw_s11_teid : gtp2_message->h.teid,
                 OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
         return;
@@ -1250,7 +1282,7 @@ void mme_s11_handle_delete_bearer_request(
 
 void mme_s11_handle_release_access_bearers_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_release_access_bearers_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -1262,6 +1294,10 @@ void mme_s11_handle_release_access_bearers_response(
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
 
+    ogs_gtp2_release_access_bearers_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->release_access_bearers_response;
     ogs_assert(rsp);
 
     ogs_debug("Release Access Bearers Response");
@@ -1415,7 +1451,7 @@ void mme_s11_handle_release_access_bearers_response(
 
 void mme_s11_handle_downlink_data_notification(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_downlink_data_notification_t *noti)
+        ogs_gtp2_message_t *gtp2_message)
 {
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
     int r;
@@ -1423,7 +1459,11 @@ void mme_s11_handle_downlink_data_notification(
     mme_bearer_t *bearer = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
+    ogs_gtp2_downlink_data_notification_t *noti = NULL;
+
     ogs_assert(xact);
+    ogs_assert(gtp2_message);
+    noti = &gtp2_message->downlink_data_notification;
     ogs_assert(noti);
 
     ogs_debug("Downlink Data Notification");
@@ -1456,7 +1496,8 @@ void mme_s11_handle_downlink_data_notification(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp2_send_error_message(xact, sgw_ue ? sgw_ue->sgw_s11_teid : 0,
+        ogs_gtp2_send_error_message(xact,
+                sgw_ue ? sgw_ue->sgw_s11_teid : gtp2_message->h.teid,
                 OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_ACKNOWLEDGE_TYPE,
                 OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
         return;
@@ -1558,7 +1599,7 @@ void mme_s11_handle_downlink_data_notification(
 
 void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int i, r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -1570,6 +1611,10 @@ void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
 
     ogs_gtp2_f_teid_t *teid = NULL;
 
+    ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->create_indirect_data_forwarding_tunnel_response;
     ogs_assert(rsp);
 
     ogs_debug("Create Indirect Data Forwarding Tunnel Response");
@@ -1694,7 +1739,7 @@ void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
 
 void mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t *rsp)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -1703,6 +1748,10 @@ void mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
     mme_ue_t *mme_ue = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
+    ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t *rsp = NULL;
+
+    ogs_assert(gtp2_message);
+    rsp = &gtp2_message->delete_indirect_data_forwarding_tunnel_response;
     ogs_assert(rsp);
 
     ogs_debug("Delete Indirect Data Forwarding Tunnel Response");
@@ -1804,7 +1853,7 @@ void mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
 
 void mme_s11_handle_bearer_resource_failure_indication(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue_from_teid,
-        ogs_gtp2_bearer_resource_failure_indication_t *ind)
+        ogs_gtp2_message_t *gtp2_message)
 {
     int r, rv;
     uint8_t cause_value = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
@@ -1813,6 +1862,12 @@ void mme_s11_handle_bearer_resource_failure_indication(
     mme_sess_t *sess = NULL;
     mme_ue_t *mme_ue = NULL;
     sgw_ue_t *sgw_ue = NULL;
+
+    ogs_gtp2_bearer_resource_failure_indication_t *ind = NULL;
+
+    ogs_assert(gtp2_message);
+    ind = &gtp2_message->bearer_resource_failure_indication;
+    ogs_assert(ind);
 
     ogs_debug("Bearer Resource Failure Indication");
 

--- a/src/mme/mme-s11-handler.h
+++ b/src/mme/mme-s11-handler.h
@@ -27,44 +27,44 @@ extern "C" {
 #endif
 
 void mme_s11_handle_echo_request(
-        ogs_gtp_xact_t *xact, ogs_gtp2_echo_request_t *req);
+        ogs_gtp_xact_t *xact, ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_echo_response(
-        ogs_gtp_xact_t *xact, ogs_gtp2_echo_response_t *rsp);
+        ogs_gtp_xact_t *xact, ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_create_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_create_session_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_modify_bearer_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_modify_bearer_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_delete_session_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_delete_session_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_create_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_create_bearer_request_t *req);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_update_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_update_bearer_request_t *req);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_delete_bearer_request(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_delete_bearer_request_t *req);
+        ogs_gtp2_message_t *gtp2_message);
 
 void mme_s11_handle_release_access_bearers_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_release_access_bearers_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_downlink_data_notification(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_downlink_data_notification_t *noti);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_create_indirect_data_forwarding_tunnel_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void mme_s11_handle_delete_indirect_data_forwarding_tunnel_response(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 
 void mme_s11_handle_bearer_resource_failure_indication(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue,
-        ogs_gtp2_bearer_resource_failure_indication_t *ind);
+        ogs_gtp2_message_t *gtp2_message);
 
 #ifdef __cplusplus
 }

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -305,8 +305,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                 sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
             } else {
                 sgwc_sxa_handle_session_establishment_response(
-                    sess, xact, e->gtp_message,
-                    &message->pfcp_session_establishment_response);
+                    sess, xact, e->gtp_message, message);
             }
             break;
 
@@ -314,23 +313,20 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             if (!message->h.seid_presence) ogs_error("No SEID");
 
             sgwc_sxa_handle_session_modification_response(
-                sess, xact, e->gtp_message,
-                &message->pfcp_session_modification_response);
+                sess, xact, e->gtp_message, message);
             break;
 
         case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
             if (!message->h.seid_presence) ogs_error("No SEID");
 
             sgwc_sxa_handle_session_deletion_response(
-                sess, xact, e->gtp_message,
-                &message->pfcp_session_deletion_response);
+                sess, xact, e->gtp_message, message);
             break;
 
         case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
             if (!message->h.seid_presence) ogs_error("No SEID");
 
-            sgwc_sxa_handle_session_report_request(
-                sess, xact, &message->pfcp_session_report_request);
+            sgwc_sxa_handle_session_report_request(sess, xact, message);
             break;
 
         default:

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -174,7 +174,7 @@ void sgwc_s11_handle_create_session_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -215,7 +215,7 @@ void sgwc_s11_handle_create_session_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -263,7 +263,7 @@ void sgwc_s11_handle_create_session_request(
     ogs_assert(sess->pfcp_node);
     if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING);
         return;
@@ -424,7 +424,7 @@ void sgwc_s11_handle_modify_bearer_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -532,7 +532,7 @@ void sgwc_s11_handle_modify_bearer_request(
     if (i == 0) {
         ogs_error("No Bearer");
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -610,7 +610,7 @@ void sgwc_s11_handle_delete_session_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -630,7 +630,7 @@ void sgwc_s11_handle_delete_session_request(
         indication->scope_indication == 1) {
         ogs_error("Invalid Indication");
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT);
         return;
@@ -1129,7 +1129,7 @@ void sgwc_s11_handle_release_access_bearers_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_RELEASE_ACCESS_BEARERS_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -1236,7 +1236,7 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 cause_value);
         return;
@@ -1254,7 +1254,7 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
         if (req->bearer_contexts[i].eps_bearer_id.presence == 0) {
             ogs_error("No EBI");
             ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
             return;
@@ -1277,7 +1277,7 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
             rv = ogs_gtp2_f_teid_to_ip(req_teid, &tunnel->remote_ip);
             if (rv != OGS_OK) {
                 ogs_gtp_send_error_message(s11_xact,
-                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                        sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
                 return;
@@ -1312,7 +1312,7 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
             rv = ogs_gtp2_f_teid_to_ip(req_teid, &tunnel->remote_ip);
             if (rv != OGS_OK) {
                 ogs_gtp_send_error_message(s11_xact,
-                        sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                        sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
                 return;
@@ -1346,12 +1346,13 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
 
 void sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
         sgwc_ue_t *sgwc_ue, ogs_gtp_xact_t *s11_xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *recv_message)
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *message)
 {
     sgwc_sess_t *sess = NULL;
     uint8_t cause_value = 0;
 
     ogs_assert(s11_xact);
+    ogs_assert(message);
 
     ogs_debug("Delete Indirect Data Forwarding Tunnel Request");
 
@@ -1367,7 +1368,8 @@ void sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact,
+                sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE,
                 cause_value);
         return;
@@ -1442,7 +1444,7 @@ void sgwc_s11_handle_bearer_resource_command(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }
@@ -1463,7 +1465,7 @@ void sgwc_s11_handle_bearer_resource_command(
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : message->h.teid,
                 OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE, cause_value);
         return;
     }

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -573,7 +573,8 @@ void sgwc_s5c_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp_send_error_message(s5c_xact,
+                sess ? sess->pgw_s5c_teid : message->h.teid,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -601,7 +602,8 @@ void sgwc_s5c_handle_create_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp_send_error_message(s5c_xact,
+                sess ? sess->pgw_s5c_teid : message->h.teid,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -631,7 +633,8 @@ void sgwc_s5c_handle_create_bearer_request(
 
     rv = ogs_gtp2_f_teid_to_ip(pgw_s5u_teid, &ul_tunnel->remote_ip);
     if (rv != OGS_OK) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp_send_error_message(s5c_xact,
+                sess ? sess->pgw_s5c_teid : message->h.teid,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE,
                 OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
         return;
@@ -709,7 +712,8 @@ void sgwc_s5c_handle_update_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp_send_error_message(s5c_xact,
+                sess ? sess->pgw_s5c_teid : message->h.teid,
                 OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }
@@ -850,7 +854,8 @@ void sgwc_s5c_handle_delete_bearer_request(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
+        ogs_gtp_send_error_message(s5c_xact,
+                sess ? sess->pgw_s5c_teid : message->h.teid,
                 OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE, cause_value);
         return;
     }

--- a/src/sgwc/sxa-handler.h
+++ b/src/sgwc/sxa-handler.h
@@ -29,18 +29,18 @@ extern "C" {
 void sgwc_sxa_handle_session_establishment_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_gtp2_message_t *recv_message,
-        ogs_pfcp_session_establishment_response_t *pfcp_rsp);
+        ogs_pfcp_message_t *pfcp_message);
 void sgwc_sxa_handle_session_modification_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_gtp2_message_t *recv_message,
-        ogs_pfcp_session_modification_response_t *pfcp_rsp);
+        ogs_pfcp_message_t *pfcp_message);
 void sgwc_sxa_handle_session_deletion_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_gtp2_message_t *gtp_message,
-        ogs_pfcp_session_deletion_response_t *pfcp_rsp);
+        ogs_pfcp_message_t *pfcp_message);
 void sgwc_sxa_handle_session_report_request(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_pfcp_session_report_request_t *pfcp_req);
+        ogs_pfcp_message_t *pfcp_message);
 
 #ifdef __cplusplus
 }

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -280,20 +280,16 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
             sess = sgwu_sess_add_by_message(message);
             if (sess)
                 OGS_SETUP_PFCP_NODE(sess, node);
-            sgwu_sxa_handle_session_establishment_request(
-                sess, xact, &message->pfcp_session_establishment_request);
+            sgwu_sxa_handle_session_establishment_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
-            sgwu_sxa_handle_session_modification_request(
-                sess, xact, &message->pfcp_session_modification_request);
+            sgwu_sxa_handle_session_modification_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
-            sgwu_sxa_handle_session_deletion_request(
-                sess, xact, &message->pfcp_session_deletion_request);
+            sgwu_sxa_handle_session_deletion_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE:
-            sgwu_sxa_handle_session_report_response(
-                sess, xact, &message->pfcp_session_report_response);
+            sgwu_sxa_handle_session_report_response(sess, xact, message);
             break;
         default:
             ogs_error("Not implemented PFCP message type[%d]",

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -22,8 +22,7 @@
 #include "sxa-handler.h"
 
 void sgwu_sxa_handle_session_establishment_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, 
-        ogs_pfcp_session_establishment_request_t *req)
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
@@ -36,7 +35,11 @@ void sgwu_sxa_handle_session_establishment_request(
     ogs_pfcp_sereq_flags_t sereq_flags;
     bool restoration_indication = false;
 
+    ogs_pfcp_session_establishment_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_establishment_request;
     ogs_assert(req);
 
     ogs_debug("Session Establishment Request");
@@ -45,7 +48,8 @@ void sgwu_sxa_handle_session_establishment_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(
+                xact, sess ? sess->sgwc_sxa_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_MANDATORY_IE_MISSING, 0);
         return;
@@ -142,14 +146,14 @@ void sgwu_sxa_handle_session_establishment_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->sgwu_sxa_seid : 0,
+    ogs_pfcp_send_error_message(
+            xact, sess ? sess->sgwc_sxa_f_seid.seid : message->h.seid,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
 
 void sgwu_sxa_handle_session_modification_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, 
-        ogs_pfcp_session_modification_request_t *req)
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
@@ -159,7 +163,11 @@ void sgwu_sxa_handle_session_modification_request(
     uint8_t offending_ie_value = 0;
     int i;
 
+    ogs_pfcp_session_modification_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_modification_request;
     ogs_assert(req);
 
     ogs_debug("Session Modification Request");
@@ -168,7 +176,8 @@ void sgwu_sxa_handle_session_modification_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(
+                xact, sess ? sess->sgwc_sxa_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -309,23 +318,28 @@ void sgwu_sxa_handle_session_modification_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->sgwu_sxa_seid : 0,
+    ogs_pfcp_send_error_message(
+            xact, sess ? sess->sgwc_sxa_f_seid.seid : message->h.seid,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
 
 void sgwu_sxa_handle_session_deletion_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_request_t *req)
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
+    ogs_pfcp_session_deletion_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_deletion_request;
     ogs_assert(req);
 
     ogs_debug("Session Deletion Request");
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(
+                xact, sess ? sess->sgwc_sxa_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -339,12 +353,15 @@ void sgwu_sxa_handle_session_deletion_request(
 }
 
 void sgwu_sxa_handle_session_report_response(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_report_response_t *rsp)
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     uint8_t cause_value = 0;
 
+    ogs_pfcp_session_report_response_t *rsp = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    rsp = &message->pfcp_session_report_response;
     ogs_assert(rsp);
 
     ogs_pfcp_xact_commit(xact);

--- a/src/sgwu/sxa-handler.h
+++ b/src/sgwu/sxa-handler.h
@@ -27,18 +27,14 @@ extern "C" {
 #endif
 
 void sgwu_sxa_handle_session_establishment_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_request_t *req);
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 void sgwu_sxa_handle_session_modification_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_modification_request_t *req);
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 void sgwu_sxa_handle_session_deletion_request(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_request_t *req);
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 
 void sgwu_sxa_handle_session_report_response(
-        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_report_response_t *rsp);
+        sgwu_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 
 #ifdef __cplusplus
 }

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -218,8 +218,7 @@ void smf_gsm_state_initial(ogs_fsm_t *s, smf_event_t *e)
         switch(gtp2_message->h.type) {
         case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
             gtp2_cause = smf_s5c_handle_create_session_request(sess,
-                            e->gtp_xact,
-                            &e->gtp2_message->create_session_request);
+                            e->gtp_xact, gtp2_message);
             if (gtp2_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                 send_gtp_create_err_msg(sess, e->gtp_xact, gtp2_cause);
                 return;
@@ -621,8 +620,7 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
                 ogs_assert(gtp_xact);
 
                 pfcp_cause = smf_epc_n4_handle_session_establishment_response(
-                        sess, pfcp_xact,
-                        &pfcp_message->pfcp_session_establishment_response);
+                        sess, pfcp_xact, pfcp_message);
                 if (pfcp_cause != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
                     /* FIXME: tear down Gy and Gx */
                     gtp_cause = gtp_cause_from_pfcp(
@@ -671,8 +669,7 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
                 smf_bearer_binding(sess);
             } else {
                 pfcp_cause = smf_5gc_n4_handle_session_establishment_response(
-                        sess, pfcp_xact,
-                        &pfcp_message->pfcp_session_establishment_response);
+                        sess, pfcp_xact, pfcp_message);
                 if (pfcp_cause != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
                     OGS_FSM_TRAN(s, smf_gsm_state_5gc_n1_n2_reject);
                     return;
@@ -784,8 +781,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
         switch(gtp2_message->h.type) {
         case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
             gtp2_cause = smf_s5c_handle_delete_session_request(
-                            sess, e->gtp_xact,
-                            &gtp2_message->delete_session_request);
+                            sess, e->gtp_xact, gtp2_message);
             if (gtp2_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
                 ogs_gtp2_send_error_message(e->gtp_xact, sess->sgw_s5c_teid,
                         OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, gtp2_cause);
@@ -795,7 +791,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
             break;
         case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
             release = smf_s5c_handle_delete_bearer_response(
-                sess, e->gtp_xact, &e->gtp2_message->delete_bearer_response);
+                sess, e->gtp_xact, gtp2_message);
             if (release) {
                 e->gtp_xact = NULL;
                 OGS_FSM_TRAN(s, smf_gsm_state_wait_pfcp_deletion);
@@ -1310,8 +1306,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                 gtp_xact = pfcp_xact->assoc_xact;
 
                 pfcp_cause = smf_epc_n4_handle_session_deletion_response(
-                            sess, pfcp_xact,
-                            &pfcp_message->pfcp_session_deletion_response);
+                            sess, pfcp_xact, pfcp_message);
                 if (pfcp_cause != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
                     /* FIXME: tear down Gy and Gx */
                     ogs_assert(gtp_xact);
@@ -1334,8 +1329,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                 ogs_pfcp_xact_commit(pfcp_xact);
 
                 status = smf_5gc_n4_handle_session_deletion_response(
-                            sess, stream, trigger,
-                            &pfcp_message->pfcp_session_deletion_response);
+                            sess, stream, trigger, pfcp_message);
                 if (status != OGS_SBI_HTTP_STATUS_OK) {
                     ogs_error(
                         "[%d] smf_5gc_n4_handle_session_deletion_response() "

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -144,7 +144,7 @@ static int sbi_status_from_pfcp(uint8_t pfcp_cause)
  * other cause value on failure */
 uint8_t smf_5gc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     int i;
 
@@ -156,8 +156,12 @@ uint8_t smf_5gc_n4_handle_session_establishment_response(
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
 
+    ogs_pfcp_session_establishment_response_t *rsp = NULL;
+
     ogs_assert(sess);
     ogs_assert(xact);
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_establishment_response;
     ogs_assert(rsp);
 
     ogs_debug("Session Establishment Response [5gc]");
@@ -240,18 +244,22 @@ uint8_t smf_5gc_n4_handle_session_establishment_response(
 
 void smf_5gc_n4_handle_session_modification_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_modification_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     int status = 0;
     uint64_t flags = 0;
     ogs_sbi_stream_t *stream = NULL;
     smf_bearer_t *qos_flow = NULL;
 
+    ogs_pfcp_session_modification_response_t *rsp = NULL;
+
     OGS_LIST(pdr_to_create_list);
 
     ogs_debug("Session Modification Response [5gc]");
 
     ogs_assert(xact);
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_modification_response;
     ogs_assert(rsp);
 
     flags = xact->modify_flags;
@@ -665,12 +673,16 @@ void smf_5gc_n4_handle_session_modification_response(
 
 int smf_5gc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, int trigger,
-        ogs_pfcp_session_deletion_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     int status = 0;
 
+    ogs_pfcp_session_deletion_response_t *rsp = NULL;
+
     ogs_debug("Session Deletion Response [5gc]");
 
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_deletion_response;
     ogs_assert(rsp);
     ogs_assert(trigger);
 
@@ -725,7 +737,7 @@ int smf_5gc_n4_handle_session_deletion_response(
  * other cause value on failure */
 uint8_t smf_epc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     uint8_t cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 
@@ -733,8 +745,12 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
 
     ogs_pfcp_f_seid_t *up_f_seid = NULL;
 
+    ogs_pfcp_session_establishment_response_t *rsp = NULL;
+
     ogs_assert(sess);
     ogs_assert(xact);
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_establishment_response;
     ogs_assert(rsp);
 
     ogs_debug("Session Establishment Response [epc]");
@@ -828,7 +844,7 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
 void smf_epc_n4_handle_session_modification_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_gtp2_message_t *recv_message,
-        ogs_pfcp_session_modification_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     int i;
 
@@ -844,9 +860,13 @@ void smf_epc_n4_handle_session_modification_response(
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
 
+    ogs_pfcp_session_modification_response_t *rsp = NULL;
+
     OGS_LIST(pdr_to_create_list);
 
     ogs_assert(xact);
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_modification_response;
     ogs_assert(rsp);
 
     ogs_debug("Session Modification Response [epc]");
@@ -1093,13 +1113,17 @@ void smf_epc_n4_handle_session_modification_response(
 
 uint8_t smf_epc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_response_t *rsp)
+        ogs_pfcp_message_t *pfcp_message)
 {
     smf_bearer_t *bearer = NULL;
     unsigned int i;
 
+    ogs_pfcp_session_deletion_response_t *rsp = NULL;
+
     ogs_assert(sess);
     ogs_assert(xact);
+    ogs_assert(pfcp_message);
+    rsp = &pfcp_message->pfcp_session_deletion_response;
     ogs_assert(rsp);
 
     ogs_debug("Session Deletion Response [epc]");
@@ -1149,7 +1173,7 @@ uint8_t smf_epc_n4_handle_session_deletion_response(
 
 void smf_n4_handle_session_report_request(
         smf_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_pfcp_session_report_request_t *pfcp_req)
+        ogs_pfcp_message_t *pfcp_message)
 {
     smf_ue_t *smf_ue = NULL;
     smf_bearer_t *qos_flow = NULL;
@@ -1162,9 +1186,13 @@ void smf_n4_handle_session_report_request(
     uint16_t pdr_id = 0;
     unsigned int i;
 
+    ogs_pfcp_session_report_request_t *pfcp_req = NULL;
+
     smf_metrics_inst_global_inc(SMF_METR_GLOB_CTR_SM_N4SESSIONREPORT);
 
     ogs_assert(pfcp_xact);
+    ogs_assert(pfcp_message);
+    pfcp_req = &pfcp_message->pfcp_session_report_request;
     ogs_assert(pfcp_req);
 
     ogs_debug("Session Report Request");
@@ -1182,7 +1210,8 @@ void smf_n4_handle_session_report_request(
     }
 
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_pfcp_send_error_message(pfcp_xact, 0,
+        ogs_pfcp_send_error_message(pfcp_xact,
+                sess ? sess->upf_n4_seid : pfcp_message->h.seid,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                 cause_value, 0);
         return;
@@ -1222,7 +1251,8 @@ void smf_n4_handle_session_report_request(
                     if (paging_policy_indication_value) {
                         ogs_warn("Not implement - "
                                 "Paging Policy Indication Value");
-                        ogs_pfcp_send_error_message(pfcp_xact, 0,
+                        ogs_pfcp_send_error_message(pfcp_xact,
+                                sess ? sess->upf_n4_seid : pfcp_message->h.seid,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED, 0);
                         return;
@@ -1232,7 +1262,8 @@ void smf_n4_handle_session_report_request(
                         qos_flow = smf_qos_flow_find_by_qfi(sess, qfi);
                         if (!qos_flow) {
                             ogs_error("Cannot find the QoS Flow[%d]", qfi);
-                            ogs_pfcp_send_error_message(pfcp_xact, 0,
+                            ogs_pfcp_send_error_message(pfcp_xact,
+                                sess ? sess->upf_n4_seid : pfcp_message->h.seid,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
                             return;
@@ -1257,7 +1288,8 @@ void smf_n4_handle_session_report_request(
 
         if (!pdr) {
             ogs_error("No Context");
-            ogs_pfcp_send_error_message(pfcp_xact, 0,
+            ogs_pfcp_send_error_message(pfcp_xact,
+                    sess ? sess->upf_n4_seid : pfcp_message->h.seid,
                     OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                     OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
             return;

--- a/src/smf/n4-handler.h
+++ b/src/smf/n4-handler.h
@@ -28,28 +28,28 @@ extern "C" {
 
 uint8_t smf_5gc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 void smf_5gc_n4_handle_session_modification_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_modification_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 int smf_5gc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, int trigger,
-        ogs_pfcp_session_deletion_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 
 uint8_t smf_epc_n4_handle_session_establishment_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 void smf_epc_n4_handle_session_modification_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_gtp2_message_t *recv_message,
-        ogs_pfcp_session_modification_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 uint8_t smf_epc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_response_t *rsp);
+        ogs_pfcp_message_t *pfcp_message);
 
 void smf_n4_handle_session_report_request(
         smf_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
-        ogs_pfcp_session_report_request_t *pfcp_req);
+        ogs_pfcp_message_t *pfcp_message);
 
 uint8_t gtp_cause_from_pfcp(uint8_t pfcp_cause, uint8_t gtp_version);
 

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -337,11 +337,10 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
 
             if (xact->epc)
                 smf_epc_n4_handle_session_modification_response(
-                    sess, xact, e->gtp2_message,
-                    &message->pfcp_session_modification_response);
+                    sess, xact, e->gtp2_message, message);
             else
                 smf_5gc_n4_handle_session_modification_response(
-                    sess, xact, &message->pfcp_session_modification_response);
+                    sess, xact, message);
             break;
 
         case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
@@ -371,7 +370,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             if (!message->h.seid_presence) ogs_error("No SEID");
 
             smf_n4_handle_session_report_request(
-                sess, xact, &message->pfcp_session_report_request);
+                sess, xact, message);
             break;
 
         default:

--- a/src/smf/s5c-handler.h
+++ b/src/smf/s5c-handler.h
@@ -33,25 +33,25 @@ void smf_s5c_handle_echo_response(
 
 uint8_t smf_s5c_handle_create_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_create_session_request_t *req);
+        ogs_gtp2_message_t *gtp2_message);
 uint8_t smf_s5c_handle_delete_session_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_delete_session_request_t *req);
+        ogs_gtp2_message_t *gtp2_message);
 void smf_s5c_handle_modify_bearer_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp2_modify_bearer_request_t *req);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_message_t *gtp2_message);
 void smf_s5c_handle_create_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_create_bearer_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void smf_s5c_handle_update_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_update_bearer_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 bool smf_s5c_handle_delete_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_delete_bearer_response_t *rsp);
+        ogs_gtp2_message_t *gtp2_message);
 void smf_s5c_handle_bearer_resource_command(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_bearer_resource_command_t *cmd);
+        ogs_gtp2_message_t *gtp2_message);
 
 #ifdef __cplusplus
 }

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -144,7 +144,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             }
             if (!sess) {
                 ogs_error("No Session");
-                ogs_gtp2_send_error_message(gtp_xact, 0,
+                ogs_gtp2_send_error_message(gtp_xact, gtp2_message.h.teid,
                         OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;
@@ -158,7 +158,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             smf_metrics_inst_gtp_node_inc(smf_gnode->metrics, SMF_METR_GTP_NODE_CTR_S5C_RX_DELETESESSIONREQ);
             if (!sess) {
                 ogs_error("No Session");
-                ogs_gtp2_send_error_message(gtp_xact, 0,
+                ogs_gtp2_send_error_message(gtp_xact, gtp2_message.h.teid,
                         OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE,
                         OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND);
                 break;
@@ -169,17 +169,17 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             smf_s5c_handle_modify_bearer_request(
-                sess, gtp_xact, recvbuf, &gtp2_message.modify_bearer_request);
+                sess, gtp_xact, recvbuf, &gtp2_message);
             break;
         case OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             smf_s5c_handle_create_bearer_response(
-                sess, gtp_xact, &gtp2_message.create_bearer_response);
+                sess, gtp_xact, &gtp2_message);
             break;
         case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             smf_s5c_handle_update_bearer_response(
-                sess, gtp_xact, &gtp2_message.update_bearer_response);
+                sess, gtp_xact, &gtp2_message);
             break;
         case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
@@ -194,7 +194,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             smf_s5c_handle_bearer_resource_command(
-                sess, gtp_xact, &gtp2_message.bearer_resource_command);
+                sess, gtp_xact, &gtp2_message);
             break;
         default:
             ogs_warn("Not implemented(type:%d)", gtp2_message.h.type);

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -44,8 +44,7 @@ static void upf_n4_handle_create_urr(upf_sess_t *sess, ogs_pfcp_tlv_create_urr_t
 }
 
 void upf_n4_handle_session_establishment_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_request_t *req)
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
@@ -58,9 +57,13 @@ void upf_n4_handle_session_establishment_request(
     ogs_pfcp_sereq_flags_t sereq_flags;
     bool restoration_indication = false;
 
+    ogs_pfcp_session_establishment_request_t *req = NULL;
+
     upf_metrics_inst_global_inc(UPF_METR_GLOB_CTR_SM_N4SESSIONESTABREQ);
 
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_establishment_request;
     ogs_assert(req);
 
     ogs_debug("Session Establishment Request");
@@ -69,7 +72,8 @@ void upf_n4_handle_session_establishment_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(
+                xact, sess ? sess->smf_n4_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_MANDATORY_IE_MISSING, 0);
         upf_metrics_inst_by_cause_add(OGS_PFCP_CAUSE_MANDATORY_IE_MISSING,
@@ -214,14 +218,14 @@ cleanup:
     upf_metrics_inst_by_cause_add(cause_value,
             UPF_METR_CTR_SM_N4SESSIONESTABFAIL, 1);
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
+    ogs_pfcp_send_error_message(
+            xact, sess ? sess->smf_n4_f_seid.seid : message->h.seid,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
 
 void upf_n4_handle_session_modification_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_modification_request_t *req)
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
@@ -231,7 +235,11 @@ void upf_n4_handle_session_modification_request(
     uint8_t offending_ie_value = 0;
     int i;
 
+    ogs_pfcp_session_modification_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_modification_request;
     ogs_assert(req);
 
     ogs_debug("Session Modification Request");
@@ -240,7 +248,8 @@ void upf_n4_handle_session_modification_request(
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(
+                xact, sess ? sess->smf_n4_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -413,25 +422,30 @@ void upf_n4_handle_session_modification_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&sess->pfcp);
-    ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
+    ogs_pfcp_send_error_message(
+            xact, sess ? sess->smf_n4_f_seid.seid : message->h.seid,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
 }
 
 void upf_n4_handle_session_deletion_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_request_t *req)
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     ogs_pfcp_qer_t *qer = NULL;
 
+    ogs_pfcp_session_deletion_request_t *req = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    req = &message->pfcp_session_deletion_request;
     ogs_assert(req);
 
     ogs_debug("Session Deletion Request");
 
     if (!sess) {
         ogs_error("No Context");
-        ogs_pfcp_send_error_message(xact, 0,
+        ogs_pfcp_send_error_message(xact,
+                sess ? sess->smf_n4_f_seid.seid : message->h.seid,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
         return;
@@ -446,12 +460,15 @@ void upf_n4_handle_session_deletion_request(
 }
 
 void upf_n4_handle_session_report_response(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_report_response_t *rsp)
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message)
 {
     uint8_t cause_value = 0;
 
+    ogs_pfcp_session_report_response_t *rsp = NULL;
+
     ogs_assert(xact);
+    ogs_assert(message);
+    rsp = &message->pfcp_session_report_response;
     ogs_assert(rsp);
 
     ogs_pfcp_xact_commit(xact);

--- a/src/upf/n4-handler.h
+++ b/src/upf/n4-handler.h
@@ -27,18 +27,14 @@ extern "C" {
 #endif
 
 void upf_n4_handle_session_establishment_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_establishment_request_t *req);
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 void upf_n4_handle_session_modification_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_modification_request_t *req);
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 void upf_n4_handle_session_deletion_request(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_deletion_request_t *req);
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 
 void upf_n4_handle_session_report_response(
-        upf_sess_t *sess, ogs_pfcp_xact_t *xact,
-        ogs_pfcp_session_report_response_t *rsp);
+        upf_sess_t *sess, ogs_pfcp_xact_t *xact, ogs_pfcp_message_t *message);
 
 #ifdef __cplusplus
 }

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -284,20 +284,16 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
             sess = upf_sess_add_by_message(message);
             if (sess)
                 OGS_SETUP_PFCP_NODE(sess, node);
-            upf_n4_handle_session_establishment_request(
-                sess, xact, &message->pfcp_session_establishment_request);
+            upf_n4_handle_session_establishment_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
-            upf_n4_handle_session_modification_request(
-                sess, xact, &message->pfcp_session_modification_request);
+            upf_n4_handle_session_modification_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
-            upf_n4_handle_session_deletion_request(
-                sess, xact, &message->pfcp_session_deletion_request);
+            upf_n4_handle_session_deletion_request(sess, xact, message);
             break;
         case OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE:
-            upf_n4_handle_session_report_response(
-                sess, xact, &message->pfcp_session_report_response);
+            upf_n4_handle_session_report_response(sess, xact, message);
             break;
         default:
             ogs_error("Not implemented PFCP message type[%d]",


### PR DESCRIPTION
If eg. PCRF or AAA diameter link is not yet ready (eg. PCRF crashed), and a client sends a CreateSessionRequest announcing its ow F-TEID, then open5gs-smfd answers with Create Session Response Cause="Remote peer not responding", but it is not setting the received F-TEID in the header of the response, instead it sends with TEID=0.

As a result, the peer cannot match the CreateSessionResponse, and needs to rely on its own timeout timer to figure out that specific request failed.

See 3GPP TS 29.274 5.5 Usage of the GTPv2-C Header:

```
Bit 4 represents a "T" flag, which indicates if TEID field is present in the GTP-C header or not. If the "T" flag is
set to 0, then the TEID field shall not be present in the GTP-C header. If the "T" flag is set to 1, then the TEID
field shall immediately follow the Length field, in octets 5 to 8. Apart from the Echo Request, Echo Response
and Version Not Supported Indication messages, in all EPC specific messages the value of the "T" flag shall be
set to "1".
```

This happens with Delete Session Requests and can happen with any PFCP message.

I've fixed TEID/SEID to send the value in the reponse message as is if it was received.