### PR TITLE
[GTP] Incorrect destination TEID=0 (#3043)

### DIFF
--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -233,7 +233,7 @@ MME-frDi  = 127.0.0.2 :3868 for S6a
 SGWC-gtpc = 127.0.0.3 :2123 for S11
 SGWC-pfcp = 127.0.0.3 :8805 for Sxa
 
-SMF-gtpc  = 127.0.0.4 :2123 for S5c, N11
+SMF-gtpc  = 127.0.0.4 :2123 for S5c
 SMF-gtpu  = 127.0.0.4 :2152 for N4u (Sxu)
 SMF-pfcp  = 127.0.0.4 :8805 for N4 (Sxb)
 SMF-frDi  = 127.0.0.4 :3868 for Gx auth

--- a/lib/gtp/util.c
+++ b/lib/gtp/util.c
@@ -180,3 +180,68 @@ uint16_t ogs_in_cksum(uint16_t *addr, int len)
 
     return answer;
 }
+
+void ogs_gtp2_sender_f_teid(
+        ogs_gtp2_sender_f_teid_t *sender_f_teid, ogs_gtp2_message_t *message)
+{
+    ogs_gtp2_tlv_f_teid_t *tlv_f_teid = NULL;
+    ogs_gtp2_f_teid_t *f_teid = NULL;
+
+    ogs_assert(sender_f_teid);
+    ogs_assert(message);
+
+    memset(sender_f_teid, 0, sizeof(*sender_f_teid));
+
+    switch (message->h.type) {
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+        tlv_f_teid = &message->create_session_request.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE:
+        tlv_f_teid = &message->create_session_response.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
+        tlv_f_teid = &message->modify_bearer_request.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
+        tlv_f_teid = &message->delete_session_request.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_MODIFY_BEARER_COMMAND_TYPE:
+        tlv_f_teid = &message->modify_bearer_command.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_DELETE_BEARER_COMMAND_TYPE:
+        tlv_f_teid = &message->delete_bearer_command.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
+        tlv_f_teid = &message->bearer_resource_command.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
+        tlv_f_teid = &message->create_indirect_data_forwarding_tunnel_request.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_RESPONSE_TYPE:
+        tlv_f_teid = &message->create_indirect_data_forwarding_tunnel_response.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
+        tlv_f_teid = &message->downlink_data_notification.
+            sender_f_teid_for_control_plane;
+        break;
+    case OGS_GTP2_MODIFY_ACCESS_BEARERS_REQUEST_TYPE:
+        tlv_f_teid = &message->modify_access_bearers_request.
+            sender_f_teid_for_control_plane;
+    default:
+        break;
+    }
+
+    if (tlv_f_teid && tlv_f_teid->presence && (f_teid = tlv_f_teid->data)) {
+        sender_f_teid->teid_presence = true;
+        sender_f_teid->teid = be32toh(f_teid->teid);
+    }
+}

--- a/lib/gtp/util.h
+++ b/lib/gtp/util.h
@@ -32,6 +32,14 @@ int ogs_gtpu_parse_header(
         ogs_gtp2_header_desc_t *header_desc, ogs_pkbuf_t *pkbuf);
 uint16_t ogs_in_cksum(uint16_t *addr, int len);
 
+typedef struct ogs_gtp2_sender_f_teid_s {
+    bool teid_presence;
+    uint32_t teid;
+} ogs_gtp2_sender_f_teid_t;
+
+void ogs_gtp2_sender_f_teid(
+        ogs_gtp2_sender_f_teid_t *sender_f_teid, ogs_gtp2_message_t *message);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/smf/s5c-handler.h
+++ b/src/smf/s5c-handler.h
@@ -39,7 +39,8 @@ uint8_t smf_s5c_handle_delete_session_request(
         ogs_gtp2_delete_session_request_t *req);
 void smf_s5c_handle_modify_bearer_request(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_pkbuf_t *gtpbuf, ogs_gtp2_modify_bearer_request_t *req);
+        ogs_pkbuf_t *gtpbuf, ogs_gtp2_modify_bearer_request_t *req,
+        ogs_gtp2_sender_f_teid_t *sender_f_teid);
 void smf_s5c_handle_create_bearer_response(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
         ogs_gtp2_create_bearer_response_t *rsp);
@@ -51,7 +52,8 @@ bool smf_s5c_handle_delete_bearer_response(
         ogs_gtp2_delete_bearer_response_t *rsp);
 void smf_s5c_handle_bearer_resource_command(
         smf_sess_t *sess, ogs_gtp_xact_t *xact,
-        ogs_gtp2_bearer_resource_command_t *cmd);
+        ogs_gtp2_bearer_resource_command_t *cmd,
+        ogs_gtp2_sender_f_teid_t *sender_f_teid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
If eg. PCRF or AAA diameter link is not yet ready (eg. PCRF crashed), and a client sends a CreateSessionRequest announcing its ow F-TEID, then open5gs-smfd answers with Create Session Response Cause= "Remote peer not responding", but it is not setting the received F-TEID in the header of the response, instead it sends with TEI=0.

As a result, the peer cannot match the CreateSessionResponse, and needs to rely on its own timeout timer to figure out that specific request failed.

To address this issue, I modified the GTP Response message to check the Sender F-TEID and send it accordingly, setting the destination TEID to the value of the Sender F-TEID.

I've made this modification only for SMF, but MME and SGW-C have not done so; if you need to, you can work from the examples in SMF.

Similarly, the same situation can happen with PFCP. If anyone needs to do this in the future, I think you can work on it this way.