### PR TITLE
[SMF/UPF] Changes subnet configuration (#2975)

### DIFF
--- a/configs/310014.yaml.in
+++ b/configs/310014.yaml.in
@@ -109,8 +109,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -189,8 +190,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/csfb.yaml.in
+++ b/configs/csfb.yaml.in
@@ -142,8 +142,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -219,8 +220,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/5gc-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-sepp1-999-70.yaml.in
@@ -112,8 +112,9 @@ smf:
       - address: 127.0.1.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -207,8 +208,9 @@ upf:
     server:
       - address: 127.0.1.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.1.7

--- a/configs/examples/5gc-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-sepp2-001-01.yaml.in
@@ -112,8 +112,9 @@ smf:
       - address: 127.0.2.4
         port: 9090
   session:
-    - subnet: 10.46.0.1/16
-    - subnet: 2001:db8:babe::1/48
+    - subnet: 10.46.0.0/16
+      gateway: 10.46.0.1
+    - subnet: 2001:db8:babe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -207,9 +208,10 @@ upf:
     server:
       - address: 127.0.2.7
   session:
-    - subnet: 10.46.0.1/16
+    - subnet: 10.46.0.0/16
+      gateway: 10.46.0.1
       dev: ogstun2
-    - subnet: 2001:db8:babe::1/48
+    - subnet: 2001:db8:babe::/48
       dev: ogstun2
   metrics:
     server:

--- a/configs/examples/5gc-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-sepp3-315-010.yaml.in
@@ -112,8 +112,9 @@ smf:
       - address: 127.0.3.4
         port: 9090
   session:
-    - subnet: 10.47.0.1/16
-    - subnet: 2001:db8:face::1/48
+    - subnet: 10.47.0.0/16
+      gateway: 10.47.0.1
+    - subnet: 2001:db8:face::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -207,9 +208,10 @@ upf:
     server:
       - address: 127.0.3.7
   session:
-    - subnet: 10.47.0.1/16
+    - subnet: 10.47.0.0/16
+      gateway: 10.47.0.1
       dev: ogstun3
-    - subnet: 2001:db8:face::1/48
+    - subnet: 2001:db8:face::/48
       dev: ogstun3
   metrics:
     server:

--- a/configs/examples/5gc-tls-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-tls-sepp1-999-70.yaml.in
@@ -113,8 +113,9 @@ smf:
       - address: 127.0.1.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -208,8 +209,9 @@ upf:
     server:
       - address: 127.0.1.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.1.7

--- a/configs/examples/5gc-tls-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-tls-sepp2-001-01.yaml.in
@@ -113,8 +113,9 @@ smf:
       - address: 127.0.2.4
         port: 9090
   session:
-    - subnet: 10.46.0.1/16
-    - subnet: 2001:db8:babe::1/48
+    - subnet: 10.46.0.0/16
+      gateway: 10.46.0.1
+    - subnet: 2001:db8:babe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -208,9 +209,10 @@ upf:
     server:
       - address: 127.0.2.7
   session:
-    - subnet: 10.46.0.1/16
+    - subnet: 10.46.0.0/16
+      gateway: 10.46.0.1
       dev: ogstun2
-    - subnet: 2001:db8:babe::1/48
+    - subnet: 2001:db8:babe::/48
       dev: ogstun2
   metrics:
     server:

--- a/configs/examples/5gc-tls-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-tls-sepp3-315-010.yaml.in
@@ -113,8 +113,9 @@ smf:
       - address: 127.0.3.4
         port: 9090
   session:
-    - subnet: 10.47.0.1/16
-    - subnet: 2001:db8:face::1/48
+    - subnet: 10.47.0.0/16
+      gateway: 10.47.0.1
+    - subnet: 2001:db8:face::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -208,9 +209,10 @@ upf:
     server:
       - address: 127.0.3.7
   session:
-    - subnet: 10.47.0.1/16
+    - subnet: 10.47.0.0/16
+      gateway: 10.47.0.1
       dev: ogstun3
-    - subnet: 2001:db8:face::1/48
+    - subnet: 2001:db8:face::/48
       dev: ogstun3
   metrics:
     server:

--- a/configs/examples/gnb-001-01-ue-001-01.yaml.in
+++ b/configs/examples/gnb-001-01-ue-001-01.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-001-01-ue-315-010.yaml.in
+++ b/configs/examples/gnb-001-01-ue-315-010.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-001-01-ue-999-70.yaml.in
+++ b/configs/examples/gnb-001-01-ue-999-70.yaml.in
@@ -116,8 +116,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -198,8 +199,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-315-010-ue-001-01.yaml.in
+++ b/configs/examples/gnb-315-010-ue-001-01.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-315-010-ue-315-010.yaml.in
+++ b/configs/examples/gnb-315-010-ue-315-010.yaml.in
@@ -116,8 +116,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -198,8 +199,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-315-010-ue-999-70.yaml.in
+++ b/configs/examples/gnb-315-010-ue-999-70.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-999-70-ue-001-01.yaml.in
+++ b/configs/examples/gnb-999-70-ue-001-01.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-999-70-ue-315-010.yaml.in
+++ b/configs/examples/gnb-999-70-ue-315-010.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/examples/gnb-999-70-ue-999-70.yaml.in
+++ b/configs/examples/gnb-999-70-ue-999-70.yaml.in
@@ -116,8 +116,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -198,8 +199,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/non3gpp.yaml.in
+++ b/configs/non3gpp.yaml.in
@@ -110,8 +110,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -192,8 +193,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -34,8 +34,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -327,23 +328,26 @@ smf:
 #  o Specific DNN/APN(e.g 'ims') uses 10.46.0.1/16, 2001:db8:babe::1/48
 #   (If the UE has unknown DNN/APN(not internet/ims), SMF/UPF will crash.)
 #  session:
-#    - subnet: 10.45.0.1/16
+#    - subnet: 10.45.0.0/16
+#      gateway: 10.45.0.1
 #      dnn: internet
-#    - subnet: 2001:db8:cafe::1/48
+#    - subnet: 2001:db8:cafe::/48
 #      dnn: internet
-#    - subnet: 10.46.0.1/16
+#    - subnet: 10.46.0.0/16
+#      gateway: 10.46.0.1
 #      dnn: ims
-#    - subnet: 2001:db8:babe::1/48
+#    - subnet: 2001:db8:babe::/48
 #      dnn: ims
 #
 #  o Pool Range
 #  session:
-#    - subnet: 10.45.0.1/16
+#    - subnet: 10.45.0.0/16
+#      gateway: 10.45.0.1
 #      range:
 #        - 10.45.0.100-10.45.0.200
 #        - 10.45.1.100-
 #        - -10.45.0.200
-#    - subnet: 2001:db8:cafe::1/48
+#    - subnet: 2001:db8:cafe::/48
 #      range:
 #        - 2001:db8:cafe:a0::0-2001:db8:cafe:b0::0
 #        - 2001:db8:cafe:c0::0-2001:db8:cafe:d0::0

--- a/configs/open5gs/upf.yaml.in
+++ b/configs/open5gs/upf.yaml.in
@@ -18,8 +18,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7
@@ -70,14 +71,16 @@ upf:
 #  $ sudo ip addr add 2001:db8:babe::1/48 dev ogstun3
 #
 #  session:
-#    - subnet: 10.45.0.1/16
+#    - subnet: 10.45.0.0/16
+#      gateway: 10.45.0.1
 #      dnn: internet
-#    - subnet: 2001:db8:cafe::1/48
+#    - subnet: 2001:db8:cafe::/48
 #      dnn: internet
 #      dev: ogstun2
-#    - subnet: 10.46.0.1/16
+#    - subnet: 10.46.0.0/16
+#      gateway: 10.46.0.1
 #      dnn: ims
 #      dev: ogstun3
-#    - subnet: 2001:db8:babe::1/48
+#    - subnet: 2001:db8:babe::/48
 #      dnn: ims
 #      dev: ogstun3

--- a/configs/sample.yaml.in
+++ b/configs/sample.yaml.in
@@ -118,8 +118,9 @@ smf:
       - address: 127.0.0.4
         port: 9090
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -203,8 +204,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/slice.yaml.in
+++ b/configs/slice.yaml.in
@@ -110,8 +110,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -194,8 +195,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/srsenb.yaml.in
+++ b/configs/srsenb.yaml.in
@@ -107,8 +107,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -184,8 +185,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/volte.yaml.in
+++ b/configs/volte.yaml.in
@@ -107,8 +107,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -187,8 +188,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/configs/vonr.yaml.in
+++ b/configs/vonr.yaml.in
@@ -110,8 +110,9 @@ smf:
     server:
       - address: 127.0.0.4
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   dns:
     - 8.8.8.8
     - 8.8.4.4
@@ -193,8 +194,9 @@ upf:
     server:
       - address: 127.0.0.7
   session:
-    - subnet: 10.45.0.1/16
-    - subnet: 2001:db8:cafe::1/48
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
   metrics:
     server:
       - address: 127.0.0.7

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -743,6 +743,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                     do {
                         ogs_pfcp_subnet_t *subnet = NULL;
                         const char *ipstr = NULL;
+                        const char *gateway = NULL;
                         const char *mask_or_numbits = NULL;
                         const char *dnn = NULL;
                         const char *dev = self.tun_ifname;
@@ -781,6 +782,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                         mask_or_numbits = (const char *)v;
                                     }
                                 }
+                            } else if (!strcmp(subnet_key, "gateway")) {
+                                gateway = ogs_yaml_iter_value(&subnet_iter);
                             } else if (!strcmp(subnet_key, "apn") ||
                                         !strcmp(subnet_key, "dnn")) {
                                 dnn = ogs_yaml_iter_value(&subnet_iter);
@@ -825,7 +828,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         }
 
                         subnet = ogs_pfcp_subnet_add(
-                                ipstr, mask_or_numbits, dnn, dev);
+                                ipstr, mask_or_numbits, gateway, dnn, dev);
                         ogs_assert(subnet);
 
                         subnet->num_of_range = num;
@@ -2150,7 +2153,7 @@ ogs_pfcp_dev_t *ogs_pfcp_dev_find_by_ifname(const char *ifname)
 
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
         const char *ipstr, const char *mask_or_numbits,
-        const char *dnn, const char *ifname)
+        const char *gateway, const char *dnn, const char *ifname)
 {
     int rv;
     ogs_pfcp_dev_t *dev = NULL;
@@ -2179,6 +2182,43 @@ ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
 
         subnet->family = subnet->gw.family;
         subnet->prefixlen = atoi(mask_or_numbits);
+
+        if (memcmp(subnet->gw.sub, subnet->sub.sub,
+                    sizeof(subnet->gw.sub)) != 0) {
+            char *subnet_string = NULL;
+
+            if (subnet->family == AF_INET) {
+                subnet_string = ogs_ipv4_to_string(subnet->sub.sub[0]);
+                ogs_assert(subnet_string);
+            } else if (subnet->family == AF_INET6) {
+                subnet_string = ogs_ipv6addr_to_string(
+                        (uint8_t*)&subnet->sub.sub[0]);
+                ogs_assert(subnet_string);
+            }
+
+            ogs_warn("Please change the configuration files of "
+                    "smf.yaml and upf.yaml as below.");
+            ogs_log_print(OGS_LOG_WARN, "\n<OLD Format>\n");
+            ogs_log_print(OGS_LOG_WARN, "smf:\n");
+            ogs_log_print(OGS_LOG_WARN, "  session:\n");
+            ogs_log_print(OGS_LOG_WARN, "    - subnet: %s/%s\n",
+                    ipstr, mask_or_numbits);
+            ogs_log_print(OGS_LOG_WARN, "\n<NEW Format>\n");
+            ogs_log_print(OGS_LOG_WARN, "smf:\n");
+            ogs_log_print(OGS_LOG_WARN, "  session:\n");
+            ogs_log_print(OGS_LOG_WARN, "    - subnet: %s/%s\n",
+                    subnet_string ? subnet_string : "Unknown", mask_or_numbits);
+            if (subnet->family == AF_INET)
+                ogs_log_print(OGS_LOG_WARN, "      gateway: %s", ipstr);
+            ogs_log_print(OGS_LOG_WARN, "\n\n\n");
+
+            ogs_free(subnet_string);
+        }
+    }
+
+    if (gateway) {
+        rv = ogs_ipsubnet(&subnet->gw, gateway, NULL);
+        ogs_assert(rv == OGS_OK);
     }
 
     if (dnn)

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -491,7 +491,7 @@ ogs_pfcp_dev_t *ogs_pfcp_dev_find_by_ifname(const char *ifname);
 
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
         const char *ipstr, const char *mask_or_numbits,
-        const char *dnn, const char *ifname);
+        const char *gateway, const char *dnn, const char *ifname);
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_next(ogs_pfcp_subnet_t *subnet);
 void ogs_pfcp_subnet_remove(ogs_pfcp_subnet_t *subnet);
 void ogs_pfcp_subnet_remove_all(void);


### PR DESCRIPTION
The way subnet is set up has changed as shown below.

```
<OLD Format>
smf:
  session:
    - subnet: 10.45.0.1/16

<NEW Format>
smf:
  session:
    - subnet: 10.45.0.0/16
      gateway: 10.45.0.1
```

For more information, please refer to Pull Request #2975.