### PR TITLE
[SEC] Stack overflow in PCRF/PCF (#3157)

### DIFF
--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -752,6 +752,15 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
         if (MediaComponentMap) {
             MediaComponent = MediaComponentMap->value;
             if (MediaComponent) {
+                if (ims_data.num_of_media_component >=
+                        OGS_ARRAY_SIZE(ims_data.media_component)) {
+                    ogs_error("OVERFLOW ims_data.num_of_media_component "
+                            "[%d:%d:%d]",
+                            ims_data.num_of_media_component,
+                            OGS_MAX_NUM_OF_MEDIA_COMPONENT,
+                            (int)OGS_ARRAY_SIZE(ims_data.media_component));
+                    break;
+                }
                 media_component = &ims_data.
                     media_component[ims_data.num_of_media_component];
                 media_component->media_component_number =
@@ -779,6 +788,15 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
 
                 SubComponentList = MediaComponent->med_sub_comps;
                 OpenAPI_list_for_each(SubComponentList, node2) {
+                    if (media_component->num_of_sub >=
+                            OGS_ARRAY_SIZE(media_component->sub)) {
+                        ogs_error("OVERFLOW media_component->num_of_sub "
+                                "[%d:%d:%d]",
+                                media_component->num_of_sub,
+                                OGS_MAX_NUM_OF_MEDIA_SUB_COMPONENT,
+                                (int)OGS_ARRAY_SIZE(media_component->sub));
+                        break;
+                    }
                     sub = &media_component->sub[media_component->num_of_sub];
 
                     SubComponentMap = node2->data;
@@ -792,8 +810,15 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
                             OpenAPI_list_for_each(fDescList, node3) {
                                 ogs_flow_t *flow = NULL;
 
-                                ogs_assert(sub->num_of_flow <
-                                    OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT);
+                                if (sub->num_of_flow >=
+                                        OGS_ARRAY_SIZE(sub->flow)) {
+                                    ogs_error(
+                                        "OVERFLOW sub->num_of_flow [%d:%d:%d]",
+                                        sub->num_of_flow,
+                                        OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT,
+                                        (int)OGS_ARRAY_SIZE(sub->flow));
+                                    break;
+                                }
                                 flow = &sub->flow[sub->num_of_flow];
                                 if (node3->data) {
                                     flow->description = ogs_strdup(node3->data);
@@ -1200,6 +1225,15 @@ bool pcf_npcf_policyauthorization_handle_update(
         if (MediaComponentMap) {
             MediaComponent = MediaComponentMap->value;
             if (MediaComponent) {
+                if (ims_data.num_of_media_component >=
+                        OGS_ARRAY_SIZE(ims_data.media_component)) {
+                    ogs_error("OVERFLOW ims_data.num_of_media_component "
+                            "[%d:%d:%d]",
+                            ims_data.num_of_media_component,
+                            OGS_MAX_NUM_OF_MEDIA_COMPONENT,
+                            (int)OGS_ARRAY_SIZE(ims_data.media_component));
+                    break;
+                }
                 media_component = &ims_data.
                     media_component[ims_data.num_of_media_component];
 
@@ -1228,6 +1262,15 @@ bool pcf_npcf_policyauthorization_handle_update(
 
                 SubComponentList = MediaComponent->med_sub_comps;
                 OpenAPI_list_for_each(SubComponentList, node2) {
+                    if (media_component->num_of_sub >=
+                            OGS_ARRAY_SIZE(media_component->sub)) {
+                        ogs_error("OVERFLOW media_component->num_of_sub "
+                                "[%d:%d:%d]",
+                                media_component->num_of_sub,
+                                OGS_MAX_NUM_OF_MEDIA_SUB_COMPONENT,
+                                (int)OGS_ARRAY_SIZE(media_component->sub));
+                        break;
+                    }
                     sub = &media_component->sub[media_component->num_of_sub];
 
                     SubComponentMap = node2->data;
@@ -1241,8 +1284,15 @@ bool pcf_npcf_policyauthorization_handle_update(
                             OpenAPI_list_for_each(fDescList, node3) {
                                 ogs_flow_t *flow = NULL;
 
-                                ogs_assert(sub->num_of_flow <
-                                    OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT);
+                                if (sub->num_of_flow >=
+                                        OGS_ARRAY_SIZE(sub->flow)) {
+                                    ogs_error(
+                                        "OVERFLOW sub->num_of_flow [%d:%d:%d]",
+                                        sub->num_of_flow,
+                                        OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT,
+                                        (int)OGS_ARRAY_SIZE(sub->flow));
+                                    break;
+                                }
                                 flow = &sub->flow[sub->num_of_flow];
                                 if (node3->data) {
                                     flow->description = ogs_strdup(node3->data);

--- a/src/pcrf/pcrf-rx-path.c
+++ b/src/pcrf/pcrf-rx-path.c
@@ -229,6 +229,16 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
             break;
         /* Gwt Media-Component-Description */
         case OGS_DIAM_RX_AVP_CODE_MEDIA_COMPONENT_DESCRIPTION:
+            if (rx_message.ims_data.num_of_media_component >=
+                    OGS_ARRAY_SIZE(rx_message.ims_data.media_component)) {
+                ogs_error("OVERFLOW rx_message.ims_data.num_of_media_component "
+                        "[%d:%d:%d]",
+                        rx_message.ims_data.num_of_media_component,
+                        OGS_MAX_NUM_OF_MEDIA_COMPONENT,
+                        (int)OGS_ARRAY_SIZE(
+                            rx_message.ims_data.media_component));
+                break;
+            }
             media_component = &rx_message.ims_data.
                     media_component[rx_message.ims_data.num_of_media_component];
 
@@ -271,6 +281,15 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
                     media_component->flow_status = hdr->avp_value->i32;
                     break;
                 case OGS_DIAM_RX_AVP_CODE_MEDIA_SUB_COMPONENT:
+                    if (media_component->num_of_sub >=
+                            OGS_ARRAY_SIZE(media_component->sub)) {
+                        ogs_error("OVERFLOW media_component->num_of_sub "
+                                "[%d:%d:%d]",
+                                media_component->num_of_sub,
+                                OGS_MAX_NUM_OF_MEDIA_SUB_COMPONENT,
+                                (int)OGS_ARRAY_SIZE(media_component->sub));
+                        break;
+                    }
                     sub = &media_component->sub[media_component->num_of_sub];
 
                     ret = fd_msg_browse(avpch2, MSG_BRW_FIRST_CHILD,
@@ -300,8 +319,14 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
                             }
                             break;
                         case OGS_DIAM_RX_AVP_CODE_FLOW_DESCRIPTION:
-                            ogs_assert(sub->num_of_flow <
-                                    OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT);
+                            if (sub->num_of_flow >= OGS_ARRAY_SIZE(sub->flow)) {
+                                ogs_error(
+                                    "OVERFLOW sub->num_of_flow [%d:%d:%d]",
+                                    sub->num_of_flow,
+                                    OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT,
+                                    (int)OGS_ARRAY_SIZE(sub->flow));
+                                break;
+                            }
                             flow = &sub->flow[sub->num_of_flow];
                             flow->description = ogs_strndup(
                                     (char*)hdr->avp_value->os.data,


### PR DESCRIPTION
The indexes rx_message.ims_data.num_of_media_component and media_component->num_of_sub can overflow.

```
static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
        struct session *sess, void *opaque, enum disp_action *act)
..
        /* Gwt Specific-Action */
        case OGS_DIAM_RX_AVP_CODE_SPECIFIC_ACTION:
            break;
        /* Gwt Media-Component-Description */
        case OGS_DIAM_RX_AVP_CODE_MEDIA_COMPONENT_DESCRIPTION:
            media_component = &rx_message.ims_data.
                    media_component[rx_message.ims_data.num_of_media_component];

            ret = fd_msg_browse(avpch1, MSG_BRW_FIRST_CHILD, &avpch2, NULL);
            ogs_assert(ret == 0);
            while (avpch2) {
                ret = fd_msg_avp_hdr(avpch2, &hdr);
..
                }

                fd_msg_browse(avpch2, MSG_BRW_NEXT, &avpch2, NULL);
            }

            rx_message.ims_data.num_of_media_component++;
            break;
        default:
            ogs_warn("Not supported(%d)", hdr->avp_code);
            break;
        }
..
}
```