### PR TITLE
[AMF] Fix for storing 5G AKA Confirmation URL

### DIFF
--- a/src/amf/nausf-handler.c
+++ b/src/amf/nausf-handler.c
@@ -133,7 +133,7 @@ int amf_nausf_auth_handle_authenticate(
     ogs_freeaddrinfo(addr);
     ogs_freeaddrinfo(addr6);
 
-    STORE_5G_AKA_CONFIRMATION(amf_ue, message->http.location);
+    STORE_5G_AKA_CONFIRMATION(amf_ue, LinksValueSchemeValue->href);
 
     ogs_ascii_to_hex(AV5G_AKA->rand, strlen(AV5G_AKA->rand),
         amf_ue->rand, sizeof(amf_ue->rand));


### PR DESCRIPTION
HTTP Location header field does not contain the "5g-aka-confirmation" substring. Which means that when we try to delete the authentication from AUSF, it does not provide the correct URL according to the standard.

/nausf-auth/v1/ue-authentications/1
vs
/nausf-auth/v1/ue-authentications/1/5g-aka-confirmation


The current code/unit tests work without an issue due to laxed requirement in AUSF for deleting the authentication. AUSF checks for only the DELETE HTTP method and `ue-authentications` URL component, without checking for the `5g-aka-confirmation` URL component.
