### PR TITLE
[SBI] SearchResult.validityPeriod 3600->30s

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -408,8 +408,8 @@ static int local_conf_prepare(void)
      *  Heartbeat Interval(e.g: 10 seconds) + No Heartbeat Margin(1 second) */
     local_conf.time.nf_instance.no_heartbeat_margin = 1;
 
-    /* 3600 seconds = 1 hour */
-    local_conf.time.nf_instance.validity_duration = 3600;
+    /* 30 seconds */
+    local_conf.time.nf_instance.validity_duration = 30;
 
     /* 86400 seconds = 1 day */
     local_conf.time.subscription.validity_duration = 86400;

--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -57,6 +57,19 @@ extern "C" {
         OGS_OBJECT_REF(__pClient); \
         ((__cTX)->client) = (__pClient); \
         ogs_debug("CLIENT Ref [%d]", (__pClient)->reference_count); \
+        if ((__pClient)->fqdn) { \
+            ogs_info("NF EndPoint(fqdn) setup [%s:%d]", \
+                    (__pClient)->fqdn, (__pClient)->fqdn_port); \
+        } \
+        if ((__pClient)->addr) { \
+            ogs_info("NF EndPoint(addr) setup [%s:%d]", \
+                OGS_ADDR((__pClient)->addr, buf), OGS_PORT((__pClient)->addr)); \
+        } \
+        if ((__pClient)->addr6) { \
+            ogs_info("NF EndPoint(addr6) setup [%s:%d]", \
+                OGS_ADDR((__pClient)->addr6, buf), \
+                OGS_PORT((__pClient)->addr6)); \
+        } \
     } while(0)
 
 typedef int (*ogs_sbi_client_cb_f)(

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1231,19 +1231,7 @@ ogs_sbi_nf_instance_t *ogs_sbi_nf_instance_find(char *id)
 {
     ogs_sbi_nf_instance_t *nf_instance = NULL;
 
-    /*
-     * This is related to Issue #3093.
-     *
-     * We want to be able to use 'ogs_sbi_nf_instance_id_find(char *id)'
-     * even if the 'id' is NULL as in the use case below.
-     *
-     * ogs_sbi_nf_instance_find(
-     *    sess->sbi.service_type_array[service_type].nf_instance_id));
-     *
-     * To do so, we changed the 'assert(id)' to 'if (!id) return NULL',
-     * as shown below.
-     */
-    if (!id) return NULL;
+    ogs_assert(id);
 
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance) {
         if (nf_instance->id && strcmp(nf_instance->id, id) == 0)
@@ -2130,9 +2118,6 @@ bool ogs_sbi_discovery_param_is_matched(
     if (NF_INSTANCE_EXCLUDED_FROM_DISCOVERY(nf_instance))
         return false;
 
-    if (!OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_registered))
-        return false;
-
     if (nf_instance->nf_type != target_nf_type)
         return false;
 
@@ -2260,26 +2245,15 @@ ogs_sbi_client_t *ogs_sbi_client_find_by_service_type(
             return nf_service->client;
     }
 
-    return nf_instance->client;
+    return NULL;
 }
 
 void ogs_sbi_object_free(ogs_sbi_object_t *sbi_object)
 {
-    int i;
-
     ogs_assert(sbi_object);
 
     if (ogs_list_count(&sbi_object->xact_list))
         ogs_error("SBI running [%d]", ogs_list_count(&sbi_object->xact_list));
-
-    for (i = 0; i < OGS_SBI_MAX_NUM_OF_SERVICE_TYPE; i++) {
-        if (sbi_object->service_type_array[i].nf_instance_id)
-            ogs_free(sbi_object->service_type_array[i].nf_instance_id);
-    }
-    for (i = 0; i < OGS_SBI_MAX_NUM_OF_NF_TYPE; i++) {
-        if (sbi_object->nf_type_array[i].nf_instance_id)
-            ogs_free(sbi_object->nf_type_array[i].nf_instance_id);
-    }
 }
 
 ogs_sbi_xact_t *ogs_sbi_xact_add(

--- a/lib/sbi/nf-sm.c
+++ b/lib/sbi/nf-sm.c
@@ -32,19 +32,6 @@ void ogs_sbi_nf_fsm_init(ogs_sbi_nf_instance_t *nf_instance)
             ogs_sbi_nf_state_initial, ogs_sbi_nf_state_final, &e);
 }
 
-void ogs_sbi_nf_fsm_tran(ogs_sbi_nf_instance_t *nf_instance, void *state)
-{
-    ogs_event_t e;
-
-    ogs_assert(nf_instance);
-    ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
-
-    memset(&e, 0, sizeof(e));
-    e.sbi.data = nf_instance;
-
-    ogs_fsm_tran(&nf_instance->sm, state, &e);
-}
-
 void ogs_sbi_nf_fsm_fini(ogs_sbi_nf_instance_t *nf_instance)
 {
     ogs_event_t e;
@@ -307,7 +294,7 @@ void ogs_sbi_nf_state_registered(ogs_fsm_t *s, ogs_event_t *e)
             break;
 
         case OGS_TIMER_NF_INSTANCE_NO_HEARTBEAT:
-            ogs_error("[%s:%s] No heartbeat",
+            ogs_error("[%s] No heartbeat [type:%s]",
                     NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
                     OpenAPI_nf_type_ToString(
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance)));
@@ -318,22 +305,24 @@ void ogs_sbi_nf_state_registered(ogs_fsm_t *s, ogs_event_t *e)
             ogs_assert(!NF_INSTANCE_TYPE_IS_NRF(nf_instance));
             ogs_assert(nf_instance->id);
 
-            ogs_info("[%s] NF expired", nf_instance->id);
+            ogs_info("[%s] NF expired [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
             OGS_FSM_TRAN(s, &ogs_sbi_nf_state_de_registered);
             break;
 
         default:
-            ogs_error("[%s:%s] Unknown timer[%s:%d]",
-                    OpenAPI_nf_type_ToString(nf_instance->nf_type),
+            ogs_error("[%s] Unknown timer [type:%s timer:%s:%d]",
                     nf_instance->id ? nf_instance->id : "Undefined",
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type),
                     ogs_timer_get_name(e->timer_id), e->timer_id);
         }
         break;
 
     default:
-        ogs_error("[%s:%s] Unknown event %s",
-                OpenAPI_nf_type_ToString(nf_instance->nf_type),
+        ogs_error("[%s] Unknown event [type:%s event:%s]",
                 nf_instance->id ? nf_instance->id : "Undefined",
+                OpenAPI_nf_type_ToString(nf_instance->nf_type),
                 ogs_event_get_name(e));
         break;
     }
@@ -353,19 +342,20 @@ void ogs_sbi_nf_state_de_registered(ogs_fsm_t *s, ogs_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        if (NF_INSTANCE_TYPE_IS_NRF(nf_instance)) {
-            ogs_info("[%s] NF de-registered",
-                    NF_INSTANCE_ID(ogs_sbi_self()->nf_instance));
-        }
+        ogs_info("[%s] NF de-registered [type:%s]",
+                nf_instance->id,
+                OpenAPI_nf_type_ToString(nf_instance->nf_type));
+        ogs_sbi_nf_fsm_fini(nf_instance);
+        ogs_sbi_nf_instance_remove(nf_instance);
         break;
 
     case OGS_FSM_EXIT_SIG:
         break;
 
     default:
-        ogs_error("[%s:%s] Unknown event %s",
-                OpenAPI_nf_type_ToString(nf_instance->nf_type),
+        ogs_error("[%s] Unknown event [type:%s event:%s]",
                 nf_instance->id ? nf_instance->id : "Undefined",
+                OpenAPI_nf_type_ToString(nf_instance->nf_type),
                 ogs_event_get_name(e));
         break;
     }
@@ -409,9 +399,9 @@ void ogs_sbi_nf_state_exception(ogs_fsm_t *s, ogs_event_t *e)
             break;
 
         default:
-            ogs_error("[%s:%s] Unknown timer[%s:%d]",
-                    OpenAPI_nf_type_ToString(nf_instance->nf_type),
+            ogs_error("[%s] Unknown timer[type:%s timer:%s:%d]",
                     nf_instance->id ? nf_instance->id : "Undefined",
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type),
                     ogs_timer_get_name(e->timer_id), e->timer_id);
         }
         break;
@@ -437,9 +427,9 @@ void ogs_sbi_nf_state_exception(ogs_fsm_t *s, ogs_event_t *e)
         break;
 
     default:
-        ogs_error("[%s:%s] Unknown event %s",
-                OpenAPI_nf_type_ToString(nf_instance->nf_type),
+        ogs_error("[%s] Unknown event [type:%s event:%s]",
                 nf_instance->id ? nf_instance->id : "Undefined",
+                OpenAPI_nf_type_ToString(nf_instance->nf_type),
                 ogs_event_get_name(e));
         break;
     }

--- a/lib/sbi/nf-sm.h
+++ b/lib/sbi/nf-sm.h
@@ -29,7 +29,6 @@ extern "C" {
 #endif
 
 void ogs_sbi_nf_fsm_init(ogs_sbi_nf_instance_t *nf_instance);
-void ogs_sbi_nf_fsm_tran(ogs_sbi_nf_instance_t *nf_instance, void *state);
 void ogs_sbi_nf_fsm_fini(ogs_sbi_nf_instance_t *nf_instance);
 
 void ogs_sbi_nf_state_initial(ogs_fsm_t *s, ogs_event_t *e);

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -1087,23 +1087,23 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
                     nf_instance, message.h.resource.component[1]);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("(NRF-notify) NF registered [%s]", nf_instance->id);
+            ogs_info("[%s] (NRF-notify) NF registered", nf_instance->id);
         } else {
-            ogs_warn("[%s] (NRF-notify) NF has already been added [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
-
-            ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
-            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
+            ogs_warn("[%s] (NRF-notify) NF has already been added [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
+            if (!OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_registered)) {
+                ogs_error("[%s] (NRF-notify) NF invalid state [type:%s]",
+                        nf_instance->id,
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type));
+            }
         }
 
         ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
 
-        ogs_info("[%s] (NRF-notify) NF Profile updated [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
+        ogs_info("[%s] (NRF-notify) NF Profile updated [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
 
         ogs_sbi_client_associate(nf_instance);
 
@@ -1119,12 +1119,10 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
             OpenAPI_notification_event_type_NF_DEREGISTERED) {
         nf_instance = ogs_sbi_nf_instance_find(message.h.resource.component[1]);
         if (nf_instance) {
-            ogs_info("[%s] (NRF-notify) NF_DEREGISTERED event [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) :
-                        "NULL",
-                    nf_instance->id);
-            ogs_sbi_nf_fsm_fini((nf_instance));
+            ogs_info("[%s] (NRF-notify) NF_DEREGISTERED event [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
+            ogs_sbi_nf_fsm_fini(nf_instance);
             ogs_sbi_nf_instance_remove(nf_instance);
         } else {
             ogs_warn("[%s] (NRF-notify) Not found",
@@ -1201,18 +1199,18 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
             ogs_sbi_nf_instance_set_id(nf_instance, NFProfile->nf_instance_id);
             ogs_sbi_nf_fsm_init(nf_instance);
 
-            ogs_info("[%s] (NRF-discover) NF registered [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
+            ogs_info("[%s] (NRF-discover) NF registered [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
         } else {
-            ogs_warn("[%s] (NRF-discover) NF has already been added [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
-
-            ogs_assert(OGS_FSM_STATE(&nf_instance->sm));
-            ogs_sbi_nf_fsm_tran(nf_instance, ogs_sbi_nf_state_registered);
+            ogs_warn("[%s] (NRF-discover) NF has already been added [type:%s]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type));
+            if (!OGS_FSM_CHECK(&nf_instance->sm, ogs_sbi_nf_state_registered)) {
+                ogs_error("[%s] (NRF-notify) NF invalid state [type:%s]",
+                        nf_instance->id,
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type));
+            }
         }
 
         if (NF_INSTANCE_ID_IS_OTHERS(nf_instance->id)) {
@@ -1239,15 +1237,18 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
                     ogs_time_from_sec(nf_instance->time.validity_duration));
 
             } else
-                ogs_warn("[%s] NF Instance validity-time should not 0 [%s]",
+                ogs_warn("[%s] NF Instance validity-time should not 0 "
+                        "[type:%s]",
+                    nf_instance->id,
                     nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
+                        OpenAPI_nf_type_ToString(nf_instance->nf_type) :
+                        "NULL");
 
-            ogs_info("[%s] (NF-discover) NF Profile updated [%s]",
-                    nf_instance->nf_type ?
-                        OpenAPI_nf_type_ToString(nf_instance->nf_type) : "NULL",
-                    nf_instance->id);
+            ogs_info("[%s] (NF-discover) NF Profile updated "
+                    "[type:%s validity:%ds]",
+                    nf_instance->id,
+                    OpenAPI_nf_type_ToString(nf_instance->nf_type),
+                    nf_instance->time.validity_duration);
         }
     }
 }

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2338,9 +2338,8 @@ void amf_sbi_select_nf(
         nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
                         target_nf_type, requester_nf_type, discovery_option);
         if (nf_instance)
-            OGS_SBI_SETUP_NF_INSTANCE_ID(
-                    sbi_object->service_type_array[service_type],
-                    nf_instance->id);
+            OGS_SBI_SETUP_NF_INSTANCE(
+                    sbi_object->service_type_array[service_type], nf_instance);
         break;
     case OGS_SBI_OBJ_SESS_TYPE:
         sess = (amf_sess_t *)sbi_object;
@@ -2353,9 +2352,8 @@ void amf_sbi_select_nf(
                         false)
                 continue;
 
-            OGS_SBI_SETUP_NF_INSTANCE_ID(
-                    sbi_object->service_type_array[service_type],
-                    nf_instance->id);
+            OGS_SBI_SETUP_NF_INSTANCE(
+                    sbi_object->service_type_array[service_type], nf_instance);
             break;
         }
         break;

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1305,9 +1305,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                 ogs_sbi_discovery_option_set_tai(
                         discovery_option, &amf_ue->nr_tai);
 
-                nf_instance = ogs_sbi_nf_instance_find(
-                        sess->sbi.service_type_array[service_type].
-                        nf_instance_id);
+                nf_instance = OGS_SBI_GET_NF_INSTANCE(
+                        sess->sbi.service_type_array[service_type]);
                 if (!nf_instance) {
                     OpenAPI_nf_type_e requester_nf_type =
                                 NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -1318,9 +1317,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                             OGS_SBI_SERVICE_TYPE_NSMF_PDUSESSION,
                             requester_nf_type,
                             discovery_option);
-                    nf_instance = ogs_sbi_nf_instance_find(
-                            sess->sbi.service_type_array[service_type].
-                            nf_instance_id);
+                    nf_instance = OGS_SBI_GET_NF_INSTANCE(
+                            sess->sbi.service_type_array[service_type]);
 
                     if (!nf_instance)
                         ogs_info("No SMF Instance");

--- a/src/amf/init.c
+++ b/src/amf/init.c
@@ -38,6 +38,10 @@ int amf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_AMF);
     amf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
@@ -48,10 +52,6 @@ int amf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = amf_context_nf_info();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     ogs_metrics_context_open(ogs_metrics_self());

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -1333,6 +1333,8 @@ int amf_namf_comm_handle_ue_context_transfer_request(
 
     OpenAPI_ue_context_transfer_rsp_data_t UeContextTransferRspData;
 
+    ogs_sbi_nf_instance_t *pcf_nf_instance = NULL;
+
     char *ue_context_id = NULL;
     char *encoded_gmm_capability = NULL;
     int status = OGS_SBI_HTTP_STATUS_OK;
@@ -1416,8 +1418,14 @@ int amf_namf_comm_handle_ue_context_transfer_request(
     encoded_gmm_capability = amf_namf_comm_base64_encode_5gmm_capability(amf_ue);
     UeContext._5g_mm_capability = encoded_gmm_capability;
 
-    UeContext.pcf_id = amf_ue->sbi.service_type_array[
-        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance_id;
+    pcf_nf_instance = OGS_SBI_GET_NF_INSTANCE(
+            amf_ue->sbi.service_type_array[
+            OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL]);
+    if (pcf_nf_instance) {
+        UeContext.pcf_id = pcf_nf_instance->id;
+    } else {
+        ogs_warn("No PCF NF Instnace");
+    }
 
     /* TODO UeContext.pcfAmPolicyUri */
     /* TODO UeContext.pcfUePolicyUri */

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -57,8 +57,8 @@ void amf_nnrf_handle_nf_discover(
     amf_sbi_select_nf(sbi_object,
             service_type, requester_nf_type, discovery_option);
 
-    nf_instance = ogs_sbi_nf_instance_find(
-            sbi_object->service_type_array[service_type].nf_instance_id);
+    nf_instance = OGS_SBI_GET_NF_INSTANCE(
+            sbi_object->service_type_array[service_type]);
 
     if (!nf_instance) {
         amf_ue_t *amf_ue = NULL;

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -36,6 +36,7 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     OpenAPI_snssai_t hplmnSnssai;
     OpenAPI_ref_to_binary_data_t n1SmMsg;
     OpenAPI_user_location_t ueLocation;
+    ogs_sbi_nf_instance_t *pcf_nf_instance = NULL;
 
     ogs_assert(sess);
     amf_ue = sess->amf_ue;
@@ -189,12 +190,14 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
         goto end;
     }
 
-    SmContextCreateData.pcf_id = amf_ue->sbi.service_type_array[
-        OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL].nf_instance_id;
-    if (!SmContextCreateData.pcf_id) {
+    pcf_nf_instance = OGS_SBI_GET_NF_INSTANCE(
+            amf_ue->sbi.service_type_array[
+            OGS_SBI_SERVICE_TYPE_NPCF_AM_POLICY_CONTROL]);
+    if (!pcf_nf_instance) {
         ogs_error("No pcf_nf_instance");
         goto end;
     }
+    SmContextCreateData.pcf_id = pcf_nf_instance->id;
 
     message.SmContextCreateData = &SmContextCreateData;
 

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -313,7 +313,8 @@ static int client_discover_cb(
     amf_sbi_select_nf(&sess->sbi,
             service_type, requester_nf_type, discovery_option);
 
-    if (!sess->sbi.service_type_array[service_type].nf_instance_id) {
+    if (!OGS_SBI_GET_NF_INSTANCE(
+                sess->sbi.service_type_array[service_type])) {
         ogs_error("[%s:%d] (NF discover) No [%s]",
                     amf_ue->supi, sess->psi,
                     ogs_sbi_service_type_to_name(service_type));

--- a/src/ausf/init.c
+++ b/src/ausf/init.c
@@ -34,14 +34,14 @@ int ausf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_AUSF);
     ausf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = ausf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = ausf_sbi_open();

--- a/src/ausf/nnrf-handler.c
+++ b/src/ausf/nnrf-handler.c
@@ -62,8 +62,8 @@ void ausf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     ogs_expect(true == ausf_sbi_send_request(nf_instance, xact));
 }

--- a/src/bsf/init.c
+++ b/src/bsf/init.c
@@ -36,14 +36,14 @@ int bsf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_BSF);
     bsf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = bsf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = bsf_sbi_open();

--- a/src/bsf/nnrf-handler.c
+++ b/src/bsf/nnrf-handler.c
@@ -62,8 +62,8 @@ void bsf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     ogs_expect(true == bsf_sbi_send_request(nf_instance, xact));
 }

--- a/src/hss/hss-init.c
+++ b/src/hss/hss-init.c
@@ -41,14 +41,14 @@ int hss_initialize(void)
     hss_context_init();
     hss_event_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_metrics_context_parse_config(APP_NAME);
     if (rv != OGS_OK) return rv;
 
     rv = hss_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     ogs_metrics_context_open(ogs_metrics_self());

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -52,6 +52,10 @@ int mme_initialize(void)
     rv = ogs_gtp_xact_init();
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_gtp_context_parse_config(APP_NAME, "sgwc");
     if (rv != OGS_OK) return rv;
 
@@ -59,10 +63,6 @@ int mme_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = mme_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     ogs_metrics_context_open(ogs_metrics_self());

--- a/src/nrf/init.c
+++ b/src/nrf/init.c
@@ -34,14 +34,14 @@ int nrf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_NRF);
     nrf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, NULL, NULL);
     if (rv != OGS_OK) return rv;
 
     rv = nrf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = nrf_sbi_open();

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -738,6 +738,7 @@ bool nrf_nnrf_handle_nf_profile_retrieval(
     ogs_assert(stream);
     ogs_assert(recvmsg);
 
+    ogs_assert(recvmsg->h.resource.component[1]);
     nf_instance = ogs_sbi_nf_instance_find(recvmsg->h.resource.component[1]);
     if (!nf_instance) {
         ogs_error("Not found [%s]", recvmsg->h.resource.component[1]);
@@ -1175,12 +1176,12 @@ static void handle_nf_discover_search_result(
              * is not executed later in nrf_context_final().
              */
 
-            ogs_info("[%s:%s] (NF-discover) NF registered",
+            ogs_info("[%s] (NF-discover) NF registered [type:%s]",
                     NFProfile->nf_instance_id,
                     OpenAPI_nf_type_ToString(NFProfile->nf_type));
         } else {
 
-            ogs_warn("[%s:%s] (NF-discover) NF has already been added",
+            ogs_warn("[%s] (NF-discover) NF has already been added [type:%s]",
                     NFProfile->nf_instance_id,
                     OpenAPI_nf_type_ToString(NFProfile->nf_type));
         }
@@ -1198,7 +1199,7 @@ static void handle_nf_discover_search_result(
                 break;
             }
 
-            ogs_info("[%s:%s] (NF-discover) NF Profile updated",
+            ogs_info("[%s] (NF-discover) NF Profile updated [type:%s]",
                         nf_instance->id,
                         OpenAPI_nf_type_ToString(nf_instance->nf_type));
         }

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -112,8 +112,10 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                     break;
 
                 DEFAULT
-                    nf_instance = ogs_sbi_nf_instance_find(
-                            message.h.resource.component[1]);
+                    if (message.h.resource.component[1]) {
+                        nf_instance = ogs_sbi_nf_instance_find(
+                                message.h.resource.component[1]);
+                    }
 
                     if (!nf_instance) {
                         SWITCH(message.h.method)

--- a/src/nssf/init.c
+++ b/src/nssf/init.c
@@ -34,14 +34,14 @@ int nssf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_NSSF);
     nssf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = nssf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = nssf_sbi_open();

--- a/src/pcf/init.c
+++ b/src/pcf/init.c
@@ -37,6 +37,10 @@ int pcf_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_PCF);
     pcf_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
@@ -44,10 +48,6 @@ int pcf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = pcf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     ogs_metrics_context_open(ogs_metrics_self());

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -84,8 +84,8 @@ void pcf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     switch (service_type) {
     case OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION:

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -505,8 +505,8 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
 
         service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
 
-        nf_instance = ogs_sbi_nf_instance_find(
-                sess->sbi.service_type_array[service_type].nf_instance_id);
+        nf_instance = OGS_SBI_GET_NF_INSTANCE(
+                sess->sbi.service_type_array[service_type]);
         if (!nf_instance) {
             OpenAPI_nf_type_e requester_nf_type =
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -514,9 +514,9 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
             nf_instance = ogs_sbi_nf_instance_find_by_service_type(
                             service_type, requester_nf_type);
             if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE_ID(
+                OGS_SBI_SETUP_NF_INSTANCE(
                         sess->sbi.service_type_array[service_type],
-                        nf_instance->id);
+                        nf_instance);
         }
 
         if (nf_instance) {

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -215,8 +215,8 @@ bool pcf_nudr_dr_handle_query_sm_data(
 
         service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
 
-        nf_instance = ogs_sbi_nf_instance_find(
-                sess->sbi.service_type_array[service_type].nf_instance_id);
+        nf_instance = OGS_SBI_GET_NF_INSTANCE(
+                sess->sbi.service_type_array[service_type]);
         if (!nf_instance) {
             OpenAPI_nf_type_e requester_nf_type =
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
@@ -224,9 +224,9 @@ bool pcf_nudr_dr_handle_query_sm_data(
             nf_instance = ogs_sbi_nf_instance_find_by_service_type(
                             service_type, requester_nf_type);
             if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE_ID(
+                OGS_SBI_SETUP_NF_INSTANCE(
                         sess->sbi.service_type_array[service_type],
-                        nf_instance->id);
+                        nf_instance);
         }
 
         if (nf_instance) {

--- a/src/pcrf/pcrf-init.c
+++ b/src/pcrf/pcrf-init.c
@@ -32,11 +32,11 @@ int pcrf_initialize(void)
 
     pcrf_context_init();
 
-    rv = pcrf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
     rv = ogs_log_config_domain(
             ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
+    rv = pcrf_context_parse_config();
     if (rv != OGS_OK) return rv;
 
     if (ogs_app()->db_uri) {

--- a/src/scp/init.c
+++ b/src/scp/init.c
@@ -36,14 +36,14 @@ int scp_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_SCP);
     scp_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "next_scp");
     if (rv != OGS_OK) return rv;
 
     rv = scp_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = scp_sbi_open();

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -283,9 +283,10 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
                     client = ogs_sbi_client_find_by_service_type(
                                 nf_instance, service_type);
                     if (!client) {
-                        ogs_error("[%s:%s] Cannot find client [%s:%s]",
-                                OpenAPI_nf_type_ToString(nf_instance->nf_type),
+                        ogs_error("[%s] Cannot find client "
+                                "[type:%s target_nf_type:%s service_name:%s]",
                                 nf_instance->id,
+                                OpenAPI_nf_type_ToString(nf_instance->nf_type),
                                 OpenAPI_nf_type_ToString(target_nf_type),
                                 ogs_sbi_service_type_to_name(service_type));
                     }

--- a/src/sepp/init.c
+++ b/src/sepp/init.c
@@ -36,14 +36,14 @@ int sepp_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_SEPP);
     sepp_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = sepp_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = sepp_sbi_open();

--- a/src/sgwc/init.c
+++ b/src/sgwc/init.c
@@ -47,6 +47,10 @@ int sgwc_initialize(void)
     rv = ogs_pfcp_xact_init();
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_gtp_context_parse_config(APP_NAME, "sgwu");
     if (rv != OGS_OK) return rv;
 
@@ -54,10 +58,6 @@ int sgwc_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = sgwc_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = sgwc_gtp_open();

--- a/src/sgwu/init.c
+++ b/src/sgwu/init.c
@@ -44,6 +44,10 @@ int sgwu_initialize(void)
     rv = ogs_pfcp_xact_init();
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_gtp_context_parse_config(APP_NAME, "sgwc");
     if (rv != OGS_OK) return rv;
 
@@ -51,10 +55,6 @@ int sgwu_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = sgwu_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = sgwu_pfcp_open();

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -51,6 +51,10 @@ int smf_initialize(void)
     rv = ogs_pfcp_xact_init();
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_gtp_context_parse_config(APP_NAME, "upf");
     if (rv != OGS_OK) return rv;
 
@@ -64,10 +68,6 @@ int smf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = smf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = ogs_pfcp_ue_pool_generate();

--- a/src/smf/nnrf-handler.c
+++ b/src/smf/nnrf-handler.c
@@ -62,8 +62,8 @@ void smf_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     ogs_expect(true == smf_sbi_send_request(nf_instance, xact));
 }

--- a/src/udm/init.c
+++ b/src/udm/init.c
@@ -34,14 +34,14 @@ int udm_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_UDM);
     udm_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = udm_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = udm_sbi_open();

--- a/src/udm/nnrf-handler.c
+++ b/src/udm/nnrf-handler.c
@@ -81,8 +81,8 @@ void udm_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     ogs_expect(true == udm_sbi_send_request(nf_instance, xact));
 }

--- a/src/udr/init.c
+++ b/src/udr/init.c
@@ -34,14 +34,14 @@ int udr_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_UDR);
     udr_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
     if (rv != OGS_OK) return rv;
 
     rv = udr_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = ogs_dbi_init(ogs_app()->db_uri);

--- a/src/upf/init.c
+++ b/src/upf/init.c
@@ -47,6 +47,10 @@ int upf_initialize(void)
     rv = ogs_pfcp_xact_init();
     if (rv != OGS_OK) return rv;
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     rv = ogs_gtp_context_parse_config(APP_NAME, "smf");
     if (rv != OGS_OK) return rv;
 
@@ -57,10 +61,6 @@ int upf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = upf_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = ogs_pfcp_ue_pool_generate();

--- a/tests/af/init.c
+++ b/tests/af/init.c
@@ -37,6 +37,10 @@ int af_initialize(void)
     ogs_sbi_context_init(OpenAPI_nf_type_AF);
     af_context_init();
 
+    rv = ogs_log_config_domain(
+            ogs_app()->logger.domain, ogs_app()->logger.level);
+    if (rv != OGS_OK) return rv;
+
     no_scp = ogs_global_conf()->parameter.no_scp;
     no_nrf = ogs_global_conf()->parameter.no_nrf;
 
@@ -50,10 +54,6 @@ int af_initialize(void)
     ogs_global_conf()->parameter.no_nrf = no_nrf;
 
     rv = af_context_parse_config();
-    if (rv != OGS_OK) return rv;
-
-    rv = ogs_log_config_domain(
-            ogs_app()->logger.domain, ogs_app()->logger.level);
     if (rv != OGS_OK) return rv;
 
     rv = af_sbi_open();

--- a/tests/af/nnrf-handler.c
+++ b/tests/af/nnrf-handler.c
@@ -62,8 +62,8 @@ void af_nnrf_handle_nf_discover(
         return;
     }
 
-    OGS_SBI_SETUP_NF_INSTANCE_ID(
-            sbi_object->service_type_array[service_type], nf_instance->id);
+    OGS_SBI_SETUP_NF_INSTANCE(
+            sbi_object->service_type_array[service_type], nf_instance);
 
     ogs_expect(true == af_sbi_send_request(nf_instance, xact));
 }


### PR DESCRIPTION
The validity time for NF Instances obtained through NF Discovery was
not properly implemented. Since the validity was 3600 seconds(1 hour),
which caused 5G Core to not work properly after 3600 seconds(1 hour).

There was an issue where an NF Instance should be deleted
when its validity time expired, but it was not working correctly
due to incorrect use of reference count.

Therefore, I have modified the Validity of NF Instances obtained
through NF Discovery to work properly.

I also changed the default value of valdityPeriod to 30 seconds.