### PR TITLE
[AMF] Fix Allowed NSSAI/SD if SST 0 is used

### DIFF
--- a/lib/nas/5gs/types.c
+++ b/lib/nas/5gs/types.c
@@ -128,8 +128,7 @@ void ogs_nas_build_s_nssai(
 
     pos = 0;
 
-    if (nas_s_nssai_ie->sst)
-        nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->sst;
+    nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->sst;
 
     if (nas_s_nssai_ie->sd.v != OGS_S_NSSAI_NO_SD_VALUE ||
 


### PR DESCRIPTION
Properly encode Allowed NSSAI/SD in Registration
accept if SST 0 is used.

Solves: [#3295](https://github.com/open5gs/open5gs/issues/3295)

Trace: [SST0SD7_proper_SDvalueInRegistrationAcceptFromAMF.zip](https://github.com/user-attachments/files/16024501/SST0SD7_proper_SDvalueInRegistrationAcceptFromAMF.zip)
