### PR TITLE
[AMF/MME] NAS message in an invaild state (#3131)

### DIFF
--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -586,10 +586,8 @@ void s1ap_handle_initial_ue_message(mme_enb_t *enb, ogs_s1ap_message_t *message)
         enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id,
         enb_ue->saved.tai.tac, enb_ue->saved.e_cgi.cell_id);
 
-    r = s1ap_send_to_nas(enb_ue,
-            S1AP_ProcedureCode_id_initialUEMessage, NAS_PDU);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
+    ogs_expect(OGS_OK == s1ap_send_to_nas(
+                enb_ue, S1AP_ProcedureCode_id_initialUEMessage, NAS_PDU));
 }
 
 void s1ap_handle_uplink_nas_transport(
@@ -777,10 +775,8 @@ void s1ap_handle_uplink_nas_transport(
         ogs_error("No UE Context in UplinkNASTransport");
     }
 
-    r = s1ap_send_to_nas(enb_ue,
-            S1AP_ProcedureCode_id_uplinkNASTransport, NAS_PDU);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
+    ogs_expect(OGS_OK == s1ap_send_to_nas(
+                enb_ue, S1AP_ProcedureCode_id_uplinkNASTransport, NAS_PDU));
 }
 
 void s1ap_handle_ue_capability_info_indication(

--- a/tests/attach/issues-test.c
+++ b/tests/attach/issues-test.c
@@ -1862,6 +1862,7 @@ static void issues_2287_v264_func(abts_case *tc, void *data)
     test_ue_remove_all();
 }
 
+#if 0 /* Deprecated to resolve issue #3131 */
 static void pull_3122_v270_func(abts_case *tc, void *data)
 {
     int rv;
@@ -1973,6 +1974,7 @@ static void pull_3122_v270_func(abts_case *tc, void *data)
 
     test_ue_remove(test_ue);
 }
+#endif
 
 abts_suite *test_issues(abts_suite *suite)
 {
@@ -1981,7 +1983,9 @@ abts_suite *test_issues(abts_suite *suite)
     abts_run_test(suite, issues_1431_func, NULL);
     abts_run_test(suite, issues_2287_v263_func, NULL);
     abts_run_test(suite, issues_2287_v264_func, NULL);
+#if 0 /* Deprecated to resolve issue #3131 */
     abts_run_test(suite, pull_3122_v270_func, NULL);
+#endif
 
     return suite;
 }

--- a/tests/registration/identity-test.c
+++ b/tests/registration/identity-test.c
@@ -354,6 +354,7 @@ static void test1_func(abts_case *tc, void *data)
     test_ue_remove(test_ue);
 }
 
+#if 0 /* Deprecated to resolve issue #3131 */
 static void pull_3122_v270_func(abts_case *tc, void *data)
 {
     int rv;
@@ -469,13 +470,16 @@ static void pull_3122_v270_func(abts_case *tc, void *data)
     /* Clear Test UE Context */
     test_ue_remove(test_ue);
 }
+#endif
 
 abts_suite *test_identity(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
 
     abts_run_test(suite, test1_func, NULL);
+#if 0 /* Deprecated to resolve issue #3131 */
     abts_run_test(suite, pull_3122_v270_func, NULL);
+#endif
 
     return suite;
 }


### PR DESCRIPTION
In InitialUEMessage, send a NAS message with a message type other than Registration Request, Deregistration Request, or Service Request, the following messages from UE will not be accepted.

We found this issue in not only the initial state but multiple states. We believe if an attacker has the ability to inject a NAS message to the core, it can perform a DoS attack on the victim UE.

So, I've fixed that The MME/AMF deletes MME_UE_S1AP_ID/AMF_UE_NGAP_ID, and will not accept any following messages from the UE.