### PR TITLE
[CORE] logger: add option to disable timestamps

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/amf.log
+  file:
+    path: @localstatedir@/log/open5gs/amf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/ausf.log
+  file:
+    path: @localstatedir@/log/open5gs/ausf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/bsf.log
+  file:
+    path: @localstatedir@/log/open5gs/bsf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/hss.yaml.in
+++ b/configs/open5gs/hss.yaml.in
@@ -1,6 +1,7 @@
 db_uri: mongodb://localhost/open5gs
 logger:
-  file: @localstatedir@/log/open5gs/hss.log
+  file:
+    path: @localstatedir@/log/open5gs/hss.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/mme.log
+  file:
+    path: @localstatedir@/log/open5gs/mme.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/nrf.yaml.in
+++ b/configs/open5gs/nrf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/nrf.log
+  file:
+    path: @localstatedir@/log/open5gs/nrf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/nssf.log
+  file:
+    path: @localstatedir@/log/open5gs/nssf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -1,6 +1,7 @@
 db_uri: mongodb://localhost/open5gs
 logger:
-  file: @localstatedir@/log/open5gs/pcf.log
+  file:
+    path: @localstatedir@/log/open5gs/pcf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/pcrf.yaml.in
+++ b/configs/open5gs/pcrf.yaml.in
@@ -1,6 +1,7 @@
 db_uri: mongodb://localhost/open5gs
 logger:
-  file: @localstatedir@/log/open5gs/pcrf.log
+  file:
+    path: @localstatedir@/log/open5gs/pcrf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/scp.log
+  file:
+    path: @localstatedir@/log/open5gs/scp.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/sepp1.yaml.in
+++ b/configs/open5gs/sepp1.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/sepp1.log
+  file:
+    path: @localstatedir@/log/open5gs/sepp1.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/sepp2.yaml.in
+++ b/configs/open5gs/sepp2.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/sepp2.log
+  file:
+    path: @localstatedir@/log/open5gs/sepp2.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/sgwc.yaml.in
+++ b/configs/open5gs/sgwc.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/sgwc.log
+  file:
+    path: @localstatedir@/log/open5gs/sgwc.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/sgwu.yaml.in
+++ b/configs/open5gs/sgwu.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/sgwu.log
+  file:
+    path: @localstatedir@/log/open5gs/sgwu.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/smf.log
+  file:
+    path: @localstatedir@/log/open5gs/smf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/udm.log
+  file:
+    path: @localstatedir@/log/open5gs/udm.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -1,6 +1,7 @@
 db_uri: mongodb://localhost/open5gs
 logger:
-  file: @localstatedir@/log/open5gs/udr.log
+  file:
+    path: @localstatedir@/log/open5gs/udr.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/configs/open5gs/upf.yaml.in
+++ b/configs/open5gs/upf.yaml.in
@@ -1,5 +1,6 @@
 logger:
-  file: @localstatedir@/log/open5gs/upf.log
+  file:
+    path: @localstatedir@/log/open5gs/upf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -428,6 +428,34 @@ $ sudo systemctl restart open5gs-amfd
 $ sudo systemctl restart open5gs-upfd
 ```
 
+#### Configure logging
+
+The Open5GS components log to `/var/log/open5gs/*.log` and to `stderr` by
+default.
+
+##### Avoid duplicate timestamps in journalctl
+
+Open5GS adds timestamps to each log line in the log file, and on `stderr`. If
+you run Open5GS with systemd and prefer looking at the logs with `journalctl`,
+then each line will have two timestamps. To fix this, disable the timestamp for
+`stderr` with the following configuration change:
+
+```diff
+diff --git a/configs/open5gs/mme.yaml.in b/configs/open5gs/mme.yaml.in
+index 87c251b9d..599032b8a 100644
+--- a/configs/open5gs/mme.yaml.in
++++ b/configs/open5gs/mme.yaml.in
+@@ -1,6 +1,9 @@
+ logger:
++  default:
++    timestamp: false
+   file:
+     path: /var/log/open5gs/mme.log
++    timestamp: true
+ #  level: info   # fatal|error|warn|info(default)|debug|trace
+ 
+ global:
+```
 
 #### Register Subscriber Information
 ---

--- a/docs/_docs/troubleshoot/01-simple-issues.md
+++ b/docs/_docs/troubleshoot/01-simple-issues.md
@@ -169,7 +169,8 @@ index a70143f08..e0dba560c 100644
 +++ b/configs/open5gs/amf.yaml.in
 @@ -1,6 +1,6 @@
  logger:
-     file: @localstatedir@/log/open5gs/amf.log
+     file:
+       path: @localstatedir@/log/open5gs/amf.log
 -#    level: info   # fatal|error|warn|info(default)|debug|trace
 +    level: debug
 

--- a/docs/_docs/troubleshoot/02-now-in-github-issues.md
+++ b/docs/_docs/troubleshoot/02-now-in-github-issues.md
@@ -485,7 +485,8 @@ index a70143f08..e0dba560c 100644
 +++ b/configs/open5gs/amf.yaml.in
 @@ -1,6 +1,6 @@
  logger:
-     file: @localstatedir@/log/open5gs/amf.log
+     file:
+       path: @localstatedir@/log/open5gs/amf.log
 -#    level: info   # fatal|error|warn|info(default)|debug|trace
 +    level: debug
 

--- a/docs/_docs/tutorial/05-roaming.md
+++ b/docs/_docs/tutorial/05-roaming.md
@@ -92,7 +92,8 @@ NRF shall follow TS23.003(28.3.2.3.2 Format of NRF FQDN) for routing.
 ```bash
 $ sh -c 'cat << EOF > ./install/etc/open5gs/h-nrf.yaml
 logger:
-  file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/h-nrf.log
+  file:
+    path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/h-nrf.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:
@@ -116,7 +117,8 @@ EOF'
 ```bash
 $ sh -c 'cat << EOF > ./install/etc/open5gs/h-scp.yaml
 logger:
-  file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/h-scp.log
+  file:
+    path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/h-scp.log
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:
@@ -302,7 +304,8 @@ $ diff -u ./install/etc/open5gs/pcf.yaml.old ./install/etc/open5gs/pcf.yaml
 @@ -1,4 +1,3 @@
 -db_uri: mongodb://localhost/open5gs
  logger:
-   file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/pcf.log
+   file:
+     path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/pcf.log
  #  level: info   # fatal|error|warn|info(default)|debug|trace
 @@ -22,6 +21,29 @@
      server:
@@ -646,7 +649,8 @@ For now we will set up SEPP without using TLS.
 ```bash
 $ sh -c 'cat << EOF > ./install/etc/open5gs/sepp.yaml
 logger:
-    file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
+    file:
+      path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
 #    level: info   # fatal|error|warn|info(default)|debug|trace
 
 max:
@@ -966,7 +970,8 @@ For now we will set up SEPP without using TLS.
 ```bash
 $ sh -c 'cat << EOF > ./install/etc/open5gs/sepp.yaml
 logger:
-    file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
+    file:
+      path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
 #    level: info   # fatal|error|warn|info(default)|debug|trace
 
 max:
@@ -1286,7 +1291,8 @@ For now we will set up SEPP without using TLS.
 ```bash
 $ sh -c 'cat << EOF > ./install/etc/open5gs/sepp.yaml
 logger:
-    file: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
+    file:
+      path: /home/acetcom/Documents/git/open5gs/install/var/log/open5gs/sepp.log
 #    level: info   # fatal|error|warn|info(default)|debug|trace
 
 max:

--- a/docs/_posts/2020-03-25-release-v1.2.2.md
+++ b/docs/_posts/2020-03-25-release-v1.2.2.md
@@ -25,7 +25,8 @@ Example of sgw.yaml to use this feature:
 
 ```
 logger:
-    file: /var/log/open5gs/sgw.log
+    file:
+      path: /var/log/open5gs/sgw.log
     level: debug
 
 parameter:

--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -37,9 +37,14 @@ typedef struct ogs_app_context_s {
     const char *db_uri;
 
     struct {
+        ogs_log_ts_e timestamp;
+    } logger_default;
+
+    struct {
         const char *file;
         const char *level;
         const char *domain;
+        ogs_log_ts_e timestamp;
     } logger;
 
     ogs_queue_t *queue;

--- a/lib/app/ogs-yaml.c
+++ b/lib/app/ogs-yaml.c
@@ -178,6 +178,34 @@ const char *ogs_yaml_iter_value(ogs_yaml_iter_t *iter)
     return NULL;
 }
 
+int ogs_yaml_iter_has_value(ogs_yaml_iter_t *iter)
+{
+    ogs_assert(iter);
+    ogs_assert(iter->document);
+    ogs_assert(iter->node);
+
+    if (iter->node->type == YAML_SCALAR_NODE) {
+        return 1;
+    } else if (iter->node->type == YAML_MAPPING_NODE) {
+        yaml_node_t *node = NULL;
+
+        ogs_assert(iter->pair);
+        node = yaml_document_get_node(iter->document, iter->pair->value);
+        ogs_assert(node);
+        return node->type == YAML_SCALAR_NODE;
+    } else if (iter->node->type == YAML_SEQUENCE_NODE) {
+        yaml_node_t *node = NULL;
+
+        ogs_assert(iter->item);
+        node = yaml_document_get_node(iter->document, *iter->item);
+        ogs_assert(node);
+        return node->type == YAML_SCALAR_NODE;
+    }
+
+    ogs_assert_if_reached();
+    return 0;
+}
+
 int ogs_yaml_iter_bool(ogs_yaml_iter_t *iter)
 {
     const char *v = ogs_yaml_iter_value(iter);

--- a/lib/app/ogs-yaml.h
+++ b/lib/app/ogs-yaml.h
@@ -59,6 +59,7 @@ void ogs_yaml_iter_recurse(ogs_yaml_iter_t *parent, ogs_yaml_iter_t *iter);
 int ogs_yaml_iter_type(ogs_yaml_iter_t *iter);
 const char *ogs_yaml_iter_key(ogs_yaml_iter_t *iter);
 const char *ogs_yaml_iter_value(ogs_yaml_iter_t *iter);
+int ogs_yaml_iter_has_value(ogs_yaml_iter_t *iter);
 int ogs_yaml_iter_bool(ogs_yaml_iter_t *iter);
 
 #ifdef __cplusplus

--- a/lib/core/ogs-log.c
+++ b/lib/core/ogs-log.c
@@ -340,6 +340,28 @@ void ogs_log_set_mask_level(const char *_mask, ogs_log_level_e level)
     }
 }
 
+void ogs_log_set_timestamp(ogs_log_ts_e ts_default, ogs_log_ts_e ts_file)
+{
+    ogs_log_t *log;
+
+    if (ts_default == OGS_LOG_TS_UNSET)
+        ts_default = OGS_LOG_TS_ENABLED;
+
+    if (ts_file == OGS_LOG_TS_UNSET)
+        ts_file = ts_default;
+
+    ogs_list_for_each(&log_list, log) {
+        switch (log->type) {
+            case OGS_LOG_FILE_TYPE:
+                log->print.timestamp = (ts_file == OGS_LOG_TS_ENABLED);
+                break;
+            default:
+                log->print.timestamp = (ts_default == OGS_LOG_TS_ENABLED);
+                break;
+        }
+    }
+}
+
 static ogs_log_level_e ogs_log_level_from_string(const char *string)
 {
     ogs_log_level_e level = OGS_ERROR;

--- a/lib/core/ogs-log.h
+++ b/lib/core/ogs-log.h
@@ -64,6 +64,12 @@ typedef enum {
     OGS_LOG_FULL = OGS_LOG_TRACE,
 } ogs_log_level_e;
 
+typedef enum {
+    OGS_LOG_TS_UNSET,
+    OGS_LOG_TS_ENABLED,
+    OGS_LOG_TS_DISABLED,
+} ogs_log_ts_e;
+
 typedef struct ogs_log_s ogs_log_t;
 typedef struct ogs_log_domain_s ogs_log_domain_t;
 
@@ -90,6 +96,7 @@ void ogs_log_install_domain(int *domain_id,
 int ogs_log_config_domain(const char *domain, const char *level);
 
 void ogs_log_set_mask_level(const char *mask, ogs_log_level_e level);
+void ogs_log_set_timestamp(ogs_log_ts_e ts_default, ogs_log_ts_e ts_file);
 
 void ogs_log_vprintf(ogs_log_level_e level, int id,
     ogs_err_t err, const char *file, int line, const char *func,


### PR DESCRIPTION
Add an option to disable printing the timestamp. This is useful to not have duplicate timestamps, when stderr is piped into a logging system that adds timestamps on its own. For example with systemd's journald:

```
$ journalctl -u open5gs-smfd
Apr 10 13:25:18 hostname open5gs-smfd[1582]: 04/10 13:25:18.274: [app] INFO: Configuration: '/etc/open5gs/smf.yaml' (../lib/app/ogs-init.c:130)
```

This is a follow-up to #3125. As discussed, now the timestamp for `default` and `file` can be set separately.

This requires a config change:
```
<OLD Format>
logger:
  file: /var/log/open5gs/smf.log

<NEW Format>
logger:
  file:
    path: /var/log/open5gs/smf.log
```

I have added backwards compatibility code similar to a6830b30a0093ed2fa9d563445bf67026588a8f2, adjusted the docs and examples and documented this in the quickstart guide:
> #### Configure logging
> 
> The Open5GS components log to `/var/log/open5gs/*.log` and to `stderr` by
> default.
> 
> ##### Avoid duplicate timestamps in journalctl
> 
> Open5GS adds timestamps to each log line in the log file, and on `stderr`. If
> you run Open5GS with systemd and prefer looking at the logs with `journalctl`,
> then each line will have two timestamps. To fix this, disable the timestamp for
> `stderr` with the following configuration change:
> 
> ```diff
> diff --git a/configs/open5gs/mme.yaml.in b/configs/open5gs/mme.yaml.in
> index 87c251b9d..599032b8a 100644
> --- a/configs/open5gs/mme.yaml.in
> +++ b/configs/open5gs/mme.yaml.in
> @@ -1,6 +1,9 @@
>  logger:
> +  default:
> +    timestamp: false
>    file:
>      path: /var/log/open5gs/mme.log
> +    timestamp: true
>  #  level: info   # fatal|error|warn|info(default)|debug|trace
>  
>  global:
> ```