### PR TITLE
[SBI] Re-factor NF Instance Context (#3093)

### DIFF
--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -2,51 +2,51 @@ name: Meson Continuous Integration
 on: [push, pull_request]
 
 jobs:
-  macos-latest:
-    name: Build and Test on MacOS Latest
-    runs-on: macos-latest
-    steps:
-#    - name: Install MongoDB with Package Manager
+#  macos-latest:
+#    name: Build and Test on MacOS Latest
+#    runs-on: macos-latest
+#    steps:
+##    - name: Install MongoDB with Package Manager
+##      run: |
+##          brew tap mongodb/brew
+##          brew install mongodb-community
+##          brew services start mongodb-community
+#    - name: Create the TUN device with the interface name `ogstun`.
 #      run: |
-#          brew tap mongodb/brew
-#          brew install mongodb-community
-#          brew services start mongodb-community
-    - name: Create the TUN device with the interface name `ogstun`.
-      run: |
-          sudo ifconfig lo0 alias 127.0.0.2 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.3 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.4 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.6 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.7 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.8 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.9 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.10 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.11 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.12 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.13 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.14 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.15 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.16 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.17 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.18 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.19 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.0.20 netmask 255.255.255.255
-          sudo ifconfig lo0 alias 127.0.1.10 netmask 255.255.255.255
-    - name: Install the dependencies for building the source code.
-      run: brew install mongo-c-driver libidn libmicrohttpd nghttp2 bison libusrsctp libtins talloc meson
-    - name: Check out repository code
-      uses: actions/checkout@main
-    - name: Setup Meson Build
-      run: PATH="/usr/local/opt/bison/bin:$PATH" PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" meson setup build
-      env:
-        CC: gcc
-    - name : Build Open5GS
-      run: ninja -C build
-    - name: Test Open5GS
-      run: sudo meson test -C build -v crypt unit
-
+#          sudo ifconfig lo0 alias 127.0.0.2 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.3 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.4 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.5 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.6 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.7 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.8 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.9 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.10 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.11 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.12 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.13 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.14 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.15 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.16 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.17 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.18 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.19 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.0.20 netmask 255.255.255.255
+#          sudo ifconfig lo0 alias 127.0.1.10 netmask 255.255.255.255
+#    - name: Install the dependencies for building the source code.
+#      run: brew install mongo-c-driver libidn libmicrohttpd nghttp2 bison libusrsctp libtins talloc meson
+#    - name: Check out repository code
+#      uses: actions/checkout@main
+#    - name: Setup Meson Build
+#      run: PATH="/usr/local/opt/bison/bin:$PATH" PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" meson setup build
+#      env:
+#        CC: gcc
+#    - name : Build Open5GS
+#      run: ninja -C build
+#    - name: Test Open5GS
+#      run: sudo meson test -C build -v crypt unit
+#
   ubuntu-latest:
     name: Build and Test on Ubuntu Latest
     runs-on: ubuntu-latest

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -175,7 +175,6 @@ typedef struct ogs_sbi_nf_instance_s {
 #define NF_INSTANCE_CLIENT(__nFInstance) \
     ((__nFInstance) ? ((__nFInstance)->client) : NULL)
     void *client;                       /* only used in CLIENT */
-    unsigned int reference_count;       /* reference count for memory free */
 } ogs_sbi_nf_instance_t;
 
 typedef enum {
@@ -193,7 +192,7 @@ typedef struct ogs_sbi_object_s {
     ogs_sbi_obj_type_e type;
 
     struct {
-        ogs_sbi_nf_instance_t *nf_instance;
+        char *nf_instance_id;
     } nf_type_array[OGS_SBI_MAX_NUM_OF_NF_TYPE],
       service_type_array[OGS_SBI_MAX_NUM_OF_SERVICE_TYPE];
 
@@ -459,19 +458,16 @@ void ogs_sbi_client_associate(ogs_sbi_nf_instance_t *nf_instance);
 
 int ogs_sbi_default_client_port(OpenAPI_uri_scheme_e scheme);
 
-#define OGS_SBI_SETUP_NF_INSTANCE(__cTX, __nFInstance) \
+#define OGS_SBI_SETUP_NF_INSTANCE_ID(__cTX, __nFInstanceId) \
     do { \
-        ogs_assert(__nFInstance); \
+        ogs_assert(__nFInstanceId); \
         \
-        if ((__cTX).nf_instance) { \
-            ogs_warn("NF Instance [%s] updated [%s]", \
-                    OpenAPI_nf_type_ToString((__nFInstance)->nf_type), \
-                    (__nFInstance)->id); \
-            ogs_sbi_nf_instance_remove((__cTX).nf_instance); \
+        if ((__cTX).nf_instance_id) { \
+            ogs_warn("NF Instance(ID) updated [%s]", (__nFInstanceId)); \
+            ogs_free((__cTX).nf_instance_id); \
         } \
         \
-        OGS_OBJECT_REF(__nFInstance); \
-        ((__cTX).nf_instance) = (__nFInstance); \
+        ((__cTX).nf_instance_id) = ogs_strdup(__nFInstanceId); \
     } while(0)
 
 bool ogs_sbi_discovery_param_is_matched(

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -1087,13 +1087,12 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
                     nf_instance, message.h.resource.component[1]);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("(NRF-notify) NF registered [%s:%d]",
-                    nf_instance->id, nf_instance->reference_count);
+            ogs_info("(NRF-notify) NF registered [%s]", nf_instance->id);
         } else {
-            ogs_warn("[%s] (NRF-notify) NF has already been added [%s:%d]",
+            ogs_warn("[%s] (NRF-notify) NF has already been added [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
 
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
             ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
@@ -1101,10 +1100,10 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
 
         ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
 
-        ogs_info("[%s] (NRF-notify) NF Profile updated [%s:%d]",
+        ogs_info("[%s] (NRF-notify) NF Profile updated [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
 
         ogs_sbi_client_associate(nf_instance);
 
@@ -1120,27 +1119,13 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
             OpenAPI_notification_event_type_NF_DEREGISTERED) {
         nf_instance = ogs_sbi_nf_instance_find(message.h.resource.component[1]);
         if (nf_instance) {
-            if (OGS_OBJECT_IS_REF(nf_instance)) {
-                /* There are references to other contexts. */
-                ogs_warn("[%s] (NRF-notify) NF was referenced "
-                        "in other contexts [%s:%d]",
-                        nf_instance->nf_type ?
-                            OpenAPI_nf_type_ToString(nf_instance->nf_type) :
-                            "NULL",
-                        nf_instance->id, nf_instance->reference_count);
-
-                ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
-                ogs_sbi_nf_fsm_tran(
-                        nf_instance, ogs_sbi_nf_state_de_registered);
-            } else {
-                ogs_info("[%s] (NRF-notify) NF_DEREGISTERED event [%s:%d]",
-                        nf_instance->nf_type ?
-                            OpenAPI_nf_type_ToString(nf_instance->nf_type) :
-                            "NULL",
-                        nf_instance->id, nf_instance->reference_count);
-                ogs_sbi_nf_fsm_fini((nf_instance));
-                ogs_sbi_nf_instance_remove(nf_instance);
-            }
+            ogs_info("[%s] (NRF-notify) NF_DEREGISTERED event [%s]",
+                    nf_instance->nf_type ?
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) :
+                        "NULL",
+                    nf_instance->id);
+            ogs_sbi_nf_fsm_fini((nf_instance));
+            ogs_sbi_nf_instance_remove(nf_instance);
         } else {
             ogs_warn("[%s] (NRF-notify) Not found",
                     message.h.resource.component[1]);
@@ -1216,15 +1201,15 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
             ogs_sbi_nf_instance_set_id(nf_instance, NFProfile->nf_instance_id);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("[%s] (NRF-discover) NF registered [%s:%d]",
+            ogs_info("[%s] (NRF-discover) NF registered [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
         } else {
-            ogs_warn("[%s] (NRF-discover) NF has already been added [%s:%d]",
+            ogs_warn("[%s] (NRF-discover) NF has already been added [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
 
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
             ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
@@ -1254,15 +1239,15 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
                     ogs_time_from_sec(nf_instance->time.validity_duration));
 
             } else
-                ogs_warn("[%s] NF Instance validity-time should not 0 [%s:%d]",
+                ogs_warn("[%s] NF Instance validity-time should not 0 [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
 
-            ogs_info("[%s] (NF-discover) NF Profile updated [%s:%d]",
+            ogs_info("[%s] (NF-discover) NF Profile updated [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
         }
     }
 }

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -208,22 +208,22 @@ static int client_discover_cb(
 
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("[%s] (SCP-discover) NF registered [%s:%d]",
+            ogs_info("[%s] (SCP-discover) NF registered [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
         } else {
-            ogs_warn("[%s] (SCP-discover) NF has already been added [%s:%d]",
+            ogs_warn("[%s] (SCP-discover) NF has already been added [%s]",
                     nf_instance->nf_type ?
                         OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id, nf_instance->reference_count);
+                    nf_instance->id);
 
             ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
             ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
         }
 
-        OGS_SBI_SETUP_NF_INSTANCE(
-                sbi_object->service_type_array[service_type], nf_instance);
+        OGS_SBI_SETUP_NF_INSTANCE_ID(
+                sbi_object->service_type_array[service_type], nf_instance->id);
     }
 
     e = ogs_event_new(OGS_EVENT_SBI_CLIENT);
@@ -281,13 +281,15 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
     }
 
     /* Target NF-Instance */
-    nf_instance = sbi_object->service_type_array[service_type].nf_instance;
+    nf_instance = ogs_sbi_nf_instance_find(
+            sbi_object->service_type_array[service_type].nf_instance_id);
     if (!nf_instance) {
         nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
                         target_nf_type, requester_nf_type, discovery_option);
-        if (nf_instance)
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
+        if (nf_instance) {
+            OGS_SBI_SETUP_NF_INSTANCE_ID(
+                    sbi_object->service_type_array[service_type], nf_instance->id);
+        }
     }
 
     /* Target Client */

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2338,8 +2338,9 @@ void amf_sbi_select_nf(
         nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
                         target_nf_type, requester_nf_type, discovery_option);
         if (nf_instance)
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
+            OGS_SBI_SETUP_NF_INSTANCE_ID(
+                    sbi_object->service_type_array[service_type],
+                    nf_instance->id);
         break;
     case OGS_SBI_OBJ_SESS_TYPE:
         sess = (amf_sess_t *)sbi_object;
@@ -2352,8 +2353,9 @@ void amf_sbi_select_nf(
                         false)
                 continue;
 
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
+            OGS_SBI_SETUP_NF_INSTANCE_ID(
+                    sbi_object->service_type_array[service_type],
+                    nf_instance->id);
             break;
         }
         break;

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1305,8 +1305,9 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                 ogs_sbi_discovery_option_set_tai(
                         discovery_option, &amf_ue->nr_tai);
 
-                nf_instance = sess->sbi.
-                    service_type_array[service_type].nf_instance;
+                nf_instance = ogs_sbi_nf_instance_find(
+                        sess->sbi.service_type_array[service_type].
+                        nf_instance_id);
                 if (!nf_instance) {
                     OpenAPI_nf_type_e requester_nf_type =
                                 NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -1317,8 +1318,9 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                             OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION,
                             requester_nf_type,
                             discovery_option);
-                    nf_instance = sess->sbi.
-                        service_type_array[service_type].nf_instance;
+                    nf_instance = ogs_sbi_nf_instance_find(
+                            sess->sbi.service_type_array[service_type].
+                            nf_instance_id);
 
                     if (!nf_instance)
                         ogs_info("No SMF Instance");

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -1417,7 +1417,7 @@ int amf_namf_comm_handle_ue_context_transfer_request(
     UeContext._5g_mm_capability = encoded_gmm_capability;
 
     UeContext.pcf_id = amf_ue->sbi.service_type_array[
-        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance->id;
+        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance_id;
 
     /* TODO UeContext.pcfAmPolicyUri */
     /* TODO UeContext.pcfUePolicyUri */

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -57,7 +57,9 @@ void amf_nnrf_handle_nf_discover(
     amf_sbi_select_nf(sbi_object,
             service_type, requester_nf_type, discovery_option);
 
-    nf_instance = sbi_object->service_type_array[service_type].nf_instance;
+    nf_instance = ogs_sbi_nf_instance_find(
+            sbi_object->service_type_array[service_type].nf_instance_id);
+
     if (!nf_instance) {
         amf_ue_t *amf_ue = NULL;
         amf_sess_t *sess = NULL;

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -36,7 +36,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     OpenAPI_snssai_t hplmnSnssai;
     OpenAPI_ref_to_binary_data_t n1SmMsg;
     OpenAPI_user_location_t ueLocation;
-    ogs_sbi_nf_instance_t *pcf_nf_instance = NULL;
 
     ogs_assert(sess);
     amf_ue = sess->amf_ue;
@@ -190,13 +189,12 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
         goto end;
     }
 
-    pcf_nf_instance = amf_ue->sbi.service_type_array[
-        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance;
-    if (!pcf_nf_instance) {
+    SmContextCreateData.pcf_id = amf_ue->sbi.service_type_array[
+        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance_id;
+    if (!SmContextCreateData.pcf_id) {
         ogs_error("No pcf_nf_instance");
         goto end;
     }
-    SmContextCreateData.pcf_id = pcf_nf_instance->id;
 
     message.SmContextCreateData = &SmContextCreateData;
 

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -313,7 +313,7 @@ static int client_discover_cb(
     amf_sbi_select_nf(&sess->sbi,
             service_type, requester_nf_type, discovery_option);
 
-    if (!sess->sbi.service_type_array[service_type].nf_instance) {
+    if (!sess->sbi.service_type_array[service_type].nf_instance_id) {
         ogs_error("[%s:%d] (NF discover) No [%s]",
                     amf_ue->supi, sess->psi,
                     ogs_sbi_service_type_to_name(service_type));

--- a/src/ausf/nnrf-handler.c
+++ b/src/ausf/nnrf-handler.c
@@ -62,8 +62,8 @@ void ausf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     ogs_expect(true == ausf_sbi_send_request(nf_instance, xact));
 }

--- a/src/bsf/nnrf-handler.c
+++ b/src/bsf/nnrf-handler.c
@@ -62,8 +62,8 @@ void bsf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     ogs_expect(true == bsf_sbi_send_request(nf_instance, xact));
 }

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -738,7 +738,6 @@ bool nrf_nnrf_handle_nf_profile_retrieval(
     ogs_assert(stream);
     ogs_assert(recvmsg);
 
-    ogs_assert(recvmsg->h.resource.component[1]);
     nf_instance = ogs_sbi_nf_instance_find(recvmsg->h.resource.component[1]);
     if (!nf_instance) {
         ogs_error("Not found [%s]", recvmsg->h.resource.component[1]);

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -112,10 +112,8 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                     break;
 
                 DEFAULT
-                    if (message.h.resource.component[1]) {
-                        nf_instance = ogs_sbi_nf_instance_find(
-                                message.h.resource.component[1]);
-                    }
+                    nf_instance = ogs_sbi_nf_instance_find(
+                            message.h.resource.component[1]);
 
                     if (!nf_instance) {
                         SWITCH(message.h.method)
@@ -165,9 +163,7 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                         ogs_fsm_dispatch(&nf_instance->sm, e);
                         if (OGS_FSM_CHECK(&nf_instance->sm,
                                     nrf_nf_state_de_registered)) {
-                            ogs_info("[%s:%d] NF de-registered",
-                                    nf_instance->id,
-                                    nf_instance->reference_count);
+                            ogs_info("[%s] NF de-registered", nf_instance->id);
                             nrf_nf_fsm_fini(nf_instance);
                             ogs_sbi_nf_instance_remove(nf_instance);
                         } else if (OGS_FSM_CHECK(&nf_instance->sm,

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -84,8 +84,8 @@ void pcf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     switch (service_type) {
     case OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION:

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -505,7 +505,8 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
 
         service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
 
-        nf_instance = sess->sbi.service_type_array[service_type].nf_instance;
+        nf_instance = ogs_sbi_nf_instance_find(
+                sess->sbi.service_type_array[service_type].nf_instance_id);
         if (!nf_instance) {
             OpenAPI_nf_type_e requester_nf_type =
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -513,9 +514,9 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
             nf_instance = ogs_sbi_nf_instance_find_by_service_type(
                             service_type, requester_nf_type);
             if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE(
+                OGS_SBI_SETUP_NF_INSTANCE_ID(
                         sess->sbi.service_type_array[service_type],
-                        nf_instance);
+                        nf_instance->id);
         }
 
         if (nf_instance) {

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -215,7 +215,8 @@ bool pcf_nudr_dr_handle_query_sm_data(
 
         service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
 
-        nf_instance = sess->sbi.service_type_array[service_type].nf_instance;
+        nf_instance = ogs_sbi_nf_instance_find(
+                sess->sbi.service_type_array[service_type].nf_instance_id);
         if (!nf_instance) {
             OpenAPI_nf_type_e requester_nf_type =
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -223,9 +224,9 @@ bool pcf_nudr_dr_handle_query_sm_data(
             nf_instance = ogs_sbi_nf_instance_find_by_service_type(
                             service_type, requester_nf_type);
             if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE(
+                OGS_SBI_SETUP_NF_INSTANCE_ID(
                         sess->sbi.service_type_array[service_type],
-                        nf_instance);
+                        nf_instance->id);
         }
 
         if (nf_instance) {

--- a/src/smf/nnrf-handler.c
+++ b/src/smf/nnrf-handler.c
@@ -62,8 +62,8 @@ void smf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     ogs_expect(true == smf_sbi_send_request(nf_instance, xact));
 }

--- a/src/udm/nnrf-handler.c
+++ b/src/udm/nnrf-handler.c
@@ -81,8 +81,8 @@ void udm_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     ogs_expect(true == udm_sbi_send_request(nf_instance, xact));
 }

--- a/tests/af/nnrf-handler.c
+++ b/tests/af/nnrf-handler.c
@@ -62,8 +62,8 @@ void af_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE(
-            sbi_object->service_type_array[service_type], nf_instance);
+    OGS_SBI_SETUP_NF_INSTANCE_ID(
+            sbi_object->service_type_array[service_type], nf_instance->id);
 
     ogs_expect(true == af_sbi_send_request(nf_instance, xact));
 }


### PR DESCRIPTION
Fixed not using Reference Count for adding/deleting NF Instances.

Up until now, NF Instances have been managed by referencing the Reference Count.

Initially, when an NF Instance is added, the Reference Count is incremented and when it is deleted, the Reference Count is decremented.

If a UE discovers another NF Instance through the NF Discovery function, the Reference Count is incremented. And if a UE de-registers, the Reference Count of the discovered NF is decremented.

However, there's a problem with this approach.

When other NF is de-registered,
there is no guarantee that it will be 100% notified.

For example, if a UDM is de-registered, but an SCP is de-registered before it, the AMF will not be notified that the UDM has been de-registered.

In situations where this is not clear, Reference Count cannot be used.

Therefore, we have modified it to not use the Reference Count method.

Also, when a UE connects, it is modified to always search whether an NF Instance exists by NF Instance ID whenever it is discovered.

To do this, we modified lib/sbi/path.c as shown below.

```diff
@@ -281,13 +281,15 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
     }

     /* Target NF-Instance */
-    nf_instance = sbi_object->service_type_array[service_type].nf_instance;
+    nf_instance = ogs_sbi_nf_instance_find(
+            sbi_object->service_type_array[service_type].nf_instance_id);
     if (!nf_instance) {
         nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
                         target_nf_type, requester_nf_type, discovery_option);
-        if (nf_instance)
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
+        if (nf_instance) {
+            OGS_SBI_SETUP_NF_INSTANCE_ID(
+                    sbi_object->service_type_array[service_type], nf_instance->id);
+        }
     }
```