### PR TITLE
NGAP Class 2 Elementary Procedure: AMF Status Indication

### DIFF
--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -495,6 +495,10 @@ int nas_5gs_send_authentication_request(amf_ue_t *amf_ue)
 
     rv = nas_5gs_send_to_downlink_nas_transport(amf_ue->ran_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
+    
+    rv = ngap_send_amf_status_indication(amf_ue);
+    ogs_expect(rv == OGS_OK);
+    ogs_assert(rv != OGS_ERROR);
 
     return rv;
 }

--- a/src/amf/ngap-build.h
+++ b/src/amf/ngap-build.h
@@ -74,6 +74,8 @@ ogs_pkbuf_t *ngap_build_downlink_ran_status_transfer(
     ran_ue_t *target_ue,
     NGAP_RANStatusTransfer_TransparentContainer_t *transfer);
 
+ogs_pkbuf_t *ngap_build_amf_status_indication(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -767,3 +767,34 @@ int ngap_send_ng_reset_ack(
 
     return rv;
 }
+
+int ngap_send_amf_status_indication(amf_ue_t *amf_ue)
+{
+    int rv;
+    ran_ue_t *ran_ue;
+    ogs_pkbuf_t *ngap_buffer;
+
+    ogs_debug("AMF Status Indication");
+
+    if (!amf_ue_cycle(amf_ue)) {
+        ogs_error("UE(amf-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
+
+    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    if (!ran_ue) {
+        ogs_error("NG context has already been removed");
+        return OGS_NOTFOUND;
+    }
+
+    ngap_buffer = ngap_build_amf_status_indication();
+    if (!ngap_buffer) {
+        ogs_error("ngap_build_amf_status_indication() failed");
+        return OGS_ERROR;
+    }
+
+    rv = ngap_send_to_ran_ue(ran_ue, ngap_buffer);
+    ogs_expect(rv == OGS_OK);
+
+    return rv;
+}

--- a/src/amf/ngap-path.h
+++ b/src/amf/ngap-path.h
@@ -86,6 +86,7 @@ int ngap_send_error_indication2(
 int ngap_send_ng_reset_ack(
         amf_gnb_t *gnb,
         NGAP_UE_associatedLogicalNG_connectionList_t *partOfNG_Interface);
+int ngap_send_amf_status_indication(amf_ue_t *amf_ue);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
…management functions.

AMF Status Indication is the NGAP Class 2 Elementary Procedure.
This message is sent by the AMF to support AMF management functions.
Direction: AMF → NG-RAN node

3GPP spec: NG Application Protocol (NGAP) (3GPP TS 38.413 version 15.0.0 Release 15) 