### PR TITLE
[SEC] Assertion to ERROR Handling (#3207)

### DIFF
--- a/lib/gtp/v2/types.c
+++ b/lib/gtp/v2/types.c
@@ -629,7 +629,11 @@ int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
     size++;
 
     if (uli->flags.cgi) {
-        ogs_assert(size + sizeof(uli->cgi) <= octet->len);
+        if (size + sizeof(uli->cgi) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->cgi)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->cgi), octet->len);
+            return 0;
+        }
         memcpy(&uli->cgi,
                 (unsigned char *)octet->data + size, sizeof(uli->cgi));
         uli->cgi.lac = be16toh(uli->cgi.lac);
@@ -637,7 +641,11 @@ int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
         size += sizeof(uli->cgi);
     }
     if (uli->flags.sai) {
-        ogs_assert(size + sizeof(uli->sai) <= octet->len);
+        if (size + sizeof(uli->sai) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->sai)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->sai), octet->len);
+            return 0;
+        }
         memcpy(&uli->sai,
                 (unsigned char *)octet->data + size, sizeof(uli->sai));
         uli->sai.lac = be16toh(uli->sai.lac);
@@ -645,7 +653,11 @@ int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
         size += sizeof(uli->sai);
     }
     if (uli->flags.rai) {
-        ogs_assert(size + sizeof(uli->rai) <= octet->len);
+        if (size + sizeof(uli->rai) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->lai)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->lai), octet->len);
+            return 0;
+        }
         memcpy(&uli->rai,
                 (unsigned char *)octet->data + size, sizeof(uli->rai));
         uli->rai.lac = be16toh(uli->rai.lac);
@@ -653,28 +665,44 @@ int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
         size += sizeof(uli->rai);
     }
     if (uli->flags.tai) {
-        ogs_assert(size + sizeof(uli->tai) <= octet->len);
+        if (size + sizeof(uli->tai) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->tai)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->tai), octet->len);
+            return 0;
+        }
         memcpy(&uli->tai,
                 (unsigned char *)octet->data + size, sizeof(uli->tai));
         uli->tai.tac = be16toh(uli->tai.tac);
         size += sizeof(uli->tai);
     }
     if (uli->flags.e_cgi) {
-        ogs_assert(size + sizeof(uli->e_cgi) <= octet->len);
+        if (size + sizeof(uli->e_cgi) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->e_cgi)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->e_cgi), octet->len);
+            return 0;
+        }
         memcpy(&uli->e_cgi,
                 (unsigned char *)octet->data + size, sizeof(uli->e_cgi));
         uli->e_cgi.cell_id = be32toh(uli->e_cgi.cell_id);
         size += sizeof(uli->e_cgi);
     }
     if (uli->flags.lai) {
-        ogs_assert(size + sizeof(uli->lai) <= octet->len);
+        if (size + sizeof(uli->lai) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->lai)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->lai), octet->len);
+            return 0;
+        }
         memcpy(&uli->lai,
                 (unsigned char *)octet->data + size, sizeof(uli->lai));
         uli->lai.lac = be16toh(uli->lai.lac);
         size += sizeof(uli->lai);
     }
     if (uli->flags.enodeb_id) {
-        ogs_assert(size + sizeof(uli->enodeb_id) <= octet->len);
+        if (size + sizeof(uli->enodeb_id) > octet->len) {
+            ogs_error("size[%d]+sizeof(uli->enodeb_id)[%d] > IE Length[%d]",
+                    size, (int)sizeof(uli->enodeb_id), octet->len);
+            return 0;
+        }
         memcpy(&uli->enodeb_id,
                 (unsigned char *)octet->data + size, sizeof(uli->enodeb_id));
         uli->enodeb_id.enodeb_id = be16toh(uli->enodeb_id.enodeb_id);
@@ -684,7 +712,8 @@ int16_t ogs_gtp2_parse_uli(ogs_gtp2_uli_t *uli, ogs_tlv_octet_t *octet)
         ogs_error("Extended Macro eNodeB ID in ULI not implemented! see 3GPP TS 29.274 8.21.8");
     }
 
-    ogs_assert(size == octet->len);
+    if (size != octet->len)
+        ogs_error("Mismatch IE Length[%d] != Decoded[%d]", octet->len, size);
 
     return size;
 }

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -94,6 +94,7 @@ bool ogs_pfcp_cp_handle_association_setup_request(
         ogs_pfcp_association_setup_request_t *req)
 {
     int i;
+    int16_t decoded;
 
     ogs_assert(xact);
     ogs_assert(node);
@@ -112,8 +113,11 @@ bool ogs_pfcp_cp_handle_association_setup_request(
         if (message->presence == 0)
             break;
 
-        ogs_pfcp_parse_user_plane_ip_resource_info(&info, message);
-        ogs_gtpu_resource_add(&node->gtpu_resource_list, &info);
+        decoded = ogs_pfcp_parse_user_plane_ip_resource_info(&info, message);
+        if (message->len == decoded)
+            ogs_gtpu_resource_add(&node->gtpu_resource_list, &info);
+        else
+            ogs_error("Invalid User Plane IP Resource Info");
     }
 
     if (req->up_function_features.presence) {
@@ -143,6 +147,7 @@ bool ogs_pfcp_cp_handle_association_setup_response(
         ogs_pfcp_association_setup_response_t *rsp)
 {
     int i;
+    int16_t decoded;
 
     ogs_assert(xact);
     ogs_pfcp_xact_commit(xact);
@@ -160,8 +165,11 @@ bool ogs_pfcp_cp_handle_association_setup_response(
         if (message->presence == 0)
             break;
 
-        ogs_pfcp_parse_user_plane_ip_resource_info(&info, message);
-        ogs_gtpu_resource_add(&node->gtpu_resource_list, &info);
+        decoded = ogs_pfcp_parse_user_plane_ip_resource_info(&info, message);
+        if (message->len == decoded)
+            ogs_gtpu_resource_add(&node->gtpu_resource_list, &info);
+        else
+            ogs_error("Invalid User Plane IP Resource Info");
     }
 
     if (rsp->up_function_features.presence) {

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -432,7 +432,10 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_create_pdr(ogs_pfcp_sess_t *sess,
 
         len = ogs_pfcp_parse_sdf_filter(
                 &sdf_filter, &message->pdi.sdf_filter[i]);
-        ogs_assert(message->pdi.sdf_filter[i].len == len);
+        if (message->pdi.sdf_filter[i].len != len) {
+            ogs_error("Invalid SDF Filter");
+            break;
+        }
 
         /* Check Previous SDF Filter ID */
         if (sdf_filter.bid) {
@@ -774,7 +777,10 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_update_pdr(ogs_pfcp_sess_t *sess,
 
             len = ogs_pfcp_parse_sdf_filter(
                     &sdf_filter, &message->pdi.sdf_filter[i]);
-            ogs_assert(message->pdi.sdf_filter[i].len == len);
+            if (message->pdi.sdf_filter[i].len != len) {
+                ogs_error("Invalid SDF Filter");
+                break;
+            }
 
             /* Check Previous SDF Filter ID */
             if (sdf_filter.bid) {

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -1329,6 +1329,7 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_create_urr(ogs_pfcp_sess_t *sess,
         ogs_pfcp_tlv_create_urr_t *message,
         uint8_t *cause_value, uint8_t *offending_ie_value)
 {
+    int16_t decoded;
     ogs_pfcp_urr_t *urr = NULL;
 
     ogs_assert(message);
@@ -1377,12 +1378,26 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_create_urr(ogs_pfcp_sess_t *sess,
 
     if (message->volume_threshold.presence &&
         (urr->meas_method & OGS_PFCP_MEASUREMENT_METHOD_VOLUME)) {
-        ogs_pfcp_parse_volume(&urr->vol_threshold, &message->volume_threshold);
+        decoded = ogs_pfcp_parse_volume(
+                &urr->vol_threshold, &message->volume_threshold);
+        if (message->volume_threshold.len != decoded) {
+            ogs_error("Invalid Volume Threshold");
+            *cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT;
+            *offending_ie_value = OGS_PFCP_VOLUME_THRESHOLD_TYPE;
+            return NULL;
+        }
     }
 
     if (message->volume_quota.presence &&
         (urr->meas_method & OGS_PFCP_MEASUREMENT_METHOD_VOLUME)) {
-        ogs_pfcp_parse_volume(&urr->vol_quota, &message->volume_quota);
+        decoded = ogs_pfcp_parse_volume(
+                &urr->vol_quota, &message->volume_quota);
+        if (message->volume_quota.len != decoded) {
+            ogs_error("Invalid Volume Quota");
+            *cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT;
+            *offending_ie_value = OGS_PFCP_VOLUME_QUOTA_TYPE;
+            return NULL;
+        }
     }
 
     if (message->event_threshold.presence &&
@@ -1431,6 +1446,7 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_update_urr(ogs_pfcp_sess_t *sess,
         ogs_pfcp_tlv_update_urr_t *message,
         uint8_t *cause_value, uint8_t *offending_ie_value)
 {
+    int16_t decoded;
     ogs_pfcp_urr_t *urr = NULL;
 
     ogs_assert(message);
@@ -1469,12 +1485,26 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_update_urr(ogs_pfcp_sess_t *sess,
 
     if (message->volume_threshold.presence &&
         (urr->meas_method & OGS_PFCP_MEASUREMENT_METHOD_VOLUME)) {
-        ogs_pfcp_parse_volume(&urr->vol_threshold, &message->volume_threshold);
+        decoded = ogs_pfcp_parse_volume(
+                &urr->vol_threshold, &message->volume_threshold);
+        if (message->volume_threshold.len != decoded) {
+            ogs_error("Invalid Volume Threshold");
+            *cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT;
+            *offending_ie_value = OGS_PFCP_VOLUME_THRESHOLD_TYPE;
+            return NULL;
+        }
     }
 
     if (message->volume_quota.presence &&
         (urr->meas_method & OGS_PFCP_MEASUREMENT_METHOD_VOLUME)) {
-        ogs_pfcp_parse_volume(&urr->vol_quota, &message->volume_quota);
+        decoded = ogs_pfcp_parse_volume(
+                &urr->vol_quota, &message->volume_quota);
+        if (message->volume_quota.len != decoded) {
+            ogs_error("Invalid Volume Quota");
+            *cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT;
+            *offending_ie_value = OGS_PFCP_VOLUME_QUOTA_TYPE;
+            return NULL;
+        }
     }
 
     if (message->event_threshold.presence &&

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -518,12 +518,13 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_create_pdr(ogs_pfcp_sess_t *sess,
     if (message->pdi.network_instance.presence) {
         char dnn[OGS_MAX_DNN_LEN+1];
 
-        ogs_assert(0 < ogs_fqdn_parse(dnn,
-            message->pdi.network_instance.data,
-            ogs_min(message->pdi.network_instance.len, OGS_MAX_DNN_LEN)));
-
-        pdr->dnn = ogs_strdup(dnn);
-        ogs_assert(pdr->dnn);
+        if (ogs_fqdn_parse(dnn, message->pdi.network_instance.data,
+            ogs_min(message->pdi.network_instance.len, OGS_MAX_DNN_LEN)) > 0) {
+            pdr->dnn = ogs_strdup(dnn);
+            ogs_assert(pdr->dnn);
+        } else {
+            ogs_error("Invalid pdi.network_instance");
+        }
     }
 
     pdr->chid = false;
@@ -855,14 +856,16 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_update_pdr(ogs_pfcp_sess_t *sess,
         if (message->pdi.network_instance.presence) {
             char dnn[OGS_MAX_DNN_LEN+1];
 
-            ogs_assert(0 < ogs_fqdn_parse(dnn,
-                message->pdi.network_instance.data,
-                ogs_min(message->pdi.network_instance.len, OGS_MAX_DNN_LEN)));
-
-            if (pdr->dnn)
-                ogs_free(pdr->dnn);
-            pdr->dnn = ogs_strdup(dnn);
-            ogs_assert(pdr->dnn);
+            if (ogs_fqdn_parse(dnn, message->pdi.network_instance.data,
+                ogs_min(message->pdi.network_instance.len,
+                    OGS_MAX_DNN_LEN)) > 0) {
+                if (pdr->dnn)
+                    ogs_free(pdr->dnn);
+                pdr->dnn = ogs_strdup(dnn);
+                ogs_assert(pdr->dnn);
+            } else {
+                ogs_error("Invalid pdi.network_instance");
+            }
         }
 
         if (message->pdi.local_f_teid.presence) {
@@ -964,13 +967,15 @@ ogs_pfcp_far_t *ogs_pfcp_handle_create_far(ogs_pfcp_sess_t *sess,
         if (message->forwarding_parameters.network_instance.presence) {
             char dnn[OGS_MAX_DNN_LEN+1];
 
-            ogs_assert(0 < ogs_fqdn_parse(dnn,
+            if (ogs_fqdn_parse(dnn,
                 message->forwarding_parameters.network_instance.data,
-                    ogs_min(message->forwarding_parameters.network_instance.len,
-                        OGS_MAX_DNN_LEN)));
-
-            far->dnn = ogs_strdup(dnn);
-            ogs_assert(far->dnn);
+                ogs_min(message->forwarding_parameters.network_instance.len,
+                    OGS_MAX_DNN_LEN)) > 0) {
+                far->dnn = ogs_strdup(dnn);
+                ogs_assert(far->dnn);
+            } else {
+                ogs_error("Invalid forwarding_parameters.network_instance");
+            }
         }
 
         if (message->forwarding_parameters.outer_header_creation.presence) {
@@ -1069,15 +1074,18 @@ ogs_pfcp_far_t *ogs_pfcp_handle_update_far(ogs_pfcp_sess_t *sess,
         if (message->update_forwarding_parameters.network_instance.presence) {
             char dnn[OGS_MAX_DNN_LEN+1];
 
-            ogs_assert(0 < ogs_fqdn_parse(dnn,
+            if (ogs_fqdn_parse(dnn,
                 message->update_forwarding_parameters.network_instance.data,
-                    ogs_min(message->update_forwarding_parameters.
-                        network_instance.len, OGS_MAX_DNN_LEN)));
-
-            if (far->dnn)
-                ogs_free(far->dnn);
-            far->dnn = ogs_strdup(dnn);
-            ogs_assert(far->dnn);
+                ogs_min(message->update_forwarding_parameters.
+                    network_instance.len, OGS_MAX_DNN_LEN)) > 0) {
+                if (far->dnn)
+                    ogs_free(far->dnn);
+                far->dnn = ogs_strdup(dnn);
+                ogs_assert(far->dnn);
+            } else {
+                ogs_error("Invalid "
+                        "update_forwarding_parameters.network_instance");
+            }
         }
 
         if (message->update_forwarding_parameters.

--- a/lib/pfcp/types.c
+++ b/lib/pfcp/types.c
@@ -173,9 +173,11 @@ int16_t ogs_pfcp_parse_user_plane_ip_resource_info(
         int len = octet->len - size;
         if (info->assosi) len--;
 
-        ogs_assert(0 < ogs_fqdn_parse(
-                    info->network_instance, (char *)octet->data + size,
-                    ogs_min(len, OGS_MAX_APN_LEN)));
+        if (ogs_fqdn_parse(info->network_instance, (char *)octet->data + size,
+            ogs_min(len, OGS_MAX_APN_LEN)) <= 0) {
+            ogs_error("Invalid info->network_instance");
+            info->network_instance[0] = 0;
+        }
         size += len;
     }
 

--- a/lib/pfcp/types.c
+++ b/lib/pfcp/types.c
@@ -311,18 +311,32 @@ int16_t ogs_pfcp_parse_sdf_filter(
 
     memset(filter, 0, sizeof(ogs_pfcp_sdf_filter_t));
 
-    ogs_assert(size + sizeof(filter->flags) <= octet->len);
+    if (size + sizeof(filter->flags) > octet->len) {
+        ogs_error("size[%d]+sizeof(filter->flags)[%d] > IE Length[%d]",
+                size, (int)sizeof(filter->flags), octet->len);
+        return 0;
+    }
     memcpy(&filter->flags,
             (unsigned char *)octet->data + size, sizeof(filter->flags));
     size++;
 
-    ogs_assert(size + sizeof(filter->spare2) <= octet->len);
+    if (size + sizeof(filter->spare2) > octet->len) {
+        ogs_error("size[%d]+sizeof(filter->spare2)[%d] > IE Length[%d]",
+                size, (int)sizeof(filter->spare2), octet->len);
+        return 0;
+    }
     memcpy(&filter->spare2,
             (unsigned char *)octet->data + size, sizeof(filter->flags));
     size++;
 
     if (filter->fd) {
-        ogs_assert(size + sizeof(filter->flow_description_len) <= octet->len);
+        if (size + sizeof(filter->flow_description_len) > octet->len) {
+            ogs_error("size[%d]+sizeof(filter->flow_description_len)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(filter->flow_description_len),
+                    octet->len);
+            return 0;
+        }
         memcpy(&filter->flow_description_len,
                 (unsigned char *)octet->data + size,
                 sizeof(filter->flow_description_len));
@@ -334,7 +348,12 @@ int16_t ogs_pfcp_parse_sdf_filter(
     }
 
     if (filter->ttc) {
-        ogs_assert(size + sizeof(filter->tos_traffic_class) <= octet->len);
+        if (size + sizeof(filter->tos_traffic_class) > octet->len) {
+            ogs_error("size[%d]+sizeof(filter->tos_traffic_class)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(filter->tos_traffic_class), octet->len);
+            return 0;
+        }
         memcpy(&filter->tos_traffic_class,
                 (unsigned char *)octet->data + size,
                 sizeof(filter->tos_traffic_class));
@@ -343,8 +362,13 @@ int16_t ogs_pfcp_parse_sdf_filter(
     }
 
     if (filter->spi) {
-        ogs_assert(size + sizeof(filter->security_parameter_index) <=
-                octet->len);
+        if (size + sizeof(filter->security_parameter_index) > octet->len) {
+            ogs_error("size[%d]+sizeof(filter->security_parameter_index)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(filter->security_parameter_index),
+                    octet->len);
+            return 0;
+        }
         memcpy(&filter->security_parameter_index,
                 (unsigned char *)octet->data + size,
                 sizeof(filter->security_parameter_index));
@@ -355,7 +379,11 @@ int16_t ogs_pfcp_parse_sdf_filter(
 
     if (filter->fl) {
         int bit24_len = 3;
-        ogs_assert(size + bit24_len <= octet->len);
+        if (size + bit24_len > octet->len) {
+            ogs_error("size[%d]+bit24_len[%d] > IE Length[%d]",
+                    size, bit24_len, octet->len);
+            return 0;
+        }
         memcpy(&filter->flow_label,
                 (unsigned char *)octet->data + size, bit24_len);
         filter->flow_label = be32toh(filter->flow_label);
@@ -363,14 +391,20 @@ int16_t ogs_pfcp_parse_sdf_filter(
     }
 
     if (filter->bid) {
-        ogs_assert(size + sizeof(filter->sdf_filter_id) <= octet->len);
+        if (size + sizeof(filter->sdf_filter_id) > octet->len) {
+            ogs_error("size[%d]+sizeof(filter->sdf_filter_id)[%d]"
+                    "> IE Length[%d]",
+                    size, (int)sizeof(filter->sdf_filter_id), octet->len);
+            return 0;
+        }
         memcpy(&filter->sdf_filter_id, (unsigned char *)octet->data + size,
                 sizeof(filter->sdf_filter_id));
         filter->sdf_filter_id = be32toh(filter->sdf_filter_id);
         size += sizeof(filter->sdf_filter_id);
     }
 
-    ogs_assert(size == octet->len);
+    if (size != octet->len)
+        ogs_error("Mismatch IE Length[%d] != Decoded[%d]", octet->len, size);
 
     return size;
 }

--- a/lib/pfcp/types.c
+++ b/lib/pfcp/types.c
@@ -542,25 +542,44 @@ int16_t ogs_pfcp_parse_volume(
     size += sizeof(volume->flags);
 
     if (volume->tovol) {
+        if (size + sizeof(volume->total_volume) > octet->len) {
+            ogs_error("size[%d]+sizeof(volume->total_volume)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(volume->total_volume), octet->len);
+            return 0;
+        }
         memcpy(&volume->total_volume, (unsigned char *)octet->data + size,
                 sizeof(volume->total_volume));
         volume->total_volume = be64toh(volume->total_volume);
         size += sizeof(volume->total_volume);
     }
     if (volume->ulvol) {
+        if (size + sizeof(volume->uplink_volume) > octet->len) {
+            ogs_error("size[%d]+sizeof(volume->uplink_volume)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(volume->uplink_volume), octet->len);
+            return 0;
+        }
         memcpy(&volume->uplink_volume, (unsigned char *)octet->data + size,
                 sizeof(volume->uplink_volume));
         volume->uplink_volume = be64toh(volume->uplink_volume);
         size += sizeof(volume->uplink_volume);
     }
     if (volume->dlvol) {
+        if (size + sizeof(volume->downlink_volume) > octet->len) {
+            ogs_error("size[%d]+sizeof(volume->downlink_volume)[%d] "
+                    "> IE Length[%d]",
+                    size, (int)sizeof(volume->downlink_volume), octet->len);
+            return 0;
+        }
         memcpy(&volume->downlink_volume, (unsigned char *)octet->data + size,
                 sizeof(volume->downlink_volume));
         volume->downlink_volume = be64toh(volume->downlink_volume);
         size += sizeof(volume->downlink_volume);
     }
 
-    ogs_assert(size == octet->len);
+    if (size != octet->len)
+        ogs_error("Mismatch IE Length[%d] != Decoded[%d]", octet->len, size);
 
     return size;
 }

--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -419,8 +419,8 @@ int ogs_fqdn_parse(char *dst, const char *src, int length)
     while (i+1 < length) {
         len = src[i++];
         if ((j + len + 1) > length) {
-            ogs_error("Invalid FQDN encoding[len:%d] + 1 > length[%d]",
-                    len, length);
+            ogs_error("Invalid FQDN encoding[j:%d+len:%d] + 1 > length[%d]",
+                    j, len, length);
             ogs_log_hexdump(OGS_LOG_ERROR, (unsigned char *)src, length);
             return 0;
         }

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -332,9 +332,11 @@ void sgsap_handle_paging_request(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
             nas_mobile_identity_imsi_len = iter->length;
             break;
         case SGSAP_IE_VLR_NAME_TYPE:
-            ogs_assert(0 < ogs_fqdn_parse(
-                    vlr_name, iter->value,
-                    ogs_min(iter->length, SGSAP_IE_VLR_NAME_LEN)));
+            if (ogs_fqdn_parse(vlr_name, iter->value,
+                ogs_min(iter->length, SGSAP_IE_VLR_NAME_LEN)) <= 0) {
+                ogs_error("Invalid VLR-Name");
+                return;
+            }
             break;
         case SGSAP_IE_LAI_TYPE:
             lai = iter->value;

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -203,6 +203,12 @@ void sgwc_s11_handle_create_session_request(
     if (req->access_point_name.presence == 0) {
         ogs_error("No APN");
         cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
+    } else {
+        if (ogs_fqdn_parse(apn, req->access_point_name.data,
+            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN)) <= 0) {
+            ogs_error("Invalid APN");
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
+        }
     }
     if (req->sender_f_teid_for_control_plane.presence == 0) {
         ogs_error("No Sender F-TEID");
@@ -221,9 +227,6 @@ void sgwc_s11_handle_create_session_request(
     }
 
     /* Add Session */
-    ogs_assert(0 < ogs_fqdn_parse(apn,
-            req->access_point_name.data,
-            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN)));
     sess = sgwc_sess_find_by_ebi(sgwc_ue,
             req->bearer_contexts_to_be_created[0].eps_bearer_id.u8);
     if (sess) {

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -242,21 +242,22 @@ void sgwc_s11_handle_create_session_request(
     /* Set User Location Information */
     if (req->user_location_information.presence == 1) {
         decoded = ogs_gtp2_parse_uli(&uli, &req->user_location_information);
-        ogs_assert(req->user_location_information.len == decoded);
+        if (req->user_location_information.len == decoded) {
+            sgwc_ue->uli_presence = true;
 
-        sgwc_ue->uli_presence = true;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
+            sgwc_ue->e_tai.tac = uli.tai.tac;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
+            sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
 
-        ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
-        sgwc_ue->e_tai.tac = uli.tai.tac;
-        ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
-        sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
-
-        ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
-                sgwc_ue->e_tai.tac);
-        ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
-                sgwc_ue->e_cgi.cell_id);
+            ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
+                    sgwc_ue->e_tai.tac);
+            ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
+                    sgwc_ue->e_cgi.cell_id);
+        } else
+            ogs_error("Invalid User Location Info(ULI)");
     }
 
     /* Select SGW-U based on UE Location Information */
@@ -542,21 +543,22 @@ void sgwc_s11_handle_modify_bearer_request(
 
     if (req->user_location_information.presence == 1) {
         decoded = ogs_gtp2_parse_uli(&uli, &req->user_location_information);
-        ogs_assert(req->user_location_information.len == decoded);
+        if (req->user_location_information.len == decoded) {
+            sgwc_ue->uli_presence = true;
 
-        sgwc_ue->uli_presence = true;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
+            sgwc_ue->e_tai.tac = uli.tai.tac;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
+            sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
 
-        ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
-        sgwc_ue->e_tai.tac = uli.tai.tac;
-        ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
-        sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
-
-        ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
-                sgwc_ue->e_tai.tac);
-        ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
-                sgwc_ue->e_cgi.cell_id);
+            ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
+                    sgwc_ue->e_tai.tac);
+            ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
+                    sgwc_ue->e_cgi.cell_id);
+        } else
+            ogs_error("Invalid User Location Info(ULI)");
     }
 
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
@@ -845,21 +847,22 @@ void sgwc_s11_handle_create_bearer_response(
 
     if (rsp->user_location_information.presence == 1) {
         decoded = ogs_gtp2_parse_uli(&uli, &rsp->user_location_information);
-        ogs_assert(rsp->user_location_information.len == decoded);
+        if (rsp->user_location_information.len == decoded) {
+            sgwc_ue->uli_presence = true;
 
-        sgwc_ue->uli_presence = true;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
+            sgwc_ue->e_tai.tac = uli.tai.tac;
+            ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
+            sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
 
-        ogs_nas_to_plmn_id(&sgwc_ue->e_tai.plmn_id, &uli.tai.nas_plmn_id);
-        sgwc_ue->e_tai.tac = uli.tai.tac;
-        ogs_nas_to_plmn_id(&sgwc_ue->e_cgi.plmn_id, &uli.e_cgi.nas_plmn_id);
-        sgwc_ue->e_cgi.cell_id = uli.e_cgi.cell_id;
-
-        ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
-                sgwc_ue->e_tai.tac);
-        ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
-                ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
-                sgwc_ue->e_cgi.cell_id);
+            ogs_debug("    TAI[PLMN_ID:%06x,TAC:%d]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_tai.plmn_id),
+                    sgwc_ue->e_tai.tac);
+            ogs_debug("    E_CGI[PLMN_ID:%06x,CELL_ID:0x%x]",
+                    ogs_plmn_id_hexdump(&sgwc_ue->e_cgi.plmn_id),
+                    sgwc_ue->e_cgi.cell_id);
+        } else
+            ogs_error("Invalid User Location Info(ULI)");
     }
 
     ogs_assert(OGS_OK ==

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -252,6 +252,10 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
         ogs_error("No CP F-SEID");
         return NULL;
     }
+    if (f_seid->ipv4 == 0 && f_seid->ipv6 == 0) {
+        ogs_error("No IPv4 or IPv6");
+        return NULL;
+    }
     f_seid->seid = be64toh(f_seid->seid);
 
     sess = sgwu_sess_find_by_sgwc_sxa_f_seid(f_seid);

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1278,7 +1278,14 @@ smf_sess_t *smf_sess_add_by_gtp1_message(ogs_gtp1_message_t *message)
     if (req->access_point_name.presence == 0) {
         ogs_error("No APN");
         return NULL;
+    } else {
+        if (ogs_fqdn_parse(apn, req->access_point_name.data,
+            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN)) <= 0) {
+            ogs_error("Invalid APN");
+            return NULL;
+        }
     }
+
     if (req->sgsn_address_for_signalling.presence == 0) {
         ogs_error("No SGSN Address for signalling");
         return NULL;
@@ -1293,12 +1300,6 @@ smf_sess_t *smf_sess_add_by_gtp1_message(ogs_gtp1_message_t *message)
     }
     if (req->rat_type.presence == 0) {
         ogs_error("No RAT Type");
-        return NULL;
-    }
-
-    if ((ogs_fqdn_parse(apn, req->access_point_name.data,
-            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN+1))) <= 0) {
-        ogs_error("No APN");
         return NULL;
     }
 
@@ -1349,14 +1350,17 @@ smf_sess_t *smf_sess_add_by_gtp2_message(ogs_gtp2_message_t *message)
     if (req->access_point_name.presence == 0) {
         ogs_error("No APN");
         return NULL;
+    } else {
+        if (ogs_fqdn_parse(apn, req->access_point_name.data,
+            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN)) <= 0) {
+            ogs_error("Invalid APN");
+            return NULL;
+        }
     }
     if (req->rat_type.presence == 0) {
         ogs_error("No RAT Type");
         return NULL;
     }
-
-    ogs_assert(0 < ogs_fqdn_parse(apn, req->access_point_name.data,
-            ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN)));
 
     ogs_trace("smf_sess_add_by_message() [APN:%s]", apn);
 

--- a/src/smf/fd-path.c
+++ b/src/smf/fd-path.c
@@ -100,7 +100,10 @@ void smf_fd_msg_avp_add_3gpp_uli(smf_sess_t *sess, struct msg *req)
     /* GTPv2C and Diameter 3GPP-User-Location-Information encoding don't match */
     uli_len = ogs_gtp2_parse_uli(
             &uli, &sess->gtp.user_location_information);
-    ogs_assert(sess->gtp.user_location_information.len == uli_len);
+    if (sess->gtp.user_location_information.len != uli_len) {
+        ogs_error("Invalid User Location Information(ULI)");
+        return;
+    }
 
     ogs_assert(sess->gtp.user_location_information.data);
     ogs_assert(sess->gtp.user_location_information.len);

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -207,7 +207,15 @@ uint8_t smf_s5c_handle_create_session_request(
     if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_EUTRAN) {
         /* User Location Inforation is mandatory only for E-UTRAN */
         ogs_assert(req->user_location_information.presence);
-        ogs_gtp2_parse_uli(&uli, &req->user_location_information);
+        if (req->user_location_information.presence == 0) {
+            ogs_error("No User Location Information(ULI)");
+            return OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
+        }
+        decoded = ogs_gtp2_parse_uli(&uli, &req->user_location_information);
+        if (req->user_location_information.len != decoded) {
+            ogs_error("Invalid User Location Information(ULI)");
+            return OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;
+        }
         memcpy(&sess->e_tai, &uli.tai, sizeof(sess->e_tai));
         memcpy(&sess->e_cgi, &uli.e_cgi, sizeof(sess->e_cgi));
 

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -365,6 +365,10 @@ upf_sess_t *upf_sess_add_by_message(ogs_pfcp_message_t *message)
         ogs_error("No CP F-SEID");
         return NULL;
     }
+    if (f_seid->ipv4 == 0 && f_seid->ipv6 == 0) {
+        ogs_error("No IPv4 or IPv6");
+        return NULL;
+    }
     f_seid->seid = be64toh(f_seid->seid);
 
     sess = upf_sess_find_by_smf_n4_f_seid(f_seid);

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -107,8 +107,12 @@ void upf_n4_handle_session_establishment_request(
     if (req->apn_dnn.presence) {
         char apn_dnn[OGS_MAX_DNN_LEN+1];
 
-        ogs_assert(0 < ogs_fqdn_parse(apn_dnn, req->apn_dnn.data,
-                ogs_min(req->apn_dnn.len, OGS_MAX_DNN_LEN)));
+        if (ogs_fqdn_parse(apn_dnn, req->apn_dnn.data,
+            ogs_min(req->apn_dnn.len, OGS_MAX_DNN_LEN)) <= 0) {
+            ogs_error("Invalid APN");
+            cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_INCORRECT;
+            goto cleanup;
+        }
 
         if (sess->apn_dnn)
             ogs_free(sess->apn_dnn);


### PR DESCRIPTION

1. UPF
- upf_sess_find_by_smf_n4_f_seid: Assertion `OGS_OK == ogs_pfcp_f_seid_to_ip(f_seid, &key.ip)' failed. (../src/upf/context.c:280)
- ogs_pfcp_parse_sdf_filter in ../lib/pfcp/types.c
- ogs_pfcp_parse_volume in ../lib/pfcp/types.c:500

2. SGW-C
- sgwc_s11_handle_create_session_request: Assertion `0 < ogs_fqdn_parse(apn, req->access_point_name.data, ogs_min(req->access_point_name.len, OGS_MAX_APN_LEN))' failed. (../src/sgwc/s11-handler.c:224)
- ogs_gtp2_parse_uli in ../lib/gtp/v2/types.c

3. SMF
- ogs_pfcp_parse_user_plane_ip_resource_info in ../lib/pfcp/types.c