### PR TITLE
[SBI] Generate URI via HTTP.location as is (#3058)

### DIFF
--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -453,7 +453,7 @@ index 87c251b9d..599032b8a 100644
      path: /var/log/open5gs/mme.log
 +    timestamp: true
  #  level: info   # fatal|error|warn|info(default)|debug|trace
- 
+
  global:
 ```
 

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2493,12 +2493,26 @@ ogs_sbi_subscription_data_t *ogs_sbi_subscription_data_add(void)
     return subscription_data;
 }
 
+void ogs_sbi_subscription_data_set_resource_uri(
+        ogs_sbi_subscription_data_t *subscription_data, char *resource_uri)
+{
+    ogs_assert(subscription_data);
+    ogs_assert(resource_uri);
+
+    if (subscription_data->resource_uri)
+        ogs_free(subscription_data->resource_uri);
+    subscription_data->resource_uri = ogs_strdup(resource_uri);
+    ogs_assert(subscription_data->resource_uri);
+}
+
 void ogs_sbi_subscription_data_set_id(
         ogs_sbi_subscription_data_t *subscription_data, char *id)
 {
     ogs_assert(subscription_data);
     ogs_assert(id);
 
+    if (subscription_data->id)
+        ogs_free(subscription_data->id);
     subscription_data->id = ogs_strdup(id);
     ogs_assert(subscription_data->id);
 }
@@ -2515,6 +2529,9 @@ void ogs_sbi_subscription_data_remove(
 
     if (subscription_data->notification_uri)
         ogs_free(subscription_data->notification_uri);
+
+    if (subscription_data->resource_uri)
+        ogs_free(subscription_data->resource_uri);
 
     if (subscription_data->req_nf_instance_id)
         ogs_free(subscription_data->req_nf_instance_id);

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -286,6 +286,7 @@ typedef struct ogs_sbi_subscription_data_s {
     OpenAPI_nf_type_e req_nf_type;          /* reqNfType */
     OpenAPI_nf_status_e nf_status;
     char *notification_uri;
+    char *resource_uri;
 
     struct {
         OpenAPI_nf_type_e nf_type;          /* nfType */
@@ -295,7 +296,7 @@ typedef struct ogs_sbi_subscription_data_s {
     uint64_t requester_features;
     uint64_t nrf_supported_features;
 
-    void *client;                           /* only used in SERVER */
+    void *client;
 } ogs_sbi_subscription_data_t;
 
 typedef struct ogs_sbi_smf_info_s {
@@ -515,6 +516,8 @@ void ogs_sbi_subscription_spec_remove(
 void ogs_sbi_subscription_spec_remove_all(void);
 
 ogs_sbi_subscription_data_t *ogs_sbi_subscription_data_add(void);
+void ogs_sbi_subscription_data_set_resource_uri(
+        ogs_sbi_subscription_data_t *subscription_data, char *resource_uri);
 void ogs_sbi_subscription_data_set_id(
         ogs_sbi_subscription_data_t *subscription_data, char *id);
 void ogs_sbi_subscription_data_remove(

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -1712,11 +1712,7 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_update(
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_PATCH;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NNRF_NFM;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_SUBSCRIPTIONS;
-    message.h.resource.component[1] = subscription_data->id;
+    message.h.uri = subscription_data->resource_uri;
 
     message.http.content_type = (char *)OGS_SBI_CONTENT_PATCH_TYPE;
 
@@ -1771,11 +1767,7 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_unsubscribe(
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NNRF_NFM;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_SUBSCRIPTIONS;
-    message.h.resource.component[1] = subscription_data->id;
+    message.h.uri = subscription_data->resource_uri;
 
     message.http.custom.callback =
         (char *)OGS_SBI_CALLBACK_NNRF_NFMANAGEMENT_NF_STATUS_NOTIFY;

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -313,6 +313,11 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
         ogs_free(fqdn);
         ogs_freeaddrinfo(addr);
         ogs_freeaddrinfo(addr6);
+
+        if (!client) {
+            ogs_fatal("No Client : [%s]", request->h.uri);
+            ogs_assert_if_reached();
+        }
     }
 
     if (scp_client) {

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1676,13 +1676,17 @@ void amf_ue_remove(amf_ue_t *amf_ue)
     /* Clear SubscribedInfo */
     amf_clear_subscribed_info(amf_ue);
 
-    if (amf_ue->policy_association_id)
-        ogs_free(amf_ue->policy_association_id);
-    if (amf_ue->data_change_subscription_id)
-        ogs_free(amf_ue->data_change_subscription_id);
+    PCF_AM_POLICY_CLEAR(amf_ue);
+    if (amf_ue->policy_association.client)
+        ogs_sbi_client_remove(amf_ue->policy_association.client);
 
-    if (amf_ue->confirmation_url_for_5g_aka)
-        ogs_free(amf_ue->confirmation_url_for_5g_aka);
+    UDM_SDM_CLEAR(amf_ue);
+    if (amf_ue->data_change_subscription.client)
+        ogs_sbi_client_remove(amf_ue->data_change_subscription.client);
+
+    CLEAR_5G_AKA_CONFIRMATION(amf_ue);
+    if (amf_ue->confirmation_for_5g_aka.client)
+        ogs_sbi_client_remove(amf_ue->confirmation_for_5g_aka.client);
 
     /* Free UeRadioCapability */
     OGS_ASN_CLEAR_DATA(&amf_ue->ueRadioCapability);
@@ -2249,8 +2253,10 @@ void amf_sess_remove(amf_sess_t *sess)
                 ogs_list_count(&sess->sbi.xact_list));
     ogs_sbi_object_free(&sess->sbi);
 
-    if (sess->sm_context_ref)
-        ogs_free(sess->sm_context_ref);
+    CLEAR_SESSION_CONTEXT(sess);
+
+    if (sess->sm_context.client)
+        ogs_sbi_client_remove(sess->sm_context.client);
 
     if (sess->payload_container)
         ogs_pkbuf_free(sess->payload_container);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -290,13 +290,33 @@ struct amf_ue_s {
     /* PCF sends the RESPONSE
      * of [POST] /npcf-am-polocy-control/v1/policies */
 #define PCF_AM_POLICY_ASSOCIATED(__aMF) \
-    ((__aMF) && ((__aMF)->policy_association_id))
-
+    ((__aMF) && ((__aMF)->policy_association.id))
 #define PCF_AM_POLICY_CLEAR(__aMF) \
-    OGS_MEM_CLEAR((__aMF)->policy_association_id);
-#define PCF_AM_POLICY_STORE(__aMF, __iD) \
-    OGS_STRING_DUP((__aMF)->policy_association_id, __iD);
-    char *policy_association_id;
+    do { \
+        ogs_assert((__aMF)); \
+        if ((__aMF)->policy_association.resource_uri) \
+            ogs_free((__aMF)->policy_association.resource_uri); \
+        (__aMF)->policy_association.resource_uri = NULL; \
+        if ((__aMF)->policy_association.id) \
+            ogs_free((__aMF)->policy_association.id); \
+        (__aMF)->policy_association.id = NULL; \
+    } while(0)
+#define PCF_AM_POLICY_STORE(__aMF, __rESOURCE_URI, __iD) \
+    do { \
+        ogs_assert((__aMF)); \
+        ogs_assert((__rESOURCE_URI)); \
+        ogs_assert((__iD)); \
+        PCF_AM_POLICY_CLEAR(__aMF); \
+        (__aMF)->policy_association.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__aMF)->policy_association.resource_uri); \
+        (__aMF)->policy_association.id = ogs_strdup(__iD); \
+        ogs_assert((__aMF)->policy_association.id); \
+    } while(0)
+    struct {
+        char *resource_uri;
+        char *id;
+        ogs_sbi_client_t *client;
+    } policy_association;
 
     /* 5GMM Capability */
     struct {
@@ -322,7 +342,27 @@ struct amf_ue_s {
     /* Security Context */
     ogs_nas_ue_security_capability_t ue_security_capability;
     ogs_nas_ue_network_capability_t ue_network_capability;
-    char            *confirmation_url_for_5g_aka;
+#define CHECK_5G_AKA_CONFIRMATION(__aMF) \
+    ((__aMF) && ((__aMF)->confirmation_for_5g_aka.resource_uri))
+#define STORE_5G_AKA_CONFIRMATION(__aMF, __rESOURCE_URI) \
+    do { \
+        ogs_assert((__aMF)); \
+        CLEAR_5G_AKA_CONFIRMATION(__aMF); \
+        (__aMF)->confirmation_for_5g_aka.resource_uri = \
+            ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__aMF)->confirmation_for_5g_aka.resource_uri); \
+    } while(0)
+#define CLEAR_5G_AKA_CONFIRMATION(__aMF) \
+    do { \
+        ogs_assert((__aMF)); \
+        if ((__aMF)->confirmation_for_5g_aka.resource_uri) \
+            ogs_free((__aMF)->confirmation_for_5g_aka.resource_uri); \
+        (__aMF)->confirmation_for_5g_aka.resource_uri = NULL; \
+    } while(0)
+    struct {
+        char *resource_uri;
+        ogs_sbi_client_t *client;
+    } confirmation_for_5g_aka;
     uint8_t         rand[OGS_RAND_LEN];
     uint8_t         autn[OGS_AUTN_LEN];
     uint8_t         xres_star[OGS_MAX_RES_LEN];
@@ -468,8 +508,34 @@ struct amf_ue_s {
 
     /* SubscriptionId of Subscription to Data Change Notification to UDM */
 #define UDM_SDM_SUBSCRIBED(__aMF) \
-    ((__aMF) && ((__aMF)->data_change_subscription_id))
-    char *data_change_subscription_id;
+    ((__aMF) && ((__aMF)->data_change_subscription.id))
+#define UDM_SDM_CLEAR(__aMF) \
+    do { \
+        ogs_assert((__aMF)); \
+        if ((__aMF)->data_change_subscription.resource_uri) \
+            ogs_free((__aMF)->data_change_subscription.resource_uri); \
+        (__aMF)->data_change_subscription.resource_uri = NULL; \
+        if ((__aMF)->data_change_subscription.id) \
+            ogs_free((__aMF)->data_change_subscription.id); \
+        (__aMF)->data_change_subscription.id = NULL; \
+    } while(0)
+#define UDM_SDM_STORE(__aMF, __rESOURCE_URI, __iD) \
+    do { \
+        ogs_assert((__aMF)); \
+        ogs_assert((__rESOURCE_URI)); \
+        ogs_assert((__iD)); \
+        UDM_SDM_CLEAR(__aMF); \
+        (__aMF)->data_change_subscription.resource_uri = \
+            ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__aMF)->data_change_subscription.resource_uri); \
+        (__aMF)->data_change_subscription.id = ogs_strdup(__iD); \
+        ogs_assert((__aMF)->data_change_subscription.id); \
+    } while(0)
+    struct {
+        char *resource_uri;
+        char *id;
+        ogs_sbi_client_t *client;
+    } data_change_subscription;
 
     struct {
         /*
@@ -499,18 +565,37 @@ typedef struct amf_sess_s {
     uint8_t pti;            /* Procedure Trasaction Identity */
 
 #define SESSION_CONTEXT_IN_SMF(__sESS)  \
-    ((__sESS) && (__sESS)->sm_context_ref)
-#define CLEAR_SM_CONTEXT_REF(__sESS) \
+    ((__sESS) && (__sESS)->sm_context.ref)
+#define STORE_SESSION_CONTEXT(__sESS, __rESOURCE_URI, __rEF) \
     do { \
         ogs_assert(__sESS); \
-        ogs_assert((__sESS)->sm_context_ref); \
-        ogs_free((__sESS)->sm_context_ref); \
-        (__sESS)->sm_context_ref = NULL; \
+        ogs_assert(__rESOURCE_URI); \
+        ogs_assert(__rEF); \
+        CLEAR_SESSION_CONTEXT(__sESS); \
+        (__sESS)->sm_context.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__sESS)->sm_context.resource_uri); \
+        (__sESS)->sm_context.ref = ogs_strdup(__rEF); \
+        ogs_assert((__sESS)->sm_context.ref); \
+    } while(0);
+#define CLEAR_SESSION_CONTEXT(__sESS) \
+    do { \
+        ogs_assert(__sESS); \
+        if ((__sESS)->sm_context.ref) \
+            ogs_free((__sESS)->sm_context.ref); \
+        (__sESS)->sm_context.ref = NULL; \
+        if ((__sESS)->sm_context.resource_uri) \
+            ogs_free((__sESS)->sm_context.resource_uri); \
+        (__sESS)->sm_context.resource_uri = NULL; \
     } while(0);
 
     /* SMF sends the RESPONSE
      * of [POST] /nsmf-pdusession/v1/sm-contexts */
-    char *sm_context_ref;
+    struct {
+        char *resource_uri;
+        char *ref;
+        ogs_sbi_client_t *client;
+    } sm_context;
+
     bool pdu_session_release_complete_received;
     bool pdu_session_resource_release_response_received;
 

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1283,9 +1283,11 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
             sess->s_nssai.sd.v = selected_slice->s_nssai.sd.v;
 
             ogs_info("UE SUPI[%s] DNN[%s] S_NSSAI[SST:%d SD:0x%x] "
-                    "smContextRef [%s]",
+                    "smContextRef[%s] smContextResourceURI[%s]",
                 amf_ue->supi, sess->dnn, sess->s_nssai.sst, sess->s_nssai.sd.v,
-                sess->sm_context_ref ? sess->sm_context_ref : "NULL");
+                sess->sm_context.ref ? sess->sm_context.ref : "NULL",
+                sess->sm_context.resource_uri ?
+                    sess->sm_context.resource_uri : "NULL");
 
             if (!SESSION_CONTEXT_IN_SMF(sess)) {
                 ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -1435,7 +1437,7 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                 sess->pdu_session_release_complete_received = true;
                 if (sess->pdu_session_resource_release_response_received ==
                         true)
-                    CLEAR_SM_CONTEXT_REF(sess);
+                    CLEAR_SESSION_CONTEXT(sess);
                 break;
             default:
                 break;
@@ -1676,7 +1678,7 @@ static void amf_namf_comm_decode_ue_session_context_list(
         sess = amf_sess_add(amf_ue, PduSessionContext->pdu_session_id);
         ogs_assert(sess);
 
-        sess->sm_context_ref = PduSessionContext->sm_context_ref;
+        sess->sm_context.ref = PduSessionContext->sm_context_ref;
 
         if (PduSessionContext->s_nssai) {
             memset(&sess->s_nssai, 0, sizeof(sess->s_nssai));

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -274,9 +274,7 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
                     ogs_warn("[%s] Ignore SBI message", amf_ue->suci);
                     break;
                 CASE(OGS_SBI_HTTP_METHOD_DELETE)
-                    if (amf_ue->confirmation_url_for_5g_aka)
-                        ogs_free(amf_ue->confirmation_url_for_5g_aka);
-                    amf_ue->confirmation_url_for_5g_aka = NULL;
+                    CLEAR_5G_AKA_CONFIRMATION(amf_ue);
 
                     if (state == AMF_RELEASE_SM_CONTEXT_NO_STATE ||
                         state == AMF_UE_INITIATED_DE_REGISTERED) {
@@ -378,10 +376,7 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
                      */
                     if (state == AMF_RELEASE_SM_CONTEXT_NO_STATE ||
                         state == AMF_UE_INITIATED_DE_REGISTERED) {
-                        if (amf_ue->data_change_subscription_id) {
-                            ogs_free(amf_ue->data_change_subscription_id);
-                            amf_ue->data_change_subscription_id = NULL;
-                        }
+                        UDM_SDM_CLEAR(amf_ue);
 
                         r = amf_ue_sbi_discover_and_send(
                                 OGS_SBI_SERVICE_TYPE_NUDM_UECM, NULL,
@@ -447,7 +442,7 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
                         if (state == AMF_RELEASE_SM_CONTEXT_NO_STATE ||
                             state == AMF_UE_INITIATED_DE_REGISTERED) {
 
-                            if (amf_ue->confirmation_url_for_5g_aka) {
+                            if (CHECK_5G_AKA_CONFIRMATION(amf_ue)) {
                                 r = amf_ue_sbi_discover_and_send(
                                     OGS_SBI_SERVICE_TYPE_NAUSF_AUTH,
                                     NULL,
@@ -857,9 +852,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
                     ogs_warn("[%s] Ignore SBI message", amf_ue->suci);
                     break;
                 CASE(OGS_SBI_HTTP_METHOD_DELETE)
-                    if (amf_ue->confirmation_url_for_5g_aka)
-                        ogs_free(amf_ue->confirmation_url_for_5g_aka);
-                    amf_ue->confirmation_url_for_5g_aka = NULL;
+                    CLEAR_5G_AKA_CONFIRMATION(amf_ue);
 
                     if (state == AMF_RELEASE_SM_CONTEXT_NO_STATE ||
                         state == AMF_UE_INITIATED_DE_REGISTERED) {
@@ -967,10 +960,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
                             AMF_NETWORK_INITIATED_IMPLICIT_DE_REGISTERED ||
                         state ==
                             AMF_NETWORK_INITIATED_EXPLICIT_DE_REGISTERED) {
-                        if (amf_ue->data_change_subscription_id) {
-                            ogs_free(amf_ue->data_change_subscription_id);
-                            amf_ue->data_change_subscription_id = NULL;
-                        }
+                        UDM_SDM_CLEAR(amf_ue);
 
                         r = amf_ue_sbi_discover_and_send(
                                 OGS_SBI_SERVICE_TYPE_NUDM_UECM, NULL,
@@ -1044,7 +1034,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
                             state ==
                                 AMF_NETWORK_INITIATED_EXPLICIT_DE_REGISTERED) {
 
-                            if (amf_ue->confirmation_url_for_5g_aka) {
+                            if (amf_ue->confirmation_for_5g_aka.resource_uri) {
                                 r = amf_ue_sbi_discover_and_send(
                                         OGS_SBI_SERVICE_TYPE_NAUSF_AUTH,
                                         NULL,

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -246,7 +246,7 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
                             amf_ue->supi, sess->psi,
                             N1N2MessageTransferReqData->
                                 n1n2_failure_txf_notif_uri);
-                    return OGS_ERROR;;
+                    return OGS_ERROR;
                 }
 
                 client = ogs_sbi_client_find(
@@ -287,7 +287,7 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
                 header.resource.component[1] = amf_ue->supi;
                 header.resource.component[2] =
                     (char *)OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES;
-                header.resource.component[3] = sess->sm_context_ref;
+                header.resource.component[3] = sess->sm_context.ref;
 
                 sendmsg.http.location = ogs_sbi_server_uri(server, &header);
 
@@ -349,13 +349,12 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
             header.resource.component[1] = amf_ue->supi;
             header.resource.component[2] =
                 (char *)OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES;
-            header.resource.component[3] = sess->sm_context_ref;
+            header.resource.component[3] = sess->sm_context.ref;
 
             sendmsg.http.location = ogs_sbi_server_uri(server, &header);
 
             /* Store Paging Info */
-            AMF_SESS_STORE_PAGING_INFO(
-                    sess, sendmsg.http.location, NULL);
+            AMF_SESS_STORE_PAGING_INFO(sess, sendmsg.http.location, NULL);
 
             /* Store 5GSM Message */
             AMF_SESS_STORE_5GSM_MESSAGE(sess,
@@ -424,13 +423,12 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
                 header.resource.component[1] = amf_ue->supi;
                 header.resource.component[2] =
                     (char *)OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES;
-                header.resource.component[3] = sess->sm_context_ref;
+                header.resource.component[3] = sess->sm_context.ref;
 
                 sendmsg.http.location = ogs_sbi_server_uri(server, &header);
 
                 /* Store Paging Info */
-                AMF_SESS_STORE_PAGING_INFO(
-                        sess, sendmsg.http.location, NULL);
+                AMF_SESS_STORE_PAGING_INFO(sess, sendmsg.http.location, NULL);
 
                 /* Store 5GSM Message */
                 AMF_SESS_STORE_5GSM_MESSAGE(sess,
@@ -1174,7 +1172,7 @@ static OpenAPI_list_t *amf_namf_comm_encode_ue_session_context_list(amf_ue_t *am
         ogs_assert(sNSSAI);
 
         PduSessionContext->pdu_session_id = sess->psi;
-        PduSessionContext->sm_context_ref = sess->sm_context_ref;
+        PduSessionContext->sm_context_ref = sess->sm_context.ref;
 
         sNSSAI->sst = sess->s_nssai.sst;
         sNSSAI->sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);

--- a/src/amf/nausf-build.c
+++ b/src/amf/nausf-build.c
@@ -87,11 +87,11 @@ ogs_sbi_request_t *amf_nausf_auth_build_authenticate_delete(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(amf_ue);
-    ogs_assert(amf_ue->confirmation_url_for_5g_aka);
+    ogs_assert(amf_ue->confirmation_for_5g_aka.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
-    message.h.uri = amf_ue->confirmation_url_for_5g_aka;
+    message.h.uri = amf_ue->confirmation_for_5g_aka.resource_uri;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
@@ -110,11 +110,11 @@ ogs_sbi_request_t *amf_nausf_auth_build_authenticate_confirmation(
     OpenAPI_confirmation_data_t *ConfirmationData = NULL;
 
     ogs_assert(amf_ue);
-    ogs_assert(amf_ue->confirmation_url_for_5g_aka);
+    ogs_assert(amf_ue->confirmation_for_5g_aka.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_PUT;
-    message.h.uri = amf_ue->confirmation_url_for_5g_aka;
+    message.h.uri = amf_ue->confirmation_for_5g_aka.resource_uri;
 
     ConfirmationData = ogs_calloc(1, sizeof(*ConfirmationData));
     if (!ConfirmationData) {

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2516,7 +2516,7 @@ void ngap_handle_pdu_session_resource_release_response(
 
         sess->pdu_session_resource_release_response_received = true;
         if (sess->pdu_session_release_complete_received == true)
-            CLEAR_SM_CONTEXT_REF(sess);
+            CLEAR_SESSION_CONTEXT(sess);
     }
 
 }

--- a/src/amf/npcf-build.c
+++ b/src/amf/npcf-build.c
@@ -221,15 +221,11 @@ ogs_sbi_request_t *amf_npcf_am_policy_control_build_delete(
 
     ogs_assert(amf_ue);
     ogs_assert(amf_ue->supi);
-    ogs_assert(amf_ue->policy_association_id);
+    ogs_assert(amf_ue->policy_association.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
-    message.h.service.name =
-        (char *)OGS_SBI_SERVICE_NAME_NPCF_AM_POLICY_CONTROL;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_POLICIES;
-    message.h.resource.component[1] = amf_ue->policy_association_id;
+    message.h.uri = amf_ue->policy_association.resource_uri;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -272,17 +272,15 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
 
     ogs_assert(param);
     ogs_assert(sess);
-    ogs_assert(sess->sm_context_ref);
+    ogs_assert(sess->sm_context.resource_uri);
     amf_ue = sess->amf_ue;
     ogs_assert(amf_ue);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NSMF_PDUSESSION;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_SM_CONTEXTS;
-    message.h.resource.component[1] = sess->sm_context_ref;
-    message.h.resource.component[2] = (char *)OGS_SBI_RESOURCE_NAME_MODIFY;
+    message.h.uri = ogs_msprintf("%s/%s",
+            sess->sm_context.resource_uri, OGS_SBI_RESOURCE_NAME_MODIFY);
+    ogs_assert(message.h.uri);
 
     memset(&ueLocation, 0, sizeof(ueLocation));
     memset(&SmContextUpdateData, 0, sizeof(SmContextUpdateData));
@@ -377,6 +375,8 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
     ogs_expect(request);
 
 end:
+    if (message.h.uri)
+        ogs_free(message.h.uri);
     if (ueLocation.nr_location) {
         if (ueLocation.nr_location->ue_location_timestamp)
             ogs_free(ueLocation.nr_location->ue_location_timestamp);
@@ -405,18 +405,15 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_release_sm_context(
     OpenAPI_user_location_t ueLocation;
 
     ogs_assert(sess);
-    ogs_assert(sess->sm_context_ref);
+    ogs_assert(sess->sm_context.resource_uri);
     amf_ue = sess->amf_ue;
     ogs_assert(amf_ue);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NSMF_PDUSESSION;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_SM_CONTEXTS;
-    message.h.resource.component[1] = sess->sm_context_ref;
-    message.h.resource.component[2] = (char *)OGS_SBI_RESOURCE_NAME_RELEASE;
+    message.h.uri = ogs_msprintf("%s/%s",
+            sess->sm_context.resource_uri, OGS_SBI_RESOURCE_NAME_RELEASE);
+    ogs_assert(message.h.uri);
 
     memset(&SmContextReleaseData, 0, sizeof(SmContextReleaseData));
 
@@ -460,6 +457,8 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_release_sm_context(
     ogs_expect(request);
 
 end:
+    if (message.h.uri)
+        ogs_free(message.h.uri);
     if (ueLocation.nr_location) {
         if (ueLocation.nr_location->ue_location_timestamp)
             ogs_free(ueLocation.nr_location->ue_location_timestamp);

--- a/src/amf/nudm-build.c
+++ b/src/amf/nudm-build.c
@@ -255,16 +255,11 @@ ogs_sbi_request_t *amf_nudm_sdm_build_subscription_delete(
 
     ogs_assert(amf_ue);
     ogs_assert(amf_ue->supi);
-    ogs_assert(amf_ue->data_change_subscription_id);
+    ogs_assert(amf_ue->data_change_subscription.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NUDM_SDM;
-    message.h.api.version = (char *)OGS_SBI_API_V2;
-    message.h.resource.component[0] = amf_ue->supi;
-    message.h.resource.component[1] =
-            (char *)OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS;
-    message.h.resource.component[2] = amf_ue->data_change_subscription_id;
+    message.h.uri = amf_ue->data_change_subscription.resource_uri;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -246,7 +246,7 @@ int amf_nudm_sdm_handle_provisioned(
         break;
 
     CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXT_IN_SMF_DATA)
-        if (amf_ue->data_change_subscription_id) {
+        if (UDM_SDM_SUBSCRIBED(amf_ue)) {
             /* we already have a SDM subscription to UDM; continue without
              * subscribing again */
             r = amf_ue_sbi_discover_and_send(
@@ -272,6 +272,13 @@ int amf_nudm_sdm_handle_provisioned(
         ogs_sbi_message_t message;
         ogs_sbi_header_t header;
 
+        bool rc;
+        ogs_sbi_client_t *client = NULL;
+        OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_NULL;
+        char *fqdn = NULL;
+        uint16_t fqdn_port = 0;
+        ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
+
         if (!recvmsg->http.location) {
             ogs_error("[%s] No http.location", amf_ue->supi);
             r = nas_5gs_send_gmm_reject_from_sbi(
@@ -288,10 +295,12 @@ int amf_nudm_sdm_handle_provisioned(
         if (rv != OGS_OK) {
             ogs_error("[%s] Cannot parse http.location [%s]",
                 amf_ue->supi, recvmsg->http.location);
+
             r = nas_5gs_send_gmm_reject_from_sbi(
                     amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
+
             return OGS_ERROR;
         }
 
@@ -304,13 +313,52 @@ int amf_nudm_sdm_handle_provisioned(
                     amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
+
             return OGS_ERROR;
         }
 
-        if (amf_ue->data_change_subscription_id)
-            ogs_free(amf_ue->data_change_subscription_id);
-        amf_ue->data_change_subscription_id =
-            ogs_strdup(message.h.resource.component[2]);
+        rc = ogs_sbi_getaddr_from_uri(
+                &scheme, &fqdn, &fqdn_port, &addr, &addr6, header.uri);
+        if (rc == false || scheme == OpenAPI_uri_scheme_NULL) {
+            ogs_error("[%s] Invalid URI [%s]", amf_ue->supi, header.uri);
+
+            ogs_sbi_header_free(&header);
+            r = nas_5gs_send_gmm_reject_from_sbi(
+                    amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+
+            return OGS_ERROR;
+        }
+
+        client = ogs_sbi_client_find(scheme, fqdn, fqdn_port, addr, addr6);
+        if (!client) {
+            ogs_debug("[%s] ogs_sbi_client_add()", amf_ue->supi);
+            client = ogs_sbi_client_add(scheme, fqdn, fqdn_port, addr, addr6);
+            if (!client) {
+                ogs_error("[%s] ogs_sbi_client_add() failed", amf_ue->supi);
+
+                ogs_sbi_header_free(&header);
+                r = nas_5gs_send_gmm_reject_from_sbi(
+                        amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+
+                ogs_free(fqdn);
+                ogs_freeaddrinfo(addr);
+                ogs_freeaddrinfo(addr6);
+
+                return OGS_ERROR;
+            }
+        }
+
+        OGS_SBI_SETUP_CLIENT(&amf_ue->policy_association, client);
+
+        ogs_free(fqdn);
+        ogs_freeaddrinfo(addr);
+        ogs_freeaddrinfo(addr6);
+
+        UDM_SDM_STORE(amf_ue, header.uri, message.h.resource.component[2]);
 
         ogs_sbi_header_free(&header);
 

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -505,7 +505,7 @@ void amf_sbi_send_release_session(
     ogs_assert(r != OGS_ERROR);
 
     /* Prevent to invoke SMF for this session */
-    CLEAR_SM_CONTEXT_REF(sess);
+    CLEAR_SESSION_CONTEXT(sess);
 }
 
 void amf_sbi_send_release_all_sessions(

--- a/src/ausf/context.c
+++ b/src/ausf/context.c
@@ -184,8 +184,9 @@ void ausf_ue_remove(ausf_ue_t *ausf_ue)
         ogs_free(ausf_ue->supi);
     }
 
-    if (ausf_ue->auth_events_url)
-        ogs_free(ausf_ue->auth_events_url);
+    AUTH_EVENT_CLEAR(ausf_ue);
+    if (ausf_ue->auth_event.client)
+        ogs_sbi_client_remove(ausf_ue->auth_event.client);
 
     if (ausf_ue->serving_network_name)
         ogs_free(ausf_ue->serving_network_name);

--- a/src/ausf/context.h
+++ b/src/ausf/context.h
@@ -52,7 +52,25 @@ struct ausf_ue_s {
     char *serving_network_name;
 
     OpenAPI_auth_type_e auth_type;
-    char *auth_events_url;
+#define AUTH_EVENT_CLEAR(__aUSF) \
+    do { \
+        ogs_assert((__aUSF)); \
+        if ((__aUSF)->auth_event.resource_uri) \
+            ogs_free((__aUSF)->auth_event.resource_uri); \
+        (__aUSF)->auth_event.resource_uri = NULL; \
+    } while(0)
+#define AUTH_EVENT_STORE(__aUSF, __rESOURCE_URI) \
+    do { \
+        ogs_assert((__aUSF)); \
+        ogs_assert((__rESOURCE_URI)); \
+        AUTH_EVENT_CLEAR(__aUSF); \
+        (__aUSF)->auth_event.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__aUSF)->auth_event.resource_uri); \
+    } while(0)
+    struct {
+        char *resource_uri;
+        ogs_sbi_client_t *client;
+    } auth_event;
     OpenAPI_auth_result_e auth_result;
 
     uint8_t rand[OGS_RAND_LEN];

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -495,8 +495,9 @@ void pcf_sess_remove(pcf_sess_t *sess)
     ogs_assert(sess->sm_policy_id);
     ogs_free(sess->sm_policy_id);
 
-    if (sess->binding_id)
-        ogs_free(sess->binding_id);
+    PCF_BINDING_CLEAR(sess);
+    if (sess->binding.client)
+        ogs_sbi_client_remove(sess->binding.client);
 
     if (sess->dnn)
         ogs_free(sess->dnn);

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -81,7 +81,34 @@ struct pcf_sess_s {
 
     /* BSF sends the RESPONSE
      * of [POST] /nbsf-management/v1/PcfBindings */
-    char *binding_id;
+#define PCF_BINDING_ASSOCIATED(__sESS) \
+    ((__sESS) && ((__sESS)->binding.id))
+#define PCF_BINDING_CLEAR(__sESS) \
+    do { \
+        ogs_assert((__sESS)); \
+        if ((__sESS)->binding.resource_uri) \
+            ogs_free((__sESS)->binding.resource_uri); \
+        (__sESS)->binding.resource_uri = NULL; \
+        if ((__sESS)->binding.id) \
+            ogs_free((__sESS)->binding.id); \
+        (__sESS)->binding.id = NULL; \
+    } while(0)
+#define PCF_BINDING_STORE(__sESS, __rESOURCE_URI, __iD) \
+    do { \
+        ogs_assert((__sESS)); \
+        ogs_assert((__rESOURCE_URI)); \
+        ogs_assert((__iD)); \
+        PCF_BINDING_CLEAR(__sESS); \
+        (__sESS)->binding.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__sESS)->binding.resource_uri); \
+        (__sESS)->binding.id = ogs_strdup(__iD); \
+        ogs_assert((__sESS)->binding.id); \
+    } while(0)
+    struct {
+        char *resource_uri;
+        char *id;
+        ogs_sbi_client_t *client;
+    } binding;
 
     uint8_t psi; /* PDU Session Identity */
 

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -189,15 +189,11 @@ ogs_sbi_request_t *pcf_nbsf_management_build_de_register(
     ogs_assert(sess);
     pcf_ue = sess->pcf_ue;
     ogs_assert(pcf_ue);
-    ogs_assert(sess->binding_id);
+    ogs_assert(sess->binding.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NBSF_MANAGEMENT;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_PCF_BINDINGS;
-    message.h.resource.component[1] = sess->binding_id;
+    message.h.uri = sess->binding.resource_uri;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1729,8 +1729,9 @@ void smf_sess_remove(smf_sess_t *sess)
     if (sess->namf.client)
         ogs_sbi_client_remove(sess->namf.client);
 
-    if (sess->policy_association_id)
-        ogs_free(sess->policy_association_id);
+    PCF_SM_POLICY_CLEAR(sess);
+    if (sess->policy_association.client)
+        ogs_sbi_client_remove(sess->policy_association.client);
 
     if (sess->session.name)
         ogs_free(sess->session.name);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -284,7 +284,34 @@ typedef struct smf_sess_s {
 
     /* PCF sends the RESPONSE
      * of [POST] /npcf-smpolocycontrol/v1/policies */
-    char *policy_association_id;
+#define PCF_SM_POLICY_ASSOCIATED(__sESS) \
+    ((__sESS) && ((__sESS)->policy_association.id))
+#define PCF_SM_POLICY_CLEAR(__sESS) \
+    do { \
+        ogs_assert((__sESS)); \
+        if ((__sESS)->policy_association.resource_uri) \
+            ogs_free((__sESS)->policy_association.resource_uri); \
+        (__sESS)->policy_association.resource_uri = NULL; \
+        if ((__sESS)->policy_association.id) \
+            ogs_free((__sESS)->policy_association.id); \
+        (__sESS)->policy_association.id = NULL; \
+    } while(0)
+#define PCF_SM_POLICY_STORE(__sESS, __rESOURCE_URI, __iD) \
+    do { \
+        ogs_assert((__sESS)); \
+        ogs_assert((__rESOURCE_URI)); \
+        ogs_assert((__iD)); \
+        PCF_SM_POLICY_CLEAR(__sESS); \
+        (__sESS)->policy_association.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__sESS)->policy_association.resource_uri); \
+        (__sESS)->policy_association.id = ogs_strdup(__iD); \
+        ogs_assert((__sESS)->policy_association.id); \
+    } while(0)
+    struct {
+        char *resource_uri;
+        char *id;
+        ogs_sbi_client_t *client;
+    } policy_association;
 
     OpenAPI_up_cnx_state_e up_cnx_state;
 

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -944,9 +944,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 } else {
                     SWITCH(sbi_message->h.resource.component[2])
                     CASE(OGS_SBI_RESOURCE_NAME_DELETE)
-                        if (sess->policy_association_id)
-                            ogs_free(sess->policy_association_id);
-                        sess->policy_association_id = NULL;
+                        PCF_SM_POLICY_CLEAR(sess);
 
                         if (sbi_message->res_status !=
                                 OGS_SBI_HTTP_STATUS_NO_CONTENT) {
@@ -1085,7 +1083,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
             break;
 
         case OGS_NAS_5GS_PDU_SESSION_RELEASE_REQUEST:
-            if (sess->policy_association_id) {
+            if (PCF_SM_POLICY_ASSOCIATED(sess)) {
                 smf_npcf_smpolicycontrol_param_t param;
 
                 memset(&param, 0, sizeof(param));
@@ -1822,7 +1820,7 @@ void smf_gsm_state_5gc_n1_n2_reject(ogs_fsm_t *s, smf_event_t *e)
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        if (sess->policy_association_id) {
+        if (PCF_SM_POLICY_ASSOCIATED(sess)) {
             smf_npcf_smpolicycontrol_param_t param;
             int r = 0;
 
@@ -1864,9 +1862,7 @@ void smf_gsm_state_5gc_n1_n2_reject(ogs_fsm_t *s, smf_event_t *e)
                 } else {
                     SWITCH(sbi_message->h.resource.component[2])
                     CASE(OGS_SBI_RESOURCE_NAME_DELETE)
-                        if (sess->policy_association_id)
-                            ogs_free(sess->policy_association_id);
-                        sess->policy_association_id = NULL;
+                        PCF_SM_POLICY_CLEAR(sess);
 
                         if (sbi_message->res_status !=
                                 OGS_SBI_HTTP_STATUS_NO_CONTENT) {

--- a/src/smf/npcf-build.c
+++ b/src/smf/npcf-build.c
@@ -303,15 +303,13 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_delete(
     ogs_assert(sess->sm_context_ref);
     smf_ue = sess->smf_ue;
     ogs_assert(smf_ue);
-    ogs_assert(sess->policy_association_id);
+    ogs_assert(sess->policy_association.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
-    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NPCF_SMPOLICYCONTROL;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_SM_POLICIES;
-    message.h.resource.component[1] = sess->policy_association_id;
-    message.h.resource.component[2] = (char *)OGS_SBI_RESOURCE_NAME_DELETE;
+    message.h.uri = ogs_msprintf("%s/%s",
+            sess->policy_association.resource_uri,
+            OGS_SBI_RESOURCE_NAME_DELETE);
 
     memset(&SmPolicyDeleteData, 0, sizeof(SmPolicyDeleteData));
 
@@ -399,6 +397,9 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_delete(
     ogs_expect(request);
 
 end:
+
+    if (message.h.uri)
+        ogs_free(message.h.uri);
 
     if (ueLocation.nr_location) {
         if (ueLocation.nr_location->ue_location_timestamp)

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -756,7 +756,7 @@ bool smf_nsmf_handle_update_sm_context(
             ogs_assert(true ==
                     ogs_sbi_server_send_response(stream, response));
 
-        } else if (sess->policy_association_id) {
+        } else if (PCF_SM_POLICY_ASSOCIATED(sess)) {
             smf_npcf_smpolicycontrol_param_t param;
 
             memset(&param, 0, sizeof(param));
@@ -862,7 +862,7 @@ bool smf_nsmf_handle_release_sm_context(
             SmContextReleaseData->_5g_mm_cause_value;
     }
 
-    if (sess->policy_association_id) {
+    if (PCF_SM_POLICY_ASSOCIATED(sess)) {
         r = smf_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NPCF_SMPOLICYCONTROL, NULL,
                 smf_npcf_smpolicycontrol_build_delete,

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -535,7 +535,7 @@ static void reselect_upf(ogs_pfcp_node_t *node)
                     ogs_error("[%s:%s] EPC restoration is not implemented",
                             smf_ue->imsi_bcd, sess->session.name);
                 } else {
-                    if (sess->policy_association_id) {
+                    if (PCF_SM_POLICY_ASSOCIATED(sess)) {
                         smf_npcf_smpolicycontrol_param_t param;
 
                         ogs_info("[%s:%d] SMF-initiated Deletion",

--- a/tests/af/context.h
+++ b/tests/af/context.h
@@ -52,8 +52,39 @@ typedef struct af_sess_s {
 
     uint64_t policyauthorization_features;
 
-    char *af_app_session_id;
-    char *pcf_app_session_id;
+#define PCF_APP_SESSION_ASSOCIATED(__sESS) \
+    ((__sESS) && ((__sESS)->app_session.pcf_id))
+#define PCF_APP_SESSION_CLEAR(__sESS) \
+    do { \
+        ogs_assert((__sESS)); \
+        if ((__sESS)->app_session.pcf.resource_uri) \
+            ogs_free((__sESS)->app_session.pcf.resource_uri); \
+        (__sESS)->app_session.pcf.resource_uri = NULL; \
+        if ((__sESS)->app_session.pcf.id) \
+            ogs_free((__sESS)->app_session.pcf.id); \
+        (__sESS)->app_session.pcf.id = NULL; \
+    } while(0)
+#define PCF_APP_SESSION_STORE(__sESS, __rESOURCE_URI, __iD) \
+    do { \
+        ogs_assert((__sESS)); \
+        ogs_assert((__rESOURCE_URI)); \
+        ogs_assert((__iD)); \
+        PCF_APP_SESSION_CLEAR(__sESS); \
+        (__sESS)->app_session.pcf.resource_uri = ogs_strdup(__rESOURCE_URI); \
+        ogs_assert((__sESS)->app_session.pcf.resource_uri); \
+        (__sESS)->app_session.pcf.id = ogs_strdup(__iD); \
+        ogs_assert((__sESS)->app_session.pcf.id); \
+    } while(0)
+    struct {
+        struct {
+            char *id;
+        } af;
+        struct {
+            char *resource_uri;
+            char *id;
+            ogs_sbi_client_t *client;
+        } pcf;
+    } app_session;
 
     char *ipv4addr;
     char *ipv6addr;
@@ -91,11 +122,8 @@ af_sess_t *af_sess_add_by_ue_address(ogs_ip_t *ue_address);
 void af_sess_remove(af_sess_t *sess);
 void af_sess_remove_all(void);
 
-bool af_sess_set_pcf_app_session_id(af_sess_t *sess, char *pcf_app_session_id);
-
 af_sess_t *af_sess_find(uint32_t index);
 af_sess_t *af_sess_find_by_af_app_session_id(char *af_app_session_id);
-af_sess_t *af_sess_find_by_pcf_app_session_id(char *pcf_app_session_id);
 
 void af_sess_associate_pcf_client(af_sess_t *sess);
 

--- a/tests/af/npcf-build.c
+++ b/tests/af/npcf-build.c
@@ -54,7 +54,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
     af_npcf_policyauthorization_param_t *af_param;
 
     ogs_assert(sess);
-    ogs_assert(sess->af_app_session_id);
+    ogs_assert(sess->app_session.af.id);
 
     af_param = data;
     ogs_assert(af_param);
@@ -82,7 +82,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
     header.service.name = (char *)OGS_SBI_SERVICE_NAME_NPCF_POLICYAUTHORIZATION;
     header.api.version = (char *)OGS_SBI_API_V1;
     header.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_APP_SESSIONS;
-    header.resource.component[1] = (char *)sess->af_app_session_id;
+    header.resource.component[1] = (char *)sess->app_session.af.id;
     AscReqData.notif_uri = ogs_sbi_server_uri(server, &header);
     ogs_assert(AscReqData.notif_uri);
 
@@ -379,19 +379,14 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_update(
     af_npcf_policyauthorization_param_t *af_param;
 
     ogs_assert(sess);
-    ogs_assert(sess->pcf_app_session_id);
+    ogs_assert(sess->app_session.pcf.resource_uri);
 
     af_param = data;
     ogs_assert(af_param);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_PATCH;
-    message.h.service.name =
-        (char *)OGS_SBI_SERVICE_NAME_NPCF_POLICYAUTHORIZATION;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_APP_SESSIONS;
-    message.h.resource.component[1] = sess->pcf_app_session_id;
+    message.h.uri = sess->app_session.pcf.resource_uri;
 
     message.AppSessionContextUpdateDataPatch =
         &AppSessionContextUpdateDataPatch;
@@ -604,21 +599,17 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_delete(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    ogs_assert(sess->pcf_app_session_id);
+    ogs_assert(sess->app_session.pcf.resource_uri);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
-    message.h.service.name =
-        (char *)OGS_SBI_SERVICE_NAME_NPCF_POLICYAUTHORIZATION;
-    message.h.api.version = (char *)OGS_SBI_API_V1;
-    message.h.resource.component[0] =
-        (char *)OGS_SBI_RESOURCE_NAME_APP_SESSIONS;
-    message.h.resource.component[1] = sess->pcf_app_session_id;
-    message.h.resource.component[2] =
-        (char *)OGS_SBI_RESOURCE_NAME_DELETE;
+    message.h.uri = ogs_msprintf("%s/%s",
+            sess->app_session.pcf.resource_uri, OGS_SBI_RESOURCE_NAME_DELETE);
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
+
+    ogs_free(message.h.uri);
 
     return request;
 }
@@ -658,7 +649,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create_video(
     af_npcf_policyauthorization_param_t *af_param;
 
     ogs_assert(sess);
-    ogs_assert(sess->af_app_session_id);
+    ogs_assert(sess->app_session.af.id);
 
     af_param = data;
     ogs_assert(af_param);
@@ -685,7 +676,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create_video(
     header.service.name = (char *)OGS_SBI_SERVICE_NAME_NPCF_POLICYAUTHORIZATION;
     header.api.version = (char *)OGS_SBI_API_V1;
     header.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_APP_SESSIONS;
-    header.resource.component[1] = (char *)sess->af_app_session_id;
+    header.resource.component[1] = (char *)sess->app_session.af.id;
     AscReqData.notif_uri = ogs_sbi_server_uri(server, &header);
     ogs_assert(AscReqData.notif_uri);
 


### PR DESCRIPTION
A friend in the community was trying to connect an SMF made by another manufacturer with an SBI interface and found a big problem with Open5GS.

All of the code in the part that generates the Resource URI from HTTP.location is invalid.

For example, suppose we create a Resource URI with SMContext as below. {apiRoot}/nsmf-pdusession/<apiVersion>/sm-contexts/{smContextRef}

In this case, Open5GS extracted the {smContextRef} part of the HTTP.location and appended it to the beginning
{apiRoot}/nsmf-pdusession/<apiVersion>/sm-contexts/.

This implementation may not work properly if the apiRoot changes. Consider a different port number as shown below.

- HTTP.location
```
http://127.0.0.4:9999/nsmf-pdusession/v1/sm-contexts/1
```

The SMF may send an apiRoot to the AMF with a changed port number, in which case the AMF must honor it.

Therefore, instead of extracting only the smContextRef from HTTP.location, we modified it to use the whole thing to create a Resource URI.

We modified all NFs that use HTTP.location in the same way, not just SMFs.