### PR TITLE
[CORE] Add logger: no_timestamp config option

### DIFF
--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -40,6 +40,7 @@ typedef struct ogs_app_context_s {
         const char *file;
         const char *level;
         const char *domain;
+        bool no_timestamp;
     } logger;
 
     ogs_queue_t *queue;

--- a/lib/app/ogs-init.c
+++ b/lib/app/ogs-init.c
@@ -114,6 +114,9 @@ int ogs_app_initialize(
             ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
+    if (ogs_app()->logger.no_timestamp)
+        ogs_log_set_timestamp(false);
+
     /**************************************************************************
      * Stage 5 : Setup Database Module
      */
@@ -286,6 +289,9 @@ static int parse_config(void)
                 } else if (!strcmp(logger_key, "domain")) {
                     ogs_app()->logger.domain =
                         ogs_yaml_iter_value(&logger_iter);
+                } else if (!strcmp(logger_key, "no_timestamp")) {
+                    ogs_app()->logger.no_timestamp =
+                        ogs_yaml_iter_bool(&logger_iter);
                 }
             }
         } else if (!strcmp(root_key, "global")) {

--- a/lib/core/ogs-log.c
+++ b/lib/core/ogs-log.c
@@ -340,6 +340,15 @@ void ogs_log_set_mask_level(const char *_mask, ogs_log_level_e level)
     }
 }
 
+void ogs_log_set_timestamp(bool enable)
+{
+    ogs_log_t *log;
+
+    ogs_list_for_each(&log_list, log) {
+        log->print.timestamp = enable;
+    }
+}
+
 static ogs_log_level_e ogs_log_level_from_string(const char *string)
 {
     ogs_log_level_e level = OGS_ERROR;

--- a/lib/core/ogs-log.h
+++ b/lib/core/ogs-log.h
@@ -90,6 +90,7 @@ void ogs_log_install_domain(int *domain_id,
 int ogs_log_config_domain(const char *domain, const char *level);
 
 void ogs_log_set_mask_level(const char *mask, ogs_log_level_e level);
+void ogs_log_set_timestamp(bool enable);
 
 void ogs_log_vprintf(ogs_log_level_e level, int id,
     ogs_err_t err, const char *file, int line, const char *func,


### PR DESCRIPTION
Add an option to disable printing the timestamp. This is useful to not have duplicate timestamps, when stderr is piped into a logging system that adds timestamps on its own. For example with systemd's journald:

```
$ journalctl -u open5gs-smfd
Apr 10 13:25:18 hostname open5gs-smfd[1582]: 04/10 13:25:18.274: [app] INFO: Configuration: '/etc/open5gs/smf.yaml' (../lib/app/ogs-init.c:130)
```