### PR TITLE
[MME,SMF]: allow setting of diameter TC_TIMER

### DIFF
--- a/lib/diameter/common/base.h
+++ b/lib/diameter/common/base.h
@@ -43,6 +43,9 @@ typedef struct ogs_diam_config_s {
     /* the local port for Diameter/TLS (default: 5658) in host byte order */
     uint16_t cnf_port_tls;
 
+    /* default TC timer */
+    int cnf_timer_tc;
+
     struct {
         /* the peer does not relay messages (0xffffff app id) */
         unsigned no_fwd: 1;
@@ -64,6 +67,7 @@ typedef struct ogs_diam_config_s {
         const char *identity;
         const char *addr; /* IP address of the remote peer */
         uint16_t port; /* port to connect to. 0: default. */
+        int tc_timer; /* TcTimer value to use for this peer, use default if 0 */
     } conn[MAX_NUM_OF_FD_CONN];
     int num_of_conn;
 } ogs_diam_config_t;

--- a/lib/diameter/common/config.c
+++ b/lib/diameter/common/config.c
@@ -69,6 +69,9 @@ static int diam_config_apply(ogs_diam_config_t *fd_config)
     if (fd_config->cnf_flags.no_fwd)
         fd_g_config->cnf_flags.no_fwd = fd_config->cnf_flags.no_fwd;
 
+    if (fd_config->cnf_timer_tc)
+        fd_g_config->cnf_timer_tc = fd_config->cnf_timer_tc;
+
     /********************************************************************
      * Diameter Client
      */
@@ -85,6 +88,8 @@ static int diam_config_apply(ogs_diam_config_t *fd_config)
         fddpi.config.pic_flags.pro4 = PI_P4_DEFAULT;
         fddpi.config.pic_flags.alg = PI_ALGPREF_SCTP;
         fddpi.config.pic_flags.sec |= PI_SEC_NONE;
+
+        fddpi.config.pic_tctimer = fd_config->conn[i].tc_timer;
 
         fddpi.config.pic_port = fd_config->conn[i].port;
         fddpi.pi_diamid = (DiamId_t)fd_config->conn[i].identity;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -508,6 +508,7 @@ int mme_context_parse_config(void)
                                     const char *identity = NULL;
                                     const char *addr = NULL;
                                     uint16_t port = 0;
+                                    int tc_timer = 0;
 
                                     if (ogs_yaml_iter_type(&conn_array) ==
                                         YAML_MAPPING_NODE) {
@@ -540,6 +541,10 @@ int mme_context_parse_config(void)
                                             const char *v =
                                                 ogs_yaml_iter_value(&conn_iter);
                                             if (v) port = atoi(v);
+                                        } else if (!strcmp(conn_key, "tc_timer")) {
+                                            const char *v =
+                                                ogs_yaml_iter_value(&conn_iter);
+                                            if (v) tc_timer = atoi(v);
                                         } else
                                             ogs_warn("unknown key `%s`",
                                                     conn_key);
@@ -555,10 +560,16 @@ int mme_context_parse_config(void)
                                         self.diam_config->
                                             conn[self.diam_config->num_of_conn].
                                                 port = port;
+                                        self.diam_config->
+                                            conn[self.diam_config->num_of_conn].
+                                                tc_timer = tc_timer;
                                         self.diam_config->num_of_conn++;
                                     }
                                 } while (ogs_yaml_iter_type(&conn_array) ==
                                         YAML_SEQUENCE_NODE);
+                            } else if (!strcmp(fd_key, "tc_timer")) {
+                                const char *v = ogs_yaml_iter_value(&fd_iter);
+                                if (v) self.diam_config->cnf_timer_tc = atoi(v);
                             } else
                                 ogs_warn("unknown key `%s`", fd_key);
                         }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -398,6 +398,7 @@ int smf_context_parse_config(void)
                                     const char *identity = NULL;
                                     const char *addr = NULL;
                                     uint16_t port = 0;
+                                    int tc_timer = 0;
 
                                     if (ogs_yaml_iter_type(&conn_array) ==
                                         YAML_MAPPING_NODE) {
@@ -430,6 +431,10 @@ int smf_context_parse_config(void)
                                             const char *v =
                                                 ogs_yaml_iter_value(&conn_iter);
                                             if (v) port = atoi(v);
+                                        } else if (!strcmp(conn_key, "tc_timer")) {
+                                            const char *v =
+                                                ogs_yaml_iter_value(&conn_iter);
+                                            if (v) tc_timer = atoi(v);
                                         } else
                                             ogs_warn("unknown key `%s`",
                                                     conn_key);
@@ -445,10 +450,16 @@ int smf_context_parse_config(void)
                                         self.diam_config->
                                             conn[self.diam_config->num_of_conn].
                                                 port = port;
+                                        self.diam_config->
+                                            conn[self.diam_config->num_of_conn].
+                                                tc_timer = tc_timer;
                                         self.diam_config->num_of_conn++;
                                     }
                                 } while (ogs_yaml_iter_type(&conn_array) ==
                                         YAML_SEQUENCE_NODE);
+                            } else if (!strcmp(fd_key, "tc_timer")) {
+                                const char *v = ogs_yaml_iter_value(&fd_iter);
+                                if (v) self.diam_config->cnf_timer_tc = atoi(v);
                             } else
                                 ogs_warn("unknown key `%s`", fd_key);
                         }


### PR DESCRIPTION
... via the YAML configuration

NOTE: when upgrading to 2.7.1 we noticed a change in behavior, where if the MME/SMF are started before their respective diameter peers, a connection will not be attempted again until the TcTimer expires, regardless of having new messages to deliver; and since the default value is 30 seconds, this becomes quite noticeable.

The timer can be set in the freediameter .conf file, but we prefer to use the yaml configuration, and this particular option was not exposed, so we added it. It would probably be a good idea to move the common freediameter parsing part to a separate library function rather than copy+pasting it in each daemon, but I did not want to make the pull request bigger than it strictly needed to be.