### PR TITLE
[log] Enable domain based level configuration

### DIFF
--- a/lib/core/ogs-log.c
+++ b/lib/core/ogs-log.c
@@ -111,6 +111,8 @@ static char *log_linefeed(char *buf, char *last);
 static void file_writer(
         ogs_log_t *log, ogs_log_level_e level, const char *string);
 
+static ogs_log_level_e ogs_log_level_from_string(const char *string);
+
 void ogs_log_init(void)
 {
     ogs_pool_init(&log_pool, ogs_core()->log.pool);
@@ -314,6 +316,7 @@ void ogs_log_install_domain(int *domain_id,
 void ogs_log_set_mask_level(const char *_mask, ogs_log_level_e level)
 {
     ogs_log_domain_t *domain = NULL;
+    ogs_log_domain_t *save_domain = NULL;
 
     if (_mask) {
         const char *delim = " \t\n,:";
@@ -330,7 +333,22 @@ void ogs_log_set_mask_level(const char *_mask, ogs_log_level_e level)
 
             domain = ogs_log_find_domain(name);
             if (domain)
+            {
                 domain->level = level;
+                save_domain = domain;
+            } else {
+                int l;
+
+                l = ogs_log_level_from_string(name);
+                if (l != OGS_ERROR) {
+                    if (save_domain) {
+                        if (l != save_domain->level) {
+                            save_domain->level = l;
+                        }
+                    }
+                }
+                save_domain = NULL;
+            }
         }
 
         ogs_free(mask);


### PR DESCRIPTION
Existing behavior:

All the installed domains get the INFO default level initially (OGS_LOG_DEFAULT = OGS_LOG_INFO).

At startup the configured level is considered:
- for all domains if there is no domain specified,
- for listed domains only;

Domain based level configuration:

Each listed domain under domain section can have a specific level defined.

Example of domain configuration for AMF:
```
logger:
  level: trace
  domain: "core:fatal, sbi:error, amf, dbi:debug"
```
Causes the following levels:
- core: fatal
- mem: info - not listed, so the default is used!
- sock: info
- event: info
- thread: info
- tlv: info
- app: info
- metrics: info
- sbi: error
- sctp: info
- ngap: info
- nas: info
- amf: trace - the level is not specified, so the top level is inherited!
- gmm: info
- dbi: debug

Legal delimiters are " \t\n,:". All of them can be used, but for the sake of clarity, ":" is recommended to separate module and its level.

Installing a new domain with the name equal to one of the levels would disable this level from being configured per domain.