### PR TITLE
[SEC] Stack overflow in open5gs-hssd/s6a (#3155)

### DIFF
--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -35,7 +35,7 @@ jobs:
           sudo ifconfig lo0 alias 127.0.0.20 netmask 255.255.255.255
           sudo ifconfig lo0 alias 127.0.1.10 netmask 255.255.255.255
     - name: Install the dependencies for building the source code.
-      run: brew install mongo-c-driver libgcrypt libidn libmicrohttpd nghttp2 bison libusrsctp libtins talloc meson
+      run: brew install mongo-c-driver libidn libmicrohttpd nghttp2 bison libusrsctp libtins talloc meson
     - name: Check out repository code
       uses: actions/checkout@main
     - name: Setup Meson Build

--- a/src/hss/hss-s6a-path.c
+++ b/src/hss/hss-s6a-path.c
@@ -180,7 +180,8 @@ static int hss_ogs_diam_s6a_air_cb( struct msg **msg, struct avp *avp,
     ogs_assert(ret == 0);
     ret = fd_msg_avp_hdr(avp, &hdr);
     ogs_assert(ret == 0);
-    memcpy(&visited_plmn_id, hdr->avp_value->os.data, hdr->avp_value->os.len);
+    memcpy(&visited_plmn_id, hdr->avp_value->os.data,
+            ogs_min(hdr->avp_value->os.len, sizeof(visited_plmn_id)));
 
     milenage_generate(opc, auth_info.amf, auth_info.k,
         ogs_uint64_to_buffer(auth_info.sqn, OGS_SQN_LEN, sqn), auth_info.rand,
@@ -910,7 +911,8 @@ static int hss_ogs_diam_s6a_ulr_cb( struct msg **msg, struct avp *avp,
     ogs_assert(ret == 0);
     ret = fd_msg_avp_hdr(avp, &hdr);
     ogs_assert(ret == 0);
-    memcpy(&visited_plmn_id, hdr->avp_value->os.data, hdr->avp_value->os.len);
+    memcpy(&visited_plmn_id, hdr->avp_value->os.data,
+            ogs_min(hdr->avp_value->os.len, sizeof(visited_plmn_id)));
 
     ret = fd_msg_search_avp(qry, ogs_diam_s6a_ulr_flags, &avp);
     ogs_assert(ret == 0);


### PR DESCRIPTION
An assert shall be triggered if a stack corruption occurs.

The vulnerable code path is in src/hss/hss-s6a-path.c:

```
static int hss_ogs_diam_s6a_air_cb( struct msg **msg, struct avp *avp,
        struct session *session, void *opaque, enum disp_action *act)
{
..
    ogs_plmn_id_t visited_plmn_id;
..
    ret = fd_msg_search_avp(qry, ogs_diam_visited_plmn_id, &avp);
    ogs_assert(ret == 0);
    ret = fd_msg_avp_hdr(avp, &hdr);
    ogs_assert(ret == 0);
    memcpy(&visited_plmn_id, hdr->avp_value->os.data, hdr->avp_value->os.len);
```