### PR TITLE
[POOL] REMOVE ogs_pool_cycle() (#3196)

### DIFF
--- a/lib/core/ogs-macros.h
+++ b/lib/core/ogs-macros.h
@@ -222,6 +222,9 @@ static ogs_inline ogs_uint24_t ogs_htobe24(ogs_uint24_t x)
     ((__oBJ)->reference_count)--
 #define OGS_OBJECT_IS_REF(__oBJ) ((__oBJ)->reference_count > 1)
 
+#define OGS_POINTER_TO_UINT(u) ((uintptr_t)(u))
+#define OGS_UINT_TO_POINTER(u) ((void *)(uintptr_t)(u))
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -165,6 +165,8 @@ typedef int32_t ogs_pool_id_t;
 } while (0)
 
 #define ogs_pool_id_free(pool, node) do { \
+    ogs_assert(((node)->id) >= OGS_MIN_POOL_ID && \
+            ((node)->id) <= OGS_MAX_POOL_ID); \
     ogs_hash_set((pool)->id_hash, \
             &((node)->id), sizeof(ogs_pool_id_t), NULL); \
     ogs_pool_free(pool, node); \

--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+#define OGS_INVALID_POOL_ID 0
 #define OGS_MIN_POOL_ID     1
 #define OGS_MAX_POOL_ID     0x7fffffff
 

--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -152,8 +152,6 @@ typedef int32_t ogs_pool_id_t;
 #define ogs_pool_index(pool, node) (((node) - (pool)->array)+1)
 #define ogs_pool_find(pool, _index) \
     (_index > 0 && _index <= (pool)->size) ? (pool)->index[_index-1] : NULL
-#define ogs_pool_cycle(pool, node) \
-    ogs_pool_find((pool), ogs_pool_index((pool), (node)))
 
 #define ogs_pool_id_calloc(pool, node) do { \
     ogs_pool_alloc(pool, node); \

--- a/lib/core/ogs-timer.c
+++ b/lib/core/ogs-timer.c
@@ -73,12 +73,6 @@ void ogs_timer_mgr_destroy(ogs_timer_mgr_t *manager)
     ogs_free(manager);
 }
 
-static ogs_timer_t *ogs_timer_cycle(ogs_timer_mgr_t *manager, ogs_timer_t *timer)
-{
-    ogs_assert(manager);
-    return ogs_pool_cycle(&manager->pool, timer);
-}
-
 ogs_timer_t *ogs_timer_add(
         ogs_timer_mgr_t *manager, void (*cb)(void *data), void *data)
 {
@@ -106,11 +100,6 @@ void ogs_timer_delete_debug(ogs_timer_t *timer, const char *file_line)
     ogs_assert(timer);
     manager = timer->manager;
     ogs_assert(manager);
-    timer = ogs_timer_cycle(manager, timer);
-    if (!timer) {
-        ogs_fatal("ogs_timer_delete() failed in %s", file_line);
-        ogs_assert_if_reached();
-    }
 
     ogs_timer_stop(timer);
 
@@ -126,11 +115,6 @@ void ogs_timer_start_debug(
 
     manager = timer->manager;
     ogs_assert(manager);
-    timer = ogs_timer_cycle(manager, timer);
-    if (!timer) {
-        ogs_fatal("ogs_timer_start() failed in %s", file_line);
-        ogs_assert_if_reached();
-    }
 
     if (timer->running == true)
         ogs_rbtree_delete(&manager->tree, timer);
@@ -145,11 +129,6 @@ void ogs_timer_stop_debug(ogs_timer_t *timer, const char *file_line)
     ogs_assert(timer);
     manager = timer->manager;
     ogs_assert(manager);
-    timer = ogs_timer_cycle(manager, timer);
-    if (!timer) {
-        ogs_fatal("ogs_timer_stop() failed in %s", file_line);
-        ogs_assert_if_reached();
-    }
 
     if (timer->running == false)
         return;

--- a/lib/gtp/xact.c
+++ b/lib/gtp/xact.c
@@ -1131,11 +1131,11 @@ void ogs_gtp_xact_associate(ogs_gtp_xact_t *xact1, ogs_gtp_xact_t *xact2)
     ogs_assert(xact1);
     ogs_assert(xact2);
 
-    ogs_assert(xact1->assoc_xact == NULL);
-    ogs_assert(xact2->assoc_xact == NULL);
+    ogs_assert(xact1->assoc_xact_id == OGS_INVALID_POOL_ID);
+    ogs_assert(xact2->assoc_xact_id == OGS_INVALID_POOL_ID);
 
-    xact1->assoc_xact = xact2;
-    xact2->assoc_xact = xact1;
+    xact1->assoc_xact_id = xact2->id;
+    xact2->assoc_xact_id = xact1->id;
 }
 
 void ogs_gtp_xact_deassociate(ogs_gtp_xact_t *xact1, ogs_gtp_xact_t *xact2)
@@ -1143,16 +1143,17 @@ void ogs_gtp_xact_deassociate(ogs_gtp_xact_t *xact1, ogs_gtp_xact_t *xact2)
     ogs_assert(xact1);
     ogs_assert(xact2);
 
-    ogs_assert(xact1->assoc_xact != NULL);
-    ogs_assert(xact2->assoc_xact != NULL);
+    ogs_assert(xact1->assoc_xact_id != OGS_INVALID_POOL_ID);
+    ogs_assert(xact2->assoc_xact_id != OGS_INVALID_POOL_ID);
 
-    xact1->assoc_xact = NULL;
-    xact2->assoc_xact = NULL;
+    xact1->assoc_xact_id = OGS_INVALID_POOL_ID;
+    xact2->assoc_xact_id = OGS_INVALID_POOL_ID;
 }
 
 static int ogs_gtp_xact_delete(ogs_gtp_xact_t *xact)
 {
     char buf[OGS_ADDRSTRLEN];
+    ogs_gtp_xact_t *assoc_xact = NULL;
 
     ogs_assert(xact);
     ogs_assert(xact->gnode);
@@ -1175,8 +1176,9 @@ static int ogs_gtp_xact_delete(ogs_gtp_xact_t *xact)
     if (xact->tm_holding)
         ogs_timer_delete(xact->tm_holding);
 
-    if (xact->assoc_xact)
-        ogs_gtp_xact_deassociate(xact, xact->assoc_xact);
+    assoc_xact = ogs_gtp_xact_find_by_id(xact->assoc_xact_id);
+    if (assoc_xact)
+        ogs_gtp_xact_deassociate(xact, assoc_xact);
 
     ogs_list_remove(xact->org == OGS_GTP_LOCAL_ORIGINATOR ?
             &xact->gnode->local_list : &xact->gnode->remote_list, xact);

--- a/lib/gtp/xact.c
+++ b/lib/gtp/xact.c
@@ -75,9 +75,8 @@ ogs_gtp_xact_t *ogs_gtp1_xact_local_create(ogs_gtp_node_t *gnode,
     ogs_assert(gnode);
     ogs_assert(hdesc);
 
-    ogs_pool_alloc(&pool, &xact);
+    ogs_pool_id_calloc(&pool, &xact);
     ogs_assert(xact);
-    memset(xact, 0, sizeof *xact);
     xact->index = ogs_pool_index(&pool, xact);
 
     xact->gtp_version = 1;
@@ -131,9 +130,8 @@ ogs_gtp_xact_t *ogs_gtp_xact_local_create(ogs_gtp_node_t *gnode,
     ogs_assert(gnode);
     ogs_assert(hdesc);
 
-    ogs_pool_alloc(&pool, &xact);
+    ogs_pool_id_calloc(&pool, &xact);
     ogs_assert(xact);
-    memset(xact, 0, sizeof *xact);
     xact->index = ogs_pool_index(&pool, xact);
 
     xact->gtp_version = 2;
@@ -184,9 +182,8 @@ static ogs_gtp_xact_t *ogs_gtp_xact_remote_create(ogs_gtp_node_t *gnode, uint8_t
 
     ogs_assert(gnode);
 
-    ogs_pool_alloc(&pool, &xact);
+    ogs_pool_id_calloc(&pool, &xact);
     ogs_assert(xact);
-    memset(xact, 0, sizeof *xact);
     xact->index = ogs_pool_index(&pool, xact);
 
     xact->gtp_version = gtp_version;
@@ -216,9 +213,9 @@ static ogs_gtp_xact_t *ogs_gtp_xact_remote_create(ogs_gtp_node_t *gnode, uint8_t
     return xact;
 }
 
-ogs_gtp_xact_t *ogs_gtp_xact_cycle(ogs_gtp_xact_t *xact)
+ogs_gtp_xact_t *ogs_gtp_xact_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&pool, xact);
+    return ogs_pool_find_by_id(&pool, id);
 }
 
 void ogs_gtp_xact_delete_all(ogs_gtp_node_t *gnode)
@@ -1183,7 +1180,7 @@ static int ogs_gtp_xact_delete(ogs_gtp_xact_t *xact)
 
     ogs_list_remove(xact->org == OGS_GTP_LOCAL_ORIGINATOR ?
             &xact->gnode->local_list : &xact->gnode->remote_list, xact);
-    ogs_pool_free(&pool, xact);
+    ogs_pool_id_free(&pool, xact);
 
     return OGS_OK;
 }

--- a/lib/gtp/xact.h
+++ b/lib/gtp/xact.h
@@ -112,7 +112,7 @@ typedef struct ogs_gtp_xact_s {
     uint32_t        local_teid;     /**< Local TEID,
                                          expected in reply from peer */
 
-    void            *assoc_xact;    /**< Associated GTP transaction */
+    ogs_pool_id_t   assoc_xact_id;  /**< Associated GTP transaction ID */
     void            *pfcp_xact;     /**< Associated PFCP transaction */
 
 #define OGS_GTP_MODIFY_TFT_UPDATE ((uint64_t)1<<0)

--- a/lib/gtp/xact.h
+++ b/lib/gtp/xact.h
@@ -59,6 +59,8 @@ extern "C" {
 typedef struct ogs_gtp_xact_s {
     ogs_lnode_t     node;           /**< A node of list */
 
+    ogs_pool_id_t   id;
+
     /*
      * Issues #3240
      *
@@ -159,7 +161,7 @@ ogs_gtp_xact_t *ogs_gtp_xact_local_create(ogs_gtp_node_t *gnode,
         ogs_gtp2_header_t *hdesc, ogs_pkbuf_t *pkbuf,
         void (*cb)(ogs_gtp_xact_t *xact, void *data), void *data);
 
-ogs_gtp_xact_t *ogs_gtp_xact_cycle(ogs_gtp_xact_t *xact);
+ogs_gtp_xact_t *ogs_gtp_xact_find_by_id(ogs_pool_id_t id);
 void ogs_gtp_xact_delete_all(ogs_gtp_node_t *gnode);
 
 int ogs_gtp1_xact_update_tx(ogs_gtp_xact_t *xact,

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -873,11 +873,6 @@ ogs_pfcp_node_t *ogs_pfcp_node_new(ogs_sockaddr_t *sa_list)
     return node;
 }
 
-ogs_pfcp_node_t *ogs_pfcp_node_cycle(ogs_pfcp_node_t *node)
-{
-    return ogs_pool_cycle(&ogs_pfcp_node_pool, node);
-}
-
 void ogs_pfcp_node_free(ogs_pfcp_node_t *node)
 {
     ogs_assert(node);

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -393,7 +393,6 @@ ogs_pfcp_context_t *ogs_pfcp_self(void);
 int ogs_pfcp_context_parse_config(const char *local, const char *remote);
 
 ogs_pfcp_node_t *ogs_pfcp_node_new(ogs_sockaddr_t *sa_list);
-ogs_pfcp_node_t *ogs_pfcp_node_cycle(ogs_pfcp_node_t *node);
 void ogs_pfcp_node_free(ogs_pfcp_node_t *node);
 
 ogs_pfcp_node_t *ogs_pfcp_node_add(

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -75,9 +75,8 @@ ogs_pfcp_xact_t *ogs_pfcp_xact_local_create(ogs_pfcp_node_t *node,
 
     ogs_assert(node);
 
-    ogs_pool_alloc(&pool, &xact);
+    ogs_pool_id_calloc(&pool, &xact);
     ogs_assert(xact);
-    memset(xact, 0, sizeof *xact);
     xact->index = ogs_pool_index(&pool, xact);
 
     xact->org = OGS_PFCP_LOCAL_ORIGINATOR;
@@ -124,9 +123,8 @@ static ogs_pfcp_xact_t *ogs_pfcp_xact_remote_create(
 
     ogs_assert(node);
 
-    ogs_pool_alloc(&pool, &xact);
+    ogs_pool_id_calloc(&pool, &xact);
     ogs_assert(xact);
-    memset(xact, 0, sizeof *xact);
     xact->index = ogs_pool_index(&pool, xact);
 
     xact->org = OGS_PFCP_REMOTE_ORIGINATOR;
@@ -169,6 +167,11 @@ void ogs_pfcp_xact_delete_all(ogs_pfcp_node_t *node)
         ogs_pfcp_xact_delete(xact);
     ogs_list_for_each_safe(&node->remote_list, next_xact, xact)
         ogs_pfcp_xact_delete(xact);
+}
+
+ogs_pfcp_xact_t *ogs_pfcp_xact_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_pool_find_by_id(&pool, id);
 }
 
 int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
@@ -802,7 +805,7 @@ int ogs_pfcp_xact_delete(ogs_pfcp_xact_t *xact)
 
     ogs_list_remove(xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
             &xact->node->local_list : &xact->node->remote_list, xact);
-    ogs_pool_free(&pool, xact);
+    ogs_pool_id_free(&pool, xact);
 
     return OGS_OK;
 }

--- a/lib/pfcp/xact.h
+++ b/lib/pfcp/xact.h
@@ -74,7 +74,7 @@ typedef struct ogs_pfcp_xact_s {
     uint8_t         gtp_pti;        /**< GTP Procedure transaction identity */
     uint8_t         gtp_cause;      /**< GTP Cause Value */
 
-    void            *assoc_stream;  /**< Associated SBI session */
+    ogs_pool_id_t   assoc_stream_id;  /**< Associated SBI session ID */
 
     bool            epc;            /**< EPC or 5GC */
 

--- a/lib/pfcp/xact.h
+++ b/lib/pfcp/xact.h
@@ -35,6 +35,8 @@ typedef struct ogs_pfcp_xact_s {
     ogs_lnode_t     lnode;          /**< A node of list */
     ogs_lnode_t     tmpnode;        /**< A node of temp-list */
 
+    ogs_pool_id_t   id;
+
     ogs_pool_id_t   index;
 
 #define OGS_PFCP_LOCAL_ORIGINATOR  0
@@ -68,7 +70,7 @@ typedef struct ogs_pfcp_xact_s {
     uint64_t        local_seid;     /**< Local SEID,
                                          expected in reply from peer */
 
-    void            *assoc_xact;    /**< Associated GTP transaction */
+    ogs_pool_id_t   assoc_xact_id;  /**< Associated GTP transaction ID */
     ogs_pkbuf_t     *gtpbuf;        /**< GTP packet buffer */
 
     uint8_t         gtp_pti;        /**< GTP Procedure transaction identity */
@@ -134,6 +136,7 @@ void ogs_pfcp_xact_final(void);
 ogs_pfcp_xact_t *ogs_pfcp_xact_local_create(ogs_pfcp_node_t *node,
         void (*cb)(ogs_pfcp_xact_t *xact, void *data), void *data);
 void ogs_pfcp_xact_delete_all(ogs_pfcp_node_t *node);
+ogs_pfcp_xact_t *ogs_pfcp_xact_find_by_id(ogs_pool_id_t id);
 
 int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
         ogs_pfcp_header_t *hdesc, ogs_pkbuf_t *pkbuf);

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2257,6 +2257,7 @@ void ogs_sbi_object_free(ogs_sbi_object_t *sbi_object)
 }
 
 ogs_sbi_xact_t *ogs_sbi_xact_add(
+        ogs_pool_id_t sbi_object_id,
         ogs_sbi_object_t *sbi_object,
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
@@ -2272,6 +2273,7 @@ ogs_sbi_xact_t *ogs_sbi_xact_add(
         return NULL;
     }
 
+    xact->sbi_object_id = sbi_object_id;
     xact->sbi_object = sbi_object;
     xact->service_type = service_type;
     xact->requester_nf_type = NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -2268,7 +2268,7 @@ ogs_sbi_xact_t *ogs_sbi_xact_add(
 
     ogs_pool_id_calloc(&xact_pool, &xact);
     if (!xact) {
-        ogs_error("ogs_pool_id_alloc() failed");
+        ogs_error("ogs_pool_id_calloc() failed");
         return NULL;
     }
 

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -225,7 +225,8 @@ typedef struct ogs_sbi_xact_s {
     ogs_sbi_request_t *request;
     ogs_timer_t *t_response;
 
-    ogs_sbi_stream_t *assoc_stream;
+    ogs_pool_id_t assoc_stream_id;
+
     int state;
     char *target_apiroot;
 

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -216,6 +216,8 @@ typedef ogs_sbi_request_t *(*ogs_sbi_build_f)(
 typedef struct ogs_sbi_xact_s {
     ogs_lnode_t lnode;
 
+    ogs_pool_id_t id;
+
     ogs_sbi_service_type_e service_type;
     OpenAPI_nf_type_e requester_nf_type;
     ogs_sbi_discovery_option_t *discovery_option;
@@ -545,7 +547,7 @@ ogs_sbi_xact_t *ogs_sbi_xact_add(
         ogs_sbi_build_f build, void *context, void *data);
 void ogs_sbi_xact_remove(ogs_sbi_xact_t *xact);
 void ogs_sbi_xact_remove_all(ogs_sbi_object_t *sbi_object);
-ogs_sbi_xact_t *ogs_sbi_xact_cycle(ogs_sbi_xact_t *xact);
+ogs_sbi_xact_t *ogs_sbi_xact_find_by_id(ogs_pool_id_t id);
 
 ogs_sbi_subscription_spec_t *ogs_sbi_subscription_spec_add(
         OpenAPI_nf_type_e nf_type, const char *service_name);

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -231,6 +231,7 @@ typedef struct ogs_sbi_xact_s {
     char *target_apiroot;
 
     ogs_sbi_object_t *sbi_object;
+    ogs_pool_id_t sbi_object_id;
 } ogs_sbi_xact_t;
 
 typedef struct ogs_sbi_nf_service_s {
@@ -542,6 +543,7 @@ bool ogs_sbi_discovery_option_target_plmn_list_is_matched(
 void ogs_sbi_object_free(ogs_sbi_object_t *sbi_object);
 
 ogs_sbi_xact_t *ogs_sbi_xact_add(
+        ogs_pool_id_t sbi_object_id,
         ogs_sbi_object_t *sbi_object,
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,

--- a/lib/sbi/mhd-server.c
+++ b/lib/sbi/mhd-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019,2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -41,6 +41,9 @@ static bool server_send_response(
 
 static ogs_sbi_server_t *server_from_stream(ogs_sbi_stream_t *stream);
 
+static ogs_pool_id_t id_from_stream(ogs_sbi_stream_t *stream);
+static void *stream_find_by_id(ogs_pool_id_t id);
+
 const ogs_sbi_server_actions_t ogs_mhd_server_actions = {
     server_init,
     server_final,
@@ -52,6 +55,8 @@ const ogs_sbi_server_actions_t ogs_mhd_server_actions = {
     server_send_response,
 
     server_from_stream,
+    id_from_stream,
+    stream_find_by_id,
 };
 
 static void run(short when, ogs_socket_t fd, void *data);
@@ -78,6 +83,8 @@ static void session_timer_expired(void *data);
 
 typedef struct ogs_sbi_session_s {
     ogs_lnode_t             lnode;
+
+    ogs_pool_id_t           id;
 
     struct MHD_Connection   *connection;
 
@@ -125,9 +132,8 @@ static ogs_sbi_session_t *session_add(ogs_sbi_server_t *server,
     ogs_assert(request);
     ogs_assert(connection);
 
-    ogs_pool_alloc(&session_pool, &sbi_sess);
+    ogs_pool_id_calloc(&session_pool, &sbi_sess);
     ogs_assert(sbi_sess);
-    memset(sbi_sess, 0, sizeof(ogs_sbi_session_t));
 
     sbi_sess->server = server;
     sbi_sess->request = request;
@@ -137,7 +143,7 @@ static ogs_sbi_session_t *session_add(ogs_sbi_server_t *server,
             ogs_app()->timer_mgr, session_timer_expired, sbi_sess);
     if (!sbi_sess->timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&session_pool, sbi_sess);
+        ogs_pool_id_free(&session_pool, sbi_sess);
         return NULL;
     }
 
@@ -170,7 +176,7 @@ static void session_remove(ogs_sbi_session_t *sbi_sess)
 
     MHD_resume_connection(connection);
 
-    ogs_pool_free(&session_pool, sbi_sess);
+    ogs_pool_id_free(&session_pool, sbi_sess);
 }
 
 static void session_timer_expired(void *data)
@@ -320,12 +326,8 @@ static bool server_send_rspmem_persistent(
     ogs_sbi_session_t *sbi_sess = NULL;
 
     ogs_assert(response);
-
-    sbi_sess = ogs_pool_cycle(&session_pool, (ogs_sbi_session_t *)stream);
-    if (!sbi_sess) {
-        ogs_error("session has already been removed");
-        return true;
-    }
+    sbi_sess = (ogs_sbi_session_t *)stream;
+    ogs_assert(sbi_sess);
 
     connection = sbi_sess->connection;
     ogs_assert(connection);
@@ -571,7 +573,7 @@ suspend:
     ogs_assert(sbi_sess);
 
     ogs_assert(server->cb);
-    if (server->cb(request, sbi_sess) != OGS_OK) {
+    if (server->cb(request, OGS_UINT_TO_POINTER(sbi_sess->id)) != OGS_OK) {
         ogs_warn("server callback error");
         ogs_assert(true ==
                 ogs_sbi_server_send_error((ogs_sbi_stream_t *)sbi_sess,
@@ -607,4 +609,17 @@ static ogs_sbi_server_t *server_from_stream(ogs_sbi_stream_t *stream)
     ogs_assert(sbi_sess->server);
 
     return sbi_sess->server;
+}
+
+static ogs_pool_id_t id_from_stream(ogs_sbi_stream_t *stream)
+{
+    ogs_sbi_session_t *sbi_sess = (ogs_sbi_session_t *)stream;
+
+    ogs_assert(sbi_sess);
+    return sbi_sess->id;
+}
+
+static void *stream_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_pool_find_by_id(&session_pool, id);
 }

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -90,6 +90,7 @@ static int client_discover_cb(
     ogs_event_t *e = NULL;
 
     ogs_sbi_xact_t *xact = NULL;
+    ogs_pool_id_t xact_id = 0;
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
@@ -99,10 +100,10 @@ static int client_discover_cb(
     ogs_hash_index_t *hi = NULL;
     char *producer_id = NULL;
 
-    xact = data;
-    ogs_assert(xact);
+    xact_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(xact_id >= OGS_MIN_POOL_ID && xact_id <= OGS_MAX_POOL_ID);
 
-    xact = ogs_sbi_xact_cycle(xact);
+    xact = ogs_sbi_xact_find_by_id(xact_id);
     if (!xact) {
         ogs_error("SBI transaction has already been removed");
         if (response)
@@ -349,7 +350,8 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
             ogs_free(apiroot);
 
             rc = ogs_sbi_client_send_via_scp_or_sepp(
-                    scp_client, ogs_sbi_client_handler, request, xact);
+                    scp_client, ogs_sbi_client_handler, request,
+                    OGS_UINT_TO_POINTER(xact->id));
             ogs_expect(rc == true);
             return (rc == true) ? OGS_OK : OGS_ERROR;
 
@@ -486,7 +488,8 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
             }
 
             rc = ogs_sbi_client_send_via_scp_or_sepp(
-                    scp_client, client_discover_cb, request, xact);
+                    scp_client, client_discover_cb, request,
+                    OGS_UINT_TO_POINTER(xact->id));
             ogs_expect(rc == true);
             return (rc == true) ? OGS_OK : OGS_ERROR;
         }
@@ -498,7 +501,8 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
 
         /* If `client` instance is available, use direct communication */
         rc = ogs_sbi_send_request_to_client(
-                client, ogs_sbi_client_handler, request, xact);
+                client, ogs_sbi_client_handler, request,
+                OGS_UINT_TO_POINTER(xact->id));
         ogs_expect(rc == true);
         return (rc == true) ? OGS_OK : OGS_ERROR;
 
@@ -558,7 +562,8 @@ int ogs_sbi_discover_only(ogs_sbi_xact_t *xact)
         }
 
         rc = ogs_sbi_client_send_request(
-                client, ogs_sbi_client_handler, request, xact);
+                client, ogs_sbi_client_handler, request,
+                OGS_UINT_TO_POINTER(xact->id));
         ogs_expect(rc == true);
 
         ogs_sbi_request_free(request);
@@ -680,7 +685,8 @@ bool ogs_sbi_send_request_to_nf_instance(
             }
 
             rc = ogs_sbi_client_send_request(
-                    nrf_client, sepp_discover_handler, nrf_request, xact);
+                    nrf_client, sepp_discover_handler, nrf_request,
+                    OGS_UINT_TO_POINTER(xact->id));
             if (rc == false) {
                 ogs_error("ogs_sbi_client_send_request() failed");
                 ogs_sbi_xact_remove(xact);
@@ -693,7 +699,8 @@ bool ogs_sbi_send_request_to_nf_instance(
     }
 
     rc = ogs_sbi_send_request_to_client(
-            client, ogs_sbi_client_handler, request, xact);
+            client, ogs_sbi_client_handler, request,
+            OGS_UINT_TO_POINTER(xact->id));
     if (rc == false) {
         ogs_error("ogs_sbi_send_request_to_client() failed");
         ogs_sbi_xact_remove(xact);
@@ -856,26 +863,40 @@ static int sepp_discover_handler(
     char *strerror = NULL;
     ogs_sbi_message_t message;
 
-    ogs_sbi_xact_t *xact = data;
+    ogs_sbi_xact_t *xact = NULL;
+    ogs_pool_id_t xact_id = 0;
 
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_client_t *scp_client = NULL, *sepp_client = NULL;
 
-    ogs_assert(xact);
-    request = xact->request;
-    ogs_assert(request);
+    xact_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(xact_id >= OGS_MIN_POOL_ID && xact_id <= OGS_MAX_POOL_ID);
+
+    xact = ogs_sbi_xact_find_by_id(xact_id);
+    if (!xact) {
+        ogs_error("SBI transaction has already been removed");
+        if (response)
+            ogs_sbi_response_free(response);
+
+        return OGS_ERROR;
+    }
 
     if (status != OGS_OK) {
-
         ogs_log_message(
                 status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
                 "sepp_discover_handler() failed [%d]", status);
 
+        if (response)
+            ogs_sbi_response_free(response);
+
         ogs_sbi_xact_remove(xact);
+
         return OGS_ERROR;
     }
 
     ogs_assert(response);
+    request = xact->request;
+    ogs_assert(request);
 
     rv = ogs_sbi_parse_response(&message, response);
     if (rv != OGS_OK) {
@@ -915,7 +936,8 @@ static int sepp_discover_handler(
 
     if (false == ogs_sbi_client_send_via_scp_or_sepp(
                 scp_client ? scp_client : sepp_client,
-                ogs_sbi_client_handler, request, xact)) {
+                ogs_sbi_client_handler, request,
+                OGS_UINT_TO_POINTER(xact->id))) {
         strerror = ogs_msprintf("ogs_sbi_client_send_via_scp_or_sepp() failed");
         goto cleanup;
     }

--- a/lib/sbi/server.c
+++ b/lib/sbi/server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019,2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -62,9 +62,8 @@ ogs_sbi_server_t *ogs_sbi_server_add(
     ogs_assert(addr);
     ogs_assert(scheme);
 
-    ogs_pool_alloc(&server_pool, &server);
+    ogs_pool_id_calloc(&server_pool, &server);
     ogs_assert(server);
-    memset(server, 0, sizeof(ogs_sbi_server_t));
 
     if (interface)
         server->interface = ogs_strdup(interface);
@@ -114,7 +113,7 @@ void ogs_sbi_server_remove(ogs_sbi_server_t *server)
     if (server->cert)
         ogs_free(server->cert);
 
-    ogs_pool_free(&server_pool, server);
+    ogs_pool_id_free(&server_pool, server);
 }
 
 void ogs_sbi_server_remove_all(void)
@@ -238,12 +237,17 @@ bool ogs_sbi_server_send_error(ogs_sbi_stream_t *stream,
 
 ogs_sbi_server_t *ogs_sbi_server_from_stream(ogs_sbi_stream_t *stream)
 {
-    return ogs_sbi_server_actions.from_stream(stream);
+    return ogs_sbi_server_actions.server_from_stream(stream);
 }
 
-char *ogs_sbi_server_id_context(ogs_sbi_server_t *server)
+ogs_pool_id_t ogs_sbi_id_from_stream(ogs_sbi_stream_t *stream)
 {
-    return ogs_msprintf("%d", (int)ogs_pool_index(&server_pool, server));
+    return ogs_sbi_server_actions.id_from_stream(stream);
+}
+
+void *ogs_sbi_stream_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_sbi_server_actions.stream_find_by_id(id);
 }
 
 static ogs_sbi_server_t *ogs_sbi_server_find_by_interface(

--- a/lib/sbi/server.h
+++ b/lib/sbi/server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019,2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -37,6 +37,8 @@ typedef struct ogs_sbi_server_s {
     ogs_socknode_t  node;
     ogs_sockaddr_t  *advertise;
 
+    ogs_pool_id_t   id;
+
     char *interface;
     OpenAPI_uri_scheme_e scheme;
     char *private_key, *cert;
@@ -64,7 +66,10 @@ typedef struct ogs_sbi_server_actions_s {
     bool (*send_response)(
             ogs_sbi_stream_t *stream, ogs_sbi_response_t *response);
 
-    ogs_sbi_server_t *(*from_stream)(ogs_sbi_stream_t *stream);
+    ogs_sbi_server_t *(*server_from_stream)(ogs_sbi_stream_t *stream);
+
+    ogs_pool_id_t (*id_from_stream)(ogs_sbi_stream_t *stream);
+    void *(*stream_find_by_id)(ogs_pool_id_t id);
 } ogs_sbi_server_actions_t;
 
 void ogs_sbi_server_init(int num_of_session_pool, int num_of_stream_pool);
@@ -96,7 +101,9 @@ bool ogs_sbi_server_send_problem(
         ogs_sbi_stream_t *stream, OpenAPI_problem_details_t *problem);
 
 ogs_sbi_server_t *ogs_sbi_server_from_stream(ogs_sbi_stream_t *stream);
-char *ogs_sbi_server_id_context(ogs_sbi_server_t *server);
+
+ogs_pool_id_t ogs_sbi_id_from_stream(ogs_sbi_stream_t *stream);
+void *ogs_sbi_stream_find_by_id(ogs_pool_id_t id);
 
 ogs_sbi_server_t *ogs_sbi_server_first(void);
 ogs_sbi_server_t *ogs_sbi_server_next(ogs_sbi_server_t *current);

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -68,6 +68,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
     ogs_pool_id_t sbi_xact_id = 0;
     int state = AMF_CREATE_SM_CONTEXT_NO_STATE;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *sbi_request = NULL;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
 
@@ -90,8 +91,16 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         sbi_request = e->h.sbi.request;
         ogs_assert(sbi_request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&sbi_message, sbi_request);
         if (rv != OGS_OK) {
@@ -374,7 +383,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
-                    ogs_error("SBI transaction has already been removed");
+                    ogs_error("SBI transaction has already been removed [%d]",
+                            sbi_xact_id);
                     break;
                 }
 
@@ -413,7 +423,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             if (!sbi_xact) {
                 /* CLIENT_WAIT timer could remove SBI transaction
                  * before receiving SBI message */
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
@@ -448,7 +459,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             if (!sbi_xact) {
                 /* CLIENT_WAIT timer could remove SBI transaction
                  * before receiving SBI message */
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
@@ -565,7 +577,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             if (!sbi_xact) {
                 /* CLIENT_WAIT timer could remove SBI transaction
                  * before receiving SBI message */
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
@@ -688,7 +701,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
             sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1203,7 +1203,7 @@ amf_gnb_t *amf_gnb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
 
     ogs_pool_id_calloc(&amf_gnb_pool, &gnb);
     if (!gnb) {
-        ogs_error("ogs_pool_id_callod() failed");
+        ogs_error("ogs_pool_id_calloc() failed");
         return NULL;
     }
 
@@ -1370,12 +1370,12 @@ ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
 void ran_ue_remove(ran_ue_t *ran_ue)
 {
     amf_gnb_t *gnb = NULL;
+
     ogs_assert(ran_ue);
 
     gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
-    ogs_assert(gnb);
 
-    ogs_list_remove(&gnb->ran_ue_list, ran_ue);
+    if (gnb) ogs_list_remove(&gnb->ran_ue_list, ran_ue);
 
     ogs_assert(ran_ue->t_ng_holding);
     ogs_timer_delete(ran_ue->t_ng_holding);
@@ -2104,7 +2104,7 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
                     ran_ue_remove(ran_ue);
                 } else {
                     ogs_error("[%s] RAN-NG Context has already been removed",
-                                suci);
+                                old_amf_ue->suci);
                 }
             }
 

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1201,9 +1201,11 @@ amf_gnb_t *amf_gnb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     ogs_assert(sock);
     ogs_assert(addr);
 
-    ogs_pool_alloc(&amf_gnb_pool, &gnb);
-    ogs_assert(gnb);
-    memset(gnb, 0, sizeof *gnb);
+    ogs_pool_id_calloc(&amf_gnb_pool, &gnb);
+    if (!gnb) {
+        ogs_error("ogs_pool_id_callod() failed");
+        return NULL;
+    }
 
     /* Defaut RAT-Type */
     gnb->rat_type = OpenAPI_rat_type_NR;
@@ -1227,7 +1229,7 @@ amf_gnb_t *amf_gnb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
             gnb->sctp.addr, sizeof(ogs_sockaddr_t), gnb);
 
     memset(&e, 0, sizeof(e));
-    e.gnb = gnb;
+    e.gnb_id = gnb->id;
     ogs_fsm_init(&gnb->sm, ngap_state_initial, ngap_state_final, &e);
 
     ogs_list_add(&self.gnb_list, gnb);
@@ -1249,7 +1251,7 @@ void amf_gnb_remove(amf_gnb_t *gnb)
     ogs_list_remove(&self.gnb_list, gnb);
 
     memset(&e, 0, sizeof(e));
-    e.gnb = gnb;
+    e.gnb_id = gnb->id;
     ogs_fsm_fini(&gnb->sm, &e);
 
     ogs_hash_set(self.gnb_addr_hash,
@@ -1258,7 +1260,7 @@ void amf_gnb_remove(amf_gnb_t *gnb)
 
     ogs_sctp_flush_and_destroy(&gnb->sctp);
 
-    ogs_pool_free(&amf_gnb_pool, gnb);
+    ogs_pool_id_free(&amf_gnb_pool, gnb);
     amf_metrics_inst_global_dec(AMF_METR_GLOB_GAUGE_GNB);
     ogs_info("[Removed] Number of gNBs is now %d",
             ogs_list_count(&self.gnb_list));
@@ -1313,9 +1315,9 @@ int amf_gnb_sock_type(ogs_sock_t *sock)
     return SOCK_STREAM;
 }
 
-amf_gnb_t *amf_gnb_cycle(amf_gnb_t *gnb)
+amf_gnb_t *amf_gnb_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&amf_gnb_pool, gnb);
+    return ogs_pool_find_by_id(&amf_gnb_pool, id);
 }
 
 /** ran_ue_context handling function */
@@ -1325,19 +1327,18 @@ ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
 
     ogs_assert(gnb);
 
-    ogs_pool_alloc(&ran_ue_pool, &ran_ue);
+    ogs_pool_id_calloc(&ran_ue_pool, &ran_ue);
     if (ran_ue == NULL) {
         ogs_error("Could not allocate ran_ue context from pool");
         return NULL;
     }
 
-    memset(ran_ue, 0, sizeof *ran_ue);
-
     ran_ue->t_ng_holding = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_ng_holding_timer_expire, ran_ue);
+            ogs_app()->timer_mgr, amf_timer_ng_holding_timer_expire,
+            OGS_UINT_TO_POINTER(ran_ue->id));
     if (!ran_ue->t_ng_holding) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&ran_ue_pool, ran_ue);
+        ogs_pool_id_free(&ran_ue_pool, ran_ue);
         return NULL;
     }
 
@@ -1357,7 +1358,7 @@ ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
     ran_ue->gnb_ostream_id =
         OGS_NEXT_ID(gnb->ostream_id, 1, gnb->max_num_of_ostreams-1);
 
-    ran_ue->gnb = gnb;
+    ran_ue->gnb_id = gnb->id;
 
     ogs_list_add(&gnb->ran_ue_list, ran_ue);
 
@@ -1368,33 +1369,40 @@ ran_ue_t *ran_ue_add(amf_gnb_t *gnb, uint64_t ran_ue_ngap_id)
 
 void ran_ue_remove(ran_ue_t *ran_ue)
 {
+    amf_gnb_t *gnb = NULL;
     ogs_assert(ran_ue);
-    ogs_assert(ran_ue->gnb);
 
-    ogs_list_remove(&ran_ue->gnb->ran_ue_list, ran_ue);
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    ogs_assert(gnb);
+
+    ogs_list_remove(&gnb->ran_ue_list, ran_ue);
 
     ogs_assert(ran_ue->t_ng_holding);
     ogs_timer_delete(ran_ue->t_ng_holding);
 
-    ogs_pool_free(&ran_ue_pool, ran_ue);
+    ogs_pool_id_free(&ran_ue_pool, ran_ue);
 
     stats_remove_ran_ue();
 }
 
 void ran_ue_switch_to_gnb(ran_ue_t *ran_ue, amf_gnb_t *new_gnb)
 {
+    amf_gnb_t *gnb = NULL;
+
     ogs_assert(ran_ue);
-    ogs_assert(ran_ue->gnb);
     ogs_assert(new_gnb);
 
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    ogs_assert(gnb);
+
     /* Remove from the old gnb */
-    ogs_list_remove(&ran_ue->gnb->ran_ue_list, ran_ue);
+    ogs_list_remove(&gnb->ran_ue_list, ran_ue);
 
     /* Add to the new gnb */
     ogs_list_add(&new_gnb->ran_ue_list, ran_ue);
 
     /* Switch to gnb */
-    ran_ue->gnb = new_gnb;
+    ran_ue->gnb_id = new_gnb->id;
 }
 
 ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(
@@ -1420,9 +1428,9 @@ ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(uint64_t amf_ue_ngap_id)
     return ran_ue_find(amf_ue_ngap_id);
 }
 
-ran_ue_t *ran_ue_cycle(ran_ue_t *ran_ue)
+ran_ue_t *ran_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&ran_ue_pool, ran_ue);
+    return ogs_pool_find_by_id(&ran_ue_pool, id);
 }
 
 void amf_ue_new_guti(amf_ue_t *amf_ue)
@@ -1520,39 +1528,44 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
     amf_ue_t *amf_ue = NULL;
 
     ogs_assert(ran_ue);
-    gnb = ran_ue->gnb;
-    ogs_assert(gnb);
 
-    ogs_pool_alloc(&amf_ue_pool, &amf_ue);
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    if (!gnb) {
+        ogs_error("[%d] gNB has already been removed", ran_ue->gnb_id);
+        return NULL;
+    }
+
+    ogs_pool_id_calloc(&amf_ue_pool, &amf_ue);
     if (amf_ue == NULL) {
         ogs_error("Could not allocate amf_ue context from pool");
         return NULL;
     }
 
-    memset(amf_ue, 0, sizeof *amf_ue);
-
     /* Add All Timers */
     amf_ue->t3513.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_t3513_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_t3513_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->t3513.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3513.pkbuf = NULL;
     amf_ue->t3522.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_t3522_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_t3522_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->t3522.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3522.pkbuf = NULL;
     amf_ue->t3550.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_t3550_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_t3550_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->t3550.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3550.pkbuf = NULL;
@@ -1560,39 +1573,43 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
             ogs_app()->timer_mgr, amf_timer_t3555_expire, amf_ue);
     if (!amf_ue->t3555.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3555.pkbuf = NULL;
     amf_ue->t3560.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_t3560_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_t3560_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->t3560.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3560.pkbuf = NULL;
     amf_ue->t3570.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_t3570_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_t3570_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->t3570.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->t3570.pkbuf = NULL;
     amf_ue->mobile_reachable.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_mobile_reachable_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_mobile_reachable_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->mobile_reachable.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->mobile_reachable.pkbuf = NULL;
     amf_ue->implicit_deregistration.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, amf_timer_implicit_deregistration_expire, amf_ue);
+            ogs_app()->timer_mgr, amf_timer_implicit_deregistration_expire,
+            OGS_UINT_TO_POINTER(amf_ue->id));
     if (!amf_ue->implicit_deregistration.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&amf_ue_pool, amf_ue);
+        ogs_pool_id_free(&amf_ue_pool, amf_ue);
         return NULL;
     }
     amf_ue->implicit_deregistration.pkbuf = NULL;
@@ -1713,7 +1730,7 @@ void amf_ue_remove(amf_ue_t *amf_ue)
 
     amf_ue_deassociate(amf_ue);
 
-    ogs_pool_free(&amf_ue_pool, amf_ue);
+    ogs_pool_id_free(&amf_ue_pool, amf_ue);
 
     ogs_info("[Removed] Number of AMF-UEs is now %d",
             ogs_list_count(&self.amf_ue_list));
@@ -1724,7 +1741,7 @@ void amf_ue_remove_all(void)
     amf_ue_t *amf_ue = NULL, *next = NULL;;
 
     ogs_list_for_each_safe(&self.amf_ue_list, next, amf_ue) {
-        ran_ue_t *ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue_t *ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
 
         if (ran_ue) ran_ue_remove(ran_ue);
 
@@ -1739,7 +1756,7 @@ void amf_ue_fsm_init(amf_ue_t *amf_ue)
     ogs_assert(amf_ue);
 
     memset(&e, 0, sizeof(e));
-    e.amf_ue = amf_ue;
+    e.amf_ue_id = amf_ue->id;
     ogs_fsm_init(&amf_ue->sm, gmm_state_initial, gmm_state_final, &e);
 }
 
@@ -1750,7 +1767,7 @@ void amf_ue_fsm_fini(amf_ue_t *amf_ue)
     ogs_assert(amf_ue);
 
     memset(&e, 0, sizeof(e));
-    e.amf_ue = amf_ue;
+    e.amf_ue_id = amf_ue->id;
     ogs_fsm_fini(&amf_ue->sm, &e);
 }
 
@@ -2075,13 +2092,20 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
             ogs_pool_index(&amf_ue_pool, old_amf_ue)) {
             ogs_warn("[%s] OLD UE Context Release", suci);
             if (CM_CONNECTED(old_amf_ue)) {
+                ran_ue_t *ran_ue = ran_ue_find_by_id(old_amf_ue->ran_ue_id);
                 /* Implcit NG release */
                 ogs_warn("[%s] Implicit NG release", suci);
-                ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
-                        old_amf_ue->suci,
-                        (long long)old_amf_ue->ran_ue->ran_ue_ngap_id,
-                        (long long)old_amf_ue->ran_ue->amf_ue_ngap_id);
-                ran_ue_remove(old_amf_ue->ran_ue);
+                if (ran_ue) {
+                    ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] "
+                            "AMF_UE_NGAP_ID[%lld]",
+                            old_amf_ue->suci,
+                            (long long)ran_ue->ran_ue_ngap_id,
+                            (long long)ran_ue->amf_ue_ngap_id);
+                    ran_ue_remove(ran_ue);
+                } else {
+                    ogs_error("[%s] RAN-NG Context has already been removed",
+                                suci);
+                }
             }
 
     /*
@@ -2099,7 +2123,7 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
 
             /* Phase-1 : Change AMF-UE Context in Session Context */
             ogs_list_for_each(&old_amf_ue->sess_list, old_sess)
-                old_sess->amf_ue = amf_ue;
+                old_sess->amf_ue_id = amf_ue->id;
 
             /* Phase-2 : Move Session Context from OLD to NEW AMF-UE Context */
             memcpy(&amf_ue->sess_list,
@@ -2138,10 +2162,17 @@ OpenAPI_rat_type_e amf_ue_rat_type(amf_ue_t *amf_ue)
     amf_gnb_t *gnb = NULL;
     ran_ue_t *ran_ue = NULL;
 
-    ran_ue = amf_ue->ran_ue;
-    ogs_assert(ran_ue);
-    gnb = ran_ue->gnb;
-    ogs_assert(gnb);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
+    if (!ran_ue) {
+        ogs_error("[%s] RAN-NG Context has already been removed", amf_ue->suci);
+        return OpenAPI_rat_type_NULL;
+    }
+
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    if (!gnb) {
+        ogs_error("[%d] gNB has already been removed", ran_ue->gnb_id);
+        return OpenAPI_rat_type_NULL;
+    }
 
     return gnb->rat_type;
 }
@@ -2151,35 +2182,31 @@ void amf_ue_associate_ran_ue(amf_ue_t *amf_ue, ran_ue_t *ran_ue)
     ogs_assert(amf_ue);
     ogs_assert(ran_ue);
 
-    amf_ue->ran_ue = ran_ue;
-    ran_ue->amf_ue = amf_ue;
+    amf_ue->ran_ue_id = ran_ue->id;
+    ran_ue->amf_ue_id = amf_ue->id;
 }
 
 void ran_ue_deassociate(ran_ue_t *ran_ue)
 {
     ogs_assert(ran_ue);
-    ran_ue->amf_ue = NULL;
+    ran_ue->amf_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void amf_ue_deassociate(amf_ue_t *amf_ue)
 {
     ogs_assert(amf_ue);
-    amf_ue->ran_ue = NULL;
+    amf_ue->ran_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void source_ue_associate_target_ue(
         ran_ue_t *source_ue, ran_ue_t *target_ue)
 {
-    amf_ue_t *amf_ue = NULL;
-
     ogs_assert(source_ue);
     ogs_assert(target_ue);
-    amf_ue = source_ue->amf_ue;
-    ogs_assert(amf_ue);
 
-    target_ue->amf_ue = amf_ue;
-    target_ue->source_ue = source_ue;
-    source_ue->target_ue = target_ue;
+    target_ue->amf_ue_id = source_ue->amf_ue_id;
+    target_ue->source_ue_id = source_ue->id;
+    source_ue->target_ue_id = target_ue->id;
 }
 
 void source_ue_deassociate_target_ue(ran_ue_t *ran_ue)
@@ -2188,22 +2215,28 @@ void source_ue_deassociate_target_ue(ran_ue_t *ran_ue)
     ran_ue_t *target_ue = NULL;
     ogs_assert(ran_ue);
 
-    if (ran_ue->target_ue) {
+    if (ran_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+        ran_ue->target_ue_id <= OGS_MAX_POOL_ID) {
         source_ue = ran_ue;
-        target_ue = ran_ue->target_ue;
+        target_ue = ran_ue_find_by_id(ran_ue->target_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
-    } else if (ran_ue->source_ue) {
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
+    } else if (ran_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                ran_ue->source_ue_id <= OGS_MAX_POOL_ID) {
         target_ue = ran_ue;
-        source_ue = ran_ue->source_ue;
+        source_ue = ran_ue_find_by_id(ran_ue->source_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
     }
 }
 
@@ -2214,13 +2247,12 @@ amf_sess_t *amf_sess_add(amf_ue_t *amf_ue, uint8_t psi)
     ogs_assert(amf_ue);
     ogs_assert(psi != OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED);
 
-    ogs_pool_alloc(&amf_sess_pool, &sess);
+    ogs_pool_id_calloc(&amf_sess_pool, &sess);
     ogs_assert(sess);
-    memset(sess, 0, sizeof *sess);
 
     sess->sbi.type = OGS_SBI_OBJ_SESS_TYPE;
 
-    sess->amf_ue = amf_ue;
+    sess->amf_ue_id = amf_ue->id;
     sess->psi = psi;
 
     sess->s_nssai.sst = 0;
@@ -2237,10 +2269,15 @@ amf_sess_t *amf_sess_add(amf_ue_t *amf_ue, uint8_t psi)
 
 void amf_sess_remove(amf_sess_t *sess)
 {
-    ogs_assert(sess);
-    ogs_assert(sess->amf_ue);
+    amf_ue_t *amf_ue = NULL;
 
-    ogs_list_remove(&sess->amf_ue->sess_list, sess);
+    ogs_assert(sess);
+
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
+    if (amf_ue)
+        ogs_list_remove(&amf_ue->sess_list, sess);
+    else
+        ogs_error("UE(amf-ue) context has already been removed");
 
     /* Free SBI object memory */
     if (ogs_list_count(&sess->sbi.xact_list))
@@ -2277,7 +2314,7 @@ void amf_sess_remove(amf_sess_t *sess)
     if (sess->nssf.nrf.client)
         ogs_sbi_client_remove(sess->nssf.nrf.client);
 
-    ogs_pool_free(&amf_sess_pool, sess);
+    ogs_pool_id_free(&amf_sess_pool, sess);
 
     stats_remove_amf_session();
 }
@@ -2302,14 +2339,14 @@ amf_sess_t *amf_sess_find_by_psi(amf_ue_t *amf_ue, uint8_t psi)
     return NULL;
 }
 
-amf_ue_t *amf_ue_cycle(amf_ue_t *amf_ue)
+amf_ue_t *amf_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&amf_ue_pool, amf_ue);
+    return ogs_pool_find_by_id(&amf_ue_pool, id);
 }
 
-amf_sess_t *amf_sess_cycle(amf_sess_t *sess)
+amf_sess_t *amf_sess_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&amf_sess_pool, sess);
+    return ogs_pool_find_by_id(&amf_sess_pool, id);
 }
 
 void amf_sbi_select_nf(
@@ -2748,15 +2785,16 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
     ran_ue_t *ran_ue = NULL;
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     if (!ran_ue) {
         ogs_error("[%s] RAN-NG Context has already been removed",
                     amf_ue->supi);
         return false;
     }
-    gnb = amf_gnb_cycle(ran_ue->gnb);
+
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
     if (!gnb) {
-        ogs_error("gNB has already been removed");
+        ogs_error("[%d] gNB has already been removed", ran_ue->gnb_id);
         return false;
     }
 

--- a/src/amf/event.h
+++ b/src/amf/event.h
@@ -74,10 +74,10 @@ typedef struct amf_event_s {
         ogs_nas_5gs_message_t *message;
     } nas;
 
-    amf_gnb_t *gnb;
-    ran_ue_t *ran_ue;
-    amf_ue_t *amf_ue;
-    amf_sess_t *sess;
+    ogs_pool_id_t gnb_id;
+    ogs_pool_id_t ran_ue_id;
+    ogs_pool_id_t amf_ue_id;
+    ogs_pool_id_t sess_id;
     amf_bearer_t *bearer;
 
     ogs_timer_t *timer;

--- a/src/amf/event.h
+++ b/src/amf/event.h
@@ -78,7 +78,6 @@ typedef struct amf_event_s {
     ogs_pool_id_t ran_ue_id;
     ogs_pool_id_t amf_ue_id;
     ogs_pool_id_t sess_id;
-    amf_bearer_t *bearer;
 
     ogs_timer_t *timer;
 } amf_event_t;

--- a/src/amf/gmm-build.c
+++ b/src/amf/gmm-build.c
@@ -636,7 +636,7 @@ ogs_pkbuf_t *gmm_build_dl_nas_transport(amf_sess_t *sess,
     ogs_nas_gprs_timer_3_t *back_off_timer_value = NULL;
 
     ogs_assert(sess);
-    amf_ue = sess->amf_ue;
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
     ogs_assert(payload_container_type);
     ogs_assert(payload_container);

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -50,7 +50,7 @@ ogs_nas_5gmm_cause_t gmm_handle_registration_request(amf_ue_t *amf_ue,
     ogs_nas_ue_security_capability_t *ue_security_capability = NULL;
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_assert(registration_request);
@@ -632,7 +632,7 @@ ogs_nas_5gmm_cause_t gmm_handle_service_request(amf_ue_t *amf_ue,
     ogs_nas_key_set_identifier_t *ngksi = NULL;
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ngksi = &service_request->ngksi;
@@ -850,7 +850,7 @@ int gmm_handle_deregistration_request(amf_ue_t *amf_ue,
     ogs_nas_de_registration_type_t *de_registration_type = NULL;
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
     ogs_assert(deregistration_request);
 
@@ -974,7 +974,7 @@ ogs_nas_5gmm_cause_t gmm_handle_identity_response(amf_ue_t *amf_ue,
     ogs_assert(identity_response);
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
     ogs_assert(identity_response);
 
@@ -1040,7 +1040,7 @@ ogs_nas_5gmm_cause_t gmm_handle_security_mode_complete(amf_ue_t *amf_ue,
     ogs_nas_mobile_identity_imeisv_t *mobile_identity_imeisv = NULL;
 
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
     ogs_assert(security_mode_complete);
 
@@ -1139,8 +1139,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
     ogs_nas_dnn_t *dnn = NULL;
     ogs_nas_5gsm_header_t *gsm_header = NULL;
 
-    ogs_assert(amf_ue_cycle(amf_ue));
-    ogs_assert(ran_ue_cycle(ran_ue));
+    ogs_assert(amf_ue);
+    ogs_assert(ran_ue);
     ogs_assert(ul_nas_transport);
 
     payload_container_type = &ul_nas_transport->payload_container_type;

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -74,12 +74,12 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -575,7 +575,7 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
 
                         xact_count = amf_sess_xact_count(amf_ue);
                         amf_sbi_send_release_all_sessions(
-                                amf_ue->ran_ue, amf_ue,
+                                ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                                 AMF_RELEASE_SM_CONTEXT_NO_STATE);
 
                         if (!AMF_SESSION_RELEASE_PENDING(amf_ue) &&
@@ -630,12 +630,12 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -1142,7 +1142,7 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
 
                         if (amf_ue->explict_de_registered.n1_done == true) {
                             r = ngap_send_ran_ue_context_release_command(
-                                    amf_ue->ran_ue,
+                                    ran_ue_find_by_id(amf_ue->ran_ue_id),
                                     NGAP_Cause_PR_misc,
                                     NGAP_CauseMisc_om_intervention,
                                     NGAP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0);
@@ -1194,12 +1194,12 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
 
     ogs_assert(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -1208,7 +1208,7 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
         nas_message = e->nas.message;
         ogs_assert(nas_message);
 
-        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         ogs_assert(ran_ue);
 
         h.type = e->nas.type;
@@ -1618,12 +1618,12 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -1636,7 +1636,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
         nas_message = e->nas.message;
         ogs_assert(nas_message);
 
-        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         ogs_assert(ran_ue);
 
         h.type = e->nas.type;
@@ -1908,7 +1908,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    amf_ue = e->amf_ue;
+    amf_ue = amf_ue_find_by_id(e->amf_ue_id);
     ogs_assert(amf_ue);
 
     switch (e->h.id) {
@@ -1924,7 +1924,7 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
         nas_message = e->nas.message;
         ogs_assert(nas_message);
 
-        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         ogs_assert(ran_ue);
 
         h.type = e->nas.type;
@@ -2068,7 +2068,8 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
             if (amf_ue->t3560.retry_count >=
                     amf_timer_cfg(AMF_TIMER_T3560)->max_count) {
                 ogs_warn("[%s] Retransmission failed. Stop", amf_ue->supi);
-                r = nas_5gs_send_gmm_reject(amf_ue->ran_ue, amf_ue,
+                r = nas_5gs_send_gmm_reject(
+                        ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                         OGS_5GMM_CAUSE_SECURITY_MODE_REJECTED_UNSPECIFIED);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
@@ -2112,12 +2113,12 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -2143,7 +2144,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
                     r = nas_5gs_send_gmm_reject(
-                            amf_ue->ran_ue, amf_ue,
+                            ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                             OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
@@ -2188,7 +2189,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                     ogs_error("[%s] HTTP response error [%d]",
                             amf_ue->supi, sbi_message->res_status);
                     r = nas_5gs_send_gmm_reject(
-                            amf_ue->ran_ue, amf_ue,
+                            ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                             OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
@@ -2275,7 +2276,7 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
         nas_message = e->nas.message;
         ogs_assert(nas_message);
 
-        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         ogs_assert(ran_ue);
 
         h.type = e->nas.type;
@@ -2459,12 +2460,12 @@ void gmm_state_ue_context_will_remove(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -2497,12 +2498,12 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    if (e->sess) {
-        sess = e->sess;
-        amf_ue = sess->amf_ue;
+    sess = amf_sess_find_by_id(e->sess_id);
+    if (sess) {
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
     } else {
-        amf_ue = e->amf_ue;
+        amf_ue = amf_ue_find_by_id(e->amf_ue_id);
         ogs_assert(amf_ue);
     }
 
@@ -2516,7 +2517,8 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         xact_count = amf_sess_xact_count(amf_ue);
 
         amf_sbi_send_release_all_sessions(
-                amf_ue->ran_ue, amf_ue, AMF_RELEASE_SM_CONTEXT_NO_STATE);
+                ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
+                AMF_RELEASE_SM_CONTEXT_NO_STATE);
 
         if (!AMF_SESSION_RELEASE_PENDING(amf_ue) &&
             amf_sess_xact_count(amf_ue) == xact_count) {
@@ -2534,7 +2536,7 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         nas_message = e->nas.message;
         ogs_assert(nas_message);
 
-        ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         ogs_assert(ran_ue);
 
         h.type = e->nas.type;

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -177,7 +177,7 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
              * 4.3.2 PDU Session Establishment *
              ***********************************/
 
-            ran_ue = ran_ue_cycle(sess->ran_ue);
+            ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
             if (ran_ue) {
                 if (sess->pdu_session_establishment_accept) {
                     ogs_pkbuf_free(sess->pdu_session_establishment_accept);
@@ -480,7 +480,8 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
         ogs_error("[%d:%d] PDU session establishment reject",
                 sess->psi, sess->pti);
 
-        r = nas_5gs_send_gsm_reject(sess->ran_ue, sess,
+        r = nas_5gs_send_gsm_reject(
+                ran_ue_find_by_id(sess->ran_ue_id), sess,
                 OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, n1buf);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -1003,7 +1004,7 @@ int amf_namf_callback_handle_sdm_data_change_notify(
     }
 
     if (amf_ue) {
-        ran_ue_t *ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+        ran_ue_t *ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         if (!ran_ue) {
             ogs_error("NG context has already been removed");
             /* ran_ue is required for amf_ue_is_rat_restricted() */
@@ -1092,6 +1093,7 @@ int amf_namf_comm_handle_ue_context_transfer_request(
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t sendmsg;
     amf_ue_t *amf_ue = NULL;
+    ran_ue_t *ran_ue = NULL;
 
     OpenAPI_ambr_t *UeAmbr = NULL;
     OpenAPI_list_t *MmContextList = NULL;
@@ -1246,8 +1248,9 @@ int amf_namf_comm_handle_ue_context_transfer_request(
      * Context TRANSFERRED !!!
      * So, we removed UE context.
      */
-    if (amf_ue->ran_ue)
-        ran_ue_remove(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
+    if (ran_ue)
+        ran_ue_remove(ran_ue);
     amf_ue_remove(amf_ue);
 
     return OGS_OK;

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -313,9 +313,8 @@ ogs_pkbuf_t *ngap_build_downlink_nas_transport(
     NGAP_AllowedNSSAI_t *AllowedNSSAI = NULL;
 
     ogs_assert(gmmbuf);
-    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
-    amf_ue = amf_ue_cycle(ran_ue->amf_ue);
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     ogs_assert(amf_ue);
 
     ogs_debug("DownlinkNASTransport");
@@ -470,9 +469,8 @@ ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
     NGAP_MaskedIMEISV_t *MaskedIMEISV = NULL;
     NGAP_NAS_PDU_t *NAS_PDU = NULL;
 
-    amf_ue = amf_ue_cycle(amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("InitialContextSetupRequest(UE)");
@@ -781,9 +779,8 @@ ogs_pkbuf_t *ngap_build_ue_context_modification_request(amf_ue_t *amf_ue)
     NGAP_UESecurityCapabilities_t *UESecurityCapabilities = NULL;
     NGAP_SecurityKey_t *SecurityKey = NULL;
 
-    amf_ue = amf_ue_cycle(amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("UEContextModificationRequest(UE)");
@@ -932,9 +929,8 @@ ogs_pkbuf_t *ngap_sess_build_initial_context_setup_request(
     NGAP_MaskedIMEISV_t *MaskedIMEISV = NULL;
 
     ogs_assert(sess);
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
 
     ogs_debug("InitialContextSetupRequest(Session)");
@@ -1222,7 +1218,6 @@ ogs_pkbuf_t *ngap_build_ue_context_release_command(
     NGAP_UE_NGAP_IDs_t *UE_NGAP_IDs = NULL;
     NGAP_Cause_t *Cause = NULL;
 
-    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
 
     ogs_debug("UEContextReleaseCommand");
@@ -1298,9 +1293,8 @@ ogs_pkbuf_t *ngap_ue_build_pdu_session_resource_setup_request(
     NGAP_PDUSessionResourceSetupListSUReq_t *PDUSessionList = NULL;
     NGAP_PDUSessionResourceSetupItemSUReq_t *PDUSessionItem = NULL;
 
-    amf_ue = amf_ue_cycle(amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("PDUSessionResourceSetupRequest(UE)");
@@ -1466,9 +1460,8 @@ ogs_pkbuf_t *ngap_sess_build_pdu_session_resource_setup_request(
     ogs_assert(n2smbuf);
     ogs_assert(sess);
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(ran_ue);
     ogs_assert(ran_ue);
 
     ogs_debug("PDUSessionResourceSetupRequest(Session)");
@@ -1609,9 +1602,9 @@ ogs_pkbuf_t *ngap_build_pdu_session_resource_modify_request(
     ogs_assert(n2smbuf);
     ogs_assert(sess);
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("PDUSessionResourceModifyRequest");
@@ -1709,9 +1702,9 @@ ogs_pkbuf_t *ngap_build_pdu_session_resource_release_command(
     ogs_assert(n2smbuf);
     ogs_assert(sess);
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("PDUSessionResourceReleaseCommand");
@@ -1815,7 +1808,6 @@ ogs_pkbuf_t *ngap_build_paging(amf_ue_t *amf_ue)
     NGAP_TAIListForPagingItem_t *TAIItem = NULL;
     NGAP_TAI_t *tAI = NULL;
 
-    amf_ue = amf_ue_cycle(amf_ue);
     ogs_assert(amf_ue);
     ogs_debug("Paging");
 
@@ -1942,9 +1934,8 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
     NGAP_PDUSessionResourceSwitchedList_t *PDUSessionResourceSwitchedList;
     NGAP_AllowedNSSAI_t *AllowedNSSAI = NULL;
 
-    amf_ue = amf_ue_cycle(amf_ue);
     ogs_assert(amf_ue);
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("PathSwitchAcknowledge");
@@ -2110,9 +2101,8 @@ ogs_pkbuf_t *ngap_build_handover_request(ran_ue_t *target_ue)
         *SourceToTarget_TransparentContainer = NULL;
     NGAP_GUAMI_t *GUAMI = NULL;
 
-    target_ue = ran_ue_cycle(target_ue);
     ogs_assert(target_ue);
-    amf_ue = amf_ue_cycle(target_ue->amf_ue);
+    amf_ue = amf_ue_find_by_id(target_ue->amf_ue_id);
     ogs_assert(amf_ue);
 
     ogs_debug("HandoverRequest");
@@ -2410,7 +2400,6 @@ ogs_pkbuf_t *ngap_build_handover_preparation_failure(
     NGAP_RAN_UE_NGAP_ID_t *RAN_UE_NGAP_ID = NULL;
     NGAP_Cause_t *Cause = NULL;
 
-    source_ue = ran_ue_cycle(source_ue);
     ogs_assert(source_ue);
     ogs_assert(cause);
 
@@ -2495,9 +2484,8 @@ ogs_pkbuf_t *ngap_build_handover_command(ran_ue_t *source_ue)
     NGAP_TargetToSource_TransparentContainer_t
         *TargetToSource_TransparentContainer = NULL;
 
-    source_ue = ran_ue_cycle(source_ue);
     ogs_assert(source_ue);
-    amf_ue = amf_ue_cycle(source_ue->amf_ue);
+    amf_ue = amf_ue_find_by_id(source_ue->amf_ue_id);
     ogs_assert(amf_ue);
 
     ogs_debug("HandoverCommand");
@@ -2614,7 +2602,6 @@ ogs_pkbuf_t *ngap_build_handover_cancel_ack(ran_ue_t *source_ue)
     NGAP_AMF_UE_NGAP_ID_t *AMF_UE_NGAP_ID = NULL;
     NGAP_RAN_UE_NGAP_ID_t *RAN_UE_NGAP_ID = NULL;
 
-    source_ue = ran_ue_cycle(source_ue);
     ogs_assert(source_ue);
 
     ogs_debug("HandoverCancelAcknowledge");
@@ -2680,7 +2667,6 @@ ogs_pkbuf_t *ngap_build_downlink_ran_status_transfer(
     NGAP_RANStatusTransfer_TransparentContainer_t
         *RANStatusTransfer_TransparentContainer = NULL;
 
-    target_ue = ran_ue_cycle(target_ue);
     ogs_assert(target_ue);
     ogs_assert(transfer);
 

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -696,7 +696,7 @@ void ngap_handle_uplink_nas_transport(
         return;
     }
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -783,6 +783,7 @@ void ngap_handle_ue_radio_capability_info_indication(
     int i, r;
 
     ran_ue_t *ran_ue = NULL;
+    amf_ue_t *amf_ue = NULL;
     uint64_t amf_ue_ngap_id;
 
     NGAP_InitiatingMessage_t *initiatingMessage = NULL;
@@ -872,9 +873,9 @@ void ngap_handle_ue_radio_capability_info_indication(
         return;
     }
 
-    if (ran_ue->amf_ue)
-        OGS_ASN_STORE_DATA(&ran_ue->amf_ue->ueRadioCapability,
-                UERadioCapability);
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
+    if (amf_ue)
+        OGS_ASN_STORE_DATA(&amf_ue->ueRadioCapability, UERadioCapability);
 }
 
 void ngap_handle_initial_context_setup_response(
@@ -969,7 +970,7 @@ void ngap_handle_initial_context_setup_response(
 
     ran_ue->initial_context_setup_response_received = true;
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1268,7 +1269,7 @@ void ngap_handle_initial_context_setup_failure(
      * may in principle be adopted. The RAN should ensure
      * that no hanging resources remain at the RAN.
      */
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (amf_ue) {
         /*
          * if T3550 is running, Registration complete will be sent.
@@ -1569,7 +1570,7 @@ void ngap_handle_ue_context_release_request(
         break;
     }
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1720,12 +1721,7 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
 
     ogs_assert(ran_ue);
 
-    if (ran_ue_cycle(ran_ue) == NULL) {
-        ogs_error("NG context has already been removed");
-        return;
-    }
-
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
 
     ogs_info("UE Context Release [Action:%d]", ran_ue->ue_ctx_rel_action);
     ogs_info("    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
@@ -1821,12 +1817,14 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
             ogs_error("No UE(amf-ue) context");
             return;
         }
-        if (!amf_ue->ran_ue) {
+
+        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
+        if (!ran_ue) {
             ogs_error("No NG context");
             return;
         }
 
-        r = ngap_send_handover_cancel_ack(amf_ue->ran_ue);
+        r = ngap_send_handover_cancel_ack(ran_ue);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
         break;
@@ -1945,7 +1943,7 @@ void ngap_handle_pdu_session_resource_setup_response(
             (long long)ran_ue->ran_ue_ngap_id,
             (long long)ran_ue->amf_ue_ngap_id);
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2267,7 +2265,7 @@ void ngap_handle_pdu_session_resource_modify_response(
             (long long)ran_ue->ran_ue_ngap_id,
             (long long)ran_ue->amf_ue_ngap_id);
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2454,7 +2452,7 @@ void ngap_handle_pdu_session_resource_release_response(
             (long long)ran_ue->ran_ue_ngap_id,
             (long long)ran_ue->amf_ue_ngap_id);
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2802,7 +2800,7 @@ void ngap_handle_path_switch_request(
         return;
     }
 
-    amf_ue = ran_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3133,7 +3131,7 @@ void ngap_handle_handover_required(
         (long long)source_ue->ran_ue_ngap_id,
         (long long)source_ue->amf_ue_ngap_id);
 
-    amf_ue = source_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(source_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3251,7 +3249,7 @@ void ngap_handle_handover_required(
         return;
     }
 
-    target_ue = ran_ue_cycle(source_ue->target_ue);
+    target_ue = ran_ue_find_by_id(source_ue->target_ue_id);
     if (target_ue) {
     /*
      * Issue #3014
@@ -3521,7 +3519,7 @@ void ngap_handle_handover_request_ack(
 
     target_ue->ran_ue_ngap_id = *RAN_UE_NGAP_ID;
 
-    source_ue = target_ue->source_ue;
+    source_ue = ran_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("Cannot find Source-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3533,7 +3531,7 @@ void ngap_handle_handover_request_ack(
         ogs_assert(r != OGS_ERROR);
         return;
     }
-    amf_ue = target_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(target_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3728,7 +3726,7 @@ void ngap_handle_handover_failure(
         return;
     }
 
-    source_ue = target_ue->source_ue;
+    source_ue = ran_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("Cannot find Source-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3853,7 +3851,7 @@ void ngap_handle_handover_cancel(
         return;
     }
 
-    target_ue = source_ue->target_ue;
+    target_ue = ran_ue_find_by_id(source_ue->target_ue_id);
     if (!target_ue) {
         ogs_error("Cannot find Source-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3865,7 +3863,7 @@ void ngap_handle_handover_cancel(
         ogs_assert(r != OGS_ERROR);
         return;
     }
-    amf_ue = source_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(source_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4005,7 +4003,7 @@ void ngap_handle_uplink_ran_status_transfer(
         return;
     }
 
-    target_ue = source_ue->target_ue;
+    target_ue = ran_ue_find_by_id(source_ue->target_ue_id);
     if (!target_ue) {
         ogs_error("Cannot find Source-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4017,7 +4015,7 @@ void ngap_handle_uplink_ran_status_transfer(
         ogs_assert(r != OGS_ERROR);
         return;
     }
-    amf_ue = source_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(source_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4127,7 +4125,7 @@ void ngap_handle_handover_notification(
         return;
     }
 
-    source_ue = target_ue->source_ue;
+    source_ue = ran_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("Cannot find Source-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4139,7 +4137,7 @@ void ngap_handle_handover_notification(
         ogs_assert(r != OGS_ERROR);
         return;
     }
-    amf_ue = target_ue->amf_ue;
+    amf_ue = amf_ue_find_by_id(target_ue->amf_ue_id);
     if (!amf_ue) {
         ogs_error("Cannot find AMF-UE Context [%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4663,7 +4661,7 @@ void ngap_handle_ng_reset(
             /* RAN_UE Context where PartOfNG_interface was requested */
             ran_ue->part_of_ng_reset_requested = true;
 
-            amf_ue = ran_ue->amf_ue;
+            amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
             /*
              * Issues #1928
              *

--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -51,12 +51,7 @@ int ngap_send_to_gnb(amf_gnb_t *gnb, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
     char buf[OGS_ADDRSTRLEN];
 
     ogs_assert(pkbuf);
-
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        ogs_pkbuf_free(pkbuf);
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(gnb);
 
     ogs_assert(gnb->sctp.sock);
     if (gnb->sctp.sock->fd == INVALID_SOCKET) {
@@ -83,15 +78,24 @@ int ngap_send_to_gnb(amf_gnb_t *gnb, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
 int ngap_send_to_ran_ue(ran_ue_t *ran_ue, ogs_pkbuf_t *pkbuf)
 {
     int rv;
+    amf_gnb_t *gnb = NULL;
+
     ogs_assert(pkbuf);
 
-    if (!ran_ue_cycle(ran_ue)) {
+    if (!ran_ue) {
         ogs_error("NG context has already been removed");
         ogs_pkbuf_free(pkbuf);
         return OGS_NOTFOUND;
     }
 
-    rv = ngap_send_to_gnb(ran_ue->gnb, pkbuf, ran_ue->gnb_ostream_id);
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    if (!gnb) {
+        ogs_error("[%d] gNB has already been removed", ran_ue->gnb_id);
+        ogs_pkbuf_free(pkbuf);
+        return OGS_NOTFOUND;
+    }
+
+    rv = ngap_send_to_gnb(gnb, pkbuf, ran_ue->gnb_ostream_id);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -112,8 +116,7 @@ int ngap_delayed_send_to_ran_ue(
                 ogs_app()->timer_mgr, amf_timer_ng_delayed_send, e);
         ogs_assert(e->timer);
         e->pkbuf = pkbuf;
-        e->ran_ue = ran_ue;
-        e->gnb = ran_ue->gnb;
+        e->ran_ue_id = ran_ue->id;
 
         ogs_timer_start(e->timer, duration);
 
@@ -136,7 +139,7 @@ int ngap_send_to_5gsm(amf_ue_t *amf_ue, ogs_pkbuf_t *esmbuf)
 
     e = amf_event_new(AMF_EVENT_5GSM_MESSAGE);
     ogs_assert(e);
-    e->amf_ue = amf_ue;
+    e->amf_ue_id = amf_ue->id;
     e->pkbuf = esmbuf;
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -153,6 +156,8 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
 {
     int rv;
 
+    amf_ue_t *amf_ue = NULL;
+
     ogs_nas_5gs_security_header_t *sh = NULL;
     ogs_nas_security_header_type_t security_header_type;
 
@@ -162,6 +167,8 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
 
     ogs_assert(ran_ue);
     ogs_assert(nasPdu);
+
+    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
 
     /* The Packet Buffer(pkbuf_t) for NAS message MUST make a HEADROOM. 
      * When calculating AES_CMAC, we need to use the headroom of the packet. */
@@ -204,8 +211,8 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
         return OGS_ERROR;
     }
 
-    if (ran_ue->amf_ue) {
-        if (nas_5gs_security_decode(ran_ue->amf_ue,
+    if (amf_ue) {
+        if (nas_5gs_security_decode(amf_ue,
                 security_header_type, nasbuf) != OGS_OK) {
             ogs_error("nas_eps_security_decode failed()");
             ran_ue_remove(ran_ue);
@@ -249,7 +256,7 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
             ogs_pkbuf_free(nasbuf);
             return OGS_ERROR;
         }
-        e->ran_ue = ran_ue;
+        e->ran_ue_id = ran_ue->id;
         e->ngap.code = procedureCode;
         e->nas.type = security_header_type.type;
         e->pkbuf = nasbuf;
@@ -262,7 +269,6 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
         return rv;
     } else if (h->extended_protocol_discriminator ==
             OGS_NAS_EXTENDED_PROTOCOL_DISCRIMINATOR_5GSM) {
-        amf_ue_t *amf_ue = ran_ue->amf_ue;
         if (!amf_ue) {
             ogs_error("No UE Context");
             ogs_pkbuf_free(nasbuf);
@@ -288,12 +294,9 @@ int ngap_send_ng_setup_response(amf_gnb_t *gnb)
     int rv;
     ogs_pkbuf_t *ngap_buffer;
 
-    ogs_debug("NG-Setup response");
+    ogs_assert(gnb);
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_debug("NG-Setup response");
 
     ngap_buffer = ngap_build_ng_setup_response();
     if (!ngap_buffer) {
@@ -313,12 +316,9 @@ int ngap_send_ng_setup_failure(
     int rv;
     ogs_pkbuf_t *ngap_buffer;
 
-    ogs_debug("NG-Setup failure");
+    ogs_assert(gnb);
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_debug("NG-Setup failure");
 
     ngap_buffer = ngap_build_ng_setup_failure(
             group, cause, NGAP_TimeToWait_v10s);
@@ -338,12 +338,9 @@ int ngap_send_ran_configuration_update_ack(amf_gnb_t *gnb)
     int rv;
     ogs_pkbuf_t *ngap_buffer;
 
-    ogs_debug("RANConfigurationUpdateAcknowledge");
+    ogs_assert(gnb);
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_debug("RANConfigurationUpdateAcknowledge");
 
     ngap_buffer = ngap_build_ran_configuration_update_ack();
     if (!ngap_buffer) {
@@ -363,12 +360,9 @@ int ngap_send_ran_configuration_update_failure(
     int rv;
     ogs_pkbuf_t *ngap_buffer;
 
-    ogs_debug("RANConfigurationUpdateFailure");
+    ogs_assert(gnb);
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_debug("RANConfigurationUpdateFailure");
 
     ngap_buffer = ngap_build_ran_configuration_update_failure(
             group, cause, NGAP_TimeToWait_v10s);
@@ -390,7 +384,7 @@ int ngap_send_ran_ue_context_release_command(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!ran_ue_cycle(ran_ue)) {
+    if (!ran_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -427,13 +421,14 @@ int ngap_send_amf_ue_context_release_command(
 {
     int rv;
 
-    if (!amf_ue_cycle(amf_ue)) {
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
     rv = ngap_send_ran_ue_context_release_command(
-            amf_ue->ran_ue, group, cause, action, duration);
+            ran_ue_find_by_id(amf_ue->ran_ue_id),
+            group, cause, action, duration);
     ogs_expect(rv == OGS_OK);
     ogs_debug("    SUPI[%s]", amf_ue->supi);
 
@@ -449,7 +444,7 @@ int ngap_send_paging(amf_ue_t *amf_ue)
 
     ogs_debug("NG-Paging");
 
-    if (!amf_ue_cycle(amf_ue)) {
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -503,10 +498,7 @@ int ngap_send_downlink_ran_configuration_transfer(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!amf_gnb_cycle(target_gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(target_gnb);
     ogs_assert(transfer);
 
     ngapbuf = ngap_build_downlink_ran_configuration_transfer(transfer);
@@ -529,20 +521,18 @@ int ngap_send_path_switch_ack(amf_sess_t *sess)
     ran_ue_t *ran_ue = NULL;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    ogs_assert(sess);
-    sess = amf_sess_cycle(sess);
     if (!sess) {
         ogs_error("Session has already been removed");
         return OGS_NOTFOUND;
     }
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    ran_ue = ran_ue_cycle(amf_ue->ran_ue);
+    ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     if (!ran_ue) {
         ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         return OGS_NOTFOUND;
@@ -567,18 +557,18 @@ int ngap_send_handover_request(amf_ue_t *amf_ue)
     ran_ue_t *source_ue = NULL, *target_ue = NULL;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!amf_ue_cycle(amf_ue)) {
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    source_ue = ran_ue_cycle(amf_ue->ran_ue);
+    source_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     if (!source_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    target_ue = ran_ue_cycle(source_ue->target_ue);
+    target_ue = ran_ue_find_by_id(source_ue->target_ue_id);
     if (!target_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
@@ -602,7 +592,7 @@ int ngap_send_handover_preparation_failure(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!ran_ue_cycle(source_ue)) {
+    if (!source_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -628,12 +618,12 @@ int ngap_send_handover_command(amf_ue_t *amf_ue)
     ran_ue_t *source_ue = NULL;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!amf_ue_cycle(amf_ue)) {
+    if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    source_ue = ran_ue_cycle(amf_ue->ran_ue);
+    source_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     if (!source_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
@@ -656,7 +646,7 @@ int ngap_send_handover_cancel_ack(ran_ue_t *source_ue)
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!ran_ue_cycle(source_ue)) {
+    if (!source_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -680,7 +670,7 @@ int ngap_send_downlink_ran_status_transfer(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!ran_ue_cycle(target_ue)) {
+    if (!target_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -707,10 +697,7 @@ int ngap_send_error_indication(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(gnb);
 
     ngapbuf = ogs_ngap_build_error_indication(
             ran_ue_ngap_id, amf_ue_ngap_id, group, cause);
@@ -729,15 +716,21 @@ int ngap_send_error_indication2(
         ran_ue_t *ran_ue, NGAP_Cause_PR group, long cause)
 {
     int rv;
+    amf_gnb_t *gnb = NULL;
 
-    ran_ue = ran_ue_cycle(ran_ue);
     if (!ran_ue) {
         ogs_error("NG context has already been removed");
         return OGS_NOTFOUND;
     }
 
+    gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
+    if (!gnb) {
+        ogs_error("[%d] gNB has already been removed", ran_ue->gnb_id);
+        return OGS_NOTFOUND;
+    }
+
     rv = ngap_send_error_indication(
-        ran_ue->gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
+        gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
         group, cause);
     ogs_expect(rv == OGS_OK);
 
@@ -751,10 +744,7 @@ int ngap_send_ng_reset_ack(
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
-    if (!amf_gnb_cycle(gnb)) {
-        ogs_error("gNB has already been removed");
-        return OGS_NOTFOUND;
-    }
+    ogs_assert(gnb);
 
     ngapbuf = ogs_ngap_build_ng_reset_ack(partOfNG_Interface);
     if (!ngapbuf) {

--- a/src/amf/ngap-sm.c
+++ b/src/amf/ngap-sm.c
@@ -54,7 +54,7 @@ void ngap_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
     amf_sm_debug(e);
 
-    gnb = e->gnb;
+    gnb = amf_gnb_find_by_id(e->gnb_id);
     ogs_assert(gnb);
 
     switch (e->h.id) {
@@ -191,10 +191,10 @@ void ngap_state_operational(ogs_fsm_t *s, amf_event_t *e)
     case AMF_EVENT_NGAP_TIMER:
         switch (e->h.timer_id) {
         case AMF_TIMER_NG_DELAYED_SEND:
-            ogs_assert(e->ran_ue);
             ogs_assert(e->pkbuf);
 
-            r = ngap_send_to_ran_ue(e->ran_ue, e->pkbuf);
+            r = ngap_send_to_ran_ue(
+                    ran_ue_find_by_id(e->ran_ue_id), e->pkbuf);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
 

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -84,13 +84,15 @@ void amf_nnrf_handle_nf_discover(
             ogs_error("[%d:%d] (NF discover) No [%s]", sess->psi, sess->pti,
                         ogs_sbi_service_type_to_name(service_type));
             if (sess->payload_container_type) {
-                r = nas_5gs_send_back_gsm_message(sess->ran_ue, sess,
+                r = nas_5gs_send_back_gsm_message(
+                        ran_ue_find_by_id(sess->ran_ue_id), sess,
                         OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                         AMF_NAS_BACKOFF_TIME);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
             } else {
-                r = ngap_send_error_indication2(sess->ran_ue,
+                r = ngap_send_error_indication2(
+                        ran_ue_find_by_id(sess->ran_ue_id),
                         NGAP_Cause_PR_transport,
                         NGAP_CauseTransport_transport_resource_unavailable);
                 ogs_expect(r == OGS_OK);

--- a/src/amf/nnssf-handler.c
+++ b/src/amf/nnssf-handler.c
@@ -42,21 +42,20 @@ int amf_nnssf_nsselection_handle_get(
     ogs_assert(recvmsg);
     ogs_assert(!SESSION_CONTEXT_IN_SMF(sess));
 
-    sess = amf_sess_cycle(sess);
     if (!sess) {
         ogs_error("Session has already been removed");
         return OGS_ERROR;
     }
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf_ue) Context has already been removed");
         return OGS_ERROR;
     }
 
-    ran_ue = ran_ue_cycle(sess->ran_ue);
+    ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
     if (!ran_ue) {
-        ogs_error("NG context has already been removed");
+        ogs_error("[%s] RAN-NG Context has already been removed", amf_ue->supi);
         return OGS_ERROR;
     }
 

--- a/src/amf/npcf-build.c
+++ b/src/amf/npcf-build.c
@@ -38,7 +38,7 @@ ogs_sbi_request_t *amf_npcf_am_policy_control_build_create(
 
     ogs_assert(amf_ue);
     ogs_assert(amf_ue->supi);
-    ogs_assert(ran_ue_cycle(amf_ue->ran_ue));
+    ogs_assert(ran_ue_find_by_id(amf_ue->ran_ue_id));
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -39,10 +39,10 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     ogs_sbi_nf_instance_t *pcf_nf_instance = NULL;
 
     ogs_assert(sess);
-    amf_ue = sess->amf_ue;
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
     ogs_assert(amf_ue->nas.access_type);
-    ogs_assert(ran_ue_cycle(amf_ue->ran_ue));
+    ogs_assert(ran_ue_find_by_id(amf_ue->ran_ue_id));
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
@@ -274,7 +274,7 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_update_sm_context(
     ogs_assert(param);
     ogs_assert(sess);
     ogs_assert(sess->sm_context.resource_uri);
-    amf_ue = sess->amf_ue;
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     ogs_assert(amf_ue);
 
     memset(&message, 0, sizeof(message));
@@ -407,8 +407,6 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_release_sm_context(
 
     ogs_assert(sess);
     ogs_assert(sess->sm_context.resource_uri);
-    amf_ue = sess->amf_ue;
-    ogs_assert(amf_ue);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
@@ -432,6 +430,13 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_release_sm_context(
     }
 
     memset(&ueLocation, 0, sizeof(ueLocation));
+
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
+    if (!amf_ue) {
+        ogs_error("UE(amf_ue) Context has already been removed");
+        goto end;
+    }
+
     ueLocation.nr_location = ogs_sbi_build_nr_location(
             &amf_ue->nr_tai, &amf_ue->nr_cgi);
     if (!ueLocation.nr_location) {

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -33,20 +33,19 @@ int amf_nsmf_pdusession_handle_create_sm_context(
     ran_ue_t *ran_ue = NULL;
 
     ogs_assert(recvmsg);
-    ogs_assert(sess);
-    sess = amf_sess_cycle(sess);
+
     if (!sess) {
         ogs_error("Session has already been removed");
         return OGS_ERROR;
     }
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf_ue) Context has already been removed");
         return OGS_ERROR;
     }
 
-    ran_ue = ran_ue_cycle(sess->ran_ue);
+    ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
     if (!ran_ue) {
         ogs_error("[%s] RAN-NG Context has already been removed", amf_ue->supi);
         return OGS_ERROR;
@@ -255,20 +254,19 @@ int amf_nsmf_pdusession_handle_update_sm_context(
     ran_ue_t *ran_ue = NULL;
 
     ogs_assert(recvmsg);
-    ogs_assert(sess);
-    sess = amf_sess_cycle(sess);
+
     if (!sess) {
         ogs_error("Session has already been removed");
         return OGS_ERROR;
     }
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf_ue) Context has already been removed");
         return OGS_ERROR;
     }
 
-    ran_ue = ran_ue_cycle(sess->ran_ue);
+    ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
 
     if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_NO_CONTENT ||
         recvmsg->res_status == OGS_SBI_HTTP_STATUS_OK) {
@@ -711,9 +709,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
                     ran_ue_t *source_ue = NULL, *target_ue = NULL;
 
-                    source_ue = sess->ran_ue;
+                    source_ue = ran_ue_find_by_id(sess->ran_ue_id);
                     ogs_assert(source_ue);
-                    target_ue = ran_ue_cycle(source_ue->target_ue);
+                    target_ue = ran_ue_find_by_id(source_ue->target_ue_id);
                     if (target_ue) {
                         r = ngap_send_ran_ue_context_release_command(
                                 target_ue,
@@ -783,7 +781,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                     amf_ue_deassociate(amf_ue);
 
                     if (ran_ue) {
-                        amf_gnb_t *gnb = ran_ue->gnb;
+                        amf_gnb_t *gnb = NULL;
+
+                        gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
                         ogs_assert(gnb);
 
                         ogs_debug("    SUPI[%s]", amf_ue->supi);
@@ -839,7 +839,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                     amf_ue_deassociate(amf_ue);
 
                     if (ran_ue) {
-                        amf_gnb_t *gnb = ran_ue->gnb;
+                        amf_gnb_t *gnb = NULL;
+
+                        gnb = amf_gnb_find_by_id(ran_ue->gnb_id);
                         ogs_assert(gnb);
 
                         ogs_debug("    SUPI[%s]", amf_ue->supi);
@@ -936,8 +938,16 @@ int amf_nsmf_pdusession_handle_update_sm_context(
         ogs_pkbuf_t *n2smbuf = NULL;
 #endif
 
-        amf_ue = sess->amf_ue;
-        ogs_assert(amf_ue);
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
+        if (!amf_ue) {
+            ogs_error("[%d:%d] UE context has already been removed [%d]",
+                    sess->psi, sess->pti, recvmsg->res_status);
+            r = ngap_send_error_indication2(ran_ue,
+                    NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+            return OGS_ERROR;
+        }
 
         SmContextUpdateError = recvmsg->SmContextUpdateError;
         if (!SmContextUpdateError) {
@@ -1072,20 +1082,18 @@ int amf_nsmf_pdusession_handle_release_sm_context(amf_sess_t *sess, int state)
     amf_ue_t *amf_ue = NULL;
     ran_ue_t *ran_ue = NULL;
 
-    ogs_assert(sess);
-    sess = amf_sess_cycle(sess);
     if (!sess) {
         ogs_error("Session has already been removed");
         return OGS_ERROR;
     }
 
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf_ue) Context has already been removed");
         return OGS_ERROR;
     }
 
-    ran_ue = ran_ue_cycle(sess->ran_ue);
+    ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
 
     /*
      * To check if Reactivation Request has been used.

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -144,7 +144,7 @@ int amf_nudm_sdm_handle_provisioned(
         if (amf_update_allowed_nssai(amf_ue) == false) {
             ogs_error("No Allowed-NSSAI");
             r = nas_5gs_send_gmm_reject(
-                    amf_ue->ran_ue, amf_ue,
+                    ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                     OGS_5GMM_CAUSE_NO_NETWORK_SLICES_AVAILABLE);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -154,7 +154,7 @@ int amf_nudm_sdm_handle_provisioned(
         if (amf_ue_is_rat_restricted(amf_ue)) {
             ogs_error("Registration rejected due to RAT restrictions");
             r = nas_5gs_send_gmm_reject(
-                    amf_ue->ran_ue, amf_ue,
+                    ran_ue_find_by_id(amf_ue->ran_ue_id), amf_ue,
                     OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -127,7 +127,7 @@ int amf_ue_sbi_discover_and_send(
     }
 
     xact = ogs_sbi_xact_add(
-            &amf_ue->sbi, service_type, discovery_option,
+            amf_ue->id, &amf_ue->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, amf_ue, data);
     if (!xact) {
         ogs_error("amf_ue_sbi_discover_and_send() failed");
@@ -169,21 +169,18 @@ int amf_sess_sbi_discover_and_send(
     ogs_assert(build);
 
     if (ran_ue) {
-        sess->ran_ue = ran_ue_cycle(ran_ue);
-        if (!sess->ran_ue) {
-            ogs_error("NG context has already been removed");
-            return OGS_NOTFOUND;
-        }
+        sess->ran_ue_id = ran_ue->id;
     } else
-        sess->ran_ue = NULL;
+        sess->ran_ue_id = OGS_INVALID_POOL_ID;
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, service_type, discovery_option,
+            sess->id, &sess->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
-        r = nas_5gs_send_back_gsm_message(sess->ran_ue, sess,
-            OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
+        r = nas_5gs_send_back_gsm_message(
+                ran_ue_find_by_id(sess->ran_ue_id), sess,
+                OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
         return OGS_ERROR;
@@ -195,8 +192,9 @@ int amf_sess_sbi_discover_and_send(
     if (rv != OGS_OK) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
         ogs_sbi_xact_remove(xact);
-        r = nas_5gs_send_back_gsm_message(sess->ran_ue, sess,
-            OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
+        r = nas_5gs_send_back_gsm_message(
+                ran_ue_find_by_id(sess->ran_ue_id), sess,
+                OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
         return rv;
@@ -211,7 +209,7 @@ static int client_discover_cb(
     ogs_sbi_message_t message;
 
     ogs_sbi_xact_t *xact = NULL;
-    ogs_pool_id_t xact_id = 0;
+    ogs_pool_id_t xact_id = OGS_INVALID_POOL_ID;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
@@ -230,16 +228,13 @@ static int client_discover_cb(
         return OGS_ERROR;
     }
 
-    sess = (amf_sess_t *)xact->sbi_object;
-    ogs_assert(sess);
-
     service_type = xact->service_type;
     ogs_assert(service_type);
     requester_nf_type = xact->requester_nf_type;
     ogs_assert(requester_nf_type);
     discovery_option = xact->discovery_option;
 
-    sess = amf_sess_cycle(sess);
+    sess = amf_sess_find_by_id(xact->sbi_object_id);
     if (!sess) {
         ogs_error("Session has already been removed");
         ogs_sbi_xact_remove(xact);
@@ -249,7 +244,7 @@ static int client_discover_cb(
     }
 
     ogs_assert(sess->sbi.type == OGS_SBI_OBJ_SESS_TYPE);
-    amf_ue = amf_ue_cycle(sess->amf_ue);
+    amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
     if (!amf_ue) {
         ogs_error("UE(amf-ue) context has already been removed");
         ogs_sbi_xact_remove(xact);
@@ -257,7 +252,7 @@ static int client_discover_cb(
             ogs_sbi_response_free(response);
         return OGS_ERROR;
     }
-    ran_ue = ran_ue_cycle(sess->ran_ue);
+    ran_ue = ran_ue_find_by_id(sess->ran_ue_id);
     if (!ran_ue) {
         ogs_error("[%s] NG context has already been removed", amf_ue->supi);
         ogs_sbi_xact_remove(xact);
@@ -368,16 +363,13 @@ int amf_sess_sbi_discover_by_nsi(
                 ogs_sbi_service_type_to_name(service_type));
 
     if (ran_ue) {
-        sess->ran_ue = ran_ue_cycle(ran_ue);
-        if (!sess->ran_ue) {
-            ogs_error("NG context has already been removed");
-            return OGS_NOTFOUND;
-        }
+        sess->ran_ue_id = ran_ue->id;
     } else
-        sess->ran_ue = NULL;
+        sess->ran_ue_id = OGS_INVALID_POOL_ID;
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, service_type, discovery_option, NULL, NULL, NULL);
+            sess->id, &sess->sbi,
+            service_type, discovery_option, NULL, NULL, NULL);
     if (!xact) {
         ogs_error("ogs_sbi_xact_add() failed");
         return OGS_ERROR;
@@ -459,7 +451,7 @@ void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state)
     ogs_list_for_each_safe(&gnb->ran_ue_list, ran_ue_next, ran_ue) {
         int old_xact_count = 0, new_xact_count = 0;
 
-        amf_ue = amf_ue_cycle(ran_ue->amf_ue);
+        amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
 
         if (amf_ue) {
             old_xact_count = amf_sess_xact_count(amf_ue);

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -211,6 +211,7 @@ static int client_discover_cb(
     ogs_sbi_message_t message;
 
     ogs_sbi_xact_t *xact = NULL;
+    ogs_pool_id_t xact_id = 0;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
@@ -218,10 +219,10 @@ static int client_discover_cb(
     ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
 
-    xact = data;
-    ogs_assert(xact);
+    xact_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(xact_id >= OGS_MIN_POOL_ID && xact_id <= OGS_MAX_POOL_ID);
 
-    xact = ogs_sbi_xact_cycle(xact);
+    xact = ogs_sbi_xact_find_by_id(xact_id);
     if (!xact) {
         ogs_error("SBI transaction has already been removed");
         if (response)
@@ -391,7 +392,8 @@ int amf_sess_sbi_discover_by_nsi(
     }
 
     return ogs_sbi_client_send_request(
-            client, client_discover_cb, xact->request, xact) == true ? OGS_OK : OGS_ERROR;
+            client, client_discover_cb, xact->request,
+            OGS_UINT_TO_POINTER(xact->id)) == true ? OGS_OK : OGS_ERROR;
 }
 
 void amf_sbi_send_activating_session(

--- a/src/amf/timer.c
+++ b/src/amf/timer.c
@@ -49,9 +49,6 @@ static amf_timer_cfg_t g_amf_timer_cfg[MAX_NUM_OF_AMF_TIMER] = {
         { .have = true, .duration = ogs_time_from_sec(30) },
 };
 
-static void gmm_timer_event_send(
-        amf_timer_e timer_id, amf_ue_t *amf_ue);
-
 amf_timer_cfg_t *amf_timer_cfg(amf_timer_e id)
 {
     ogs_assert(id < MAX_NUM_OF_AMF_TIMER);
@@ -124,16 +121,17 @@ void amf_timer_ng_delayed_send(void *data)
 }
 
 static void gmm_timer_event_send(
-        amf_timer_e timer_id, amf_ue_t *amf_ue)
+        amf_timer_e timer_id, void *data)
 {
     int rv;
     amf_event_t *e = NULL;
-    ogs_assert(amf_ue);
+
+    ogs_assert(data);
 
     e = amf_event_new(AMF_EVENT_5GMM_TIMER);
     ogs_assert(e);
     e->h.timer_id = timer_id;
-    e->amf_ue = amf_ue;
+    e->amf_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -172,16 +170,14 @@ void amf_timer_ng_holding_timer_expire(void *data)
 {
     int rv;
     amf_event_t *e = NULL;
-    ran_ue_t *ran_ue = NULL;
 
     ogs_assert(data);
-    ran_ue = data;
 
     e = amf_event_new(AMF_EVENT_NGAP_TIMER);
     ogs_assert(e);
 
     e->h.timer_id = AMF_TIMER_NG_HOLDING;
-    e->ran_ue = ran_ue;
+    e->ran_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -39,7 +39,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -47,7 +47,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     ausf_ue_t *ausf_ue = NULL;
 

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -50,6 +50,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     ausf_ue_t *ausf_ue = NULL;
+    ogs_pool_id_t ausf_ue_id = OGS_INVALID_POOL_ID;
 
     ausf_sm_debug(e);
 
@@ -164,7 +165,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
 
             ogs_assert(OGS_FSM_STATE(&ausf_ue->sm));
 
-            e->ausf_ue = ausf_ue;
+            e->ausf_ue_id = ausf_ue->id;
             e->h.sbi.message = &message;
             ogs_fsm_dispatch(&ausf_ue->sm, e);
             if (OGS_FSM_CHECK(&ausf_ue->sm, ausf_ue_state_exception)) {
@@ -326,8 +327,9 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                 break;
             }
 
-            ausf_ue = (ausf_ue_t *)sbi_xact->sbi_object;
-            ogs_assert(ausf_ue);
+            ausf_ue_id = sbi_xact->sbi_object_id;
+            ogs_assert(ausf_ue_id >= OGS_MIN_POOL_ID &&
+                    ausf_ue_id <= OGS_MAX_POOL_ID);
 
             ogs_assert(sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
                     sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID);
@@ -335,13 +337,13 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
 
             ogs_sbi_xact_remove(sbi_xact);
 
-            ausf_ue = ausf_ue_cycle(ausf_ue);
+            ausf_ue = ausf_ue_find_by_id(ausf_ue_id);
             if (!ausf_ue) {
                 ogs_error("UE(ausf-ue) Context has already been removed");
                 break;
             }
 
-            e->ausf_ue = ausf_ue;
+            e->ausf_ue_id = ausf_ue->id;
             e->h.sbi.message = &message;
 
             ogs_fsm_dispatch(&ausf_ue->sm, e);

--- a/src/ausf/context.c
+++ b/src/ausf/context.c
@@ -131,13 +131,11 @@ ausf_ue_t *ausf_ue_add(char *suci)
 
     ogs_assert(suci);
 
-    ogs_pool_alloc(&ausf_ue_pool, &ausf_ue);
+    ogs_pool_id_calloc(&ausf_ue_pool, &ausf_ue);
     if (!ausf_ue) {
-        ogs_error("ogs_pool_alloc() failed");
+        ogs_error("ogs_pool_id_calloc() failed");
         return NULL;
     }
-    ogs_assert(ausf_ue);
-    memset(ausf_ue, 0, sizeof *ausf_ue);
 
     ausf_ue->ctx_id =
         ogs_msprintf("%d", (int)ogs_pool_index(&ausf_ue_pool, ausf_ue));
@@ -148,7 +146,7 @@ ausf_ue_t *ausf_ue_add(char *suci)
     ogs_hash_set(self.suci_hash, ausf_ue->suci, strlen(ausf_ue->suci), ausf_ue);
 
     memset(&e, 0, sizeof(e));
-    e.ausf_ue = ausf_ue;
+    e.ausf_ue_id = ausf_ue->id;
     ogs_fsm_init(&ausf_ue->sm, ausf_ue_state_initial, ausf_ue_state_final, &e);
 
     ogs_list_add(&self.ausf_ue_list, ausf_ue);
@@ -165,7 +163,7 @@ void ausf_ue_remove(ausf_ue_t *ausf_ue)
     ogs_list_remove(&self.ausf_ue_list, ausf_ue);
 
     memset(&e, 0, sizeof(e));
-    e.ausf_ue = ausf_ue;
+    e.ausf_ue_id = ausf_ue->id;
     ogs_fsm_fini(&ausf_ue->sm, &e);
 
     /* Free SBI object memory */
@@ -191,7 +189,7 @@ void ausf_ue_remove(ausf_ue_t *ausf_ue)
     if (ausf_ue->serving_network_name)
         ogs_free(ausf_ue->serving_network_name);
     
-    ogs_pool_free(&ausf_ue_pool, ausf_ue);
+    ogs_pool_id_free(&ausf_ue_pool, ausf_ue);
 }
 
 void ausf_ue_remove_all(void)
@@ -229,9 +227,9 @@ ausf_ue_t *ausf_ue_find_by_ctx_id(char *ctx_id)
     return ogs_pool_find(&ausf_ue_pool, atoll(ctx_id));
 }
 
-ausf_ue_t *ausf_ue_cycle(ausf_ue_t *ausf_ue)
+ausf_ue_t *ausf_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&ausf_ue_pool, ausf_ue);
+    return ogs_pool_find_by_id(&ausf_ue_pool, id);
 }
 
 int get_ue_load(void)

--- a/src/ausf/context.h
+++ b/src/ausf/context.h
@@ -44,6 +44,7 @@ typedef struct ausf_context_s {
 
 struct ausf_ue_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
     ogs_fsm_t sm;
 
     char *ctx_id;
@@ -93,8 +94,8 @@ ausf_ue_t *ausf_ue_find_by_suci(char *suci);
 ausf_ue_t *ausf_ue_find_by_supi(char *supi);
 ausf_ue_t *ausf_ue_find_by_suci_or_supi(char *suci_or_supi);
 ausf_ue_t *ausf_ue_find_by_ctx_id(char *ctx_id);
+ausf_ue_t *ausf_ue_find_by_id(ogs_pool_id_t id);
 
-ausf_ue_t *ausf_ue_cycle(ausf_ue_t *ausf_ue);
 int get_ue_load(void);
 
 #ifdef __cplusplus

--- a/src/ausf/event.h
+++ b/src/ausf/event.h
@@ -31,7 +31,7 @@ typedef struct ausf_ue_s ausf_ue_t;
 typedef struct ausf_event_s {
     ogs_event_t h;
 
-    ausf_ue_t *ausf_ue;
+    ogs_pool_id_t ausf_ue_id;
 } ausf_event_t;
 
 OGS_STATIC_ASSERT(OGS_EVENT_SIZE >= sizeof(ausf_event_t));

--- a/src/ausf/sbi-path.c
+++ b/src/ausf/sbi-path.c
@@ -89,7 +89,7 @@ int ausf_sbi_discover_and_send(
     ogs_assert(build);
 
     xact = ogs_sbi_xact_add(
-            &ausf_ue->sbi, service_type, discovery_option,
+            0, &ausf_ue->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, ausf_ue, data);
     if (!xact) {
         ogs_error("ausf_sbi_discover_and_send() failed");

--- a/src/ausf/sbi-path.c
+++ b/src/ausf/sbi-path.c
@@ -100,7 +100,9 @@ int ausf_sbi_discover_and_send(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+    ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+            xact->assoc_stream_id <= OGS_MAX_POOL_ID);
 
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {

--- a/src/ausf/sbi-path.c
+++ b/src/ausf/sbi-path.c
@@ -88,8 +88,11 @@ int ausf_sbi_discover_and_send(
     ogs_assert(stream);
     ogs_assert(build);
 
+    ogs_assert(ausf_ue->id >= OGS_MIN_POOL_ID &&
+            ausf_ue->id <= OGS_MAX_POOL_ID);
+
     xact = ogs_sbi_xact_add(
-            0, &ausf_ue->sbi, service_type, discovery_option,
+            ausf_ue->id, &ausf_ue->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, ausf_ue, data);
     if (!xact) {
         ogs_error("ausf_sbi_discover_and_send() failed");

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -31,7 +31,7 @@ void ausf_ue_state_initial(ogs_fsm_t *s, ausf_event_t *e)
 
     ausf_sm_debug(e);
 
-    ausf_ue = e->ausf_ue;
+    ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
     ogs_assert(ausf_ue);
 
     OGS_FSM_TRAN(s, &ausf_ue_state_operational);
@@ -46,7 +46,7 @@ void ausf_ue_state_final(ogs_fsm_t *s, ausf_event_t *e)
 
     ausf_sm_debug(e);
 
-    ausf_ue = e->ausf_ue;
+    ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
     ogs_assert(ausf_ue);
 }
 
@@ -64,7 +64,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
 
     ausf_sm_debug(e);
 
-    ausf_ue = e->ausf_ue;
+    ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
     ogs_assert(ausf_ue);
 
     switch (e->h.id) {
@@ -152,7 +152,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
         message = e->h.sbi.message;
         ogs_assert(message);
 
-        ausf_ue = e->ausf_ue;
+        ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
         ogs_assert(ausf_ue);
 
         stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
@@ -242,7 +242,7 @@ void ausf_ue_state_deleted(ogs_fsm_t *s, ausf_event_t *e)
 
     ausf_sm_debug(e);
 
-    ausf_ue = e->ausf_ue;
+    ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
     ogs_assert(ausf_ue);
 
     switch (e->h.id) {
@@ -266,7 +266,7 @@ void ausf_ue_state_exception(ogs_fsm_t *s, ausf_event_t *e)
 
     ausf_sm_debug(e);
 
-    ausf_ue = e->ausf_ue;
+    ausf_ue = ausf_ue_find_by_id(e->ausf_ue_id);
     ogs_assert(ausf_ue);
 
     switch (e->h.id) {

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -56,7 +56,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     ausf_ue_t *ausf_ue = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -56,6 +56,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     ausf_ue_t *ausf_ue = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -76,8 +77,16 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.method)
         CASE(OGS_SBI_HTTP_METHOD_POST)
@@ -145,8 +154,16 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
 
         ausf_ue = e->ausf_ue;
         ogs_assert(ausf_ue);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_UEAU)

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -44,7 +44,7 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
     bsf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -52,7 +52,7 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     bsf_sm_debug(e);
 

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -51,6 +51,7 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
+    ogs_pool_id_t sbi_xact_id = 0;
 
     bsf_sm_debug(e);
 
@@ -285,8 +286,17 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_DISC)
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
+
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
+                if (!sbi_xact) {
+                    /* CLIENT_WAIT timer could remove SBI transaction
+                     * before receiving SBI message */
+                    ogs_error("SBI transaction has already been removed");
+                    break;
+                }
 
                 SWITCH(message.h.method)
                 CASE(OGS_SBI_HTTP_METHOD_GET)
@@ -393,9 +403,13 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
              * 4. timer expiration event is processed. (double-free SBI xact)
              *
              * To avoid double-free SBI xact,
-             * we need to check ogs_sbi_xact_cycle()
+             * we need to check ogs_sbi_xact_find_by_id()
              */
-            sbi_xact = ogs_sbi_xact_cycle(e->h.sbi.data);
+            sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+            ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact_id <= OGS_MAX_POOL_ID);
+
+            sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
                 ogs_error("SBI transaction has already been removed");
                 break;

--- a/src/bsf/sbi-path.c
+++ b/src/bsf/sbi-path.c
@@ -89,7 +89,7 @@ int bsf_sbi_discover_and_send(
     ogs_assert(build);
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, service_type, discovery_option,
+            0, &sess->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("bsf_sbi_discover_and_send() failed");

--- a/src/bsf/sbi-path.c
+++ b/src/bsf/sbi-path.c
@@ -100,7 +100,9 @@ int bsf_sbi_discover_and_send(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+    ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+            xact->assoc_stream_id <= OGS_MAX_POOL_ID);
 
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {

--- a/src/mme/emm-handler.c
+++ b/src/mme/emm-handler.c
@@ -55,15 +55,14 @@ int emm_handle_attach_request(mme_ue_t *mme_ue,
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
 
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_assert(esm_message_container);
     if (!esm_message_container->length) {
         ogs_error("No ESM Message Container");
-        r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE,
                 OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
         ogs_expect(r == OGS_OK);
@@ -143,7 +142,7 @@ int emm_handle_attach_request(mme_ue_t *mme_ue,
         /* Send Attach Reject */
         ogs_warn("Cannot find Served TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-        r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_TRACKING_AREA_NOT_ALLOWED,
                 OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
         ogs_expect(r == OGS_OK);
@@ -187,7 +186,7 @@ int emm_handle_attach_request(mme_ue_t *mme_ue,
             "but Integrity[0x%x] cannot be bypassed with EIA0",
             mme_selected_enc_algorithm(mme_ue),
             mme_selected_int_algorithm(mme_ue));
-        r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_UE_SECURITY_CAPABILITIES_MISMATCH,
                 OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
         ogs_expect(r == OGS_OK);
@@ -210,7 +209,7 @@ int emm_handle_attach_request(mme_ue_t *mme_ue,
         emm_cause = emm_cause_from_access_control(mme_ue);
         if (emm_cause != OGS_NAS_EMM_CAUSE_REQUEST_ACCEPTED) {
             ogs_error("Rejected by PLMN-ID access control");
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     emm_cause, OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -270,7 +269,6 @@ int emm_handle_attach_complete(
     struct tm gmt, local;
 
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
     ogs_info("    IMSI[%s]", mme_ue->imsi_bcd);
 
@@ -358,7 +356,8 @@ int emm_handle_attach_complete(
         return OGS_ERROR;
     }
 
-    r = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    r = nas_eps_send_to_downlink_nas_transport(
+            enb_ue_find_by_id(mme_ue->enb_ue_id), emmbuf);
     ogs_expect(r == OGS_OK);
     ogs_assert(r != OGS_ERROR);
 
@@ -379,7 +378,7 @@ int emm_handle_identity_response(
     ogs_assert(identity_response);
 
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     mobile_identity = &identity_response->mobile_identity;
@@ -391,7 +390,7 @@ int emm_handle_identity_response(
             ogs_error("mobile_identity length (%d != %d)",
                     (int)sizeof(ogs_nas_mobile_identity_imsi_t),
                     mobile_identity->length);
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     OGS_NAS_EMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE,
                     OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
@@ -404,7 +403,7 @@ int emm_handle_identity_response(
         emm_cause = emm_cause_from_access_control(mme_ue);
         if (emm_cause != OGS_NAS_EMM_CAUSE_REQUEST_ACCEPTED) {
             ogs_error("Rejected by PLMN-ID access control");
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     emm_cause, OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
@@ -417,7 +416,7 @@ int emm_handle_identity_response(
 
         if (mme_ue->imsi_len != OGS_MAX_IMSI_LEN) {
             ogs_error("Invalid IMSI LEN[%d]", mme_ue->imsi_len);
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     OGS_NAS_EMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE,
                     OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
@@ -595,7 +594,7 @@ int emm_handle_tau_request(mme_ue_t *mme_ue,
     enb_ue_t *enb_ue = NULL;
 
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_assert(pkbuf);
@@ -656,7 +655,7 @@ int emm_handle_tau_request(mme_ue_t *mme_ue,
         /* Send TAU reject */
         ogs_warn("Cannot find Served TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-        r = nas_eps_send_tau_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_tau_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_TRACKING_AREA_NOT_ALLOWED);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -750,7 +749,7 @@ int emm_handle_extended_service_request(mme_ue_t *mme_ue,
     enb_ue_t *enb_ue = NULL;
 
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     /* Set Service Type */
@@ -793,7 +792,7 @@ int emm_handle_extended_service_request(mme_ue_t *mme_ue,
         /* Send TAU reject */
         ogs_warn("Cannot find Served TAI[PLMN_ID:%06x,TAC:%d]",
             ogs_plmn_id_hexdump(&mme_ue->tai.plmn_id), mme_ue->tai.tac);
-        r = nas_eps_send_tau_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_tau_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_TRACKING_AREA_NOT_ALLOWED);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -823,7 +822,6 @@ int emm_handle_security_mode_complete(mme_ue_t *mme_ue,
     ogs_nas_mobile_identity_t *imeisv = &security_mode_complete->imeisv;
 
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
     if (security_mode_complete->presencemask &
         OGS_NAS_EPS_SECURITY_MODE_COMMAND_IMEISV_REQUEST_PRESENT) {

--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -72,7 +72,7 @@ void emm_state_de_registered(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -123,7 +123,7 @@ void emm_state_registered(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -296,7 +296,7 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -304,7 +304,7 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
         message = e->nas_message;
         ogs_assert(message);
 
-        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         ogs_assert(enb_ue);
 
         h.type = e->nas_type;
@@ -895,17 +895,22 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
             } else {
                 S1AP_MME_UE_S1AP_ID_t MME_UE_S1AP_ID;
                 S1AP_ENB_UE_S1AP_ID_t ENB_UE_S1AP_ID;
+                mme_enb_t *enb = NULL;
 
                 ogs_warn("No connection of MSC/VLR");
                 MME_UE_S1AP_ID = enb_ue->mme_ue_s1ap_id;
                 ENB_UE_S1AP_ID = enb_ue->enb_ue_s1ap_id;
 
-                r = s1ap_send_error_indication(enb_ue->enb,
-                        &MME_UE_S1AP_ID, &ENB_UE_S1AP_ID,
-                        S1AP_Cause_PR_transport,
-                        S1AP_CauseTransport_transport_resource_unavailable);
-                ogs_expect(r == OGS_OK);
-                ogs_assert(r != OGS_ERROR);
+                enb = mme_enb_find_by_id(enb_ue->enb_id);
+                if (enb) {
+                    r = s1ap_send_error_indication(enb,
+                            &MME_UE_S1AP_ID, &ENB_UE_S1AP_ID,
+                            S1AP_Cause_PR_transport,
+                            S1AP_CauseTransport_transport_resource_unavailable);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+                } else
+                    ogs_error("eNB has already been removed");
             }
             break;
 
@@ -942,9 +947,8 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
@@ -955,7 +959,7 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
         message = e->nas_message;
         ogs_assert(message);
 
-        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         ogs_assert(enb_ue);
 
         switch (message->emm.h.message_type) {
@@ -1143,7 +1147,7 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -1159,7 +1163,7 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
         message = e->nas_message;
         ogs_assert(message);
 
-        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         ogs_assert(enb_ue);
 
         if (message->emm.h.security_header_type
@@ -1324,7 +1328,8 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
                         "Stop retransmission", mme_ue->imsi_bcd);
                 OGS_FSM_TRAN(&mme_ue->sm, &emm_state_exception);
 
-                r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+                r = nas_eps_send_attach_reject(
+                        enb_ue_find_by_id(mme_ue->enb_ue_id), mme_ue,
                         OGS_NAS_EMM_CAUSE_SECURITY_MODE_REJECTED_UNSPECIFIED,
                         OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
                 ogs_expect(r == OGS_OK);
@@ -1361,7 +1366,7 @@ void emm_state_initial_context_setup(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -1373,7 +1378,7 @@ void emm_state_initial_context_setup(ogs_fsm_t *s, mme_event_t *e)
         message = e->nas_message;
         ogs_assert(message);
 
-        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         ogs_assert(enb_ue);
 
         xact_count = mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR);
@@ -1603,7 +1608,7 @@ void emm_state_initial_context_setup(ogs_fsm_t *s, mme_event_t *e)
                         mme_timer_cfg(MME_TIMER_T3450)->duration);
 
                 r = nas_eps_send_to_downlink_nas_transport(
-                        mme_ue->enb_ue, emmbuf);
+                        enb_ue_find_by_id(mme_ue->enb_ue_id), emmbuf);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
             }
@@ -1632,7 +1637,7 @@ void emm_state_exception(ogs_fsm_t *s, mme_event_t *e)
     ogs_assert(e);
     mme_sm_debug(e);
 
-    mme_ue = e->mme_ue;
+    mme_ue = mme_ue_find_by_id(e->mme_ue_id);
     ogs_assert(mme_ue);
 
     switch (e->id) {
@@ -1647,7 +1652,7 @@ void emm_state_exception(ogs_fsm_t *s, mme_event_t *e)
         message = e->nas_message;
         ogs_assert(message);
 
-        enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         ogs_assert(enb_ue);
 
         h.type = e->nas_type;

--- a/src/mme/esm-build.c
+++ b/src/mme/esm-build.c
@@ -33,7 +33,7 @@ ogs_pkbuf_t *esm_build_pdn_connectivity_reject(
             &message.esm.pdn_connectivity_reject;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("PDN connectivity reject");
@@ -68,9 +68,9 @@ ogs_pkbuf_t *esm_build_information_request(mme_bearer_t *bearer)
     mme_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("ESM information request");
@@ -117,7 +117,7 @@ ogs_pkbuf_t *esm_build_activate_default_bearer_context_request(
     ogs_session_t *session = NULL;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
     session = sess->session;
     ogs_assert(session);
@@ -269,9 +269,9 @@ ogs_pkbuf_t *esm_build_activate_dedicated_bearer_context_request(
         &activate_dedicated_eps_bearer_context_request->tft;
     
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
     linked_bearer = mme_linked_bearer(bearer); 
     ogs_assert(linked_bearer);
@@ -333,9 +333,9 @@ ogs_pkbuf_t *esm_build_modify_bearer_context_request(
         &modify_eps_bearer_context_request->tft;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("Modify bearer context request");
@@ -383,9 +383,9 @@ ogs_pkbuf_t *esm_build_deactivate_bearer_context_request(
             &message.esm.deactivate_eps_bearer_context_request;
     
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("Deactivate bearer context request");

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -37,11 +37,10 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
     uint8_t security_protected_required = 0;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
     ogs_assert(req);
 
@@ -180,9 +179,8 @@ int esm_handle_information_response(mme_sess_t *sess,
     mme_ue_t *mme_ue = NULL;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
 
     ogs_assert(rsp);
 
@@ -278,9 +276,9 @@ int esm_handle_bearer_resource_allocation_request(
     mme_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
 
     r = nas_eps_send_bearer_resource_allocation_reject(
@@ -297,7 +295,7 @@ int esm_handle_bearer_resource_modification_request(
     mme_ue_t *mme_ue = NULL;
 
     ogs_assert(bearer);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_assert(OGS_OK ==

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2617,7 +2617,7 @@ static bool compare_apn_enb_info(
     ogs_assert(sess);
     ogs_assert(sess->session);
     ogs_assert(sess->session->name);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
 
     for (i = 0; i < pgw->num_of_apn; i++)
@@ -2795,9 +2795,11 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     ogs_assert(sock);
     ogs_assert(addr);
 
-    ogs_pool_alloc(&mme_enb_pool, &enb);
-    ogs_assert(enb);
-    memset(enb, 0, sizeof *enb);
+    ogs_pool_id_calloc(&mme_enb_pool, &enb);
+    if (!enb) {
+        ogs_error("ogs_pool_id_calloc() failed");
+        return NULL;
+    }
 
     enb->sctp.sock = sock;
     enb->sctp.addr = addr;
@@ -2820,7 +2822,7 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
             enb->sctp.addr, sizeof(ogs_sockaddr_t), enb);
 
     memset(&e, 0, sizeof(e));
-    e.enb = enb;
+    e.enb_id = enb->id;
     ogs_fsm_init(&enb->sm, s1ap_state_initial, s1ap_state_final, &e);
 
     ogs_list_add(&self.enb_list, enb);
@@ -2842,7 +2844,7 @@ int mme_enb_remove(mme_enb_t *enb)
     ogs_list_remove(&self.enb_list, enb);
 
     memset(&e, 0, sizeof(e));
-    e.enb = enb;
+    e.enb_id = enb->id;
     ogs_fsm_fini(&enb->sm, &e);
 
     ogs_hash_set(self.enb_addr_hash,
@@ -2858,7 +2860,7 @@ int mme_enb_remove(mme_enb_t *enb)
 
     ogs_sctp_flush_and_destroy(&enb->sctp);
 
-    ogs_pool_free(&mme_enb_pool, enb);
+    ogs_pool_id_free(&mme_enb_pool, enb);
     mme_metrics_inst_global_dec(MME_METR_GLOB_GAUGE_ENB);
     ogs_info("[Removed] Number of eNBs is now %d",
             ogs_list_count(&self.enb_list));
@@ -2917,9 +2919,9 @@ int mme_enb_sock_type(ogs_sock_t *sock)
     return SOCK_STREAM;
 }
 
-mme_enb_t *mme_enb_cycle(mme_enb_t *enb)
+mme_enb_t *mme_enb_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&mme_enb_pool, enb);
+    return ogs_pool_find_by_id(&mme_enb_pool, id);
 }
 
 /** enb_ue_context handling function */
@@ -2929,19 +2931,18 @@ enb_ue_t *enb_ue_add(mme_enb_t *enb, uint32_t enb_ue_s1ap_id)
 
     ogs_assert(enb);
 
-    ogs_pool_alloc(&enb_ue_pool, &enb_ue);
+    ogs_pool_id_calloc(&enb_ue_pool, &enb_ue);
     if (enb_ue == NULL) {
         ogs_error("Could not allocate enb_ue context from pool");
         return NULL;
     }
 
-    memset(enb_ue, 0, sizeof *enb_ue);
-
     enb_ue->t_s1_holding = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_s1_holding_timer_expire, enb_ue);
+            ogs_app()->timer_mgr, mme_timer_s1_holding_timer_expire,
+            OGS_UINT_TO_POINTER(enb_ue->id));
     if (!enb_ue->t_s1_holding) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&enb_ue_pool, enb_ue);
+        ogs_pool_id_free(&enb_ue_pool, enb_ue);
         return NULL;
     }
 
@@ -2961,7 +2962,7 @@ enb_ue_t *enb_ue_add(mme_enb_t *enb, uint32_t enb_ue_s1ap_id)
     enb_ue->enb_ostream_id =
         OGS_NEXT_ID(enb->ostream_id, 1, enb->max_num_of_ostreams-1);
 
-    enb_ue->enb = enb;
+    enb_ue->enb_id = enb->id;
 
     ogs_list_add(&enb->enb_ue_list, enb_ue);
 
@@ -2975,33 +2976,35 @@ void enb_ue_remove(enb_ue_t *enb_ue)
     mme_enb_t *enb = NULL;
 
     ogs_assert(enb_ue);
-    enb = enb_ue->enb;
-    ogs_assert(enb);
 
-    ogs_list_remove(&enb->enb_ue_list, enb_ue);
+    enb = mme_enb_find_by_id(enb_ue->enb_id);
+
+    if (enb) ogs_list_remove(&enb->enb_ue_list, enb_ue);
 
     ogs_assert(enb_ue->t_s1_holding);
     ogs_timer_delete(enb_ue->t_s1_holding);
 
-    ogs_pool_free(&enb_ue_pool, enb_ue);
+    ogs_pool_id_free(&enb_ue_pool, enb_ue);
 
     stats_remove_enb_ue();
 }
 
 void enb_ue_switch_to_enb(enb_ue_t *enb_ue, mme_enb_t *new_enb)
 {
+    mme_enb_t *enb = NULL;
     ogs_assert(enb_ue);
-    ogs_assert(enb_ue->enb);
     ogs_assert(new_enb);
 
+    enb = mme_enb_find_by_id(enb_ue->enb_id);
+
     /* Remove from the old enb */
-    ogs_list_remove(&enb_ue->enb->enb_ue_list, enb_ue);
+    ogs_list_remove(&enb->enb_ue_list, enb_ue);
 
     /* Add to the new enb */
     ogs_list_add(&new_enb->enb_ue_list, enb_ue);
 
     /* Switch to enb */
-    enb_ue->enb = new_enb;
+    enb_ue->enb_id = new_enb->id;
 }
 
 enb_ue_t *enb_ue_find_by_enb_ue_s1ap_id(
@@ -3027,9 +3030,9 @@ enb_ue_t *enb_ue_find_by_mme_ue_s1ap_id(uint32_t mme_ue_s1ap_id)
     return enb_ue_find(mme_ue_s1ap_id);
 }
 
-enb_ue_t *enb_ue_cycle(enb_ue_t *enb_ue)
+enb_ue_t *enb_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&enb_ue_pool, enb_ue);
+    return ogs_pool_find_by_id(&enb_ue_pool, id);
 }
 
 /** sgw_ue_context handling function */
@@ -3039,15 +3042,15 @@ sgw_ue_t *sgw_ue_add(mme_sgw_t *sgw)
 
     ogs_assert(sgw);
 
-    ogs_pool_alloc(&sgw_ue_pool, &sgw_ue);
+    ogs_pool_id_calloc(&sgw_ue_pool, &sgw_ue);
     ogs_assert(sgw_ue);
-    memset(sgw_ue, 0, sizeof *sgw_ue);
 
     sgw_ue->t_s11_holding = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_s11_holding_timer_expire, sgw_ue);
+            ogs_app()->timer_mgr, mme_timer_s11_holding_timer_expire,
+            OGS_UINT_TO_POINTER(sgw_ue->id));
     if (!sgw_ue->t_s11_holding) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&sgw_ue_pool, sgw_ue);
+        ogs_pool_id_free(&sgw_ue_pool, sgw_ue);
         return NULL;
     }
 
@@ -3071,7 +3074,7 @@ void sgw_ue_remove(sgw_ue_t *sgw_ue)
     ogs_assert(sgw_ue->t_s11_holding);
     ogs_timer_delete(sgw_ue->t_s11_holding);
 
-    ogs_pool_free(&sgw_ue_pool, sgw_ue);
+    ogs_pool_id_free(&sgw_ue_pool, sgw_ue);
 }
 
 void sgw_ue_switch_to_sgw(sgw_ue_t *sgw_ue, mme_sgw_t *new_sgw)
@@ -3090,9 +3093,9 @@ void sgw_ue_switch_to_sgw(sgw_ue_t *sgw_ue, mme_sgw_t *new_sgw)
     sgw_ue->sgw = new_sgw;
 }
 
-sgw_ue_t *sgw_ue_cycle(sgw_ue_t *sgw_ue)
+sgw_ue_t *sgw_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&sgw_ue_pool, sgw_ue);
+    return ogs_pool_find_by_id(&sgw_ue_pool, id);
 }
 
 sgw_relocation_e sgw_ue_check_if_relocated(mme_ue_t *mme_ue)
@@ -3102,9 +3105,9 @@ sgw_relocation_e sgw_ue_check_if_relocated(mme_ue_t *mme_ue)
     mme_sgw_t *current = NULL, *changed = NULL;
 
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
-    source_ue = sgw_ue_cycle(mme_ue->sgw_ue);
+    source_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(source_ue);
 
     current = source_ue->sgw;
@@ -3114,13 +3117,13 @@ sgw_relocation_e sgw_ue_check_if_relocated(mme_ue_t *mme_ue)
     if (!changed) return SGW_WITHOUT_RELOCATION;
 
     /* Check if Old Source UE */
-    old_source_ue = sgw_ue_cycle(source_ue->source_ue);
+    old_source_ue = sgw_ue_find_by_id(source_ue->source_ue_id);
     if (old_source_ue) {
         sgw_ue_source_deassociate_target(old_source_ue);
         sgw_ue_remove(old_source_ue);
     }
 
-    target_ue = sgw_ue_cycle(source_ue->target_ue);
+    target_ue = sgw_ue_find_by_id(source_ue->target_ue_id);
     if (target_ue) {
         ogs_error("SGW-UE source has already been associated with target");
         return SGW_HAS_ALREADY_BEEN_RELOCATED;
@@ -3254,80 +3257,90 @@ mme_ue_t *mme_ue_add(enb_ue_t *enb_ue)
     char buf[OGS_ADDRSTRLEN];
 
     ogs_assert(enb_ue);
-    enb = enb_ue->enb;
-    ogs_assert(enb);
 
-    ogs_pool_alloc(&mme_ue_pool, &mme_ue);
+    enb = mme_enb_find_by_id(enb_ue->enb_id);
+    if (!enb) {
+        ogs_error("[%d] eNB has already been removed", enb_ue->enb_id);
+        return NULL;
+    }
+
+    ogs_pool_id_calloc(&mme_ue_pool, &mme_ue);
     if (mme_ue == NULL) {
         ogs_error("Could not allocate mme_ue context from pool");
         return NULL;
     }
 
-    memset(mme_ue, 0, sizeof *mme_ue);
-
     /* Add All Timers */
     mme_ue->t3413.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3413_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_t3413_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t3413.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t3413.pkbuf = NULL;
     mme_ue->t3422.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3422_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_t3422_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t3422.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t3422.pkbuf = NULL;
     mme_ue->t3450.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3450_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_t3450_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t3450.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t3450.pkbuf = NULL;
     mme_ue->t3460.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3460_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_t3460_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t3460.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t3460.pkbuf = NULL;
     mme_ue->t3470.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3470_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_t3470_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t3470.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t3470.pkbuf = NULL;
     mme_ue->t_mobile_reachable.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_mobile_reachable_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_mobile_reachable_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t_mobile_reachable.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t_mobile_reachable.pkbuf = NULL;
     mme_ue->t_implicit_detach.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_implicit_detach_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_implicit_detach_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (!mme_ue->t_implicit_detach.timer) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
     mme_ue->t_implicit_detach.pkbuf = NULL;
 
     mme_ue->gn.t_gn_holding = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_gn_holding_timer_expire, mme_ue);
+            ogs_app()->timer_mgr, mme_timer_gn_holding_timer_expire,
+            OGS_UINT_TO_POINTER(mme_ue->id));
     if (! mme_ue->gn.t_gn_holding) {
         ogs_error("ogs_timer_add() failed");
-        ogs_pool_free(&mme_ue_pool, mme_ue);
+        ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
 
@@ -3384,6 +3397,7 @@ mme_ue_t *mme_ue_add(enb_ue_t *enb_ue)
 
 void mme_ue_remove(mme_ue_t *mme_ue)
 {
+    sgw_ue_t *sgw_ue = NULL;
     ogs_assert(mme_ue);
 
     ogs_list_remove(&self.mme_ue_list, mme_ue);
@@ -3395,8 +3409,8 @@ void mme_ue_remove(mme_ue_t *mme_ue)
     ogs_hash_set(self.mme_gn_teid_hash,
             &mme_ue->gn.mme_gn_teid, sizeof(mme_ue->gn.mme_gn_teid), NULL);
 
-    ogs_assert(mme_ue->sgw_ue);
-    sgw_ue_remove(mme_ue->sgw_ue);
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
+    if (sgw_ue) sgw_ue_remove(sgw_ue);
 
     if (mme_ue->imsi_len != 0)
         ogs_hash_set(mme_self()->imsi_ue_hash,
@@ -3443,7 +3457,7 @@ void mme_ue_remove(mme_ue_t *mme_ue)
 
     ogs_pool_free(&mme_s11_teid_pool, mme_ue->mme_s11_teid_node);
     ogs_pool_free(&mme_gn_teid_pool, mme_ue->gn.mme_gn_teid_node);
-    ogs_pool_free(&mme_ue_pool, mme_ue);
+    ogs_pool_id_free(&mme_ue_pool, mme_ue);
 
     ogs_info("[Removed] Number of MME-UEs is now %d",
             ogs_list_count(&self.mme_ue_list));
@@ -3454,7 +3468,7 @@ void mme_ue_remove_all(void)
     mme_ue_t *mme_ue = NULL, *next = NULL;;
 
     ogs_list_for_each_safe(&self.mme_ue_list, next, mme_ue) {
-        enb_ue_t *enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
         if (enb_ue) enb_ue_remove(enb_ue);
 
@@ -3462,9 +3476,9 @@ void mme_ue_remove_all(void)
     }
 }
 
-mme_ue_t *mme_ue_cycle(mme_ue_t *mme_ue)
+mme_ue_t *mme_ue_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&mme_ue_pool, mme_ue);
+    return ogs_pool_find_by_id(&mme_ue_pool, id);
 }
 
 void mme_ue_fsm_init(mme_ue_t *mme_ue)
@@ -3474,7 +3488,7 @@ void mme_ue_fsm_init(mme_ue_t *mme_ue)
     ogs_assert(mme_ue);
 
     memset(&e, 0, sizeof(e));
-    e.mme_ue = mme_ue;
+    e.mme_ue_id = mme_ue->id;
     ogs_fsm_init(&mme_ue->sm, emm_state_initial, emm_state_final, &e);
 }
 
@@ -3485,7 +3499,7 @@ void mme_ue_fsm_fini(mme_ue_t *mme_ue)
     ogs_assert(mme_ue);
 
     memset(&e, 0, sizeof(e));
-    e.mme_ue = mme_ue;
+    e.mme_ue_id = mme_ue->id;
     ogs_fsm_fini(&mme_ue->sm, &e);
 }
 
@@ -3705,6 +3719,7 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
     mme_ue_t *old_mme_ue = NULL;
     mme_sess_t *old_sess = NULL;
     mme_bearer_t *old_bearer = NULL;
+    sgw_ue_t *sgw_ue = NULL, *old_sgw_ue = NULL;
     ogs_assert(mme_ue && imsi_bcd);
 
     ogs_cpystrn(mme_ue->imsi_bcd, imsi_bcd, OGS_MAX_IMSI_BCD_LEN+1);
@@ -3718,13 +3733,19 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
             ogs_pool_index(&mme_ue_pool, old_mme_ue)) {
             ogs_warn("[%s] OLD UE Context Release", mme_ue->imsi_bcd);
             if (ECM_CONNECTED(old_mme_ue)) {
+                enb_ue_t *enb_ue = enb_ue_find_by_id(old_mme_ue->enb_ue_id);
                 /* Implcit S1 release */
                 ogs_warn("[%s] Implicit S1 release", mme_ue->imsi_bcd);
-                ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
-                        old_mme_ue->imsi_bcd,
-                        old_mme_ue->enb_ue->enb_ue_s1ap_id,
-                        old_mme_ue->enb_ue->mme_ue_s1ap_id);
-                enb_ue_remove(old_mme_ue->enb_ue);
+                if (enb_ue) {
+                    ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
+                            old_mme_ue->imsi_bcd,
+                            enb_ue->enb_ue_s1ap_id,
+                            enb_ue->mme_ue_s1ap_id);
+                    enb_ue_remove(enb_ue);
+                } else {
+                    ogs_error("[%s] S1 Context has already been removed",
+                                old_mme_ue->imsi_bcd);
+                }
             }
 
     /*
@@ -3742,14 +3763,14 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
             /* Phase-1 : Change MME-UE Context in Session Context */
             ogs_list_for_each(&old_mme_ue->sess_list, old_sess) {
                 ogs_list_for_each(&old_sess->bearer_list, old_bearer) {
-                    old_bearer->mme_ue = mme_ue;
+                    old_bearer->mme_ue_id = mme_ue->id;
 
                     if (old_bearer->ebi_node)
                         ogs_pool_free(
                                 &old_mme_ue->ebi_pool, old_bearer->ebi_node);
                     old_bearer->ebi_node = NULL;
                 }
-                old_sess->mme_ue = mme_ue;
+                old_sess->mme_ue_id = mme_ue->id;
             }
 
             /* Phase-2 : Move Session Context from OLD to NEW MME-UE Context */
@@ -3760,11 +3781,12 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
             memset(&old_mme_ue->sess_list, 0, sizeof(old_mme_ue->sess_list));
 
             /* Phase-4 : Move sgw_ue->sgw_s11_teid */
-            ogs_assert(old_mme_ue->sgw_ue);
-            ogs_assert(mme_ue->sgw_ue);
-            mme_ue->sgw_ue->sgw_s11_teid = old_mme_ue->sgw_ue->sgw_s11_teid;
+            sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
+            ogs_assert(sgw_ue);
+            old_sgw_ue = sgw_ue_find_by_id(old_mme_ue->sgw_ue_id);
+            ogs_assert(old_sgw_ue);
+            sgw_ue->sgw_s11_teid = old_sgw_ue->sgw_s11_teid;
 
-            MME_UE_CHECK(OGS_LOG_WARN, old_mme_ue);
             mme_ue_remove(old_mme_ue);
         }
     }
@@ -3875,7 +3897,7 @@ int mme_ue_xact_count(mme_ue_t *mme_ue, uint8_t org)
     ogs_assert(org == OGS_GTP_LOCAL_ORIGINATOR ||
                 org == OGS_GTP_REMOTE_ORIGINATOR);
 
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     if (!sgw_ue) return 0;
 
     gnode = sgw_ue->gnode;
@@ -3891,34 +3913,30 @@ void enb_ue_associate_mme_ue(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     ogs_assert(mme_ue);
     ogs_assert(enb_ue);
 
-    mme_ue->enb_ue = enb_ue;
-    enb_ue->mme_ue = mme_ue;
+    mme_ue->enb_ue_id = enb_ue->id;
+    enb_ue->mme_ue_id = mme_ue->id;
 }
 
 void enb_ue_deassociate(enb_ue_t *enb_ue)
 {
     ogs_assert(enb_ue);
-    enb_ue->mme_ue = NULL;
+    enb_ue->mme_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void enb_ue_unlink(mme_ue_t *mme_ue)
 {
     ogs_assert(mme_ue);
-    mme_ue->enb_ue = NULL;
+    mme_ue->enb_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void enb_ue_source_associate_target(enb_ue_t *source_ue, enb_ue_t *target_ue)
 {
-    mme_ue_t *mme_ue = NULL;
-
     ogs_assert(source_ue);
     ogs_assert(target_ue);
-    mme_ue = source_ue->mme_ue;
-    ogs_assert(mme_ue);
 
-    target_ue->mme_ue = mme_ue;
-    target_ue->source_ue = source_ue;
-    source_ue->target_ue = target_ue;
+    target_ue->mme_ue_id = source_ue->mme_ue_id;
+    target_ue->source_ue_id = source_ue->id;
+    source_ue->target_ue_id = target_ue->id;
 }
 
 void enb_ue_source_deassociate_target(enb_ue_t *enb_ue)
@@ -3927,22 +3945,28 @@ void enb_ue_source_deassociate_target(enb_ue_t *enb_ue)
     enb_ue_t *target_ue = NULL;
     ogs_assert(enb_ue);
 
-    if (enb_ue->target_ue) {
+    if (enb_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+        enb_ue->target_ue_id <= OGS_MAX_POOL_ID) {
         source_ue = enb_ue;
-        target_ue = enb_ue->target_ue;
+        target_ue = enb_ue_find_by_id(enb_ue->target_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
-    } else if (enb_ue->source_ue) {
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
+    } else if (enb_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                enb_ue->source_ue_id <= OGS_MAX_POOL_ID) {
         target_ue = enb_ue;
-        source_ue = enb_ue->source_ue;
+        source_ue = enb_ue_find_by_id(enb_ue->source_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
     }
 }
 
@@ -3951,34 +3975,30 @@ void sgw_ue_associate_mme_ue(sgw_ue_t *sgw_ue, mme_ue_t *mme_ue)
     ogs_assert(mme_ue);
     ogs_assert(sgw_ue);
 
-    mme_ue->sgw_ue = sgw_ue;
-    sgw_ue->mme_ue = mme_ue;
+    mme_ue->sgw_ue_id = sgw_ue->id;
+    sgw_ue->mme_ue_id = mme_ue->id;
 }
 
 void sgw_ue_deassociate(sgw_ue_t *sgw_ue)
 {
     ogs_assert(sgw_ue);
-    sgw_ue->mme_ue = NULL;
+    sgw_ue->mme_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void sgw_ue_unlink(mme_ue_t *mme_ue)
 {
     ogs_assert(mme_ue);
-    mme_ue->sgw_ue = NULL;
+    mme_ue->sgw_ue_id = OGS_INVALID_POOL_ID;
 }
 
 void sgw_ue_source_associate_target(sgw_ue_t *source_ue, sgw_ue_t *target_ue)
 {
-    mme_ue_t *mme_ue = NULL;
-
     ogs_assert(source_ue);
     ogs_assert(target_ue);
-    mme_ue = source_ue->mme_ue;
-    ogs_assert(mme_ue);
 
-    target_ue->mme_ue = mme_ue;
-    target_ue->source_ue = source_ue;
-    source_ue->target_ue = target_ue;
+    target_ue->mme_ue_id = source_ue->mme_ue_id;
+    target_ue->source_ue_id = source_ue->id;
+    source_ue->target_ue_id = target_ue->id;
 }
 
 void sgw_ue_source_deassociate_target(sgw_ue_t *sgw_ue)
@@ -3987,22 +4007,28 @@ void sgw_ue_source_deassociate_target(sgw_ue_t *sgw_ue)
     sgw_ue_t *target_ue = NULL;
     ogs_assert(sgw_ue);
 
-    if (sgw_ue->target_ue) {
+    if (sgw_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+        sgw_ue->target_ue_id <= OGS_MAX_POOL_ID) {
         source_ue = sgw_ue;
-        target_ue = sgw_ue->target_ue;
+        target_ue = sgw_ue_find_by_id(sgw_ue->target_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
-    } else if (sgw_ue->source_ue) {
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
+    } else if (sgw_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                sgw_ue->source_ue_id <= OGS_MAX_POOL_ID) {
         target_ue = sgw_ue;
-        source_ue = sgw_ue->source_ue;
+        source_ue = sgw_ue_find_by_id(sgw_ue->source_ue_id);
 
-        ogs_assert(source_ue->target_ue);
-        ogs_assert(target_ue->source_ue);
-        source_ue->target_ue = NULL;
-        target_ue->source_ue = NULL;
+        ogs_assert(source_ue->target_ue_id >= OGS_MIN_POOL_ID &&
+                source_ue->target_ue_id <= OGS_MAX_POOL_ID);
+        ogs_assert(target_ue->source_ue_id >= OGS_MIN_POOL_ID &&
+                target_ue->source_ue_id <= OGS_MAX_POOL_ID);
+        source_ue->target_ue_id = OGS_INVALID_POOL_ID;
+        target_ue->source_ue_id = OGS_INVALID_POOL_ID;
     }
 }
 
@@ -4014,13 +4040,12 @@ mme_sess_t *mme_sess_add(mme_ue_t *mme_ue, uint8_t pti)
     ogs_assert(mme_ue);
     ogs_assert(pti != OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED);
 
-    ogs_pool_alloc(&mme_sess_pool, &sess);
+    ogs_pool_id_calloc(&mme_sess_pool, &sess);
     ogs_assert(sess);
-    memset(sess, 0, sizeof *sess);
 
     ogs_list_init(&sess->bearer_list);
 
-    sess->mme_ue = mme_ue;
+    sess->mme_ue_id = mme_ue->id;
     sess->pti = pti;
 
     bearer = mme_bearer_add(sess);
@@ -4038,7 +4063,7 @@ void mme_sess_remove(mme_sess_t *sess)
     mme_ue_t *mme_ue = NULL;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_list_remove(&mme_ue->sess_list, sess);
@@ -4050,7 +4075,7 @@ void mme_sess_remove(mme_sess_t *sess)
     OGS_TLV_CLEAR_DATA(&sess->pgw_pco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_epco);
 
-    ogs_pool_free(&mme_sess_pool, sess);
+    ogs_pool_id_free(&mme_sess_pool, sess);
 
     stats_remove_mme_session();
 }
@@ -4090,7 +4115,7 @@ mme_sess_t *mme_sess_find_by_ebi(const mme_ue_t *mme_ue, uint8_t ebi)
 
     bearer = mme_bearer_find_by_ue_ebi(mme_ue, ebi);
     if (bearer)
-        return bearer->sess;
+        return mme_sess_find_by_id(bearer->sess_id);
 
     return NULL;
 }
@@ -4110,6 +4135,11 @@ mme_sess_t *mme_sess_find_by_apn(const mme_ue_t *mme_ue, const char *apn)
     }
 
     return NULL;
+}
+
+mme_sess_t *mme_sess_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_pool_find_by_id(&mme_sess_pool, id);
 }
 
 mme_sess_t *mme_sess_first(const mme_ue_t *mme_ue)
@@ -4142,12 +4172,11 @@ mme_bearer_t *mme_bearer_add(mme_sess_t *sess)
     mme_ue_t *mme_ue = NULL;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
 
-    ogs_pool_alloc(&mme_bearer_pool, &bearer);
+    ogs_pool_id_calloc(&mme_bearer_pool, &bearer);
     ogs_assert(bearer);
-    memset(bearer, 0, sizeof *bearer);
 
     ogs_list_init(&bearer->update.xact_list);
 
@@ -4159,17 +4188,18 @@ mme_bearer_t *mme_bearer_add(mme_sess_t *sess)
     ogs_assert(bearer->ebi >= MIN_EPS_BEARER_ID &&
                 bearer->ebi <= MAX_EPS_BEARER_ID);
 
-    bearer->mme_ue = mme_ue;
-    bearer->sess = sess;
+    bearer->mme_ue_id = mme_ue->id;
+    bearer->sess_id = sess->id;
 
     ogs_list_add(&sess->bearer_list, bearer);
 
     bearer->t3489.timer = ogs_timer_add(
-            ogs_app()->timer_mgr, mme_timer_t3489_expire, bearer);
+            ogs_app()->timer_mgr, mme_timer_t3489_expire,
+            OGS_UINT_TO_POINTER(bearer->id));
     bearer->t3489.pkbuf = NULL;
 
     memset(&e, 0, sizeof(e));
-    e.bearer = bearer;
+    e.bearer_id = bearer->id;
     ogs_fsm_init(&bearer->sm, esm_state_initial, esm_state_final, &e);
 
     return bearer;
@@ -4178,32 +4208,36 @@ mme_bearer_t *mme_bearer_add(mme_sess_t *sess)
 void mme_bearer_remove(mme_bearer_t *bearer)
 {
     mme_event_t e;
+    mme_ue_t *mme_ue = NULL;
+    mme_sess_t *sess = NULL;
     ogs_gtp_xact_t *xact = NULL, *next_xact = NULL;
 
     ogs_assert(bearer);
-    ogs_assert(bearer->mme_ue);
-    ogs_assert(bearer->sess);
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    ogs_assert(mme_ue);
+    sess = mme_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
 
     memset(&e, 0, sizeof(e));
-    e.bearer = bearer;
+    e.bearer_id = bearer->id;
     ogs_fsm_fini(&bearer->sm, &e);
 
     CLEAR_BEARER_ALL_TIMERS(bearer);
     ogs_timer_delete(bearer->t3489.timer);
 
-    ogs_list_remove(&bearer->sess->bearer_list, bearer);
+    ogs_list_remove(&sess->bearer_list, bearer);
 
     OGS_TLV_CLEAR_DATA(&bearer->tft);
 
     if (bearer->ebi_node)
-        ogs_pool_free(&bearer->mme_ue->ebi_pool, bearer->ebi_node);
+        ogs_pool_free(&mme_ue->ebi_pool, bearer->ebi_node);
 
     ogs_list_for_each_entry_safe(&bearer->update.xact_list,
             next_xact, xact, to_update_node) {
         ogs_list_remove(&bearer->update.xact_list, &xact->to_update_node);
     }
 
-    ogs_pool_free(&mme_bearer_pool, bearer);
+    ogs_pool_id_free(&mme_bearer_pool, bearer);
 }
 
 void mme_bearer_remove_all(mme_sess_t *sess)
@@ -4268,9 +4302,13 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
 
     mme_bearer_t *bearer = NULL;
     mme_sess_t *sess = NULL;
+    mme_ue_t *sess_mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(mme_ue);
     ogs_assert(message);
+
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
     pti = message->esm.h.procedure_transaction_identity;
     ebi = message->esm.h.eps_bearer_identity;
@@ -4283,7 +4321,7 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
         bearer = mme_bearer_find_by_ue_ebi(mme_ue, ebi);
         if (!bearer) {
             ogs_error("No Bearer : EBI[%d]", ebi);
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
                     OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
@@ -4297,7 +4335,7 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
     if (pti == OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED) {
         ogs_error("ESM message type: %d, Both PTI[%d] and EBI[%d] are 0",
                 message->esm.h.message_type, pti, ebi);
-        r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+        r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
                 OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
         ogs_expect(r == OGS_OK);
@@ -4316,7 +4354,7 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
         if (!bearer) {
             ogs_error("No Bearer : Linked-EBI[%d]",
                     linked_eps_bearer_identity->eps_bearer_identity);
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
                     OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
@@ -4367,7 +4405,7 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
     }
 
     if (bearer) {
-        sess = bearer->sess;
+        sess = mme_sess_find_by_id(bearer->sess_id);
         ogs_assert(sess);
         sess->pti = pti;
 
@@ -4402,11 +4440,12 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
                 ogs_debug("[%s:%d:%d:%p]",
                     sess->session ? sess->session->name : "Unknown",
                     sess->pti, pti, sess);
+
+                sess_mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
                 ogs_debug("[%s:%p]",
-                    sess->mme_ue ? sess->mme_ue->imsi_bcd : "Unknown",
-                    sess->mme_ue);
+                    sess_mme_ue ? sess_mme_ue->imsi_bcd : "Unknown",
+                    sess_mme_ue);
             }
-            MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
         }
 
         if (!sess) {
@@ -4417,20 +4456,22 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
             ogs_debug("[%s:%d:%d:%p]",
                 sess->session ? sess->session->name : "Unknown",
                 sess->pti, pti, sess);
+
+            sess_mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
             ogs_debug("[%s:%p]",
-                sess->mme_ue ? sess->mme_ue->imsi_bcd : "Unknown",
-                sess->mme_ue);
-            MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
+                sess_mme_ue ? sess_mme_ue->imsi_bcd : "Unknown",
+                sess_mme_ue);
         } else {
             sess->pti = pti;
             ogs_debug("[%s:%p]", mme_ue->imsi_bcd, mme_ue);
             ogs_debug("[%s:%d:%d:%p]",
                 sess->session ? sess->session->name : "Unknown",
                 sess->pti, pti, sess);
+
+            sess_mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
             ogs_debug("[%s:%p]",
-                sess->mme_ue ? sess->mme_ue->imsi_bcd : "Unknown",
-                sess->mme_ue);
-            MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
+                sess_mme_ue ? sess_mme_ue->imsi_bcd : "Unknown",
+                sess_mme_ue);
         }
 
     } else {
@@ -4438,7 +4479,7 @@ mme_bearer_t *mme_bearer_find_or_add_by_message(
         if (!sess) {
             ogs_error("No Session : ESM message type[%d], PTI[%d]",
                     message->esm.h.message_type, pti);
-            r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+            r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                     OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
                     OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
             ogs_expect(r == OGS_OK);
@@ -4468,7 +4509,7 @@ mme_bearer_t *mme_linked_bearer(mme_bearer_t *bearer)
     mme_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     return mme_default_bearer_in_sess(sess);
@@ -4487,9 +4528,9 @@ mme_bearer_t *mme_bearer_next(mme_bearer_t *bearer)
     return ogs_list_next(bearer);
 }
 
-mme_bearer_t *mme_bearer_cycle(mme_bearer_t *bearer)
+mme_bearer_t *mme_bearer_find_by_id(ogs_pool_id_t id)
 {
-    return ogs_pool_cycle(&mme_bearer_pool, bearer);
+    return ogs_pool_find_by_id(&mme_bearer_pool, id);
 }
 
 void mme_session_remove_all(mme_ue_t *mme_ue)

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -889,7 +889,7 @@ typedef struct mme_bearer_s {
      * as a list so that we can manage multiple of them.
      */
     struct {
-        ogs_gtp_xact_t  *xact;
+        ogs_pool_id_t  xact_id;
     } create, delete, notify;
     struct {
         ogs_list_t  xact_list;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -146,45 +146,6 @@ typedef struct mme_context_s {
     /* Generator for unique identification */
     uint32_t        mme_ue_s1ap_id;         /* mme_ue_s1ap_id generator */
 
-#define MME_UE_CHECK(level, __mME) \
-    do { \
-        sgw_ue_t *__sGW = (((mme_ue_t *)__mME)->sgw_ue); \
-        mme_sess_t *__sESS = NULL; \
-        mme_bearer_t *__bEARER = NULL; \
-        \
-        ogs_log_message(level, 0, "MME-UE Context Memory[%p:%p]", \
-                (__mME), mme_ue_cycle((__mME))); \
-        ogs_log_message(level, 0, "SGW-UE Context Memory[%p:%p]", \
-                (__sGW), sgw_ue_cycle((__sGW))); \
-        ogs_log_message(level, 0, \
-                "IMSI [%s] NAS-EPS Type[%d]", \
-                (__mME) ? ((mme_ue_t *)__mME)->imsi_bcd : "No MME_UE", \
-                (__mME) ? ((mme_ue_t *)__mME)->nas_eps.type : 0); \
-        ogs_log_message(level, 0, \
-                "MME_S11_TEID[%d] SGW_S11_TEID[%d]", \
-                (__mME) ? ((mme_ue_t *)__mME)->mme_s11_teid : 0, \
-                (__sGW) ? (__sGW)->sgw_s11_teid : 0); \
-        if (!mme_ue_cycle(__mME)) { \
-            ogs_log_message(level, 0, \
-                    "MME-UE Context has already been removed"); \
-            break; \
-        } \
-        ogs_list_for_each(&((mme_ue_t *)__mME)->sess_list, (__sESS)) { \
-            ogs_log_message(level, 0, "SESS(%p) [%s:%d]", (__sESS), \
-                    (__sESS)->session ? (__sESS)->session->name : "Unknown", \
-                    (__sESS)->pti); \
-            ogs_list_for_each(&(__sESS)->bearer_list, (__bEARER)) { \
-                ogs_log_message(level, 0, \
-                        "BEARER(%p) [%d] ENB_S1U_TEID[%d] SGW_S1U_TEID[%d]", \
-                        (__bEARER), (__bEARER)->ebi, \
-                        (__bEARER)->enb_s1u_teid, (__bEARER)->sgw_s1u_teid); \
-                ogs_assert((__bEARER)->sess == (__sESS)); \
-                ogs_assert((__bEARER)->mme_ue == (__mME)); \
-            } \
-            ogs_assert((__sESS)->mme_ue == (__mME)); \
-        } \
-    } while(0)
-
     ogs_list_t      mme_ue_list;
 
     ogs_hash_t *enb_addr_hash;  /* hash table for ENB Address */
@@ -273,6 +234,7 @@ typedef struct mme_csmap_s {
 
 typedef struct mme_enb_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
 
     ogs_fsm_t       sm;         /* A state machine */
 
@@ -298,6 +260,7 @@ typedef struct mme_enb_s {
 
 struct enb_ue_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     uint32_t        index;
 
     /* UE identity */
@@ -309,8 +272,8 @@ struct enb_ue_s {
 
     /* Handover Info */
     S1AP_HandoverType_t handover_type;
-    enb_ue_t        *source_ue;
-    enb_ue_t        *target_ue;
+    ogs_pool_id_t source_ue_id;
+    ogs_pool_id_t target_ue_id;
 
     /* Use mme_ue->tai, mme_ue->e_cgi.
      * Do not access enb_ue->saved.tai enb_ue->saved.e_cgi.
@@ -339,15 +302,16 @@ struct enb_ue_s {
     bool            part_of_s1_reset_requested;
 
     /* Related Context */
-    mme_enb_t       *enb;
-    mme_ue_t        *mme_ue;
+    ogs_pool_id_t   enb_id;
+    ogs_pool_id_t   mme_ue_id;
 };
 
 struct sgw_ue_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
 
-    sgw_ue_t        *source_ue;
-    sgw_ue_t        *target_ue;
+    ogs_pool_id_t   source_ue_id;
+    ogs_pool_id_t   target_ue_id;
 
     /* UE identity */
     uint32_t        sgw_s11_teid;   /* SGW-S11-TEID is received from SGW */
@@ -360,11 +324,12 @@ struct sgw_ue_s {
         mme_sgw_t       *sgw;
         ogs_gtp_node_t  *gnode;
     };
-    mme_ue_t        *mme_ue;
+    ogs_pool_id_t mme_ue_id;
 };
 
 struct mme_ue_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     ogs_fsm_t       sm;     /* A state machine */
 
     struct {
@@ -536,50 +501,66 @@ struct mme_ue_s {
 
     /* Paging Info */
 #define ECM_CONNECTED(__mME) \
-    ((__mME) && ((__mME)->enb_ue != NULL) && enb_ue_cycle((__mME)->enb_ue))
+    ((__mME) && \
+     ((__mME)->enb_ue_id >= OGS_MIN_POOL_ID) && \
+     ((__mME)->enb_ue_id <= OGS_MAX_POOL_ID) && \
+     (enb_ue_find_by_id((__mME)->enb_ue_id)))
 #define ECM_IDLE(__mME) \
     ((__mME) && \
-     (((__mME)->enb_ue == NULL) || (enb_ue_cycle((__mME)->enb_ue) == NULL)))
-    enb_ue_t        *enb_ue;    /* S1 UE context */
+     (((__mME)->enb_ue_id < OGS_MIN_POOL_ID) || \
+      ((__mME)->enb_ue_id > OGS_MAX_POOL_ID) || \
+      (enb_ue_find_by_id((__mME)->enb_ue_id) == NULL)))
+    ogs_pool_id_t   enb_ue_id;
 
 #define HOLDING_S1_CONTEXT(__mME) \
     do { \
-        enb_ue_deassociate((__mME)->enb_ue); \
+        enb_ue_t *enb_ue_holding = NULL; \
         \
-        (__mME)->enb_ue_holding = enb_ue_cycle((__mME)->enb_ue); \
-        if ((__mME)->enb_ue_holding) { \
+        (__mME)->enb_ue_holding_id = OGS_INVALID_POOL_ID; \
+        \
+        enb_ue_holding = enb_ue_find_by_id((__mME)->enb_ue_id); \
+        if (enb_ue_holding) { \
+            enb_ue_deassociate(enb_ue_holding); \
+            \
             ogs_warn("[%s] Holding S1 Context", (__mME)->imsi_bcd); \
             ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]", \
-                    (__mME)->imsi_bcd, (__mME)->enb_ue_holding->enb_ue_s1ap_id, \
-                    (__mME)->enb_ue_holding->mme_ue_s1ap_id); \
+                    (__mME)->imsi_bcd, \
+                    enb_ue_holding->enb_ue_s1ap_id, \
+                    enb_ue_holding->mme_ue_s1ap_id); \
             \
-            (__mME)->enb_ue_holding->ue_ctx_rel_action = \
+            enb_ue_holding->ue_ctx_rel_action = \
                 S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE; \
-            ogs_timer_start((__mME)->enb_ue_holding->t_s1_holding, \
+            ogs_timer_start(enb_ue_holding->t_s1_holding, \
                     mme_timer_cfg(MME_TIMER_S1_HOLDING)->duration); \
+            \
+            (__mME)->enb_ue_holding_id = (__mME)->enb_ue_id; \
         } else \
             ogs_error("[%s] S1 Context has already been removed", \
                     (__mME)->imsi_bcd); \
     } while(0)
 #define CLEAR_S1_CONTEXT(__mME) \
     do { \
-        if (enb_ue_cycle((__mME)->enb_ue_holding)) { \
+        enb_ue_t *enb_ue_holding = NULL; \
+        \
+        enb_ue_holding = enb_ue_find_by_id((__mME)->enb_ue_holding_id); \
+        if (enb_ue_holding) { \
             int r; \
             ogs_warn("[%s] Clear S1 Context", (__mME)->imsi_bcd); \
             ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]", \
-                    (__mME)->imsi_bcd, (__mME)->enb_ue_holding->enb_ue_s1ap_id, \
-                    (__mME)->enb_ue_holding->mme_ue_s1ap_id); \
+                    (__mME)->imsi_bcd, \
+                    enb_ue_holding->enb_ue_s1ap_id, \
+                    enb_ue_holding->mme_ue_s1ap_id); \
             \
             r = s1ap_send_ue_context_release_command( \
-                    (__mME)->enb_ue_holding, \
+                    enb_ue_holding, \
                     S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release, \
                     S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE, 0); \
             ogs_expect(r == OGS_OK); \
             ogs_assert(r != OGS_ERROR); \
         } \
-        (__mME)->enb_ue_holding = NULL; \
+        (__mME)->enb_ue_holding_id = OGS_INVALID_POOL_ID; \
     } while(0)
-    enb_ue_t        *enb_ue_holding;
+    ogs_pool_id_t   enb_ue_holding_id;
 
     struct {
 #define MME_CLEAR_PAGING_INFO(__mME) \
@@ -596,7 +577,7 @@ struct mme_ue_s {
         ogs_assert(__tYPE); \
         ogs_debug("[%s] Store Paging Info", mme_ue->imsi_bcd); \
         (__mME)->paging.type = __tYPE; \
-        (__mME)->paging.data = __dATA; \
+        (__mME)->paging.data = OGS_UINT_TO_POINTER(__dATA); \
     } while(0)
 
 #define MME_PAGING_ONGOING(__mME) ((__mME) && ((__mME)->paging.type))
@@ -614,7 +595,7 @@ struct mme_ue_s {
     } paging;
 
     /* SGW UE context */
-    sgw_ue_t        *sgw_ue;
+    ogs_pool_id_t sgw_ue_id;
 
     /* Save PDN Connectivity Request */
     ogs_nas_esm_message_container_t pdn_connectivity_request;
@@ -715,19 +696,25 @@ struct mme_ue_s {
 };
 
 #define SESSION_CONTEXT_IS_AVAILABLE(__mME) \
-     ((__mME) && ((__mME)->sgw_ue) && (((__mME)->sgw_ue)->sgw_s11_teid))
+    ((__mME) && \
+     ((__mME)->sgw_ue_id >= OGS_MIN_POOL_ID) && \
+     ((__mME)->sgw_ue_id <= OGS_MAX_POOL_ID) && \
+     (sgw_ue_find_by_id((__mME)->sgw_ue_id)) && \
+     (sgw_ue_find_by_id((__mME)->sgw_ue_id)->sgw_s11_teid))
 
 #define CLEAR_SESSION_CONTEXT(__mME) \
     do { \
+        sgw_ue_t *sgw_ue = NULL; \
         ogs_assert((__mME)); \
-        ((__mME)->sgw_ue)->sgw_s11_teid = 0; \
+        sgw_ue = sgw_ue_find_by_id((__mME)->sgw_ue_id); \
+        if (sgw_ue) sgw_ue->sgw_s11_teid = 0; \
     } while(0)
 
 #define MME_SESS_CLEAR(__sESS) \
     do { \
         mme_ue_t *mme_ue = NULL; \
         ogs_assert(__sESS); \
-        mme_ue = (__sESS)->mme_ue; \
+        mme_ue = mme_ue_find_by_id((__sESS)->mme_ue_id); \
         ogs_assert(mme_ue); \
         ogs_info("Removed Session: UE IMSI:[%s] APN:[%s]", \
                 mme_ue->imsi_bcd, \
@@ -743,6 +730,7 @@ struct mme_ue_s {
     (mme_ue_have_session_release_pending(__mME))
 typedef struct mme_sess_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
 
     uint8_t         pti;        /* Procedure Trasaction Identity */
 
@@ -756,7 +744,7 @@ typedef struct mme_sess_s {
     ogs_list_t      bearer_list;
 
     /* Related Context */
-    mme_ue_t        *mme_ue;
+    ogs_pool_id_t   mme_ue_id;
 
     ogs_session_t   *session;
 
@@ -821,6 +809,8 @@ typedef struct mme_bearer_s {
     ogs_lnode_t     lnode;
     ogs_lnode_t     to_modify_node;
 
+    ogs_pool_id_t   id;
+
     ogs_fsm_t       sm;             /* State Machine */
 
     uint8_t         *ebi_node;      /* Pool-Node for EPS Bearer ID */
@@ -870,8 +860,8 @@ typedef struct mme_bearer_s {
     } t3489;
 
     /* Related Context */
-    mme_ue_t        *mme_ue;
-    mme_sess_t      *sess;
+    ogs_pool_id_t   mme_ue_id;
+    ogs_pool_id_t   sess_id;
 
     /*
      * Issues #3240
@@ -940,7 +930,7 @@ mme_enb_t *mme_enb_find_by_addr(const ogs_sockaddr_t *addr);
 mme_enb_t *mme_enb_find_by_enb_id(uint32_t enb_id);
 int mme_enb_set_enb_id(mme_enb_t *enb, uint32_t enb_id);
 int mme_enb_sock_type(ogs_sock_t *sock);
-mme_enb_t *mme_enb_cycle(mme_enb_t *enb);
+mme_enb_t *mme_enb_find_by_id(ogs_pool_id_t id);
 
 enb_ue_t *enb_ue_add(mme_enb_t *enb, uint32_t enb_ue_s1ap_id);
 void enb_ue_remove(enb_ue_t *enb_ue);
@@ -949,12 +939,12 @@ enb_ue_t *enb_ue_find_by_enb_ue_s1ap_id(
         const mme_enb_t *enb, uint32_t enb_ue_s1ap_id);
 enb_ue_t *enb_ue_find(uint32_t index);
 enb_ue_t *enb_ue_find_by_mme_ue_s1ap_id(uint32_t mme_ue_s1ap_id);
-enb_ue_t *enb_ue_cycle(enb_ue_t *enb_ue);
+enb_ue_t *enb_ue_find_by_id(ogs_pool_id_t id);
 
 sgw_ue_t *sgw_ue_add(mme_sgw_t *sgw);
 void sgw_ue_remove(sgw_ue_t *sgw_ue);
 void sgw_ue_switch_to_sgw(sgw_ue_t *sgw_ue, mme_sgw_t *new_sgw);
-sgw_ue_t *sgw_ue_cycle(sgw_ue_t *sgw_ue);
+sgw_ue_t *sgw_ue_find_by_id(ogs_pool_id_t id);
 
 typedef enum {
     SGW_WITHOUT_RELOCATION = 1,
@@ -969,7 +959,7 @@ void mme_ue_confirm_guti(mme_ue_t *mme_ue);
 mme_ue_t *mme_ue_add(enb_ue_t *enb_ue);
 void mme_ue_remove(mme_ue_t *mme_ue);
 void mme_ue_remove_all(void);
-mme_ue_t *mme_ue_cycle(mme_ue_t *mme_ue);
+mme_ue_t *mme_ue_find_by_id(ogs_pool_id_t id);
 
 void mme_ue_fsm_init(mme_ue_t *mme_ue);
 void mme_ue_fsm_fini(mme_ue_t *mme_ue);
@@ -1059,6 +1049,7 @@ void mme_sess_remove_all(mme_ue_t *mme_ue);
 mme_sess_t *mme_sess_find_by_pti(const mme_ue_t *mme_ue, uint8_t pti);
 mme_sess_t *mme_sess_find_by_ebi(const mme_ue_t *mme_ue, uint8_t ebi);
 mme_sess_t *mme_sess_find_by_apn(const mme_ue_t *mme_ue, const char *apn);
+mme_sess_t *mme_sess_find_by_id(ogs_pool_id_t id);
 
 mme_sess_t *mme_sess_first(const mme_ue_t *mme_ue);
 mme_sess_t *mme_sess_next(mme_sess_t *sess);
@@ -1075,7 +1066,7 @@ mme_bearer_t *mme_default_bearer_in_sess(mme_sess_t *sess);
 mme_bearer_t *mme_linked_bearer(mme_bearer_t *bearer);
 mme_bearer_t *mme_bearer_first(const mme_sess_t *sess);
 mme_bearer_t *mme_bearer_next(mme_bearer_t *bearer);
-mme_bearer_t *mme_bearer_cycle(mme_bearer_t *bearer);
+mme_bearer_t *mme_bearer_find_by_id(ogs_pool_id_t id);
 
 void mme_session_remove_all(mme_ue_t *mme_ue);
 ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, const char *apn);

--- a/src/mme/mme-event.h
+++ b/src/mme/mme-event.h
@@ -94,12 +94,11 @@ typedef struct mme_event_s {
     ogs_diam_s6a_message_t *s6a_message;
 
     mme_vlr_t *vlr;
-    mme_enb_t *enb;
-    enb_ue_t *enb_ue;
-    sgw_ue_t *sgw_ue;
-    mme_ue_t *mme_ue;
-    mme_sess_t *sess;
-    mme_bearer_t *bearer;
+    ogs_pool_id_t enb_id;
+    ogs_pool_id_t enb_ue_id;
+    ogs_pool_id_t sgw_ue_id;
+    ogs_pool_id_t mme_ue_id;
+    ogs_pool_id_t bearer_id;
 
     ogs_timer_t *timer;
 } mme_event_t;

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -34,8 +34,8 @@ static int mme_s6a_subscription_data_from_avp(struct avp *avp,
     mme_ue_t *mme_ue, uint32_t *subdatamask);
 
 struct sess_state {
-    mme_ue_t *mme_ue;
-    enb_ue_t *enb_ue;
+    ogs_pool_id_t mme_ue_id;
+    ogs_pool_id_t enb_ue_id;
     struct timespec ts; /* Time of sending the message */
 };
 
@@ -678,12 +678,12 @@ void mme_s6a_send_air(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
 
     uint8_t resync[OGS_AUTS_LEN + OGS_RAND_LEN];
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return;
     }
@@ -697,8 +697,8 @@ void mme_s6a_send_air(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
     sess_data = ogs_calloc(1, sizeof (*sess_data));
     ogs_assert(sess_data);
 
-    sess_data->mme_ue = mme_ue;
-    sess_data->enb_ue = enb_ue;
+    sess_data->mme_ue_id = mme_ue->id;
+    sess_data->enb_ue_id = enb_ue->id;
 
     /* Create the request */
     ret = fd_msg_new(ogs_diam_s6a_cmd_air, MSGFL_ALLOC_ETEID, &req);
@@ -870,9 +870,9 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
         return;
     }
 
-    mme_ue = sess_data->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess_data->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = sess_data->enb_ue;
+    enb_ue = enb_ue_find_by_id(sess_data->enb_ue_id);
     ogs_assert(enb_ue);
 
     /* Set Authentication-Information Command */
@@ -1033,8 +1033,8 @@ out:
         int rv;
         e = mme_event_new(MME_EVENT_S6A_MESSAGE);
         ogs_assert(e);
-        e->mme_ue = mme_ue;
-        e->enb_ue = enb_ue;
+        e->mme_ue_id = mme_ue->id;
+        e->enb_ue_id = enb_ue->id;
         e->s6a_message = s6a_message;
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {
@@ -1102,12 +1102,12 @@ void mme_s6a_send_ulr(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     struct session *session = NULL;
     ogs_nas_plmn_id_t nas_plmn_id;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return;
     }
@@ -1117,8 +1117,8 @@ void mme_s6a_send_ulr(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     /* Create the random value to store with the session */
     sess_data = ogs_calloc(1, sizeof(*sess_data));
     ogs_assert(sess_data);
-    sess_data->mme_ue = mme_ue;
-    sess_data->enb_ue = enb_ue;
+    sess_data->mme_ue_id = mme_ue->id;
+    sess_data->enb_ue_id = enb_ue->id;
 
     /* Create the request */
     ret = fd_msg_new(ogs_diam_s6a_cmd_ulr, MSGFL_ALLOC_ETEID, &req);
@@ -1307,9 +1307,9 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
         return;
     }
 
-    mme_ue = sess_data->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess_data->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = sess_data->enb_ue;
+    enb_ue = enb_ue_find_by_id(sess_data->enb_ue_id);
     ogs_assert(enb_ue);
 
     /* Set Update-Location Command */
@@ -1451,8 +1451,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
         int rv;
         e = mme_event_new(MME_EVENT_S6A_MESSAGE);
         ogs_assert(e);
-        e->mme_ue = mme_ue;
-        e->enb_ue = enb_ue;
+        e->mme_ue_id = mme_ue->id;
+        e->enb_ue_id = enb_ue->id;
         e->s6a_message = s6a_message;
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {
@@ -1524,12 +1524,12 @@ void mme_s6a_send_pur(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     struct sess_state *sess_data = NULL, *svg;
     struct session *session = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return;
     }
@@ -1539,8 +1539,8 @@ void mme_s6a_send_pur(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     /* Create the random value to store with the session */
     sess_data = ogs_calloc(1, sizeof(*sess_data));
     ogs_assert(sess_data);
-    sess_data->mme_ue = mme_ue;
-    sess_data->enb_ue = enb_ue;
+    sess_data->mme_ue_id = mme_ue->id;
+    sess_data->enb_ue_id = enb_ue->id;
 
     /* Create the request */
     ret = fd_msg_new(ogs_diam_s6a_cmd_pur, MSGFL_ALLOC_ETEID, &req);
@@ -1664,9 +1664,9 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
         return;
     }
 
-    mme_ue = sess_data->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess_data->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = sess_data->enb_ue;
+    enb_ue = enb_ue_find_by_id(sess_data->enb_ue_id);
     ogs_assert(enb_ue);
 
     /* Set Purge-UE Command */
@@ -1764,8 +1764,8 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
         int rv;
         e = mme_event_new(MME_EVENT_S6A_MESSAGE);
         ogs_assert(e);
-        e->mme_ue = mme_ue;
-        e->enb_ue = enb_ue;
+        e->mme_ue_id = mme_ue->id;
+        e->enb_ue_id = enb_ue->id;
         e->s6a_message = s6a_message;
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {
@@ -1922,7 +1922,7 @@ static int mme_ogs_diam_s6a_clr_cb( struct msg **msg, struct avp *avp,
 
     e = mme_event_new(MME_EVENT_S6A_MESSAGE);
     ogs_assert(e);
-    e->mme_ue = mme_ue;
+    e->mme_ue_id = mme_ue->id;
     e->s6a_message = s6a_message;
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -2213,7 +2213,7 @@ static int mme_ogs_diam_s6a_idr_cb( struct msg **msg, struct avp *avp,
     int rv;
     e = mme_event_new(MME_EVENT_S6A_MESSAGE);
     ogs_assert(e);
-    e->mme_ue = mme_ue;
+    e->mme_ue_id = mme_ue->id;
     e->s6a_message = s6a_message;
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {

--- a/src/mme/mme-gn-build.c
+++ b/src/mme/mme-gn-build.c
@@ -24,7 +24,11 @@
 
 static int sess_fill_mm_context_decoded(mme_sess_t *sess, ogs_gtp1_mm_context_decoded_t *mmctx_dec)
 {
-    mme_ue_t *mme_ue = sess->mme_ue;
+    mme_ue_t *mme_ue = NULL;
+
+    ogs_assert(sess);
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    ogs_assert(mme_ue);
     *mmctx_dec = (ogs_gtp1_mm_context_decoded_t) {
         .gupii = 1, /* Integrity Protection not required */
         .ugipai = 1, /* Ignore "Used GPRS integrity protection algorithm" field" */
@@ -55,8 +59,13 @@ static int sess_fill_mm_context_decoded(mme_sess_t *sess, ogs_gtp1_mm_context_de
 static void build_qos_profile_from_session(ogs_gtp1_qos_profile_decoded_t *qos_pdec,
         const mme_sess_t *sess, const mme_bearer_t *bearer)
 {
-    const mme_ue_t *mme_ue = sess->mme_ue;
+    mme_ue_t *mme_ue = NULL;
     const ogs_session_t *session = sess->session;
+
+    ogs_assert(sess);
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    ogs_assert(mme_ue);
+
     /* FIXME: Initialize with defaults: */
     memset(qos_pdec, 0, sizeof(*qos_pdec));
 

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -304,6 +304,7 @@ int mme_gn_handle_sgsn_context_response(
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
     ogs_gtp1_mm_context_decoded_t gtp1_mm_ctx;
     ogs_gtp1_pdp_context_decoded_t gtp1_pdp_ctx;
+    enb_ue_t *enb_ue = NULL;
     mme_sess_t *sess = NULL;
     uint8_t ret_cause = OGS_GTP1_CAUSE_REQUEST_ACCEPTED;
 
@@ -319,6 +320,8 @@ int mme_gn_handle_sgsn_context_response(
         ogs_error("MME-UE Context has already been removed");
         return OGS_GTP1_CAUSE_IMSI_IMEI_NOT_KNOWN;
     }
+
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
     switch (resp->cause.u8) {
      case OGS_GTP1_CAUSE_REQUEST_ACCEPTED:
@@ -340,7 +343,7 @@ int mme_gn_handle_sgsn_context_response(
 
     if (resp->cause.u8 != OGS_GTP1_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("[Gn] Rx SGSN Context Response cause:%u", resp->cause.u8);
-        rv = nas_eps_send_tau_reject(mme_ue->enb_ue, mme_ue, emm_cause);
+        rv = nas_eps_send_tau_reject(enb_ue, mme_ue, emm_cause);
         return OGS_GTP1_CAUSE_SYSTEM_FAILURE;
     }
 
@@ -430,7 +433,7 @@ int mme_gn_handle_sgsn_context_response(
 nack_and_reject:
     rv = mme_gtp1_send_sgsn_context_ack(mme_ue, gtp1_cause, xact);
     ogs_info("[%s] TAU Reject [OGS_NAS_EMM_CAUSE:%d]", mme_ue->imsi_bcd, emm_cause);
-    rv = nas_eps_send_tau_reject(mme_ue->enb_ue, mme_ue, emm_cause);
+    rv = nas_eps_send_tau_reject(enb_ue, mme_ue, emm_cause);
     return OGS_GTP1_CAUSE_SYSTEM_FAILURE;
 }
 
@@ -439,6 +442,7 @@ void mme_gn_handle_sgsn_context_acknowledge(
         ogs_gtp_xact_t *xact, mme_ue_t *mme_ue, ogs_gtp1_sgsn_context_acknowledge_t *req)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_debug("[Gn] Rx SGSN Context Acknowledge");
 
@@ -452,6 +456,8 @@ void mme_gn_handle_sgsn_context_acknowledge(
         ogs_error("MME-UE Context has already been removed");
         return;
     }
+
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
     /* 3GPP TS 23.060 6.9.1.2.2 Step 4), 3GPP TS 23.401 D.3.5 Step 4)
     * The new SGSN sends an SGSN Context Acknowledge message to the old SGSN. The old MME (which is the old
@@ -475,8 +481,8 @@ void mme_gn_handle_sgsn_context_acknowledge(
     * connection is released by the source eNodeB. The source eNodeB confirms the release of the RRC connection
     * and of the S1-U connection by sending a S1-U Release Complete message to the source MME."
     */
-    if (mme_ue->enb_ue) {
-        rv = s1ap_send_ue_context_release_command(mme_ue->enb_ue,
+    if (enb_ue) {
+        rv = s1ap_send_ue_context_release_command(enb_ue,
             S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
             S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0);
         ogs_expect(rv == OGS_OK);

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -102,9 +102,12 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
 {
     int r;
     mme_ue_t *mme_ue = NULL;
+    ogs_pool_id_t mme_ue_id = OGS_INVALID_POOL_ID;
     enb_ue_t *enb_ue = NULL;
     mme_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     mme_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     uint8_t type = 0;
 
     ogs_assert(xact);
@@ -115,18 +118,26 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
     case OGS_GTP2_RELEASE_ACCESS_BEARERS_REQUEST_TYPE:
     case OGS_GTP2_CREATE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
     case OGS_GTP2_DELETE_INDIRECT_DATA_FORWARDING_TUNNEL_REQUEST_TYPE:
-        mme_ue = mme_ue_find_by_id(OGS_POINTER_TO_UINT(data));
+        mme_ue_id = OGS_POINTER_TO_UINT(data);
+        ogs_assert(mme_ue_id >= OGS_MIN_POOL_ID &&
+                mme_ue_id <= OGS_MAX_POOL_ID);
+        mme_ue = mme_ue_find_by_id(mme_ue_id);
         ogs_assert(mme_ue);
         break;
     case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
     case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
-        sess = mme_sess_find_by_id(OGS_POINTER_TO_UINT(data));
+        sess_id = OGS_POINTER_TO_UINT(data);
+        ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+        sess = mme_sess_find_by_id(sess_id);
         ogs_assert(sess);
         mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
         ogs_assert(mme_ue);
         break;
     case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
-        bearer = mme_bearer_find_by_id(OGS_POINTER_TO_UINT(data));
+        bearer_id = OGS_POINTER_TO_UINT(data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
+        bearer = mme_bearer_find_by_id(bearer_id);
         ogs_assert(bearer);
         sess = mme_sess_find_by_id(bearer->sess_id);
         ogs_assert(sess);

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -390,15 +390,18 @@ int mme_gtp_send_create_bearer_response(
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
+    ogs_assert(bearer->create.xact_id >= OGS_MIN_POOL_ID &&
+            bearer->create.xact_id <= OGS_MAX_POOL_ID);
+    xact = ogs_gtp_xact_find_by_id(bearer->create.xact_id);
+    if (!xact) {
+        ogs_error("GTP transaction(CREATE) has already been removed");
+        return OGS_OK;
+    }
+
     mme_ue = bearer->mme_ue;
     ogs_assert(mme_ue);
     sgw_ue = mme_ue->sgw_ue;
     ogs_assert(sgw_ue);
-    xact = ogs_gtp_xact_cycle(bearer->create.xact);
-    if (!xact) {
-        ogs_warn("GTP transaction(CREATE) has already been removed");
-        return OGS_OK;
-    }
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE;
@@ -500,15 +503,18 @@ int mme_gtp_send_delete_bearer_response(
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(bearer);
+    ogs_assert(bearer->delete.xact_id >= OGS_MIN_POOL_ID &&
+            bearer->delete.xact_id <= OGS_MAX_POOL_ID);
+    xact = ogs_gtp_xact_find_by_id(bearer->delete.xact_id);
+    if (!xact) {
+        ogs_error("GTP transaction(DELETE) has already been removed");
+        return OGS_OK;
+    }
+
     mme_ue = bearer->mme_ue;
     ogs_assert(mme_ue);
     sgw_ue = mme_ue->sgw_ue;
     ogs_assert(sgw_ue);
-    xact = ogs_gtp_xact_cycle(bearer->delete.xact);
-    if (!xact) {
-        ogs_warn("GTP transaction(DELETE) has already been removed");
-        return OGS_OK;
-    }
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
     h.type = OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE;
@@ -631,11 +637,14 @@ int mme_gtp_send_downlink_data_notification_ack(
     ogs_pkbuf_t *s11buf = NULL;
 
     ogs_assert(bearer);
-    xact = ogs_gtp_xact_cycle(bearer->notify.xact);
+    ogs_assert(bearer->notify.xact_id >= OGS_MIN_POOL_ID &&
+            bearer->notify.xact_id <= OGS_MAX_POOL_ID);
+    xact = ogs_gtp_xact_find_by_id(bearer->notify.xact_id);
     if (!xact) {
-        ogs_warn("GTP transaction(NOTIFY) has already been removed");
+        ogs_error("GTP transaction(NOTIFY) has already been removed");
         return OGS_OK;
     }
+
     mme_ue = bearer->mme_ue;
     ogs_assert(mme_ue);
     sgw_ue = mme_ue->sgw_ue;

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -76,14 +76,13 @@ void mme_send_delete_session_or_detach(mme_ue_t *mme_ue)
         if (!MME_SESSION_RELEASE_PENDING(mme_ue) &&
             mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR) ==
                 xact_count) {
-            enb_ue_t *enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+            enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
             if (enb_ue) {
                 ogs_assert(OGS_OK ==
                     s1ap_send_ue_context_release_command(enb_ue,
                         S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
                         S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0));
             } else {
-                MME_UE_CHECK(OGS_LOG_WARN, mme_ue);
                 mme_ue_remove(mme_ue);
             }
         }
@@ -129,7 +128,7 @@ void mme_send_delete_session_or_mme_ue_context_release(mme_ue_t *mme_ue)
     if (!MME_SESSION_RELEASE_PENDING(mme_ue) &&
         mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR) ==
             xact_count) {
-        enb_ue_t *enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+        enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         if (enb_ue) {
             r = s1ap_send_ue_context_release_command(enb_ue,
                     S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
@@ -148,7 +147,7 @@ void mme_send_release_access_bearer_or_ue_context_release(enb_ue_t *enb_ue)
     mme_ue_t *mme_ue = NULL;
     ogs_assert(enb_ue);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (mme_ue) {
         ogs_debug("[%s] Release access bearer request", mme_ue->imsi_bcd);
         ogs_assert(OGS_OK ==
@@ -173,7 +172,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, bool failed)
 
     switch (mme_ue->paging.type) {
     case MME_PAGING_TYPE_DOWNLINK_DATA_NOTIFICATION:
-        bearer = mme_bearer_cycle(mme_ue->paging.data);
+        bearer = mme_bearer_find_by_id(
+                OGS_POINTER_TO_UINT(mme_ue->paging.data));
         if (!bearer) {
             ogs_error("No Bearer [%d]", mme_ue->paging.type);
             goto cleanup;
@@ -190,7 +190,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, bool failed)
         }
         break;
     case MME_PAGING_TYPE_CREATE_BEARER:
-        bearer = mme_bearer_cycle(mme_ue->paging.data);
+        bearer = mme_bearer_find_by_id(
+                OGS_POINTER_TO_UINT(mme_ue->paging.data));
         if (!bearer) {
             ogs_error("No Bearer [%d]", mme_ue->paging.type);
             goto cleanup;
@@ -207,7 +208,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, bool failed)
         }
         break;
     case MME_PAGING_TYPE_UPDATE_BEARER:
-        bearer = mme_bearer_cycle(mme_ue->paging.data);
+        bearer = mme_bearer_find_by_id(
+                OGS_POINTER_TO_UINT(mme_ue->paging.data));
         if (!bearer) {
             ogs_error("No Bearer [%d]", mme_ue->paging.type);
             goto cleanup;
@@ -240,7 +242,8 @@ void mme_send_after_paging(mme_ue_t *mme_ue, bool failed)
         }
         break;
     case MME_PAGING_TYPE_DELETE_BEARER:
-        bearer = mme_bearer_cycle(mme_ue->paging.data);
+        bearer = mme_bearer_find_by_id(
+                OGS_POINTER_TO_UINT(mme_ue->paging.data));
         if (!bearer) {
             ogs_error("No Bearer [%d]", mme_ue->paging.type);
             goto cleanup;

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -55,13 +55,13 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
     session = sess->session;
     ogs_assert(session);
     ogs_assert(session->name);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST) {
-        sgw_ue = sgw_ue_cycle(sgw_ue->target_ue);
+        sgw_ue = sgw_ue_find_by_id(sgw_ue->target_ue_id);
         ogs_assert(sgw_ue);
     }
 
@@ -405,7 +405,7 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
     ogs_debug("Modifty Bearer Request");
 
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
     ogs_assert(ogs_list_count(&mme_ue->bearer_to_modify_list));
 
@@ -448,7 +448,7 @@ ogs_pkbuf_t *mme_s11_build_modify_bearer_request(
     memset(&indication, 0, sizeof(ogs_gtp2_indication_t));
     ogs_list_for_each_entry(
             &mme_ue->bearer_to_modify_list, bearer, to_modify_node) {
-        mme_sess_t *sess = bearer->sess;
+        mme_sess_t *sess = mme_sess_find_by_id(bearer->sess_id);
         ogs_assert(sess);
 
         if (sess->ue_request_type.value == OGS_NAS_EPS_REQUEST_TYPE_HANDOVER) {
@@ -513,9 +513,9 @@ ogs_pkbuf_t *mme_s11_build_delete_session_request(
     sgw_ue_t *sgw_ue = NULL;
 
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
     bearer = mme_default_bearer_in_sess(sess);
     ogs_assert(bearer);
@@ -576,9 +576,9 @@ ogs_pkbuf_t *mme_s11_build_create_bearer_response(
     sgw_ue_t *sgw_ue = NULL;
 
     ogs_assert(bearer);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     ogs_debug("Create Bearer Response");
@@ -683,9 +683,9 @@ ogs_pkbuf_t *mme_s11_build_update_bearer_response(
     sgw_ue_t *sgw_ue = NULL;
 
     ogs_assert(bearer);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     ogs_debug("Update Bearer Response");
@@ -762,9 +762,9 @@ ogs_pkbuf_t *mme_s11_build_delete_bearer_response(
     sgw_ue_t *sgw_ue = NULL;
 
     ogs_assert(bearer);
-    mme_ue = bearer->mme_ue;
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     ogs_debug("Delete Bearer Response");
@@ -918,7 +918,7 @@ ogs_pkbuf_t *mme_s11_build_create_indirect_data_forwarding_tunnel_request(
     int len;
 
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     ogs_debug("Create Indirect Data Forwarding Tunnel Request");
@@ -1002,11 +1002,11 @@ ogs_pkbuf_t *mme_s11_build_bearer_resource_command(
     mme_bearer_t *linked_bearer = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    mme_ue = sess->mme_ue;
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
-    sgw_ue = mme_ue->sgw_ue;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
 
     ogs_debug("Bearer Resource Command");

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -66,22 +66,22 @@ static void gtp_remote_holding_timeout(ogs_gtp_xact_t *xact, void *data)
     uint8_t type;
 
     ogs_assert(xact);
-    ogs_assert(data);
-    bearer = mme_bearer_find_by_id(OGS_POINTER_TO_UINT(data));
-    if (!bearer) {
-        ogs_error("No Bearer");
-        return;
-    }
-
     type = xact->seq[xact->step-1].type;
 
-    ogs_warn("[%d] %s HOLDING TIMEOUT "
+    ogs_error("[%d] %s HOLDING TIMEOUT "
             "for step %d type %d peer [%s]:%d",
             xact->xid,
             xact->org == OGS_GTP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             xact->step, type,
             OGS_ADDR(&xact->gnode->addr, buf),
             OGS_PORT(&xact->gnode->addr));
+
+    ogs_assert(data);
+    bearer = mme_bearer_find_by_id(OGS_POINTER_TO_UINT(data));
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
 
     /*
      * Issues #3240

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -1028,7 +1028,8 @@ void mme_s11_handle_create_bearer_request(
      * If GTP-xact Holding timer is expired,
      * OLD bearer->xact memory will be automatically removed.
      */
-    bearer->create.xact = xact;
+    ogs_assert(xact->id >= OGS_MIN_POOL_ID && xact->id <= OGS_MAX_POOL_ID);
+    bearer->create.xact_id = xact->id;
 
     /* Before Activate DEDICATED bearer, check DEFAULT bearer status */
     default_bearer = mme_default_bearer_in_sess(sess);
@@ -1329,7 +1330,8 @@ void mme_s11_handle_delete_bearer_request(
      * If GTP-xact Holding timer is expired,
      * OLD bearer->xact memory will be automatically removed.
      */
-    bearer->delete.xact = xact;
+    ogs_assert(xact->id >= OGS_MIN_POOL_ID && xact->id <= OGS_MAX_POOL_ID);
+    bearer->delete.xact_id = xact->id;
 
     if (ECM_IDLE(mme_ue)) {
         MME_STORE_PAGING_INFO(mme_ue,
@@ -1577,7 +1579,8 @@ void mme_s11_handle_downlink_data_notification(
      * If GTP-xact Holding timer is expired,
      * OLD bearer->xact memory will be automatically removed.
      */
-    bearer->notify.xact = xact;
+    ogs_assert(xact->id >= OGS_MIN_POOL_ID && xact->id <= OGS_MAX_POOL_ID);
+    bearer->notify.xact_id = xact->id;
 
     if (noti->cause.presence) {
         ogs_gtp2_cause_t *cause = noti->cause.data;

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -153,7 +153,6 @@ uint8_t mme_s6a_handle_pua(
     if (s6a_message->result_code != ER_DIAMETER_SUCCESS) {
         ogs_error("Purge UE failed for IMSI[%s] [%d]", mme_ue->imsi_bcd,
             s6a_message->result_code);
-        MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
         mme_ue_remove(mme_ue);
         return OGS_ERROR;
     }
@@ -161,7 +160,6 @@ uint8_t mme_s6a_handle_pua(
     if (pua_message->pua_flags & OGS_DIAM_S6A_PUA_FLAGS_FREEZE_MTMSI)
         ogs_debug("Freeze M-TMSI requested but not implemented.");
 
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
     mme_ue_remove(mme_ue);
 
     return OGS_OK;
@@ -220,7 +218,6 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
     clr_message = &s6a_message->clr_message;
     ogs_assert(clr_message);
 
-    mme_ue = mme_ue_cycle(mme_ue);
     if (!mme_ue) {
         ogs_warn("UE(mme-ue) context has already been removed");
         return;
@@ -236,7 +233,6 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
      */
     if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_de_registered)) {
         ogs_warn("UE has already been de-registered");
-        MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
         mme_ue_remove(mme_ue);
         return;
     }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -111,7 +111,11 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         enb = mme_enb_find_by_addr(addr);
         if (!enb) {
             enb = mme_enb_add(sock, addr);
-            ogs_assert(enb);
+            if (!enb) {
+                ogs_error("mme_enb_add() failed");
+                ogs_sock_destroy(sock);
+                ogs_free(addr);
+            }
         } else {
             ogs_warn("eNB context duplicated with IP-address [%s]!!!",
                     OGS_ADDR(addr, buf));
@@ -136,7 +140,10 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         enb = mme_enb_find_by_addr(addr);
         if (!enb) {
             enb = mme_enb_add(sock, addr);
-            ogs_assert(enb);
+            if (!enb) {
+                ogs_error("amf_enb_add() failed");
+                ogs_free(addr);
+            }
         } else {
             ogs_free(addr);
         }
@@ -193,7 +200,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
 
         rc = ogs_s1ap_decode(&s1ap_message, pkbuf);
         if (rc == OGS_OK) {
-            e->enb = enb;
+            e->enb_id = enb->id;
             e->s1ap_message = &s1ap_message;
             ogs_fsm_dispatch(&enb->sm, e);
         } else {
@@ -210,13 +217,14 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         break;
 
     case MME_EVENT_S1AP_TIMER:
-        enb_ue = e->enb_ue;
-        ogs_assert(enb_ue);
+        enb_ue = enb_ue_find_by_id(e->enb_ue_id);
+        if (!enb_ue) {
+            ogs_error("S1 Context has already been removed");
+            break;
+        }
 
         switch (e->timer_id) {
         case MME_TIMER_S1_DELAYED_SEND:
-            enb = e->enb;
-            ogs_assert(enb);
             pkbuf = e->pkbuf;
             ogs_assert(pkbuf);
 
@@ -239,10 +247,14 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         break;
 
     case MME_EVENT_EMM_MESSAGE:
-        enb_ue = e->enb_ue;
-        ogs_assert(enb_ue);
         pkbuf = e->pkbuf;
         ogs_assert(pkbuf);
+
+        enb_ue = enb_ue_find_by_id(e->enb_ue_id);
+        if (!enb_ue) {
+            ogs_error("S1 Context has already been removed");
+            break;
+        }
 
         if (ogs_nas_emm_decode(&nas_message, pkbuf) != OGS_OK) {
             ogs_error("ogs_nas_emm_decode() failed");
@@ -250,7 +262,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             return;
         }
 
-        mme_ue = enb_ue->mme_ue;
+        mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
         if (!mme_ue) {
             mme_ue = mme_ue_find_by_message(&nas_message);
             if (!mme_ue) {
@@ -266,7 +278,6 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
                     return;
                 }
 
-                MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
                 ogs_assert(ECM_IDLE(mme_ue));
             } else {
                 /* Here, if the MME_UE Context is found,
@@ -326,14 +337,12 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
                     enb_ue ? enb_ue->enb_ue_s1ap_id : 0,
                     enb_ue ? enb_ue->mme_ue_s1ap_id : 0);
             ogs_fatal("context [%p:%p]", enb_ue, mme_ue);
-            ogs_fatal("cycle [%p:%p]",
-                    enb_ue_cycle(enb_ue), mme_ue_cycle(mme_ue));
             ogs_fatal("IMSI [%s]", mme_ue ? mme_ue->imsi_bcd : "No MME_UE");
             ogs_assert_if_reached();
         }
         ogs_assert(OGS_FSM_STATE(&mme_ue->sm));
 
-        e->mme_ue = mme_ue;
+        e->mme_ue_id = mme_ue->id;
         e->nas_message = &nas_message;
 
         ogs_fsm_dispatch(&mme_ue->sm, e);
@@ -344,7 +353,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         ogs_pkbuf_free(pkbuf);
         break;
     case MME_EVENT_EMM_TIMER:
-        mme_ue = e->mme_ue;
+        mme_ue = mme_ue_find_by_id(e->mme_ue_id);
         ogs_assert(mme_ue);
         ogs_assert(OGS_FSM_STATE(&mme_ue->sm));
 
@@ -352,7 +361,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         break;
 
     case MME_EVENT_ESM_MESSAGE:
-        mme_ue = e->mme_ue;
+        mme_ue = mme_ue_find_by_id(e->mme_ue_id);
         ogs_assert(mme_ue);
 
         pkbuf = e->pkbuf;
@@ -438,24 +447,20 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
      */
         if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_de_registered)) {
             ESM_MESSAGE_CHECK;
-            MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
             ogs_pkbuf_free(pkbuf);
             break;
         } else if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_authentication)) {
             ESM_MESSAGE_CHECK;
-            MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
             ogs_pkbuf_free(pkbuf);
             break;
         } else if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_security_mode)) {
             ESM_MESSAGE_CHECK;
-            MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
             ogs_pkbuf_free(pkbuf);
             break;
         } else if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_initial_context_setup)) {
         } else if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_registered)) {
         } else if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_exception)) {
             ESM_MESSAGE_CHECK;
-            MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
             ogs_pkbuf_free(pkbuf);
             break;
         }
@@ -467,12 +472,12 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
             break;
         }
 
-        sess = bearer->sess;
+        sess = mme_sess_find_by_id(bearer->sess_id);
         ogs_assert(sess);
         default_bearer = mme_default_bearer_in_sess(sess);
         ogs_assert(default_bearer);
 
-        e->bearer = bearer;
+        e->bearer_id = bearer->id;
         e->nas_message = &nas_message;
 
         ogs_fsm_dispatch(&bearer->sm, e);
@@ -508,7 +513,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         break;
 
     case MME_EVENT_ESM_TIMER:
-        bearer = e->bearer;
+        bearer = mme_bearer_find_by_id(e->bearer_id);
         ogs_assert(bearer);
         ogs_assert(OGS_FSM_STATE(&bearer->sm));
 
@@ -560,13 +565,13 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
          * decide whether to process or
          * ignore the Authentication-Information-Answer as shown below.
          */
-        mme_ue = mme_ue_cycle(e->mme_ue);
+        mme_ue = mme_ue_find_by_id(e->mme_ue_id);
         if (!mme_ue) {
             ogs_error("UE(mme-ue) context has already been removed");
             goto cleanup;
         }
 
-        enb_ue = enb_ue_cycle(e->enb_ue);
+        enb_ue = enb_ue_find_by_id(e->enb_ue_id);
         /*
          * The 'enb_ue' context is not checked
          * because the status is checked in the sending routine.
@@ -616,7 +621,7 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
 
                 r = s1ap_send_ue_context_release_command(enb_ue,
                         S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
-                        mme_ue_cycle(enb_ue->mme_ue) ?
+                        mme_ue_find_by_id(enb_ue->mme_ue_id) ?
                             S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE :
                             S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE, 0);
                 ogs_expect(r == OGS_OK);
@@ -775,10 +780,16 @@ cleanup:
         break;
 
     case MME_EVENT_S11_TIMER:
-        sgw_ue = e->sgw_ue;
-        ogs_assert(sgw_ue);
-        mme_ue = sgw_ue->mme_ue;
-        ogs_assert(mme_ue);
+        sgw_ue = sgw_ue_find_by_id(e->sgw_ue_id);
+        if (!sgw_ue) {
+            ogs_error("SGW-UE Context has already been removed");
+            break;
+        }
+        mme_ue = mme_ue_find_by_id(sgw_ue->mme_ue_id);
+        if (!mme_ue) {
+            ogs_error("MME-UE Context has already been removed");
+            break;
+        }
 
         switch (e->timer_id) {
         case MME_TIMER_S11_HOLDING:
@@ -867,9 +878,9 @@ cleanup:
         break;
 
     case MME_EVENT_GN_TIMER:
-        mme_ue = e->mme_ue;
+        mme_ue = mme_ue_find_by_id(e->mme_ue_id);
         ogs_assert(mme_ue);
-        sgw_ue = mme_ue->sgw_ue;
+        sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
         ogs_assert(sgw_ue);
 
         switch (e->timer_id) {

--- a/src/mme/mme-timer.c
+++ b/src/mme/mme-timer.c
@@ -63,11 +63,6 @@ static mme_timer_cfg_t g_mme_timer_cfg[MAX_NUM_OF_MME_TIMER] = {
         { .have = true, .duration = ogs_time_from_sec(20) },
 };
 
-static void emm_timer_event_send(
-        mme_timer_e timer_id, mme_ue_t *mme_ue);
-static void esm_timer_event_send(
-        mme_timer_e timer_id, mme_bearer_t *bearer);
-
 mme_timer_cfg_t *mme_timer_cfg(mme_timer_e id)
 {
     ogs_assert(id < MAX_NUM_OF_MME_TIMER);
@@ -129,16 +124,16 @@ void mme_timer_s1_delayed_send(void *data)
 }
 
 
-static void emm_timer_event_send(
-        mme_timer_e timer_id, mme_ue_t *mme_ue)
+static void emm_timer_event_send(mme_timer_e timer_id, void *data)
 {
     int rv;
     mme_event_t *e = NULL;
-    ogs_assert(mme_ue);
+
+    ogs_assert(data);
 
     e = mme_event_new(MME_EVENT_EMM_TIMER);
     e->timer_id = timer_id;
-    e->mme_ue = mme_ue;
+    e->mme_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -176,20 +171,16 @@ void mme_timer_implicit_detach_expire(void *data)
     emm_timer_event_send(MME_TIMER_IMPLICIT_DETACH, data);
 }
 
-static void esm_timer_event_send(
-        mme_timer_e timer_id, mme_bearer_t *bearer)
+static void esm_timer_event_send(mme_timer_e timer_id, void *data)
 {
     int rv;
     mme_event_t *e = NULL;
-    mme_ue_t *mme_ue = NULL;
-    ogs_assert(bearer);
-    mme_ue = bearer->mme_ue;
-    ogs_assert(bearer);
+
+    ogs_assert(data);
 
     e = mme_event_new(MME_EVENT_ESM_TIMER);
     e->timer_id = timer_id;
-    e->mme_ue = mme_ue;
-    e->bearer = bearer;
+    e->bearer_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -224,15 +215,13 @@ void mme_timer_s1_holding_timer_expire(void *data)
 {
     int rv;
     mme_event_t *e = NULL;
-    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(data);
-    enb_ue = data;
 
     e = mme_event_new(MME_EVENT_S1AP_TIMER);
 
     e->timer_id = MME_TIMER_S1_HOLDING;
-    e->enb_ue = enb_ue;
+    e->enb_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -245,15 +234,13 @@ void mme_timer_s11_holding_timer_expire(void *data)
 {
     int rv;
     mme_event_t *e = NULL;
-    sgw_ue_t *sgw_ue = NULL;
 
     ogs_assert(data);
-    sgw_ue = data;
 
     e = mme_event_new(MME_EVENT_S11_TIMER);
 
     e->timer_id = MME_TIMER_S11_HOLDING;
-    e->sgw_ue = sgw_ue;
+    e->sgw_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
@@ -266,15 +253,13 @@ void mme_timer_gn_holding_timer_expire(void *data)
 {
     int rv;
     mme_event_t *e = NULL;
-    mme_ue_t *mme_ue;
 
     ogs_assert(data);
-    mme_ue = data;
 
     e = mme_event_new(MME_EVENT_GN_TIMER);
 
     e->timer_id = MME_TIMER_GN_HOLDING;
-    e->mme_ue = mme_ue;
+    e->mme_ue_id = OGS_POINTER_TO_UINT(data);
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -29,16 +29,24 @@
 int nas_eps_send_to_enb(mme_ue_t *mme_ue, ogs_pkbuf_t *pkbuf)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(pkbuf);
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         ogs_pkbuf_free(pkbuf);
         return OGS_NOTFOUND;
     }
 
-    rv = s1ap_send_to_enb_ue(mme_ue->enb_ue, pkbuf);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
+        ogs_error("S1 context has already been removed");
+        ogs_pkbuf_free(pkbuf);
+        return OGS_NOTFOUND;
+    }
+
+    rv = s1ap_send_to_enb_ue(enb_ue, pkbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -56,7 +64,7 @@ int nas_eps_send_emm_to_esm(mme_ue_t *mme_ue,
         return OGS_ERROR;
     }
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -84,7 +92,7 @@ int nas_eps_send_to_downlink_nas_transport(
 
     ogs_assert(pkbuf);
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         ogs_pkbuf_free(pkbuf);
         return OGS_NOTFOUND;
@@ -105,16 +113,18 @@ int nas_eps_send_to_downlink_nas_transport(
 int nas_eps_send_attach_accept(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     mme_sess_t *sess = NULL;
     ogs_pkbuf_t *s1apbuf = NULL;
     ogs_pkbuf_t *esmbuf = NULL, *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -184,12 +194,12 @@ int nas_eps_send_attach_reject(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
     mme_sess_t *sess = NULL;
     ogs_pkbuf_t *esmbuf = NULL, *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -221,14 +231,16 @@ int nas_eps_send_attach_reject(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
 int nas_eps_send_identity_request(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -254,7 +266,7 @@ int nas_eps_send_identity_request(mme_ue_t *mme_ue)
     ogs_timer_start(mme_ue->t3470.timer, 
             mme_timer_cfg(MME_TIMER_T3470)->duration);
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -263,14 +275,16 @@ int nas_eps_send_identity_request(mme_ue_t *mme_ue)
 int nas_eps_send_authentication_request(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -296,7 +310,7 @@ int nas_eps_send_authentication_request(mme_ue_t *mme_ue)
     ogs_timer_start(mme_ue->t3460.timer, 
             mme_timer_cfg(MME_TIMER_T3460)->duration);
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -305,14 +319,16 @@ int nas_eps_send_authentication_request(mme_ue_t *mme_ue)
 int nas_eps_send_security_mode_command(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -338,7 +354,7 @@ int nas_eps_send_security_mode_command(mme_ue_t *mme_ue)
     ogs_timer_start(mme_ue->t3460.timer, 
             mme_timer_cfg(MME_TIMER_T3460)->duration);
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -347,14 +363,16 @@ int nas_eps_send_security_mode_command(mme_ue_t *mme_ue)
 int nas_eps_send_authentication_reject(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -367,7 +385,7 @@ int nas_eps_send_authentication_reject(mme_ue_t *mme_ue)
         return OGS_ERROR;
     }
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -376,14 +394,16 @@ int nas_eps_send_authentication_reject(mme_ue_t *mme_ue)
 int nas_eps_send_detach_request(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -409,7 +429,7 @@ int nas_eps_send_detach_request(mme_ue_t *mme_ue)
     ogs_timer_start(mme_ue->t3422.timer, 
             mme_timer_cfg(MME_TIMER_T3422)->duration);    
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -418,15 +438,16 @@ int nas_eps_send_detach_request(mme_ue_t *mme_ue)
 int nas_eps_send_detach_accept(mme_ue_t *mme_ue)
 {
     int rv;
- 
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -441,14 +462,14 @@ int nas_eps_send_detach_accept(mme_ue_t *mme_ue)
             return OGS_ERROR;
         }
 
-        rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+        rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
         if (rv != OGS_OK) {
             ogs_error("nas_eps_send_to_downlink_nas_transport() failed");
             return rv;
         }
     }
 
-    rv = s1ap_send_ue_context_release_command(mme_ue->enb_ue,
+    rv = s1ap_send_ue_context_release_command(enb_ue,
             S1AP_Cause_PR_nas, S1AP_CauseNas_detach,
             S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0);
     ogs_expect(rv == OGS_OK);
@@ -460,18 +481,20 @@ int nas_eps_send_pdn_connectivity_reject(
     mme_sess_t *sess, ogs_nas_esm_cause_t esm_cause, int create_action)
 {
     int rv;
-    mme_ue_t *mme_ue;
+    mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
 
     ogs_assert(sess);
 
-    mme_ue = sess->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -479,14 +502,14 @@ int nas_eps_send_pdn_connectivity_reject(
     if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
         /* During the UE-attach process, we'll send Attach-Reject
          * with pyggybacking PDN-connectivity-Reject */
-        rv = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+        rv = nas_eps_send_attach_reject(enb_ue, mme_ue,
             OGS_NAS_EMM_CAUSE_ESM_FAILURE, esm_cause);
         if (rv != OGS_OK) {
             ogs_error("nas_eps_send_attach_reject() failed");
             return rv;
         }
 
-        rv = s1ap_send_ue_context_release_command(mme_ue->enb_ue,
+        rv = s1ap_send_ue_context_release_command(enb_ue,
                 S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
                 S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0);
         ogs_expect(rv == OGS_OK);
@@ -498,7 +521,7 @@ int nas_eps_send_pdn_connectivity_reject(
             return OGS_ERROR;
         }
 
-        rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, esmbuf);
+        rv = nas_eps_send_to_downlink_nas_transport(enb_ue, esmbuf);
         ogs_expect(rv == OGS_OK);
     }
 
@@ -509,17 +532,19 @@ int nas_eps_send_esm_information_request(mme_bearer_t *bearer)
 {
     int rv;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
 
     ogs_assert(bearer);
 
-    mme_ue = bearer->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -543,7 +568,7 @@ int nas_eps_send_esm_information_request(mme_bearer_t *bearer)
     ogs_timer_start(bearer->t3489.timer, 
             mme_timer_cfg(MME_TIMER_T3489)->duration);
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, esmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, esmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -557,18 +582,20 @@ int nas_eps_send_activate_default_bearer_context_request(
     ogs_pkbuf_t *esmbuf = NULL;
     mme_sess_t *sess = NULL;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = mme_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
-    mme_ue = bearer->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -599,16 +626,18 @@ int nas_eps_send_activate_dedicated_bearer_context_request(
     ogs_pkbuf_t *s1apbuf = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(bearer);
 
-    mme_ue = bearer->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -654,16 +683,18 @@ int nas_eps_send_modify_bearer_context_request(
     ogs_pkbuf_t *s1apbuf = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(bearer);
 
-    mme_ue = bearer->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -685,7 +716,7 @@ int nas_eps_send_modify_bearer_context_request(
         rv = nas_eps_send_to_enb(mme_ue, s1apbuf);
         ogs_expect(rv == OGS_OK);
     } else {
-        rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, esmbuf);
+        rv = nas_eps_send_to_downlink_nas_transport(enb_ue, esmbuf);
         ogs_expect(rv == OGS_OK);
     }
 
@@ -698,16 +729,18 @@ int nas_eps_send_deactivate_bearer_context_request(mme_bearer_t *bearer)
     ogs_pkbuf_t *s1apbuf = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     ogs_assert(bearer);
 
-    mme_ue = bearer->mme_ue;
-    if (!mme_ue_cycle(mme_ue)) {
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -736,14 +769,16 @@ int nas_eps_send_bearer_resource_allocation_reject(
         mme_ue_t *mme_ue, uint8_t pti, ogs_nas_esm_cause_t esm_cause)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -757,7 +792,7 @@ int nas_eps_send_bearer_resource_allocation_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, esmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, esmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -767,14 +802,16 @@ int nas_eps_send_bearer_resource_modification_reject(
         mme_ue_t *mme_ue, uint8_t pti, ogs_nas_esm_cause_t esm_cause)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *esmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -788,7 +825,7 @@ int nas_eps_send_bearer_resource_modification_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, esmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, esmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -798,14 +835,16 @@ int nas_eps_send_tau_accept(
         mme_ue_t *mme_ue, S1AP_ProcedureCode_t procedureCode)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -841,7 +880,7 @@ int nas_eps_send_tau_accept(
         rv = nas_eps_send_to_enb(mme_ue, s1apbuf);
         ogs_expect(rv == OGS_OK);
     } else if (procedureCode == S1AP_ProcedureCode_id_downlinkNASTransport) {
-        rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+        rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
         ogs_expect(rv == OGS_OK);
     } else
         ogs_assert_if_reached();
@@ -855,12 +894,12 @@ int nas_eps_send_tau_reject(
     int rv;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -886,12 +925,12 @@ int nas_eps_send_service_reject(
     int rv;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(enb_ue)) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -914,14 +953,16 @@ int nas_eps_send_service_reject(
 int nas_eps_send_cs_service_notification(mme_ue_t *mme_ue)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -934,7 +975,7 @@ int nas_eps_send_cs_service_notification(mme_ue_t *mme_ue)
         return OGS_ERROR;
     }
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -944,14 +985,16 @@ int nas_eps_send_downlink_nas_transport(
         mme_ue_t *mme_ue, uint8_t *buffer, uint8_t length)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     ogs_pkbuf_t *emmbuf = NULL;
 
-    if (!mme_ue_cycle(mme_ue)) {
+    if (!mme_ue) {
         ogs_error("UE(mme-ue) context has already been removed");
         return OGS_NOTFOUND;
     }
 
-    if (!enb_ue_cycle(mme_ue->enb_ue)) {
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return OGS_NOTFOUND;
     }
@@ -967,7 +1010,7 @@ int nas_eps_send_downlink_nas_transport(
         return OGS_ERROR;
     }
 
-    rv = nas_eps_send_to_downlink_nas_transport(mme_ue->enb_ue, emmbuf);
+    rv = nas_eps_send_to_downlink_nas_transport(enb_ue, emmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;

--- a/src/mme/s1ap-build.c
+++ b/src/mme/s1ap-build.c
@@ -283,7 +283,6 @@ ogs_pkbuf_t *s1ap_build_downlink_nas_transport(
     S1AP_NAS_PDU_t *NAS_PDU = NULL;
 
     ogs_assert(emmbuf);
-    enb_ue = enb_ue_cycle(enb_ue);
     ogs_assert(enb_ue);
 
     ogs_debug("DownlinkNASTransport");
@@ -427,9 +426,8 @@ ogs_pkbuf_t *s1ap_build_initial_context_setup_request(
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
 
-    mme_ue = mme_ue_cycle(mme_ue);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("InitialContextSetupRequest");
@@ -621,7 +619,6 @@ ogs_pkbuf_t *s1ap_build_initial_context_setup_request(
     }
 
     if (!E_RABToBeSetupListCtxtSUReq->list.count) {
-        MME_UE_CHECK(OGS_LOG_ERROR, mme_ue);
         ogs_list_for_each(&mme_ue->sess_list, sess) {
             ogs_error("    APN[%s]",
                     sess->session ? sess->session->name : "Unknown");
@@ -847,9 +844,8 @@ ogs_pkbuf_t *s1ap_build_ue_context_modification_request(mme_ue_t *mme_ue)
 
     enb_ue_t *enb_ue = NULL;
 
-    mme_ue = mme_ue_cycle(mme_ue);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("UEContextModificationRequest");
@@ -983,7 +979,6 @@ ogs_pkbuf_t *s1ap_build_ue_context_release_command(
     S1AP_UE_S1AP_IDs_t *UE_S1AP_IDs = NULL;
     S1AP_Cause_t *Cause = NULL;
 
-    enb_ue = enb_ue_cycle(enb_ue);
     ogs_assert(enb_ue);
 
     if (enb_ue->mme_ue_s1ap_id == 0) {
@@ -1069,9 +1064,9 @@ ogs_pkbuf_t *s1ap_build_e_rab_setup_request(
     ogs_assert(esmbuf);
     ogs_assert(bearer);
 
-    mme_ue = mme_ue_cycle(bearer->mme_ue);
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("E-RABSetupRequest");
@@ -1202,9 +1197,9 @@ ogs_pkbuf_t *s1ap_build_e_rab_modify_request(
     ogs_assert(esmbuf);
     ogs_assert(bearer);
 
-    mme_ue = mme_ue_cycle(bearer->mme_ue);
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("E-RABModifyRequest");
@@ -1330,9 +1325,9 @@ ogs_pkbuf_t *s1ap_build_e_rab_release_command(
     ogs_assert(esmbuf);
     ogs_assert(bearer);
 
-    mme_ue = mme_ue_cycle(bearer->mme_ue);
+    mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("E-RABReleaseCommand");
@@ -1451,9 +1446,8 @@ ogs_pkbuf_t *s1ap_build_e_rab_modification_confirm(mme_ue_t *mme_ue)
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
 
-    mme_ue = mme_ue_cycle(mme_ue);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("E-RABModificationConfirm");
@@ -1553,7 +1547,6 @@ ogs_pkbuf_t *s1ap_build_paging(
     uint64_t ue_imsi_value = 0;
     int i = 0;
 
-    mme_ue = mme_ue_cycle(mme_ue);
     ogs_assert(mme_ue);
 
     ogs_debug("Paging");
@@ -1776,9 +1769,8 @@ ogs_pkbuf_t *s1ap_build_path_switch_ack(
     mme_bearer_t *bearer = NULL;
     enb_ue_t *enb_ue = NULL;
 
-    mme_ue = mme_ue_cycle(mme_ue);
     ogs_assert(mme_ue);
-    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
     ogs_assert(enb_ue);
 
     ogs_debug("PathSwitchAcknowledge");
@@ -1973,9 +1965,8 @@ ogs_pkbuf_t *s1ap_build_handover_command(enb_ue_t *source_ue)
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
 
-    source_ue = enb_ue_cycle(source_ue);
     ogs_assert(source_ue);
-    mme_ue = mme_ue_cycle(source_ue->mme_ue);
+    mme_ue = mme_ue_find_by_id(source_ue->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("HandoverCommand");
@@ -2132,7 +2123,6 @@ ogs_pkbuf_t *s1ap_build_handover_preparation_failure(
     S1AP_ENB_UE_S1AP_ID_t *ENB_UE_S1AP_ID = NULL;
     S1AP_Cause_t *Cause = NULL;
 
-    source_ue = enb_ue_cycle(source_ue);
     ogs_assert(source_ue);
     ogs_assert(group);
 
@@ -2225,9 +2215,8 @@ ogs_pkbuf_t *s1ap_build_handover_request(
     ogs_assert(cause);
     ogs_assert(source_totarget_transparentContainer);
 
-    target_ue = enb_ue_cycle(target_ue);
     ogs_assert(target_ue);
-    mme_ue = mme_ue_cycle(target_ue->mme_ue);
+    mme_ue = mme_ue_find_by_id(target_ue->mme_ue_id);
     ogs_assert(mme_ue);
 
     ogs_debug("HandoverRequest");
@@ -2460,7 +2449,6 @@ ogs_pkbuf_t *s1ap_build_handover_cancel_ack(enb_ue_t *source_ue)
     S1AP_MME_UE_S1AP_ID_t *MME_UE_S1AP_ID = NULL;
     S1AP_ENB_UE_S1AP_ID_t *ENB_UE_S1AP_ID = NULL;
 
-    source_ue = enb_ue_cycle(source_ue);
     ogs_assert(source_ue);
 
     ogs_debug("HandoverCancelAcknowledge");
@@ -2524,7 +2512,6 @@ ogs_pkbuf_t *s1ap_build_mme_status_transfer(
     S1AP_ENB_StatusTransfer_TransparentContainer_t
         *ENB_StatusTransfer_TransparentContainer = NULL;
 
-    target_ue = enb_ue_cycle(target_ue);
     ogs_assert(target_ue);
     ogs_assert(enb_statustransfer_transparentContainer);
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -505,7 +505,6 @@ void s1ap_handle_initial_ue_message(mme_enb_t *enb, ogs_s1ap_message_t *message)
                 ogs_info("Unknown UE by S_TMSI[G:%d,C:%d,M_TMSI:0x%x]",
                         nas_guti.mme_gid, nas_guti.mme_code, nas_guti.m_tmsi);
             } else {
-                MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
                 ogs_info("    S_TMSI[G:%d,C:%d,M_TMSI:0x%x] IMSI:[%s]",
                         mme_ue->current.guti.mme_gid,
                         mme_ue->current.guti.mme_code,
@@ -542,16 +541,15 @@ void s1ap_handle_initial_ue_message(mme_enb_t *enb, ogs_s1ap_message_t *message)
             }
         }
     } else {
+        mme_ue_t *mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
         ogs_error("Known UE ENB_UE_S1AP_ID[%d] [%p:%p]",
-                (int)*ENB_UE_S1AP_ID, enb_ue, enb_ue->mme_ue);
-        if (enb_ue->mme_ue) {
-            MME_UE_CHECK(OGS_LOG_DEBUG, enb_ue->mme_ue);
+                (int)*ENB_UE_S1AP_ID, enb_ue, mme_ue);
+        if (mme_ue) {
             ogs_error("    S_TMSI[G:%d,C:%d,M_TMSI:0x%x] IMSI:[%s]",
-                enb_ue->mme_ue->current.guti.mme_gid,
-                enb_ue->mme_ue->current.guti.mme_code,
-                enb_ue->mme_ue->current.guti.m_tmsi,
-                MME_UE_HAVE_IMSI(enb_ue->mme_ue)
-                ? enb_ue->mme_ue->imsi_bcd : "Unknown");
+                mme_ue->current.guti.mme_gid,
+                mme_ue->current.guti.mme_code,
+                mme_ue->current.guti.m_tmsi,
+                MME_UE_HAVE_IMSI(mme_ue) ? mme_ue->imsi_bcd : "Unknown");
         }
     }
 
@@ -631,6 +629,7 @@ void s1ap_handle_uplink_nas_transport(
     S1AP_CellIdentity_t *cell_ID = NULL;
 
     enb_ue_t *enb_ue = NULL;
+    mme_ue_t *mme_ue = NULL;
 
     ogs_eps_tai_t tai;
     int served_tai_index = 0;
@@ -784,10 +783,8 @@ void s1ap_handle_uplink_nas_transport(
         enb_ue->saved.tai.tac, enb_ue->saved.e_cgi.cell_id);
 
     /* Copy Stream-No/TAI/ECGI from enb_ue */
-    if (enb_ue->mme_ue) {
-        mme_ue_t *mme_ue = enb_ue->mme_ue;
-
-        MME_UE_CHECK(OGS_LOG_DEBUG, enb_ue->mme_ue);
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
+    if (mme_ue) {
         memcpy(&mme_ue->tai, &enb_ue->saved.tai, sizeof(ogs_eps_tai_t));
         memcpy(&mme_ue->e_cgi, &enb_ue->saved.e_cgi, sizeof(ogs_e_cgi_t));
         mme_ue->ue_location_timestamp = ogs_time_now();
@@ -814,6 +811,7 @@ void s1ap_handle_ue_capability_info_indication(
     S1AP_UERadioCapability_t *UERadioCapability = NULL;
 
     enb_ue_t *enb_ue = NULL;
+    mme_ue_t *mme_ue = NULL;
 
     ogs_assert(enb);
     ogs_assert(enb->sctp.sock);
@@ -889,11 +887,10 @@ void s1ap_handle_ue_capability_info_indication(
     ogs_debug("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
-    if (enb_ue->mme_ue) {
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
+    if (mme_ue) {
         ogs_assert(UERadioCapability);
-        MME_UE_CHECK(OGS_LOG_DEBUG, enb_ue->mme_ue);
-        OGS_ASN_STORE_DATA(&enb_ue->mme_ue->ueRadioCapability,
-                UERadioCapability);
+        OGS_ASN_STORE_DATA(&mme_ue->ueRadioCapability, UERadioCapability);
     }
 }
 
@@ -989,13 +986,12 @@ void s1ap_handle_initial_context_setup_response(
     ogs_debug("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
     }
 
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
     if (E_RABSetupListCtxtSURes) {
         int uli_presence = 0;
 
@@ -1188,7 +1184,7 @@ void s1ap_handle_initial_context_setup_failure(
     ogs_debug("    Cause[Group:%d Cause:%d]",
             Cause->present, (int)Cause->choice.radioNetwork);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
 
     if (mme_ue) {
         /*
@@ -1300,7 +1296,7 @@ void s1ap_handle_ue_context_modification_response(
     ogs_debug("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -1412,7 +1408,7 @@ void s1ap_handle_ue_context_modification_failure(
     ogs_debug("    Cause[Group:%d Cause:%d]",
             Cause->present, (int)Cause->choice.radioNetwork);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -1522,7 +1518,7 @@ void s1ap_handle_e_rab_setup_response(
     ogs_debug("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
         enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -1857,9 +1853,7 @@ void s1ap_handle_ue_context_release_action(enb_ue_t *enb_ue)
     int r;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_assert(enb_ue);
-
-    if (enb_ue_cycle(enb_ue) == NULL) {
+    if (!enb_ue) {
         ogs_error("S1 context has already been removed");
         return;
     }
@@ -1868,7 +1862,7 @@ void s1ap_handle_ue_context_release_action(enb_ue_t *enb_ue)
     ogs_info("    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
-    mme_ue = mme_ue_cycle(enb_ue->mme_ue);
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (mme_ue) {
         ogs_info("    IMSI[%s]", mme_ue->imsi_bcd);
 
@@ -1964,7 +1958,6 @@ void s1ap_handle_ue_context_release_action(enb_ue_t *enb_ue)
             return;
         }
 
-        MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
         mme_ue_remove(mme_ue);
         break;
     case S1AP_UE_CTX_REL_S1_HANDOVER_COMPLETE:
@@ -2008,11 +2001,12 @@ void s1ap_handle_ue_context_release_action(enb_ue_t *enb_ue)
             ogs_warn("  Packet could be dropped during S1-Handover");
             mme_ue_clear_indirect_tunnel(mme_ue);
 
-            if (!mme_ue->enb_ue) {
+            enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+            if (!enb_ue) {
                 ogs_error("No S1 context");
                 return;
             }
-            r = s1ap_send_handover_cancel_ack(mme_ue->enb_ue);
+            r = s1ap_send_handover_cancel_ack(enb_ue);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
         }
@@ -2153,13 +2147,12 @@ void s1ap_handle_e_rab_modification_indication(
         return;
     }
 
-    mme_ue = enb_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
     }
 
-    MME_UE_CHECK(OGS_LOG_DEBUG, mme_ue);
     ogs_list_init(&mme_ue->bearer_to_modify_list);
 
     for (i = 0; i < E_RABToBeModifiedListBearerModInd->list.count; i++) {
@@ -2510,7 +2503,7 @@ void s1ap_handle_path_switch_request(
         return;
     }
 
-    mme_ue = mme_ue_cycle(enb_ue->mme_ue);
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -2816,7 +2809,7 @@ static void s1ap_handle_handover_required_intralte(enb_ue_t *source_ue,
         return;
     }
 
-    mme_ue = source_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(source_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -3112,7 +3105,7 @@ void s1ap_handle_handover_request_ack(
         return;
     }
 
-    source_ue = target_ue->source_ue;
+    source_ue = enb_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("No Source UE");
         r = s1ap_send_error_indication(enb, MME_UE_S1AP_ID, ENB_UE_S1AP_ID,
@@ -3122,7 +3115,7 @@ void s1ap_handle_handover_request_ack(
         return;
     }
 
-    mme_ue = source_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(source_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -3315,7 +3308,7 @@ void s1ap_handle_handover_failure(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
-    source_ue = target_ue->source_ue;
+    source_ue = enb_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("No Source UE");
         r = s1ap_send_error_indication(enb, MME_UE_S1AP_ID, NULL,
@@ -3437,7 +3430,7 @@ void s1ap_handle_handover_cancel(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
-    target_ue = source_ue->target_ue;
+    target_ue = enb_ue_find_by_id(source_ue->target_ue_id);
     if (!target_ue) {
         ogs_error("No Target UE");
         r = s1ap_send_error_indication(enb, MME_UE_S1AP_ID, ENB_UE_S1AP_ID,
@@ -3565,7 +3558,7 @@ void s1ap_handle_enb_status_transfer(
         return;
     }
 
-    target_ue = source_ue->target_ue;
+    target_ue = enb_ue_find_by_id(source_ue->target_ue_id);
     if (!target_ue) {
         ogs_error("No Target UE");
         r = s1ap_send_error_indication(enb, MME_UE_S1AP_ID, ENB_UE_S1AP_ID,
@@ -3711,7 +3704,7 @@ void s1ap_handle_handover_notification(
     tAC = &TAI->tAC;
     ogs_assert(tAC && tAC->size == sizeof(uint16_t));
 
-    source_ue = target_ue->source_ue;
+    source_ue = enb_ue_find_by_id(target_ue->source_ue_id);
     if (!source_ue) {
         ogs_error("No Source UE");
         r = s1ap_send_error_indication(enb, MME_UE_S1AP_ID, ENB_UE_S1AP_ID,
@@ -3721,7 +3714,7 @@ void s1ap_handle_handover_notification(
         return;
     }
 
-    mme_ue = source_ue->mme_ue;
+    mme_ue = mme_ue_find_by_id(source_ue->mme_ue_id);
     if (!mme_ue) {
         ogs_error("No UE(mme-ue) context");
         return;
@@ -3944,7 +3937,7 @@ void s1ap_handle_s1_reset(
             /* ENB_UE Context where PartOfS1_interface was requested */
             enb_ue->part_of_s1_reset_requested = true;
 
-            mme_ue = enb_ue->mme_ue;
+            mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
             if (mme_ue) {
                 ogs_assert(OGS_OK ==
                     mme_gtp_send_release_access_bearers_request(mme_ue,

--- a/src/mme/s1ap-sm.c
+++ b/src/mme/s1ap-sm.c
@@ -59,7 +59,7 @@ void s1ap_state_operational(ogs_fsm_t *s, mme_event_t *e)
 
     mme_sm_debug(e);
 
-    enb = e->enb;
+    enb = mme_enb_find_by_id(e->enb_id);
     ogs_assert(enb);
 
     switch (e->id) {

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -124,7 +124,8 @@ void sgsap_handle_location_update_accept(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
     return;
 
 error:
-    r = nas_eps_send_attach_reject(mme_ue->enb_ue, mme_ue,
+    r = nas_eps_send_attach_reject(
+            enb_ue_find_by_id(mme_ue->enb_ue_id), mme_ue,
             OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
             OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
     ogs_expect(r == OGS_OK);

--- a/src/nrf/nf-sm.c
+++ b/src/nrf/nf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019,2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -85,6 +85,7 @@ void nrf_nf_state_will_register(ogs_fsm_t *s, nrf_event_t *e)
     ogs_sbi_nf_instance_t *nf_instance = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -105,8 +106,16 @@ void nrf_nf_state_will_register(ogs_fsm_t *s, nrf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_NFM)
@@ -176,6 +185,7 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
     ogs_sbi_nf_instance_t *nf_instance = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
     ogs_sbi_response_t *response = NULL;
 
@@ -218,8 +228,16 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_NFM)

--- a/src/nrf/nf-sm.c
+++ b/src/nrf/nf-sm.c
@@ -85,7 +85,7 @@ void nrf_nf_state_will_register(ogs_fsm_t *s, nrf_event_t *e)
     ogs_sbi_nf_instance_t *nf_instance = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -185,7 +185,7 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
     ogs_sbi_nf_instance_t *nf_instance = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
     ogs_sbi_response_t *response = NULL;
 

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,6 +40,7 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
 {
     int rv;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -63,8 +64,15 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -40,7 +40,7 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
 {
     int rv;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -43,7 +43,7 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
     const char *api_version = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -43,6 +43,7 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
     const char *api_version = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -64,8 +65,16 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {

--- a/src/pcf/am-sm.c
+++ b/src/pcf/am-sm.c
@@ -48,7 +48,7 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    pcf_ue = e->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {
@@ -177,7 +177,7 @@ void pcf_am_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    pcf_ue = e->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {
@@ -201,7 +201,7 @@ void pcf_am_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    pcf_ue = e->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {

--- a/src/pcf/am-sm.c
+++ b/src/pcf/am-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,6 +40,7 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     pcf_ue_t *pcf_ue = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -60,8 +61,16 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.method)
         CASE(OGS_SBI_HTTP_METHOD_POST)
@@ -91,8 +100,16 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_CLIENT:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDR_DR)

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -47,6 +47,7 @@ typedef struct pcf_context_s {
 
 struct pcf_ue_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
     ogs_fsm_t sm;
 
     char *association_id;
@@ -75,6 +76,7 @@ struct pcf_ue_s {
 
 struct pcf_sess_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
     ogs_fsm_t sm;
 
     char *sm_policy_id;
@@ -154,7 +156,7 @@ struct pcf_sess_s {
     ogs_list_t app_list;
 
     /* Related Context */
-    pcf_ue_t *pcf_ue;
+    ogs_pool_id_t pcf_ue_id;
 };
 
 typedef struct pcf_app_s {
@@ -202,8 +204,8 @@ pcf_sess_t *pcf_sess_find_by_ipv6prefix(char *ipv6prefix_string);
 int pcf_sessions_number_by_snssai_and_dnn(
         pcf_ue_t *pcf_ue, ogs_s_nssai_t *s_nssai, char *dnn);
 
-pcf_ue_t *pcf_ue_cycle(pcf_ue_t *pcf_ue);
-pcf_sess_t *pcf_sess_cycle(pcf_sess_t *sess);
+pcf_ue_t *pcf_ue_find_by_id(ogs_pool_id_t id);
+pcf_sess_t *pcf_sess_find_by_id(ogs_pool_id_t id);
 
 pcf_app_t *pcf_app_add(pcf_sess_t *sess);
 int pcf_app_remove(pcf_app_t *app);

--- a/src/pcf/event.h
+++ b/src/pcf/event.h
@@ -33,8 +33,8 @@ typedef struct pcf_app_s pcf_app_t;
 typedef struct pcf_event_s {
     ogs_event_t h;
 
-    pcf_ue_t *pcf_ue;
-    pcf_sess_t *sess;
+    ogs_pool_id_t pcf_ue_id;
+    ogs_pool_id_t sess_id;
     pcf_app_t *app;
 } pcf_event_t;
 

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -38,7 +38,7 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     int i;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     nf_instance = data;
@@ -187,7 +187,7 @@ ogs_sbi_request_t *pcf_nbsf_management_build_de_register(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
     ogs_assert(sess->binding.resource_uri);
 

--- a/src/pcf/nbsf-handler.c
+++ b/src/pcf/nbsf-handler.c
@@ -70,7 +70,7 @@ bool pcf_nbsf_management_handle_register(
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);
@@ -423,7 +423,7 @@ bool pcf_nbsf_management_handle_register(
     if (SmPolicyDecision.supp_feat)
         ogs_free(SmPolicyDecision.supp_feat);
 
-    pcf_metrics_inst_by_slice_add(&sess->pcf_ue->guami.plmn_id,
+    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
             &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOSUCC, 1);
 
     OGS_SESSION_DATA_FREE(&session_data);

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -49,7 +49,10 @@ void pcf_nnrf_handle_nf_discover(
     ogs_assert(requester_nf_type);
 
     discovery_option = xact->discovery_option;
-    stream = xact->assoc_stream;
+
+    if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+        xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+        stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
 
     SearchResult = recvmsg->SearchResult;
     if (!SearchResult) {

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -26,6 +26,7 @@ void pcf_nnrf_handle_nf_discover(
     int r;
     ogs_sbi_nf_instance_t *nf_instance = NULL;
     ogs_sbi_object_t *sbi_object = NULL;
+    ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
     ogs_sbi_stream_t *stream = NULL;
@@ -48,6 +49,10 @@ void pcf_nnrf_handle_nf_discover(
     requester_nf_type = xact->requester_nf_type;
     ogs_assert(requester_nf_type);
 
+    sbi_object_id = xact->sbi_object_id;
+    ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+            sbi_object_id <= OGS_MAX_POOL_ID);
+
     discovery_option = xact->discovery_option;
 
     if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
@@ -61,12 +66,12 @@ void pcf_nnrf_handle_nf_discover(
     }
 
     if (sbi_object->type == OGS_SBI_OBJ_UE_TYPE) {
-        pcf_ue = (pcf_ue_t *)sbi_object;
+        pcf_ue = pcf_ue_find_by_id(sbi_object_id);
         ogs_assert(pcf_ue);
     } else if (sbi_object->type == OGS_SBI_OBJ_SESS_TYPE) {
-        sess = (pcf_sess_t *)sbi_object;
+        sess = pcf_sess_find_by_id(sbi_object_id);
         ogs_assert(sess);
-        pcf_ue = sess->pcf_ue;
+        pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
         ogs_assert(pcf_ue);
     } else {
         ogs_fatal("(NF discover) Not implemented [%s:%d]",

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -235,7 +235,7 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
     char *home_network_domain = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(stream);
     ogs_assert(message);
 
@@ -580,7 +580,7 @@ bool pcf_npcf_smpolicycontrol_handle_delete(pcf_sess_t *sess,
     OpenAPI_sm_policy_delete_data_t *SmPolicyDeleteData = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(stream);
     ogs_assert(message);
 
@@ -681,7 +681,7 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     OpenAPI_lnode_t *node = NULL, *node2 = NULL, *node3 = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(stream);
     ogs_assert(recvmsg);
 
@@ -1188,7 +1188,7 @@ bool pcf_npcf_policyauthorization_handle_update(
     OpenAPI_lnode_t *node = NULL, *node2 = NULL, *node3 = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(app_session);
     ogs_assert(stream);
     ogs_assert(recvmsg);

--- a/src/pcf/nudr-build.c
+++ b/src/pcf/nudr-build.c
@@ -51,7 +51,7 @@ ogs_sbi_request_t *pcf_nudr_dr_build_query_sm_data(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     memset(&message, 0, sizeof(message));

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -193,7 +193,7 @@ bool pcf_nudr_dr_handle_query_sm_data(
     int r;
 
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -39,7 +39,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -49,7 +49,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
 

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -48,6 +48,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_sbi_xact_t *sbi_xact = NULL;
+    ogs_pool_id_t sbi_xact_id = 0;
 
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
 
@@ -428,8 +429,17 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_DISC)
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
+
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
+                if (!sbi_xact) {
+                    /* CLIENT_WAIT timer could remove SBI transaction
+                     * before receiving SBI message */
+                    ogs_error("SBI transaction has already been removed");
+                    break;
+                }
 
                 SWITCH(message.h.method)
                 CASE(OGS_SBI_HTTP_METHOD_GET)
@@ -458,10 +468,11 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             CASE(OGS_SBI_RESOURCE_NAME_POLICY_DATA)
                 SWITCH(message.h.resource.component[3])
                 CASE(OGS_SBI_RESOURCE_NAME_AM_DATA)
-                    sbi_xact = e->h.sbi.data;
-                    ogs_assert(sbi_xact);
+                    sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                    ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                            sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                    sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                    sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
@@ -494,10 +505,11 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     break;
 
                 CASE(OGS_SBI_RESOURCE_NAME_SM_DATA)
-                    sbi_xact = e->h.sbi.data;
-                    ogs_assert(sbi_xact);
+                    sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                    ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                            sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                    sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                    sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
@@ -552,11 +564,11 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_PCF_BINDINGS)
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
-
-                sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
@@ -687,9 +699,13 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
              * 4. timer expiration event is processed. (double-free SBI xact)
              *
              * To avoid double-free SBI xact,
-             * we need to check ogs_sbi_xact_cycle()
+             * we need to check ogs_sbi_xact_find_by_id()
              */
-            sbi_xact = ogs_sbi_xact_cycle(e->h.sbi.data);
+            sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+            ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact_id <= OGS_MAX_POOL_ID);
+
+            sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
                 ogs_error("SBI transaction has already been removed");
                 break;

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -39,6 +39,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -70,8 +71,16 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {
@@ -437,7 +446,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
-                    ogs_error("SBI transaction has already been removed");
+                    ogs_error("SBI transaction has already been removed [%d]",
+                            sbi_xact_id);
                     break;
                 }
 
@@ -476,14 +486,19 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
-                        ogs_error("SBI transaction has already been removed");
+                        ogs_error(
+                                "SBI transaction has already been removed [%d]",
+                                sbi_xact_id);
                         break;
                     }
 
                     pcf_ue = (pcf_ue_t *)sbi_xact->sbi_object;
                     ogs_assert(pcf_ue);
 
-                    e->h.sbi.data = sbi_xact->assoc_stream;
+                    if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                        e->h.sbi.data =
+                            OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
 
                     ogs_sbi_xact_remove(sbi_xact);
 
@@ -513,14 +528,19 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
-                        ogs_error("SBI transaction has already been removed");
+                        ogs_error(
+                                "SBI transaction has already been removed [%d]",
+                                sbi_xact_id);
                         break;
                     }
 
                     sess = (pcf_sess_t *)sbi_xact->sbi_object;
                     ogs_assert(sess);
 
-                    e->h.sbi.data = sbi_xact->assoc_stream;
+                    if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                        e->h.sbi.data =
+                            OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
 
                     ogs_sbi_xact_remove(sbi_xact);
 
@@ -572,14 +592,17 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
-                    ogs_error("SBI transaction has already been removed");
+                    ogs_error("SBI transaction has already been removed [%d]",
+                            sbi_xact_id);
                     break;
                 }
 
                 sess = (pcf_sess_t *)sbi_xact->sbi_object;
                 ogs_assert(sess);
 
-                e->h.sbi.data = sbi_xact->assoc_stream;
+                if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                    e->h.sbi.data = OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
 
                 ogs_sbi_xact_remove(sbi_xact);
 
@@ -707,15 +730,17 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
             sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
             sbi_object = sbi_xact->sbi_object;
             ogs_assert(sbi_object);
 
-            stream = sbi_xact->assoc_stream;
-            ogs_assert(stream);
+            ogs_assert(sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+            stream = ogs_sbi_stream_find_by_id(sbi_xact->assoc_stream_id);
 
             service_type = sbi_xact->service_type;
 
@@ -755,6 +780,12 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             }
 
             ogs_error("Cannot receive SBI message");
+
+            if (!stream) {
+                ogs_error("STREAM has alreadt been removed [%d]",
+                        sbi_xact->assoc_stream_id);
+                break;
+            }
             ogs_assert(true ==
                 ogs_sbi_server_send_error(stream,
                     OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT, NULL,

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -146,7 +146,11 @@ static int pcf_sbi_discover_and_send(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
 
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {
@@ -196,7 +200,11 @@ int pcf_sess_sbi_discover_only(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
 
     return ogs_sbi_discover_only(xact);
 }

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -139,7 +139,7 @@ static int pcf_sbi_discover_and_send(
     ogs_assert(build);
 
     xact = ogs_sbi_xact_add(
-            sbi_object, service_type, discovery_option,
+            0, sbi_object, service_type, discovery_option,
             build, context, data);
     if (!xact) {
         ogs_error("ogs_sbi_xact_add() failed");
@@ -194,7 +194,8 @@ int pcf_sess_sbi_discover_only(
     ogs_assert(sess);
     ogs_assert(service_type);
 
-    xact = ogs_sbi_xact_add(&sess->sbi, service_type, NULL, NULL, NULL, NULL);
+    xact = ogs_sbi_xact_add(
+            0, &sess->sbi, service_type, NULL, NULL, NULL, NULL);
     if (!xact) {
         ogs_error("ogs_sbi_xact_add() failed");
         return OGS_ERROR;

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -124,6 +124,7 @@ bool pcf_sbi_send_request(
 }
 
 static int pcf_sbi_discover_and_send(
+        ogs_pool_id_t sbi_object_id,
         ogs_sbi_object_t *sbi_object,
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
@@ -138,8 +139,11 @@ static int pcf_sbi_discover_and_send(
     ogs_assert(stream);
     ogs_assert(build);
 
+    ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+            sbi_object_id <= OGS_MAX_POOL_ID);
+
     xact = ogs_sbi_xact_add(
-            0, sbi_object, service_type, discovery_option,
+            sbi_object_id, sbi_object, service_type, discovery_option,
             build, context, data);
     if (!xact) {
         ogs_error("ogs_sbi_xact_add() failed");
@@ -171,8 +175,8 @@ int pcf_ue_sbi_discover_and_send(
     int r;
 
     r = pcf_sbi_discover_and_send(
-                &pcf_ue->sbi, service_type, discovery_option,
-                (ogs_sbi_build_f)build, pcf_ue, stream, data);
+            pcf_ue->id, &pcf_ue->sbi, service_type, discovery_option,
+            (ogs_sbi_build_f)build, pcf_ue, stream, data);
     if (r != OGS_OK) {
         ogs_error("pcf_ue_sbi_discover_and_send() failed");
         ogs_assert(true ==
@@ -219,8 +223,8 @@ int pcf_sess_sbi_discover_and_send(
     int r;
 
     r = pcf_sbi_discover_and_send(
-                &sess->sbi, service_type, discovery_option,
-                (ogs_sbi_build_f)build, sess, stream, data);
+            sess->id, &sess->sbi, service_type, discovery_option,
+            (ogs_sbi_build_f)build, sess, stream, data);
     if (r != OGS_OK) {
         ogs_error("pcf_sess_sbi_discover_and_send() failed");
         ogs_assert(true ==

--- a/src/pcf/sm-sm.c
+++ b/src/pcf/sm-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -42,6 +42,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     pcf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -64,8 +65,16 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NPCF_SMPOLICYCONTROL)
@@ -161,8 +170,16 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_CLIENT:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDR_DR)

--- a/src/pcf/sm-sm.c
+++ b/src/pcf/sm-sm.c
@@ -50,9 +50,9 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    sess = e->sess;
+    sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {
@@ -334,15 +334,14 @@ void pcf_sm_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    sess = e->sess;
+    sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_assert(sess->pcf_ue);
-        pcf_metrics_inst_by_slice_add(&sess->pcf_ue->guami.plmn_id,
+        pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
                 &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, -1);
         break;
 
@@ -366,15 +365,14 @@ void pcf_sm_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    sess = e->sess;
+    sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = sess->pcf_ue;
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_assert(sess->pcf_ue);
-        pcf_metrics_inst_by_slice_add(&sess->pcf_ue->guami.plmn_id,
+        pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
                 &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, -1);
         break;
 

--- a/src/scp/context.c
+++ b/src/scp/context.c
@@ -304,11 +304,11 @@ int scp_context_parse_config(void)
     return OGS_OK;
 }
 
-scp_assoc_t *scp_assoc_add(ogs_sbi_stream_t *stream)
+scp_assoc_t *scp_assoc_add(ogs_pool_id_t stream_id)
 {
     scp_assoc_t *assoc = NULL;
 
-    ogs_assert(stream);
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
 
     ogs_pool_alloc(&scp_assoc_pool, &assoc);
     if (!assoc) {
@@ -318,7 +318,7 @@ scp_assoc_t *scp_assoc_add(ogs_sbi_stream_t *stream)
     }
     memset(assoc, 0, sizeof *assoc);
 
-    assoc->stream = stream;
+    assoc->stream_id = stream_id;
 
     assoc->discovery_option = ogs_sbi_discovery_option_new();
     ogs_assert(assoc->discovery_option);

--- a/src/scp/context.h
+++ b/src/scp/context.h
@@ -43,7 +43,7 @@ typedef struct scp_assoc_s scp_assoc_t;
 typedef struct scp_assoc_s {
     ogs_lnode_t lnode;
 
-    ogs_sbi_stream_t *stream;
+    ogs_pool_id_t stream_id;
 
     ogs_sbi_client_t *client;
     ogs_sbi_client_t *nrf_client;
@@ -67,7 +67,7 @@ scp_context_t *scp_self(void);
 
 int scp_context_parse_config(void);
 
-scp_assoc_t *scp_assoc_add(ogs_sbi_stream_t *stream);
+scp_assoc_t *scp_assoc_add(ogs_pool_id_t stream_id);
 void scp_assoc_remove(scp_assoc_t *assoc);
 void scp_assoc_remove_all(void);
 

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -110,7 +110,8 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
     ogs_hash_index_t *hi;
     ogs_sbi_client_t *client = NULL, *nrf_client = NULL, *next_scp = NULL;
     ogs_sbi_client_t *sepp_client = NULL;
-    ogs_sbi_stream_t *stream = data;
+    ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
 
     OpenAPI_nf_type_e target_nf_type = OpenAPI_nf_type_NULL;
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
@@ -133,10 +134,19 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
 
     ogs_assert(request);
     ogs_assert(request->h.uri);
-    ogs_assert(stream);
+
+    stream_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+            stream_id <= OGS_MAX_POOL_ID);
+
+    stream = ogs_sbi_stream_find_by_id(stream_id);
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
 
     /* SCP Context */
-    assoc = scp_assoc_add(stream);
+    assoc = scp_assoc_add(stream_id);
     if (!assoc) {
         ogs_error("scp_assoc_add() failed");
         return OGS_ERROR;
@@ -621,10 +631,13 @@ static int response_handler(
 {
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
 
     ogs_assert(assoc);
-    stream = assoc->stream;
-    ogs_assert(stream);
+
+    stream_id = assoc->stream_id;
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
+    stream = ogs_sbi_stream_find_by_id(stream_id);
 
     if (status != OGS_OK) {
 
@@ -632,12 +645,16 @@ static int response_handler(
                 status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
                 "response_handler() failed [%d]", status);
 
+        scp_assoc_remove(assoc);
+
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            return OGS_ERROR;
+        }
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream,
                 OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR, NULL,
                 "response_handler() failed", NULL, NULL));
-
-        scp_assoc_remove(assoc);
 
         return OGS_ERROR;
     }
@@ -652,8 +669,13 @@ static int response_handler(
             ogs_error("No NF-Instance ID");
     }
 
-    ogs_expect(true == ogs_sbi_server_send_response(stream, response));
     scp_assoc_remove(assoc);
+
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
+    ogs_expect(true == ogs_sbi_server_send_response(stream, response));
 
     return OGS_OK;
 }
@@ -667,6 +689,7 @@ static int nf_discover_handler(
 
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
 
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
@@ -680,9 +703,6 @@ static int nf_discover_handler(
     ogs_sbi_client_t *sepp_client = NULL;
 
     ogs_assert(assoc);
-    stream = assoc->stream;
-
-    ogs_assert(stream);
     request = assoc->request;
     ogs_assert(request);
     service_type = assoc->service_type;
@@ -695,18 +715,27 @@ static int nf_discover_handler(
     discovery_option = assoc->discovery_option;
     ogs_assert(discovery_option);
 
+    stream_id = assoc->stream_id;
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
+    stream = ogs_sbi_stream_find_by_id(stream_id);
+
     if (status != OGS_OK) {
 
         ogs_log_message(
                 status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
                 "nf_discover_handler() failed [%d]", status);
 
+        scp_assoc_remove(assoc);
+
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            return OGS_ERROR;
+        }
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream,
                 OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR, NULL,
                 "nf_discover_handler() failed", NULL, NULL));
 
-        scp_assoc_remove(assoc);
         return OGS_ERROR;
     }
 
@@ -789,14 +818,18 @@ cleanup:
     ogs_assert(strerror);
     ogs_error("%s", strerror);
 
+    scp_assoc_remove(assoc);
+
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
     ogs_assert(true ==
         ogs_sbi_server_send_error(
             stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, NULL, strerror, NULL,
             NULL));
 
     ogs_free(strerror);
-
-    scp_assoc_remove(assoc);
 
     ogs_sbi_response_free(response);
     ogs_sbi_message_free(&message);
@@ -813,17 +846,17 @@ static int sepp_discover_handler(
 
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
 
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_client_t *sepp_client = NULL;
 
     ogs_assert(assoc);
-    ogs_assert(assoc->target_apiroot);
-    stream = assoc->stream;
-    ogs_assert(stream);
-    request = assoc->request;
-    ogs_assert(request);
+
+    stream_id = assoc->stream_id;
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
+    stream = ogs_sbi_stream_find_by_id(stream_id);
 
     if (status != OGS_OK) {
 
@@ -831,12 +864,17 @@ static int sepp_discover_handler(
                 status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
                 "sepp_discover_handler() failed [%d]", status);
 
+        scp_assoc_remove(assoc);
+
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            return OGS_ERROR;
+        }
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream,
                 OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR, NULL,
                 "sepp_discover_handler() failed", NULL, NULL));
 
-        scp_assoc_remove(assoc);
         return OGS_ERROR;
     }
 
@@ -869,6 +907,10 @@ static int sepp_discover_handler(
         goto cleanup;
     }
 
+    ogs_assert(assoc->target_apiroot);
+    request = assoc->request;
+    ogs_assert(request);
+
     if (false == send_request(
                 sepp_client, response_handler, request, false, assoc)) {
         strerror = ogs_msprintf("send_request() failed");
@@ -884,14 +926,18 @@ cleanup:
     ogs_assert(strerror);
     ogs_error("%s", strerror);
 
+    scp_assoc_remove(assoc);
+
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
     ogs_assert(true ==
         ogs_sbi_server_send_error(
             stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, NULL, strerror, NULL,
             NULL));
 
     ogs_free(strerror);
-
-    scp_assoc_remove(assoc);
 
     ogs_sbi_response_free(response);
     ogs_sbi_message_free(&message);

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -111,7 +111,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
     ogs_sbi_client_t *client = NULL, *nrf_client = NULL, *next_scp = NULL;
     ogs_sbi_client_t *sepp_client = NULL;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
 
     OpenAPI_nf_type_e target_nf_type = OpenAPI_nf_type_NULL;
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
@@ -631,7 +631,7 @@ static int response_handler(
 {
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
 
     ogs_assert(assoc);
 
@@ -689,7 +689,7 @@ static int nf_discover_handler(
 
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
 
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
@@ -846,7 +846,7 @@ static int sepp_discover_handler(
 
     scp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
 
     ogs_sbi_request_t *request = NULL;
 

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -40,7 +40,7 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -48,7 +48,7 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     scp_sm_debug(e);
 

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,6 +40,7 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -63,8 +64,16 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {
@@ -301,17 +310,19 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
              * we need to check ogs_sbi_xact_find_by_id()
              */
             sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
-            ogs_fatal("xact_id = %d", sbi_xact_id);
             ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
                     sbi_xact_id <= OGS_MAX_POOL_ID);
 
             sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
-            stream = sbi_xact->assoc_stream;
+            if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                stream = ogs_sbi_stream_find_by_id(sbi_xact->assoc_stream_id);
             /* Here, we should not use ogs_assert(stream)
              * since 'namf-comm' service has no an associated stream. */
 

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -47,6 +47,7 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
+    ogs_pool_id_t sbi_xact_id = 0;
 
     scp_sm_debug(e);
 
@@ -297,9 +298,14 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
              * 4. timer expiration event is processed. (double-free SBI xact)
              *
              * To avoid double-free SBI xact,
-             * we need to check ogs_sbi_xact_cycle()
+             * we need to check ogs_sbi_xact_find_by_id()
              */
-            sbi_xact = ogs_sbi_xact_cycle(e->h.sbi.data);
+            sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+            ogs_fatal("xact_id = %d", sbi_xact_id);
+            ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact_id <= OGS_MAX_POOL_ID);
+
+            sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
                 ogs_error("SBI transaction has already been removed");
                 break;

--- a/src/sepp/context.c
+++ b/src/sepp/context.c
@@ -538,11 +538,11 @@ sepp_node_t *sepp_node_find_by_plmn_id(uint16_t mcc, uint16_t mnc)
     return NULL;
 }
 
-sepp_assoc_t *sepp_assoc_add(ogs_sbi_stream_t *stream)
+sepp_assoc_t *sepp_assoc_add(ogs_pool_id_t stream_id)
 {
     sepp_assoc_t *assoc = NULL;
 
-    ogs_assert(stream);
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
 
     ogs_pool_alloc(&sepp_assoc_pool, &assoc);
     if (!assoc) {
@@ -552,7 +552,7 @@ sepp_assoc_t *sepp_assoc_add(ogs_sbi_stream_t *stream)
     }
     memset(assoc, 0, sizeof *assoc);
 
-    assoc->stream = stream;
+    assoc->stream_id = stream_id;
 
     ogs_list_add(&self.assoc_list, assoc);
 

--- a/src/sepp/context.h
+++ b/src/sepp/context.h
@@ -82,7 +82,7 @@ typedef struct sepp_assoc_s sepp_assoc_t;
 typedef struct sepp_assoc_s {
     ogs_lnode_t lnode;
 
-    ogs_sbi_stream_t *stream;
+    ogs_pool_id_t stream_id;
 
     ogs_sbi_client_t *client;
     ogs_sbi_client_t *nrf_client;
@@ -106,7 +106,7 @@ void sepp_node_remove_all(void);
 sepp_node_t *sepp_node_find_by_receiver(char *receiver);
 sepp_node_t *sepp_node_find_by_plmn_id(uint16_t mcc, uint16_t mnc);
 
-sepp_assoc_t *sepp_assoc_add(ogs_sbi_stream_t *stream);
+sepp_assoc_t *sepp_assoc_add(ogs_pool_id_t stream_id);
 void sepp_assoc_remove(sepp_assoc_t *assoc);
 void sepp_assoc_remove_all(void);
 

--- a/src/sepp/handshake-sm.c
+++ b/src/sepp/handshake-sm.c
@@ -87,7 +87,7 @@ void sepp_handshake_state_will_establish(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -291,7 +291,7 @@ void sepp_handshake_state_established(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -438,7 +438,7 @@ void sepp_handshake_state_terminated(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);

--- a/src/sepp/handshake-sm.c
+++ b/src/sepp/handshake-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2023-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -87,6 +87,7 @@ void sepp_handshake_state_will_establish(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -118,8 +119,16 @@ void sepp_handshake_state_will_establish(ogs_fsm_t *s, sepp_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_N32C_HANDSHAKE)
@@ -282,6 +291,7 @@ void sepp_handshake_state_established(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -304,8 +314,16 @@ void sepp_handshake_state_established(ogs_fsm_t *s, sepp_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_N32C_HANDSHAKE)
@@ -420,6 +438,7 @@ void sepp_handshake_state_terminated(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -447,8 +466,16 @@ void sepp_handshake_state_terminated(ogs_fsm_t *s, sepp_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_N32C_HANDSHAKE)

--- a/src/sepp/sbi-path.c
+++ b/src/sepp/sbi-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2023-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -158,6 +158,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
     ogs_hash_index_t *hi;
     ogs_sbi_client_t *client = NULL, *scp_client = NULL;
     ogs_sbi_stream_t *stream = data;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_server_t *server = NULL;
 
     ogs_sbi_request_t sepp_request;
@@ -177,7 +178,17 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
 
     ogs_assert(request);
     ogs_assert(request->h.uri);
-    ogs_assert(stream);
+
+    stream_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+            stream_id <= OGS_MAX_POOL_ID);
+
+    stream = ogs_sbi_stream_find_by_id(stream_id);
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
+
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);
 
@@ -207,7 +218,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
         sepp_node_t *sepp_node = NULL;
         bool do_not_remove_custom_header;
 
-        assoc = sepp_assoc_add(stream);
+        assoc = sepp_assoc_add(stream_id);
         if (!assoc) {
             ogs_error("sepp_assoc_add() failed");
             return OGS_ERROR;
@@ -408,10 +419,13 @@ static int response_handler(
 {
     sepp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
 
     ogs_assert(assoc);
-    stream = assoc->stream;
-    ogs_assert(stream);
+
+    stream_id = assoc->stream_id;
+    ogs_assert(stream_id >= OGS_MIN_POOL_ID && stream_id <= OGS_MAX_POOL_ID);
+    stream = ogs_sbi_stream_find_by_id(stream_id);
 
     if (status != OGS_OK) {
 
@@ -419,20 +433,29 @@ static int response_handler(
                 status == OGS_DONE ? OGS_LOG_DEBUG : OGS_LOG_WARN, 0,
                 "response_handler() failed [%d]", status);
 
+        sepp_assoc_remove(assoc);
+
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            return OGS_ERROR;
+        }
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream,
                 OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR, NULL,
                 "response_handler() failed", NULL, NULL));
-
-        sepp_assoc_remove(assoc);
 
         return OGS_ERROR;
     }
 
     ogs_assert(response);
 
-    ogs_expect(true == ogs_sbi_server_send_response(stream, response));
     sepp_assoc_remove(assoc);
+
+    if (!stream) {
+        ogs_error("STREAM has already been removed [%d]", stream_id);
+        return OGS_ERROR;
+    }
+    ogs_expect(true == ogs_sbi_server_send_response(stream, response));
 
     return OGS_OK;
 }

--- a/src/sepp/sbi-path.c
+++ b/src/sepp/sbi-path.c
@@ -158,7 +158,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
     ogs_hash_index_t *hi;
     ogs_sbi_client_t *client = NULL, *scp_client = NULL;
     ogs_sbi_stream_t *stream = data;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_server_t *server = NULL;
 
     ogs_sbi_request_t sepp_request;
@@ -419,7 +419,7 @@ static int response_handler(
 {
     sepp_assoc_t *assoc = data;
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
 
     ogs_assert(assoc);
 

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -42,6 +42,7 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_server_t *server = NULL;
 
@@ -64,8 +65,17 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
+
         server = ogs_sbi_server_from_stream(stream);
         ogs_assert(server);
 

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -42,7 +42,7 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
     sepp_node_t *sepp_node = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_server_t *server = NULL;
 

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -51,6 +51,7 @@ typedef struct sgwc_context_s {
 
 typedef struct sgwc_ue_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     ogs_pool_id_t   *sgw_s11_teid_node; /* A node of SGW-S11-TEID */
 
     uint32_t        sgw_s11_teid;   /* SGW-S11-TEID is derived from NODE */
@@ -74,6 +75,7 @@ typedef struct sgwc_ue_s {
 #define SGWC_SESS(pfcp_sess) ogs_container_of(pfcp_sess, sgwc_sess_t, pfcp)
 typedef struct sgwc_sess_s {
     ogs_lnode_t     lnode;                  /* A node of list_t */
+    ogs_pool_id_t   id;
     ogs_pool_id_t   *sgwc_sxa_seid_node;    /* A node of SGWC-SXA-SEID */
 
     ogs_pfcp_sess_t pfcp;           /* PFCP session context */
@@ -93,22 +95,24 @@ typedef struct sgwc_sess_s {
     ogs_gtp_node_t  *gnode;
     ogs_pfcp_node_t *pfcp_node;
 
-    sgwc_ue_t       *sgwc_ue;
+    ogs_pool_id_t   sgwc_ue_id;
 } sgwc_sess_t;
 
 typedef struct sgwc_bearer_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     ogs_lnode_t     to_modify_node;
 
     uint8_t         ebi;
 
     ogs_list_t      tunnel_list;
-    sgwc_sess_t     *sess;
-    sgwc_ue_t       *sgwc_ue;
+    ogs_pool_id_t   sess_id;
+    ogs_pool_id_t   sgwc_ue_id;
 } sgwc_bearer_t;
 
 typedef struct sgwc_tunnel_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
 
     uint8_t         interface_type;
 
@@ -123,7 +127,7 @@ typedef struct sgwc_tunnel_s {
     ogs_ip_t        remote_ip;
 
     /* Related Context */
-    sgwc_bearer_t   *bearer;
+    ogs_pool_id_t   bearer_id;
     ogs_gtp_node_t  *gnode;
 } sgwc_tunnel_t;
 
@@ -141,6 +145,7 @@ sgwc_ue_t *sgwc_ue_find_by_teid(uint32_t teid);
 sgwc_ue_t *sgwc_ue_add(uint8_t *imsi, int imsi_len);
 int sgwc_ue_remove(sgwc_ue_t *sgwc_ue);
 void sgwc_ue_remove_all(void);
+sgwc_ue_t *sgwc_ue_find_by_id(ogs_pool_id_t id);
 
 sgwc_sess_t *sgwc_sess_add(sgwc_ue_t *sgwc_ue, char *apn);
 
@@ -154,7 +159,7 @@ sgwc_sess_t *sgwc_sess_find_by_seid(uint64_t seid);
 
 sgwc_sess_t *sgwc_sess_find_by_apn(sgwc_ue_t *sgwc_ue, char *apn);
 sgwc_sess_t *sgwc_sess_find_by_ebi(sgwc_ue_t *sgwc_ue, uint8_t ebi);
-sgwc_sess_t *sgwc_sess_cycle(sgwc_sess_t *sess);
+sgwc_sess_t *sgwc_sess_find_by_id(ogs_pool_id_t id);
 
 #define SGWC_SESSION_SYNC_DONE(__sGWC, __tYPE, __fLAGS) \
     (sgwc_sess_pfcp_xact_count(__sGWC, __tYPE, __fLAGS) == 0)
@@ -169,7 +174,7 @@ sgwc_bearer_t *sgwc_bearer_find_by_sess_ebi(
 sgwc_bearer_t *sgwc_bearer_find_by_ue_ebi(
                                 sgwc_ue_t *sgwc_ue, uint8_t ebi);
 sgwc_bearer_t *sgwc_default_bearer_in_sess(sgwc_sess_t *sess);
-sgwc_bearer_t *sgwc_bearer_cycle(sgwc_bearer_t *bearer);
+sgwc_bearer_t *sgwc_bearer_find_by_id(ogs_pool_id_t id);
 
 sgwc_tunnel_t *sgwc_tunnel_add(
         sgwc_bearer_t *bearer, uint8_t interface_type);
@@ -184,6 +189,7 @@ sgwc_tunnel_t *sgwc_tunnel_find_by_far_id(
         sgwc_sess_t *sess, ogs_pfcp_far_id_t far_id);
 sgwc_tunnel_t *sgwc_dl_tunnel_in_bearer(sgwc_bearer_t *bearer);
 sgwc_tunnel_t *sgwc_ul_tunnel_in_bearer(sgwc_bearer_t *bearer);
+sgwc_tunnel_t *sgwc_tunnel_find_by_id(ogs_pool_id_t id);
 
 #ifdef __cplusplus
 }

--- a/src/sgwc/event.h
+++ b/src/sgwc/event.h
@@ -57,10 +57,8 @@ typedef struct sgwc_event_s {
     ogs_gtp2_message_t *gtp_message;
 
     ogs_pfcp_node_t *pfcp_node;
-    ogs_pfcp_xact_t *pfcp_xact;
+    ogs_pool_id_t pfcp_xact_id;
     ogs_pfcp_message_t *pfcp_message;
-
-    sgwc_bearer_t *bearer;
 } sgwc_event_t;
 
 OGS_STATIC_ASSERT(OGS_EVENT_SIZE >= sizeof(sgwc_event_t));

--- a/src/sgwc/gtp-path.c
+++ b/src/sgwc/gtp-path.c
@@ -144,18 +144,28 @@ void sgwc_gtp_close(void)
 static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
     sgwc_bearer_t *bearer = data;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_sess_t *sess = NULL;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
-    ogs_assert(sgwc_ue);
-
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = sgwc_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
+    ogs_assert(sgwc_ue);
 
     switch (type) {
     case OGS_GTP2_DOWNLINK_DATA_NOTIFICATION_TYPE:
@@ -178,7 +188,7 @@ int sgwc_gtp_send_create_session_response(
     ogs_pkbuf_t *pkbuf = NULL;
 
     ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
     ogs_assert(sgwc_ue);
     ogs_assert(xact);
 
@@ -219,9 +229,9 @@ int sgwc_gtp_send_downlink_data_notification(
 
     ogs_assert(bearer);
 
-    sess = bearer->sess;
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
-    sgwc_ue = bearer->sgwc_ue;
+    sgwc_ue = sgwc_ue_find_by_id(bearer->sgwc_ue_id);
     ogs_assert(sgwc_ue);
     ogs_assert(sgwc_ue->gnode);
 
@@ -240,7 +250,8 @@ int sgwc_gtp_send_downlink_data_notification(
     }
 
     gtp_xact = ogs_gtp_xact_local_create(
-            sgwc_ue->gnode, &h, pkbuf, bearer_timeout, bearer);
+            sgwc_ue->gnode, &h, pkbuf, bearer_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!gtp_xact) {
         ogs_error("ogs_gtp_xact_local_create() failed");
         return OGS_ERROR;

--- a/src/sgwc/pfcp-path.h
+++ b/src/sgwc/pfcp-path.h
@@ -33,18 +33,18 @@ int sgwc_pfcp_send_bearer_to_modify_list(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *xact);
 
 int sgwc_pfcp_send_session_establishment_request(
-        sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact, ogs_pkbuf_t *gtpbuf,
+        sgwc_sess_t *sess, ogs_pool_id_t gtp_xact_id, ogs_pkbuf_t *gtpbuf,
         uint64_t flags);
 
 int sgwc_pfcp_send_session_modification_request(
-        sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact,
+        sgwc_sess_t *sess, ogs_pool_id_t gtp_xact_id,
         ogs_pkbuf_t *gtpbuf, uint64_t flags);
 int sgwc_pfcp_send_bearer_modification_request(
-        sgwc_bearer_t *bearer, ogs_gtp_xact_t *gtp_xact,
+        sgwc_bearer_t *bearer, ogs_pool_id_t gtp_xact_id,
         ogs_pkbuf_t *gtpbuf, uint64_t flags);
 
 int sgwc_pfcp_send_session_deletion_request(
-        sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact, ogs_pkbuf_t *gtpbuf);
+        sgwc_sess_t *sess, ogs_pool_id_t gtp_xact_id, ogs_pkbuf_t *gtpbuf);
 
 int sgwc_pfcp_send_session_report_response(
         ogs_pfcp_xact_t *xact, sgwc_sess_t *sess, uint8_t cause);

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -121,7 +121,7 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
     case SGWC_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         switch (message->h.type) {
@@ -203,7 +203,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
     case SGWC_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         if (message->h.seid_presence && message->h.seid != 0) {
@@ -400,7 +400,7 @@ static void pfcp_restoration(ogs_pfcp_node_t *node)
                     sgwc_ue->imsi_bcd, sess->session.name);
                 ogs_assert(OGS_OK ==
                     sgwc_pfcp_send_session_establishment_request(
-                        sess, NULL, NULL,
+                        sess, OGS_INVALID_POOL_ID, NULL,
                         OGS_PFCP_CREATE_RESTORATION_INDICATION));
             }
         }

--- a/src/sgwc/s11-build.c
+++ b/src/sgwc/s11-build.c
@@ -44,7 +44,7 @@ ogs_pkbuf_t *sgwc_s11_build_create_session_response(
     ogs_debug("[SGWC] Create Session Response");
 
     ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
     ogs_assert(sgwc_ue);
 
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
@@ -141,7 +141,7 @@ ogs_pkbuf_t *sgwc_s11_build_downlink_data_notification(
     sgwc_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     /* Build downlink notification message */

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -24,27 +24,33 @@
 
 static void gtp_sess_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    sgwc_sess_t *sess = data;
+    sgwc_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
-    ogs_assert(sgwc_ue);
-
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = sgwc_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
+
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
+    ogs_assert(sgwc_ue);
 
     switch (type) {
     case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
         ogs_error("[%s] No Delete Session Response", sgwc_ue->imsi_bcd);
-        if (!sgwc_sess_cycle(sess)) {
-            ogs_error("[%s] Session has already been removed",
-                    sgwc_ue->imsi_bcd);
-            break;
-        }
         ogs_assert(OGS_OK ==
-            sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
+            sgwc_pfcp_send_session_deletion_request(
+                sess, OGS_INVALID_POOL_ID, NULL));
         break;
     default:
         ogs_error("GTP Timeout : IMSI[%s] Message-Type[%d]",
@@ -54,19 +60,29 @@ static void gtp_sess_timeout(ogs_gtp_xact_t *xact, void *data)
 
 static void gtp_bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    sgwc_bearer_t *bearer = data;
+    sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_sess_t *sess = NULL;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
-    ogs_assert(sgwc_ue);
-
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = sgwc_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
+    ogs_assert(sgwc_ue);
 
     ogs_error("GTP Timeout : IMSI[%s] Message-Type[%d]",
             sgwc_ue->imsi_bcd, type);
@@ -74,10 +90,22 @@ static void gtp_bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 
 static void pfcp_sess_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
+    sgwc_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     uint8_t type;
 
     ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = sgwc_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
 
     switch (type) {
     case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
@@ -383,7 +411,7 @@ void sgwc_s11_handle_create_session_request(
 
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_session_establishment_request(
-            sess, s11_xact, gtpbuf, 0));
+            sess, s11_xact->id, gtpbuf, 0));
 }
 
 void sgwc_s11_handle_modify_bearer_request(
@@ -465,22 +493,28 @@ void sgwc_s11_handle_modify_bearer_request(
             break;
         }
 
-        sess = bearer->sess;
+        sess = sgwc_sess_find_by_id(bearer->sess_id);
         ogs_assert(sess);
 
         ogs_list_for_each_entry(&pfcp_xact_list, pfcp_xact, tmpnode) {
-            if (sess == pfcp_xact->data) {
-                current_xact = pfcp_xact;
-                break;
+            if (pfcp_xact->modify_flags & OGS_PFCP_MODIFY_SESSION) {
+                ogs_pool_id_t sess_id = OGS_POINTER_TO_UINT(pfcp_xact->data);
+                ogs_assert(sess_id >= OGS_MIN_POOL_ID &&
+                        sess_id <= OGS_MAX_POOL_ID);
+                if (sess->id == sess_id) {
+                    current_xact = pfcp_xact;
+                    break;
+                }
             }
         }
 
         if (!current_xact) {
             current_xact = ogs_pfcp_xact_local_create(
-                    sess->pfcp_node, pfcp_sess_timeout, sess);
+                    sess->pfcp_node, pfcp_sess_timeout,
+                    OGS_UINT_TO_POINTER(sess->id));
             ogs_assert(current_xact);
 
-            current_xact->assoc_xact = s11_xact;
+            current_xact->assoc_xact_id = s11_xact->id;
             current_xact->modify_flags = OGS_PFCP_MODIFY_SESSION|
                 OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_ACTIVATE;
             if (gtpbuf) {
@@ -566,8 +600,20 @@ void sgwc_s11_handle_modify_bearer_request(
     ogs_debug("    ENB_S1U_TEID[%d] SGW_S1U_TEID[%d]",
         dl_tunnel->remote_teid, dl_tunnel->local_teid);
 
-    ogs_list_for_each_entry(&pfcp_xact_list, pfcp_xact, tmpnode)
-        sgwc_pfcp_send_bearer_to_modify_list(pfcp_xact->data, pfcp_xact);
+    ogs_list_for_each_entry(&pfcp_xact_list, pfcp_xact, tmpnode) {
+        if (pfcp_xact->modify_flags & OGS_PFCP_MODIFY_SESSION) {
+            sgwc_sess_t *sess = NULL;
+
+            ogs_pool_id_t sess_id = OGS_POINTER_TO_UINT(pfcp_xact->data);
+            ogs_assert(sess_id >= OGS_MIN_POOL_ID &&
+                    sess_id <= OGS_MAX_POOL_ID);
+
+            sess = sgwc_sess_find_by_id(sess_id);
+            ogs_assert(sess);
+
+            sgwc_pfcp_send_bearer_to_modify_list(sess, pfcp_xact);
+        }
+    }
 }
 
 void sgwc_s11_handle_delete_session_request(
@@ -657,7 +703,8 @@ void sgwc_s11_handle_delete_session_request(
         indication->scope_indication == 1) {
 
         ogs_assert(OGS_OK ==
-            sgwc_pfcp_send_session_deletion_request(sess, s11_xact, gtpbuf));
+            sgwc_pfcp_send_session_deletion_request(
+                sess, s11_xact->id, gtpbuf));
 
     } else {
         message->h.type = OGS_GTP2_DELETE_SESSION_REQUEST_TYPE;
@@ -670,7 +717,8 @@ void sgwc_s11_handle_delete_session_request(
         }
 
         s5c_xact = ogs_gtp_xact_local_create(
-                sess->gnode, &message->h, gtpbuf, gtp_sess_timeout, sess);
+                sess->gnode, &message->h, gtpbuf, gtp_sess_timeout,
+                OGS_UINT_TO_POINTER(sess->id));
         if (!s5c_xact) {
             ogs_error("ogs_gtp_xact_local_create() failed");
             return;
@@ -695,6 +743,7 @@ void sgwc_s11_handle_create_bearer_response(
 
     sgwc_sess_t *sess = NULL;
     sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_tunnel_t *dl_tunnel = NULL, *ul_tunnel = NULL;
     ogs_pfcp_far_t *far = NULL;
 
@@ -715,17 +764,29 @@ void sgwc_s11_handle_create_bearer_response(
      * Check Transaction
      ********************/
     ogs_assert(s11_xact);
-    s5c_xact = s11_xact->assoc_xact;
+    s5c_xact = ogs_gtp_xact_find_by_id(s11_xact->assoc_xact_id);
     ogs_assert(s5c_xact);
 
-    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID)
+    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID) {
         /* MME received Bearer Resource Modification Request */
-        bearer = s5c_xact->data;
-    else
-        bearer = s11_xact->data;
+        ogs_assert(s5c_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s5c_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
 
-    ogs_assert(bearer);
-    sess = bearer->sess;
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    } else {
+        ogs_assert(s11_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s11_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
+
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     rv = ogs_gtp_xact_commit(s11_xact);
@@ -765,7 +826,7 @@ void sgwc_s11_handle_create_bearer_response(
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_bearer_modification_request(
-                bearer, NULL, NULL,
+                bearer, OGS_INVALID_POOL_ID, NULL,
                 OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_REMOVE));
         ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
@@ -784,7 +845,7 @@ void sgwc_s11_handle_create_bearer_response(
         ogs_error("GTP Cause [Value:%d]", cause_value);
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_bearer_modification_request(
-                bearer, NULL, NULL,
+                bearer, OGS_INVALID_POOL_ID, NULL,
                 OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_REMOVE));
         ogs_gtp_send_error_message(s5c_xact, sess ? sess->pgw_s5c_teid : 0,
                 OGS_GTP2_CREATE_BEARER_RESPONSE_TYPE, cause_value);
@@ -867,7 +928,7 @@ void sgwc_s11_handle_create_bearer_response(
 
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_bearer_modification_request(
-            bearer, s5c_xact, gtpbuf,
+            bearer, s5c_xact->id, gtpbuf,
             OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_CREATE));
 }
 
@@ -882,6 +943,7 @@ void sgwc_s11_handle_update_bearer_response(
     ogs_gtp_xact_t *s5c_xact = NULL;
     sgwc_sess_t *sess = NULL;
     sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     ogs_gtp2_update_bearer_response_t *rsp = NULL;
 
     ogs_assert(sgwc_ue);
@@ -895,17 +957,29 @@ void sgwc_s11_handle_update_bearer_response(
      * Check Transaction
      ********************/
     ogs_assert(s11_xact);
-    s5c_xact = s11_xact->assoc_xact;
+    s5c_xact = ogs_gtp_xact_find_by_id(s11_xact->assoc_xact_id);
     ogs_assert(s5c_xact);
 
-    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID)
+    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID) {
         /* MME received Bearer Resource Modification Request */
-        bearer = s5c_xact->data;
-    else
-        bearer = s11_xact->data;
+        ogs_assert(s5c_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s5c_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
 
-    ogs_assert(bearer);
-    sess = bearer->sess;
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    } else {
+        ogs_assert(s11_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s11_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
+
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     rv = ogs_gtp_xact_commit(s11_xact);
@@ -1005,6 +1079,7 @@ void sgwc_s11_handle_delete_bearer_response(
 
     sgwc_sess_t *sess = NULL;
     sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     ogs_gtp2_delete_bearer_response_t *rsp = NULL;
 
     ogs_assert(sgwc_ue);
@@ -1018,17 +1093,29 @@ void sgwc_s11_handle_delete_bearer_response(
      * Check Transaction
      ********************/
     ogs_assert(s11_xact);
-    s5c_xact = s11_xact->assoc_xact;
+    s5c_xact = ogs_gtp_xact_find_by_id(s11_xact->assoc_xact_id);
     ogs_assert(s5c_xact);
 
-    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID)
+    if (s11_xact->xid & OGS_GTP_CMD_XACT_ID) {
         /* MME received Bearer Resource Modification Request */
-        bearer = s5c_xact->data;
-    else
-        bearer = s11_xact->data;
+        ogs_assert(s5c_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s5c_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
 
-    ogs_assert(bearer);
-    sess = bearer->sess;
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    } else {
+        ogs_assert(s11_xact->data);
+        bearer_id = OGS_POINTER_TO_UINT(s11_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
+
+        bearer = sgwc_bearer_find_by_id(bearer_id);
+        ogs_assert(bearer);
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     rv = ogs_gtp_xact_commit(s11_xact);
@@ -1065,7 +1152,8 @@ void sgwc_s11_handle_delete_bearer_response(
         }
 
         ogs_assert(OGS_OK ==
-            sgwc_pfcp_send_session_deletion_request(sess, s5c_xact, gtpbuf));
+            sgwc_pfcp_send_session_deletion_request(
+                sess, s5c_xact->id, gtpbuf));
     } else {
        /*
         * << EPS Bearer IDs >>
@@ -1117,7 +1205,7 @@ void sgwc_s11_handle_delete_bearer_response(
 
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_bearer_modification_request(
-                bearer, s5c_xact, gtpbuf, OGS_PFCP_MODIFY_REMOVE));
+                bearer, s5c_xact->id, gtpbuf, OGS_PFCP_MODIFY_REMOVE));
     }
 }
 
@@ -1166,7 +1254,7 @@ void sgwc_s11_handle_release_access_bearers_request(
 
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_session_modification_request(
-                sess, s11_xact, gtpbuf,
+                sess, s11_xact->id, gtpbuf,
                 OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE));
     }
 }
@@ -1179,6 +1267,7 @@ void sgwc_s11_handle_downlink_data_notification_ack(
     uint8_t cause_value;
 
     sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_sess_t *sess = NULL;
 
     ogs_gtp2_downlink_data_notification_acknowledge_t *ack = NULL;
@@ -1191,9 +1280,14 @@ void sgwc_s11_handle_downlink_data_notification_ack(
      * Check Transaction
      ********************/
     ogs_assert(s11_xact);
-    bearer = s11_xact->data;
+    ogs_assert(s11_xact->data);
+    bearer_id = OGS_POINTER_TO_UINT(s11_xact->data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+            bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = sgwc_bearer_find_by_id(bearer_id);
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     rv = ogs_gtp_xact_commit(s11_xact);
@@ -1359,7 +1453,7 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
 
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_session_modification_request(
-                sess, s11_xact, gtpbuf,
+                sess, s11_xact->id, gtpbuf,
                 OGS_PFCP_MODIFY_INDIRECT|OGS_PFCP_MODIFY_CREATE));
     }
 }
@@ -1405,7 +1499,7 @@ void sgwc_s11_handle_delete_indirect_data_forwarding_tunnel_request(
 
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_session_modification_request(
-                sess, s11_xact, gtpbuf,
+                sess, s11_xact->id, gtpbuf,
                 OGS_PFCP_MODIFY_INDIRECT| OGS_PFCP_MODIFY_REMOVE));
     }
 }
@@ -1492,7 +1586,7 @@ void sgwc_s11_handle_bearer_resource_command(
      * Check ALL Context
      ********************/
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
     ogs_assert(sess->gnode);
     ogs_assert(sgwc_ue);
@@ -1512,7 +1606,8 @@ void sgwc_s11_handle_bearer_resource_command(
     }
 
     s5c_xact = ogs_gtp_xact_local_create(
-            sess->gnode, &message->h, pkbuf, gtp_bearer_timeout, bearer);
+            sess->gnode, &message->h, pkbuf, gtp_bearer_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!s5c_xact) {
         ogs_error("ogs_gtp_xact_local_create() failed");
         return;

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -24,19 +24,29 @@
 
 static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    sgwc_bearer_t *bearer = data;
+    sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_sess_t *sess = NULL;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
-    ogs_assert(sgwc_ue);
-
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = sgwc_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
+    ogs_assert(sgwc_ue);
 
     switch (type) {
     case OGS_GTP2_UPDATE_BEARER_REQUEST_TYPE:
@@ -44,14 +54,9 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
         break;
     case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Delete Bearer Response", sgwc_ue->imsi_bcd);
-        if (!sgwc_bearer_cycle(bearer)) {
-            ogs_error("[%s] Bearer has already been removed",
-                    sgwc_ue->imsi_bcd);
-            break;
-        }
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_bearer_modification_request(
-                bearer, NULL, NULL, OGS_PFCP_MODIFY_REMOVE));
+                bearer, OGS_INVALID_POOL_ID, NULL, OGS_PFCP_MODIFY_REMOVE));
         break;
     default:
         ogs_error("GTP Timeout : IMSI[%s] Message-Type[%d]",
@@ -91,7 +96,7 @@ void sgwc_s5c_handle_create_session_response(
      * Check Transaction
      ********************/
     ogs_assert(s5c_xact);
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     ogs_assert(s11_xact);
 
     rv = ogs_gtp_xact_commit(s5c_xact);
@@ -117,7 +122,7 @@ void sgwc_s5c_handle_create_session_response(
         ogs_error("No Context in TEID [Cause:%d]", session_cause);
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 
@@ -280,7 +285,7 @@ void sgwc_s5c_handle_create_session_response(
 
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_session_modification_request(
-            sess, s11_xact, gtpbuf,
+            sess, s11_xact->id, gtpbuf,
             OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_ACTIVATE));
 }
 
@@ -309,7 +314,7 @@ void sgwc_s5c_handle_modify_bearer_response(
      * Check Transaction
      ********************/
     ogs_assert(s5c_xact);
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     ogs_assert(s11_xact);
     modify_action = s5c_xact->modify_action;
 
@@ -336,7 +341,7 @@ void sgwc_s5c_handle_modify_bearer_response(
         ogs_error("No Context in TEID [Cause:%d]", session_cause);
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 
@@ -450,7 +455,7 @@ void sgwc_s5c_handle_delete_session_response(
      * Check Transaction
      ********************/
     ogs_assert(s5c_xact);
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     ogs_assert(s11_xact);
 
     rv = ogs_gtp_xact_commit(s5c_xact);
@@ -476,7 +481,7 @@ void sgwc_s5c_handle_delete_session_response(
         ogs_error("No Context in TEID [Cause:%d]", session_cause);
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 
@@ -518,7 +523,7 @@ void sgwc_s5c_handle_delete_session_response(
      * 2. SMF sends Delete Session Response to SGW/MME.
      */
     ogs_assert(OGS_OK ==
-        sgwc_pfcp_send_session_deletion_request(sess, s11_xact, gtpbuf));
+        sgwc_pfcp_send_session_deletion_request(sess, s11_xact->id, gtpbuf));
 }
 
 void sgwc_s5c_handle_create_bearer_request(
@@ -556,7 +561,7 @@ void sgwc_s5c_handle_create_bearer_request(
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 
@@ -637,7 +642,7 @@ void sgwc_s5c_handle_create_bearer_request(
 
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_bearer_modification_request(
-            bearer, s5c_xact, gtpbuf,
+            bearer, s5c_xact->id, gtpbuf,
             OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_CREATE));
 }
 
@@ -673,7 +678,7 @@ void sgwc_s5c_handle_update_bearer_request(
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
 
         if (req->bearer_contexts.presence == 0) {
@@ -725,10 +730,11 @@ void sgwc_s5c_handle_update_bearer_request(
         return;
     }
 
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     if (!s11_xact) {
         s11_xact = ogs_gtp_xact_local_create(
-                sgwc_ue->gnode, &message->h, pkbuf, bearer_timeout, bearer);
+                sgwc_ue->gnode, &message->h, pkbuf, bearer_timeout,
+                OGS_UINT_TO_POINTER(bearer->id));
         if (!s11_xact) {
             ogs_error("ogs_gtp_xact_local_create() failed");
             return;
@@ -783,7 +789,7 @@ void sgwc_s5c_handle_delete_bearer_request(
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
 
         if (req->linked_eps_bearer_id.presence == 0 &&
@@ -866,7 +872,7 @@ void sgwc_s5c_handle_delete_bearer_request(
         return;
     }
 
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     if (!s11_xact) {
        /*
         * 1. SMF sends Delete Bearer Request(DEFAULT BEARER) to SGW/MME.
@@ -883,7 +889,8 @@ void sgwc_s5c_handle_delete_bearer_request(
         * 2. MME sends Delete Bearer Response(DEDICATED BEARER) to SGW/SMF.
         */
         s11_xact = ogs_gtp_xact_local_create(
-                sgwc_ue->gnode, &message->h, pkbuf, bearer_timeout, bearer);
+                sgwc_ue->gnode, &message->h, pkbuf, bearer_timeout,
+                OGS_UINT_TO_POINTER(bearer->id));
         if (!s11_xact) {
             ogs_error("ogs_gtp_xact_local_create() failed");
             return;
@@ -929,7 +936,7 @@ void sgwc_s5c_handle_bearer_resource_failure_indication(
      * Check Transaction
      ********************/
     ogs_assert(s5c_xact);
-    s11_xact = s5c_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(s5c_xact->assoc_xact_id);
     ogs_assert(s11_xact);
 
     /************************
@@ -941,7 +948,7 @@ void sgwc_s5c_handle_bearer_resource_failure_indication(
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 

--- a/src/sgwc/sgwc-sm.c
+++ b/src/sgwc/sgwc-sm.c
@@ -114,7 +114,7 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         }
 
         e->pfcp_message = pfcp_message;
-        e->pfcp_xact = pfcp_xact;
+        e->pfcp_xact_id = pfcp_xact ? pfcp_xact->id : OGS_INVALID_POOL_ID;
 
         e->gtp_message = NULL;
         if (pfcp_xact->gtpbuf) {

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -62,13 +62,25 @@ static uint8_t gtp_cause_from_pfcp(uint8_t pfcp_cause)
 
 static void sess_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    sgwc_sess_t *sess = data;
+    sgwc_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
+    type = xact->seq[0].type;
+
+    ogs_assert(data);
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = sgwc_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
+
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
     ogs_assert(sgwc_ue);
 
     type = xact->seq[0].type;
@@ -76,13 +88,9 @@ static void sess_timeout(ogs_gtp_xact_t *xact, void *data)
     switch (type) {
     case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
         ogs_error("[%s] No Create Session Response", sgwc_ue->imsi_bcd);
-        if (!sgwc_sess_cycle(sess)) {
-            ogs_warn("[%s] Session has already been removed",
-                    sgwc_ue->imsi_bcd);
-            break;
-        }
         ogs_assert(OGS_OK ==
-            sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
+            sgwc_pfcp_send_session_deletion_request(
+                sess, OGS_INVALID_POOL_ID, NULL));
         break;
     default:
         ogs_error("GTP Timeout : IMSI[%s] Message-Type[%d]",
@@ -92,30 +100,36 @@ static void sess_timeout(ogs_gtp_xact_t *xact, void *data)
 
 static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    sgwc_bearer_t *bearer = data;
+    sgwc_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     sgwc_sess_t *sess = NULL;
     sgwc_ue_t *sgwc_ue = NULL;
     uint8_t type = 0;
 
     ogs_assert(xact);
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
-    ogs_assert(sgwc_ue);
-
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = sgwc_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = sgwc_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
+    ogs_assert(sgwc_ue);
 
     switch (type) {
     case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Create Bearer Response", sgwc_ue->imsi_bcd);
-        if (!sgwc_bearer_cycle(bearer)) {
-            ogs_warn("[%s] Bearer has already been removed", sgwc_ue->imsi_bcd);
-            break;
-        }
         ogs_assert(OGS_OK ==
             sgwc_pfcp_send_bearer_modification_request(
-                bearer, NULL, NULL,
+                bearer, OGS_INVALID_POOL_ID, NULL,
                 OGS_PFCP_MODIFY_UL_ONLY|OGS_PFCP_MODIFY_REMOVE));
         break;
     default:
@@ -164,7 +178,7 @@ void sgwc_sxa_handle_session_establishment_response(
     create_session_request = &recv_message->create_session_request;
     ogs_assert(create_session_request);
 
-    s11_xact = pfcp_xact->assoc_xact;
+    s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
     ogs_assert(s11_xact);
 
     ogs_pfcp_xact_commit(pfcp_xact);
@@ -244,7 +258,7 @@ void sgwc_sxa_handle_session_establishment_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        if (sess) sgwc_ue = sess->sgwc_ue;
+        if (sess) sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
@@ -383,7 +397,8 @@ void sgwc_sxa_handle_session_establishment_response(
 
         ogs_assert(sess->gnode);
         s5c_xact = ogs_gtp_xact_local_create(
-                sess->gnode, &send_message.h, pkbuf, sess_timeout, sess);
+                sess->gnode, &send_message.h, pkbuf, sess_timeout,
+                OGS_UINT_TO_POINTER(sess->id));
         if (!s5c_xact) {
             ogs_error("ogs_gtp_xact_local_create() failed");
             return;
@@ -427,7 +442,8 @@ void sgwc_sxa_handle_session_establishment_response(
 
         ogs_assert(sess->gnode);
         s5c_xact = ogs_gtp_xact_local_create(
-                sess->gnode, &recv_message->h, pkbuf, sess_timeout, sess);
+                sess->gnode, &recv_message->h, pkbuf, sess_timeout,
+                OGS_UINT_TO_POINTER(sess->id));
         if (!s5c_xact) {
             ogs_error("ogs_gtp_xact_local_create() failed");
             return;
@@ -475,31 +491,41 @@ void sgwc_sxa_handle_session_modification_response(
 
     if (flags & OGS_PFCP_MODIFY_SESSION) {
         if (!sess) {
+            ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
+
             ogs_error("No Context");
 
-            sess = pfcp_xact->data;
+            sess_id = OGS_POINTER_TO_UINT(pfcp_xact->data);
+            ogs_assert(sess_id >= OGS_MIN_POOL_ID &&
+                    sess_id <= OGS_MAX_POOL_ID);
+
+            sess = sgwc_sess_find_by_id(sess_id);
             ogs_assert(sess);
 
             cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
 
-        sgwc_ue = sess->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         ogs_assert(sgwc_ue);
 
     } else {
-        bearer = pfcp_xact->data;
+        ogs_pool_id_t bearer_id = OGS_POINTER_TO_UINT(pfcp_xact->data);
+        ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                bearer_id <= OGS_MAX_POOL_ID);
+
+        bearer = sgwc_bearer_find_by_id(bearer_id);
         ogs_assert(bearer);
 
         if (!sess) {
             ogs_error("No Context");
 
-            sess = bearer->sess;
+            sess = sgwc_sess_find_by_id(bearer->sess_id);
             ogs_assert(sess);
 
             cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
 
-        sgwc_ue = bearer->sgwc_ue;
+        sgwc_ue = sgwc_ue_find_by_id(bearer->sgwc_ue_id);
         ogs_assert(sgwc_ue);
     }
 
@@ -578,7 +604,7 @@ void sgwc_sxa_handle_session_modification_response(
          *    }
          */
         if (flags & OGS_PFCP_MODIFY_REMOVE) {
-            s5c_xact = pfcp_xact->assoc_xact;
+            s5c_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
 
             if (s5c_xact) {
                 ogs_gtp_send_error_message(
@@ -588,7 +614,7 @@ void sgwc_sxa_handle_session_modification_response(
 
             sgwc_bearer_remove(bearer);
         } else if (flags & OGS_PFCP_MODIFY_CREATE) {
-            s5c_xact = pfcp_xact->assoc_xact;
+            s5c_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s5c_xact);
 
             ogs_gtp_send_error_message(
@@ -598,7 +624,7 @@ void sgwc_sxa_handle_session_modification_response(
 
         } else if (flags & OGS_PFCP_MODIFY_ACTIVATE) {
             if (flags & OGS_PFCP_MODIFY_UL_ONLY) {
-                s11_xact = pfcp_xact->assoc_xact;
+                s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
                 ogs_assert(s11_xact);
 
                 ogs_gtp_send_error_message(
@@ -606,7 +632,7 @@ void sgwc_sxa_handle_session_modification_response(
                         OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
 
             } else if (flags & OGS_PFCP_MODIFY_DL_ONLY) {
-                s11_xact = pfcp_xact->assoc_xact;
+                s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
                 ogs_assert(s11_xact);
 
                 ogs_gtp_send_error_message(
@@ -617,7 +643,7 @@ void sgwc_sxa_handle_session_modification_response(
                 ogs_assert_if_reached();
             }
         } else if (flags & OGS_PFCP_MODIFY_DEACTIVATE) {
-            s11_xact = pfcp_xact->assoc_xact;
+            s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s11_xact);
 
             ogs_gtp_send_error_message(
@@ -652,7 +678,7 @@ void sgwc_sxa_handle_session_modification_response(
      */
     if (flags & OGS_PFCP_MODIFY_REMOVE) {
         if (flags & OGS_PFCP_MODIFY_INDIRECT) {
-            s11_xact = pfcp_xact->assoc_xact;
+            s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s11_xact);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -713,7 +739,7 @@ void sgwc_sxa_handle_session_modification_response(
             }
 
         } else {
-            s5c_xact = pfcp_xact->assoc_xact;
+            s5c_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
 
             ogs_pfcp_xact_commit(pfcp_xact);
 
@@ -746,7 +772,7 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_gtp2_create_bearer_request_t *gtp_req = NULL;
             ogs_gtp2_f_teid_t sgw_s1u_teid;
 
-            s5c_xact = pfcp_xact->assoc_xact;
+            s5c_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s5c_xact);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -780,7 +806,8 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_assert(sgwc_ue->gnode);
             ogs_assert(bearer);
             s11_xact = ogs_gtp_xact_local_create(sgwc_ue->gnode,
-                    &recv_message->h, pkbuf, bearer_timeout, bearer);
+                    &recv_message->h, pkbuf, bearer_timeout,
+                    OGS_UINT_TO_POINTER(bearer->id));
             if (!s11_xact) {
                 ogs_error("ogs_gtp_xact_local_create() failed");
                 return;
@@ -796,7 +823,7 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_gtp2_create_bearer_response_t *gtp_rsp = NULL;
             ogs_gtp2_f_teid_t sgw_s5u_teid, pgw_s5u_teid;
 
-            s5c_xact = pfcp_xact->assoc_xact;
+            s5c_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s5c_xact);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -854,7 +881,7 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_expect(rv == OGS_OK);
 
         } else if (flags & OGS_PFCP_MODIFY_INDIRECT) {
-            s11_xact = pfcp_xact->assoc_xact;
+            s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s11_xact);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -987,7 +1014,7 @@ void sgwc_sxa_handle_session_modification_response(
     } else if (flags & OGS_PFCP_MODIFY_ACTIVATE) {
         OGS_LIST(bearer_to_modify_list);
 
-        s11_xact = pfcp_xact->assoc_xact;
+        s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
         ogs_assert(s11_xact);
 
         ogs_list_copy(&bearer_to_modify_list,
@@ -1094,7 +1121,7 @@ void sgwc_sxa_handle_session_modification_response(
                     ogs_assert(sess->gnode);
                     s5c_xact = ogs_gtp_xact_local_create(
                             sess->gnode, &recv_message->h, pkbuf,
-                            sess_timeout, sess);
+                            sess_timeout, OGS_UINT_TO_POINTER(sess->id));
                     if (!s5c_xact) {
                         ogs_error("ogs_gtp_xact_local_create() failed");
                         return;
@@ -1194,7 +1221,7 @@ void sgwc_sxa_handle_session_modification_response(
     } else if (flags & OGS_PFCP_MODIFY_DEACTIVATE) {
         if (flags & OGS_PFCP_MODIFY_ERROR_INDICATION) {
             /* It's faked method for receiving `bearer` context */
-            bearer = pfcp_xact->assoc_xact;
+            bearer = sgwc_bearer_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(bearer);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -1208,7 +1235,7 @@ void sgwc_sxa_handle_session_modification_response(
             }
 
         } else {
-            s11_xact = pfcp_xact->assoc_xact;
+            s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
             ogs_assert(s11_xact);
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -1293,7 +1320,7 @@ void sgwc_sxa_handle_session_deletion_response(
         cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    gtp_xact = pfcp_xact->assoc_xact;
+    gtp_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
 
     ogs_pfcp_xact_commit(pfcp_xact);
 
@@ -1314,7 +1341,7 @@ void sgwc_sxa_handle_session_deletion_response(
          * 1. MME sends Delete Session Request to SGW/SMF.
          * 2. SMF sends Delete Session Response to SGW/MME.
          */
-        if (sess) sgwc_ue = sess->sgwc_ue;
+        if (sess) sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
         teid = sgwc_ue ? sgwc_ue->mme_s11_teid : 0;
         break;
     case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
@@ -1347,7 +1374,7 @@ void sgwc_sxa_handle_session_deletion_response(
     }
 
     ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
     ogs_assert(sgwc_ue);
 
     if (gtp_xact) {
@@ -1377,10 +1404,7 @@ void sgwc_sxa_handle_session_deletion_response(
     }
 
 cleanup:
-    if (sgwc_sess_cycle(sess))
-        sgwc_sess_remove(sess);
-    else
-        ogs_error("Session has already been removed");
+    sgwc_sess_remove(sess);
 }
 
 void sgwc_sxa_handle_session_report_request(
@@ -1426,7 +1450,7 @@ void sgwc_sxa_handle_session_report_request(
     }
 
     ogs_assert(sess);
-    sgwc_ue = sess->sgwc_ue;
+    sgwc_ue = sgwc_ue_find_by_id(sess->sgwc_ue_id);
     ogs_assert(sgwc_ue);
 
     if (!sgwc_ue->gnode) {
@@ -1476,7 +1500,7 @@ void sgwc_sxa_handle_session_report_request(
         if (far) {
             tunnel = sgwc_tunnel_find_by_far_id(sess, far->id);
             ogs_assert(tunnel);
-            bearer = tunnel->bearer;
+            bearer = sgwc_bearer_find_by_id(tunnel->bearer_id);
             ogs_assert(bearer);
             if (far->dst_if == OGS_PFCP_INTERFACE_ACCESS) {
                 ogs_warn("[%s] Error Indication from eNB", sgwc_ue->imsi_bcd);
@@ -1485,7 +1509,7 @@ void sgwc_sxa_handle_session_report_request(
                         sgwc_pfcp_send_session_modification_request(sess,
                     /* We only use the `assoc_xact` parameter temporarily here
                      * to pass the `bearer` context. */
-                            (ogs_gtp_xact_t *)bearer,
+                            bearer->id,
                             NULL,
                             OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE|
                             OGS_PFCP_MODIFY_ERROR_INDICATION));
@@ -1496,13 +1520,14 @@ void sgwc_sxa_handle_session_report_request(
                                 sgwc_ue->imsi_bcd);
                     ogs_assert(OGS_OK ==
                         sgwc_pfcp_send_session_deletion_request(
-                            sess, NULL, NULL));
+                            sess, OGS_INVALID_POOL_ID, NULL));
                 } else {
                     ogs_error("[%s] Error Indication(Dedicated Bearer) "
                             "from SMF", sgwc_ue->imsi_bcd);
                     ogs_assert(OGS_OK ==
                         sgwc_pfcp_send_bearer_modification_request(
-                            bearer, NULL, NULL, OGS_PFCP_MODIFY_REMOVE));
+                            bearer, OGS_INVALID_POOL_ID, NULL,
+                            OGS_PFCP_MODIFY_REMOVE));
                 }
             } else {
                 ogs_error("Error Indication Ignored for Indirect Tunnel");

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -141,9 +141,8 @@ sgwu_sess_t *sgwu_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
 
     ogs_assert(cp_f_seid);
 
-    ogs_pool_alloc(&sgwu_sess_pool, &sess);
+    ogs_pool_id_calloc(&sgwu_sess_pool, &sess);
     ogs_assert(sess);
-    memset(sess, 0, sizeof *sess);
 
     ogs_pfcp_pool_init(&sess->pfcp);
 
@@ -197,7 +196,7 @@ int sgwu_sess_remove(sgwu_sess_t *sess)
     ogs_pfcp_pool_final(&sess->pfcp);
 
     ogs_pool_free(&sgwu_sxa_seid_pool, sess->sgwu_sxa_seid_node);
-    ogs_pool_free(&sgwu_sess_pool, sess);
+    ogs_pool_id_free(&sgwu_sess_pool, sess);
 
     ogs_info("[Removed] Number of SGWU-sessions is now %d",
             ogs_list_count(&self.sess_list));
@@ -236,6 +235,11 @@ sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_f_seid(ogs_pfcp_f_seid_t *f_seid)
 sgwu_sess_t *sgwu_sess_find_by_sgwu_sxa_seid(uint64_t seid)
 {
     return ogs_hash_get(self.sgwu_sxa_seid_hash, &seid, sizeof(seid));
+}
+
+sgwu_sess_t *sgwu_sess_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_pool_find_by_id(&sgwu_sess_pool, id);
 }
 
 sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)

--- a/src/sgwu/context.h
+++ b/src/sgwu/context.h
@@ -47,6 +47,7 @@ typedef struct sgwu_context_s {
 #define SGWU_SESS(pfcp_sess) ogs_container_of(pfcp_sess, sgwu_sess_t, pfcp)
 typedef struct sgwu_sess_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     ogs_pool_id_t   *sgwu_sxa_seid_node;    /* A node of SGWU-SXA-SEID */
 
     ogs_pfcp_sess_t pfcp;
@@ -74,6 +75,7 @@ void sgwu_sess_remove_all(void);
 sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_seid(uint64_t seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_f_seid(ogs_pfcp_f_seid_t *f_seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwu_sxa_seid(uint64_t seid);
+sgwu_sess_t *sgwu_sess_find_by_id(ogs_pool_id_t id);
 
 #ifdef __cplusplus
 }

--- a/src/sgwu/event.h
+++ b/src/sgwu/event.h
@@ -52,7 +52,7 @@ typedef struct sgwu_event_s {
     ogs_gtp_node_t *gnode;
 
     ogs_pfcp_node_t *pfcp_node;
-    ogs_pfcp_xact_t *pfcp_xact;
+    ogs_pool_id_t pfcp_xact_id;
     ogs_pfcp_message_t *pfcp_message;
 
     sgwu_bearer_t *bearer;

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -117,7 +117,7 @@ void sgwu_pfcp_state_will_associate(ogs_fsm_t *s, sgwu_event_t *e)
     case SGWU_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         switch (message->h.type) {
@@ -199,7 +199,7 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
     case SGWU_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         if (message->h.seid_presence && message->h.seid != 0)

--- a/src/sgwu/sgwu-sm.c
+++ b/src/sgwu/sgwu-sm.c
@@ -82,7 +82,7 @@ void sgwu_state_operational(ogs_fsm_t *s, sgwu_event_t *e)
         }
 
         e->pfcp_message = pfcp_message;
-        e->pfcp_xact = xact;
+        e->pfcp_xact_id = xact ? xact->id : OGS_INVALID_POOL_ID;
         ogs_fsm_dispatch(&node->sm, e);
         if (OGS_FSM_CHECK(&node->sm, sgwu_pfcp_state_exception)) {
             ogs_error("PFCP state machine exception");

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -26,29 +26,36 @@
 
 static void gtp_bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    smf_bearer_t *bearer = data;
+    smf_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     smf_sess_t *sess = NULL;
     smf_ue_t *smf_ue = NULL;
     uint8_t type = 0;
 
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    smf_ue = sess->smf_ue;
-    ogs_assert(smf_ue);
-
+    ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = smf_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = smf_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+    ogs_assert(smf_ue);
 
     switch (type) {
     case OGS_GTP2_CREATE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Create Bearer Response", smf_ue->imsi_bcd);
-        if (!smf_bearer_cycle(bearer)) {
-            ogs_warn("[%s] Bearer has already been removed", smf_ue->imsi_bcd);
-            break;
-        }
         ogs_assert(OGS_OK ==
             smf_epc_pfcp_send_one_bearer_modification_request(
-                bearer, NULL, OGS_PFCP_MODIFY_REMOVE,
+                bearer, OGS_INVALID_POOL_ID, OGS_PFCP_MODIFY_REMOVE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                 OGS_GTP2_CAUSE_UNDEFINED_VALUE));
         break;
@@ -348,7 +355,7 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 ogs_assert(OGS_OK ==
                     smf_epc_pfcp_send_one_bearer_modification_request(
-                        bearer, NULL, OGS_PFCP_MODIFY_CREATE,
+                        bearer, OGS_INVALID_POOL_ID, OGS_PFCP_MODIFY_CREATE,
                         OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                         OGS_GTP2_CAUSE_UNDEFINED_VALUE));
             } else {
@@ -376,7 +383,8 @@ void smf_bearer_binding(smf_sess_t *sess)
                 }
 
                 xact = ogs_gtp_xact_local_create(
-                        sess->gnode, &h, pkbuf, gtp_bearer_timeout, bearer);
+                        sess->gnode, &h, pkbuf, gtp_bearer_timeout,
+                        OGS_UINT_TO_POINTER(bearer->id));
                 if (!xact) {
                     ogs_error("ogs_gtp_xact_local_create() failed");
                     return;
@@ -413,7 +421,7 @@ void smf_bearer_binding(smf_sess_t *sess)
              */
             ogs_assert(OGS_OK ==
                 smf_epc_pfcp_send_one_bearer_modification_request(
-                    bearer, NULL,
+                    bearer, OGS_INVALID_POOL_ID,
                     OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                     OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                     OGS_GTP2_CAUSE_UNDEFINED_VALUE));
@@ -435,7 +443,7 @@ int smf_gtp2_send_create_bearer_request(smf_bearer_t *bearer)
     ogs_gtp2_tft_t tft;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     h.type = OGS_GTP2_CREATE_BEARER_REQUEST_TYPE;
@@ -452,7 +460,8 @@ int smf_gtp2_send_create_bearer_request(smf_bearer_t *bearer)
     }
 
     xact = ogs_gtp_xact_local_create(
-            sess->gnode, &h, pkbuf, gtp_bearer_timeout, bearer);
+            sess->gnode, &h, pkbuf, gtp_bearer_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!xact) {
         ogs_error("ogs_gtp_xact_local_create() failed");
         return OGS_ERROR;

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -112,6 +112,7 @@ typedef struct smf_gtp_node_s {
 
 typedef struct smf_ue_s {
     ogs_lnode_t lnode;
+    ogs_pool_id_t id;
 
     /* SUPI */
     char *supi;
@@ -138,7 +139,7 @@ typedef struct smf_ue_s {
     do { \
         smf_ue_t *smf_ue = NULL; \
         ogs_assert(__sESS); \
-        smf_ue = (__sESS)->smf_ue; \
+        smf_ue = smf_ue_find_by_id((__sESS)->smf_ue_id); \
         ogs_assert(smf_ue); \
         smf_metrics_inst_by_slice_add(&(__sESS)->serving_plmn_id, \
                 &(__sESS)->s_nssai, SMF_METR_GAUGE_SM_SESSIONNBR, -1); \
@@ -155,6 +156,8 @@ typedef struct smf_pf_s {
     ogs_lnode_t     lnode;
     ogs_lnode_t     to_add_node;
 
+    ogs_pool_id_t   id;
+
 ED3(uint8_t spare:2;,
     uint8_t direction:2;,
     uint8_t identifier:4;)
@@ -169,11 +172,12 @@ ED3(uint8_t spare:2;,
     ogs_ipfw_rule_t ipfw_rule;
     char *flow_description;
 
-    smf_bearer_t    *bearer;
+    ogs_pool_id_t bearer_id;
 } smf_pf_t;
 
 typedef struct smf_bearer_s {
     ogs_lnode_t     lnode;          /**< A node of list_t */
+    ogs_pool_id_t   id;
 
     ogs_lnode_t     to_modify_node;
     ogs_lnode_t     to_delete_node;
@@ -212,12 +216,13 @@ typedef struct smf_bearer_s {
     uint8_t num_of_pf_to_delete;
     uint8_t pf_to_delete[OGS_MAX_NUM_OF_FLOW_IN_NAS];
 
-    smf_sess_t      *sess;
+    ogs_pool_id_t   sess_id;
 } smf_bearer_t;
 
 #define SMF_SESS(pfcp_sess) ogs_container_of(pfcp_sess, smf_sess_t, pfcp)
 typedef struct smf_sess_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
 
     uint32_t        index;              /* An index of this node */
     ogs_pool_id_t   *smf_n4_seid_node;  /* A node of SMF-N4-SEID */
@@ -464,7 +469,7 @@ typedef struct smf_sess_s {
     ogs_gtp_node_t  *gnode;
     ogs_pfcp_node_t *pfcp_node;
 
-    smf_ue_t *smf_ue;
+    ogs_pool_id_t smf_ue_id;
 
     bool n1_released;
     bool n2_released;
@@ -544,15 +549,17 @@ smf_bearer_t *smf_default_bearer_in_sess(smf_sess_t *sess);
 void smf_bearer_tft_update(smf_bearer_t *bearer);
 void smf_bearer_qos_update(smf_bearer_t *bearer);
 
-smf_ue_t *smf_ue_cycle(smf_ue_t *smf_ue);
-smf_sess_t *smf_sess_cycle(smf_sess_t *sess);
-smf_bearer_t *smf_qos_flow_cycle(smf_bearer_t *qos_flow);
-smf_bearer_t *smf_bearer_cycle(smf_bearer_t *bearer);
+smf_ue_t *smf_ue_find_by_id(ogs_pool_id_t id);
+smf_sess_t *smf_sess_find_by_id(ogs_pool_id_t id);
+smf_bearer_t *smf_bearer_find_by_id(ogs_pool_id_t id);
+smf_bearer_t *smf_qos_flow_find_by_id(ogs_pool_id_t id);
+smf_pf_t *smf_pf_find_by_id(ogs_pool_id_t id);
 
 smf_pf_t *smf_pf_add(smf_bearer_t *bearer);
 int smf_pf_remove(smf_pf_t *pf);
 void smf_pf_remove_all(smf_bearer_t *bearer);
-smf_pf_t *smf_pf_find_by_id(smf_bearer_t *smf_bearer, uint8_t id);
+smf_pf_t *smf_pf_find_by_identifier(
+        smf_bearer_t *bearer, uint8_t identifier);
 smf_pf_t *smf_pf_find_by_flow(
     smf_bearer_t *bearer, uint8_t direction, char *flow_description);
 smf_pf_t *smf_pf_first(smf_bearer_t *bearer);

--- a/src/smf/event.h
+++ b/src/smf/event.h
@@ -72,10 +72,10 @@ typedef struct smf_event_s {
     ogs_pkbuf_t *pkbuf;
 
     smf_gtp_node_t *gnode;
-    ogs_gtp_xact_t *gtp_xact;
+    ogs_pool_id_t gtp_xact_id;
 
     ogs_pfcp_node_t *pfcp_node;
-    ogs_pfcp_xact_t *pfcp_xact;
+    ogs_pool_id_t pfcp_xact_id;
     ogs_pfcp_message_t *pfcp_message;
 
     union {
@@ -99,7 +99,7 @@ typedef struct smf_event_s {
         ogs_nas_5gs_message_t *message;
     } nas;
 
-    smf_sess_t *sess;
+    ogs_pool_id_t sess_id;
 } smf_event_t;
 
 OGS_STATIC_ASSERT(OGS_EVENT_SIZE >= sizeof(smf_event_t));

--- a/src/smf/fd-path.h
+++ b/src/smf/fd-path.h
@@ -38,9 +38,9 @@ void smf_gy_final(void);
 int smf_s6b_init(void);
 void smf_s6b_final(void);
 
-void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
+void smf_gx_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         uint32_t cc_request_type);
-void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
+void smf_gy_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         uint32_t cc_request_type);
 
 void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact);

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -118,7 +118,7 @@ uint8_t smf_gn_handle_create_pdp_context_request(
     if (cause_value != OGS_GTP1_CAUSE_REQUEST_ACCEPTED)
         return cause_value;
 
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     /* Store NSAPI */
@@ -383,7 +383,7 @@ void smf_gn_handle_update_pdp_context_request(
     }
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
@@ -485,7 +485,7 @@ void smf_gn_handle_update_pdp_context_request(
     h.teid = sess->sgw_s5c_teid;
 
     /* Set bearer so it's accessible later when handling PFCP Session Modification Response */
-    xact->data = bearer;
+    xact->data = OGS_UINT_TO_POINTER(bearer->id);
 
     /* Update remote TEID and GTP-U IP address on the UPF. UpdatePDPContextResp
      * will be sent when UPF answers back this request
@@ -509,7 +509,7 @@ void smf_gn_handle_update_pdp_context_request(
         }
     }
 
-    rv = smf_epc_pfcp_send_all_pdr_modification_request(sess, xact, NULL,
+    rv = smf_epc_pfcp_send_all_pdr_modification_request(sess, xact->id, NULL,
             OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_ACTIVATE,
             OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
             OGS_GTP1_CAUSE_REACTIACTION_REQUESTED);

--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -212,7 +212,7 @@ int gsm_handle_pdu_session_modification_request(
     ogs_pkbuf_t *n1smbuf = NULL;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(stream);
     ogs_assert(pdu_session_modification_request);
@@ -256,7 +256,7 @@ int gsm_handle_pdu_session_modification_request(
                 for (j = 0; j < qos_rule[i].num_of_packet_filter &&
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
-                    pf = smf_pf_find_by_id(
+                    pf = smf_pf_find_by_identifier(
                             qos_flow, qos_rule[i].pf[j].identifier+1);
                     if (pf) {
                         ogs_assert(
@@ -328,7 +328,7 @@ int gsm_handle_pdu_session_modification_request(
                 for (j = 0; j < qos_rule[i].num_of_packet_filter &&
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
-                    pf = smf_pf_find_by_id(
+                    pf = smf_pf_find_by_identifier(
                             qos_flow, qos_rule[i].pf[j].identifier+1);
                     if (!pf)
                         pf = smf_pf_add(qos_flow);
@@ -405,7 +405,7 @@ int gsm_handle_pdu_session_modification_request(
                 for (j = 0; j < qos_rule[i].num_of_packet_filter &&
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
-                    pf = smf_pf_find_by_id(
+                    pf = smf_pf_find_by_identifier(
                             qos_flow, qos_rule[i].pf[j].identifier+1);
                     if (pf) {
                         qos_flow->pf_to_delete

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -168,7 +168,7 @@ void smf_gsm_state_initial(ogs_fsm_t *s, smf_event_t *e)
     ogs_nas_5gs_message_t *nas_message = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     ogs_assert(s);
@@ -463,7 +463,7 @@ void smf_gsm_state_wait_5gc_sm_policy_association(ogs_fsm_t *s, smf_event_t *e)
     smf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     int state = 0;
@@ -759,7 +759,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
     ogs_nas_5gs_message_t *nas_message = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     ogs_gtp1_message_t *gtp1_message = NULL;
@@ -1315,7 +1315,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
     smf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     ogs_pfcp_xact_t *pfcp_xact = NULL;
@@ -1657,7 +1657,7 @@ void smf_gsm_state_wait_5gc_n1_n2_release(ogs_fsm_t *s, smf_event_t *e)
     ogs_nas_5gs_message_t *nas_message = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     ogs_assert(s);
@@ -2028,7 +2028,7 @@ void smf_gsm_state_5gc_session_will_deregister(ogs_fsm_t *s, smf_event_t *e)
     smf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *sbi_message = NULL;
 
     ogs_assert(s);

--- a/src/smf/gtp-path.c
+++ b/src/smf/gtp-path.c
@@ -369,7 +369,7 @@ int smf_gtp1_send_update_pdp_context_request(
     smf_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     memset(&h, 0, sizeof(ogs_gtp1_header_t));
@@ -384,7 +384,8 @@ int smf_gtp1_send_update_pdp_context_request(
     }
 
     xact = ogs_gtp1_xact_local_create(
-            sess->gnode, &h, pkbuf, bearer_timeout, bearer);
+            sess->gnode, &h, pkbuf, bearer_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!xact) {
         ogs_error("ogs_gtp1_xact_local_create() failed");
         return OGS_ERROR;
@@ -409,7 +410,7 @@ int smf_gtp1_send_update_pdp_context_response(
 
     ogs_assert(bearer);
     ogs_assert(xact);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     memset(&h, 0, sizeof(ogs_gtp1_header_t));
@@ -546,7 +547,7 @@ int smf_gtp2_send_delete_bearer_request(
     smf_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     memset(&h, 0, sizeof(ogs_gtp2_header_t));
@@ -561,7 +562,8 @@ int smf_gtp2_send_delete_bearer_request(
     }
 
     xact = ogs_gtp_xact_local_create(
-            sess->gnode, &h, pkbuf, bearer_timeout, bearer);
+            sess->gnode, &h, pkbuf, bearer_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!xact) {
         ogs_error("ogs_gtp_xact_local_create() failed");
         return OGS_ERROR;
@@ -730,30 +732,36 @@ static void send_router_advertisement(smf_sess_t *sess, uint8_t *ip6_dst)
 
 static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 {
-    smf_bearer_t *bearer = data;
+    smf_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     smf_sess_t *sess = NULL;
     smf_ue_t *smf_ue = NULL;
     uint8_t type = 0;
 
-    ogs_assert(bearer);
-    sess = bearer->sess;
-    ogs_assert(sess);
-    smf_ue = sess->smf_ue;
-    ogs_assert(smf_ue);
-
+    ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = smf_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
+
+    sess = smf_sess_find_by_id(bearer->sess_id);
+    ogs_assert(sess);
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+    ogs_assert(smf_ue);
 
     switch (type) {
     case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Delete Bearer Response", smf_ue->imsi_bcd);
-        if (!smf_bearer_cycle(bearer)) {
-            ogs_warn("[%s] Bearer has already been removed", smf_ue->imsi_bcd);
-            break;
-        }
-
         ogs_assert(OGS_OK ==
             smf_epc_pfcp_send_one_bearer_modification_request(
-                bearer, NULL, OGS_PFCP_MODIFY_REMOVE,
+                bearer, OGS_INVALID_POOL_ID, OGS_PFCP_MODIFY_REMOVE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                 OGS_GTP2_CAUSE_UNDEFINED_VALUE));
         break;

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -29,10 +29,10 @@ struct sess_state {
     os0_t       peer_host;          /* Peer Host */
 
 #define NUM_CC_REQUEST_SLOT 4
-    smf_sess_t *sess;
+    ogs_pool_id_t sess_id;
     struct {
         uint32_t cc_req_no;
-        ogs_gtp_xact_t *ptr;
+        ogs_pool_id_t id;
     } xact_data[NUM_CC_REQUEST_SLOT];
 
     uint32_t cc_request_type;
@@ -88,7 +88,7 @@ static void state_cleanup(struct sess_state *sess_data, os0_t sid, void *opaque)
 }
 
 /* 3GPP TS 29.212 5.6.2 Credit-Control-Request */
-void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
+void smf_gx_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         uint32_t cc_request_type)
 {
     int ret;
@@ -112,7 +112,7 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
     ogs_assert(sess);
 
     ogs_assert(sess->ipv4 || sess->ipv6);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("[Credit-Control-Request]");
@@ -198,9 +198,9 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_gtp_xact_t *xact,
         sess_data->cc_request_type, sess_data->cc_request_number);
 
     /* Update session state */
-    sess_data->sess = sess;
+    sess_data->sess_id = sess->id;
     req_slot = sess_data->cc_request_number % NUM_CC_REQUEST_SLOT;
-    sess_data->xact_data[req_slot].ptr = xact;
+    sess_data->xact_data[req_slot].id = xact_id;
     sess_data->xact_data[req_slot].cc_req_no = sess_data->cc_request_number;
 
     /* Set Origin-Host & Origin-Realm */
@@ -718,7 +718,6 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
     int new;
     struct msg *req = NULL;
     smf_event_t *e = NULL;
-    ogs_gtp_xact_t *xact = NULL;
     smf_sess_t *sess = NULL;
     ogs_diam_gx_message_t *gx_message = NULL;
     uint32_t req_slot, cc_request_number = 0;
@@ -767,8 +766,7 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
 
     ogs_debug("    CC-Request-Number[%d]", cc_request_number);
 
-    xact = sess_data->xact_data[req_slot].ptr;
-    sess = sess_data->sess;
+    sess = smf_sess_find_by_id(sess_data->sess_id);
     ogs_assert(sess_data->xact_data[req_slot].cc_req_no == cc_request_number);
     ogs_assert(sess);
 
@@ -1039,9 +1037,9 @@ out:
         e = smf_event_new(SMF_EVT_GX_MESSAGE);
         ogs_assert(e);
 
-        e->sess = sess;
+        e->sess_id = sess->id;
         e->gx_message = gx_message;
-        e->gtp_xact = xact;
+        e->gtp_xact_id = sess_data->xact_data[req_slot].id;
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {
             ogs_error("ogs_queue_push() failed:%d", (int)rv);
@@ -1166,7 +1164,7 @@ static int smf_gx_rar_cb( struct msg **msg, struct avp *avp,
     }
 
     /* Get Session Information */
-    sess = sess_data->sess;
+    sess = smf_sess_find_by_id(sess_data->sess_id);
     ogs_assert(sess);
 
     ret = fd_msg_browse(qry, MSG_BRW_FIRST_CHILD, &avp, NULL);
@@ -1283,7 +1281,7 @@ static int smf_gx_rar_cb( struct msg **msg, struct avp *avp,
     e = smf_event_new(SMF_EVT_GX_MESSAGE);
     ogs_assert(e);
 
-    e->sess = sess;
+    e->sess_id = sess->id;
     e->gx_message = gx_message;
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {

--- a/src/smf/gy-handler.c
+++ b/src/smf/gy-handler.c
@@ -257,7 +257,7 @@ uint32_t smf_gy_handle_cca_update_request(
     if (modify_flags) {
         modify_flags |= OGS_PFCP_MODIFY_URR|OGS_PFCP_MODIFY_UL_ONLY;
         rv = smf_epc_pfcp_send_all_pdr_modification_request(
-                sess, pfcp_xact, NULL, modify_flags,
+                sess, OGS_INVALID_POOL_ID, NULL, modify_flags,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                 OGS_GTP1_CAUSE_REACTIACTION_REQUESTED);
         ogs_assert(rv == OGS_OK);

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -31,11 +31,11 @@ struct sess_state {
 
 #define NUM_CC_REQUEST_SLOT 4
 
-    smf_sess_t *sess;
+    ogs_pool_id_t sess_id;
     struct {
         uint32_t cc_req_no;
         bool pfcp;
-        void *ptr; /* INITIAL: ogs_gtp_xact_t, UPDATE: ogs_pfcp_xact_t */
+        ogs_pool_id_t id; /* INITIAL: ogs_gtp_xact_t, UPDATE: ogs_pfcp_xact_t */
     } xact_data[NUM_CC_REQUEST_SLOT];
     uint32_t cc_request_type;
     uint32_t cc_request_number;
@@ -345,6 +345,12 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     char buf[OGS_PLMNIDSTRLEN];
     char digit;
 
+    smf_ue_t *smf_ue = NULL;
+
+    ogs_assert(sess);
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+    ogs_assert(smf_ue);
+
     /* PS-Information, TS 32.299 sec 7.2.158 */
     ret = fd_msg_avp_new(ogs_diam_gy_ps_information, 0, &avpch1);
     ogs_assert(ret == 0);
@@ -555,7 +561,7 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     ret = fd_msg_avp_add(avpch1, MSG_BRW_LAST_CHILD, avpch2);
     ogs_assert(ret == 0);
 
-    if (sess->smf_ue->imeisv_len > 0) {
+    if (smf_ue->imeisv_len > 0) {
         /* User-Equipment-Info, 3GPP TS 32.299 7.1.17 */
         ret = fd_msg_avp_new(ogs_diam_gy_user_equipment_info, 0, &avpch2);
 
@@ -572,7 +578,7 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
         ret = fd_msg_avp_new(ogs_diam_gy_user_equipment_info_value, 0, &avpch3);
         ogs_assert(ret == 0);
         digit = '0';
-        val.os.data = (uint8_t*)&sess->smf_ue->imeisv_bcd[0];
+        val.os.data = (uint8_t*)&smf_ue->imeisv_bcd[0];
         val.os.len = 16;
         ret = fd_msg_avp_setvalue(avpch3, &val);
         ogs_assert(ret == 0);
@@ -610,7 +616,7 @@ static void fill_service_information_ccr(smf_sess_t *sess,
 }
 
 /* 3GPP TS 32.299  6.4.2 Credit-Control-Request message */
-void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
+void smf_gy_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         uint32_t cc_request_type)
 {
 
@@ -630,7 +636,7 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
     ogs_assert(sess);
 
     ogs_assert(sess->ipv4 || sess->ipv6);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("[Gy][Credit-Control-Request]");
@@ -713,14 +719,14 @@ void smf_gy_send_ccr(smf_sess_t *sess, void *xact,
         sess_data->cc_request_type, sess_data->cc_request_number);
 
     /* Update session state */
-    sess_data->sess = sess;
+    sess_data->sess_id = sess->id;
     req_slot = sess_data->cc_request_number % NUM_CC_REQUEST_SLOT;
     if (cc_request_type == OGS_DIAM_GY_CC_REQUEST_TYPE_UPDATE_REQUEST)
         sess_data->xact_data[req_slot].pfcp = true;
     else
         sess_data->xact_data[req_slot].pfcp = false;
     sess_data->xact_data[req_slot].cc_req_no = sess_data->cc_request_number;
-    sess_data->xact_data[req_slot].ptr = xact;
+    sess_data->xact_data[req_slot].id = xact_id;
 
 
     /* Origin-Host & Origin-Realm */
@@ -958,7 +964,6 @@ static void smf_gy_cca_cb(void *data, struct msg **msg)
     int new;
     struct msg *req = NULL;
     smf_event_t *e = NULL;
-    void *xact = NULL;
     smf_sess_t *sess = NULL;
     ogs_diam_gy_message_t *gy_message = NULL;
     uint32_t req_slot, cc_request_number = 0;
@@ -1007,9 +1012,8 @@ static void smf_gy_cca_cb(void *data, struct msg **msg)
 
     ogs_debug("    CC-Request-Number[%d]", cc_request_number);
 
-    xact = sess_data->xact_data[req_slot].ptr;
     ogs_assert(sess_data->xact_data[req_slot].cc_req_no == cc_request_number);
-    sess = sess_data->sess;
+    sess = smf_sess_find_by_id(sess_data->sess_id);
     ogs_assert(sess);
 
     gy_message = ogs_calloc(1, sizeof(ogs_diam_gy_message_t));
@@ -1175,15 +1179,13 @@ out:
         e = smf_event_new(SMF_EVT_GY_MESSAGE);
         ogs_assert(e);
 
-        e->sess = sess;
+        e->sess_id = sess->id;
         e->gy_message = gy_message;
-        if (gy_message->cc_request_type == OGS_DIAM_GY_CC_REQUEST_TYPE_UPDATE_REQUEST) {
-            ogs_assert(sess_data->xact_data[req_slot].pfcp == true);
-            e->pfcp_xact = xact;
-        } else {
-            ogs_assert(sess_data->xact_data[req_slot].pfcp == false);
-            e->gtp_xact = xact;
-        }
+        if (sess_data->xact_data[req_slot].pfcp == true)
+            e->pfcp_xact_id = sess_data->xact_data[req_slot].id;
+        else
+            e->gtp_xact_id = sess_data->xact_data[req_slot].id;
+
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {
             ogs_error("ogs_queue_push() failed:%d", (int)rv);
@@ -1302,7 +1304,7 @@ static int smf_gy_rar_cb( struct msg **msg, struct avp *avp,
     }
 
     /* Get Session Information */
-    sess = sess_data->sess;
+    sess = smf_sess_find_by_id(sess_data->sess_id);
     ogs_assert(sess);
 
     /* TODO: parsing of msg into gy_message */
@@ -1311,7 +1313,7 @@ static int smf_gy_rar_cb( struct msg **msg, struct avp *avp,
     e = smf_event_new(SMF_EVT_GY_MESSAGE);
     ogs_assert(e);
 
-    e->sess = sess;
+    e->sess_id = sess->id;
     e->gy_message = gy_message;
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {

--- a/src/smf/n4-build.c
+++ b/src/smf/n4-build.c
@@ -44,7 +44,7 @@ ogs_pkbuf_t *smf_n4_build_session_establishment_request(
 
     ogs_debug("Session Establishment Request");
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(xact);
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -267,8 +267,7 @@ void smf_5gc_n4_handle_session_modification_response(
 
     } else {
         /* If smf_5gc_pfcp_send_qos_flow_modification_request() is called */
-        qos_flow = xact->data;
-        ogs_assert(qos_flow);
+        qos_flow = smf_qos_flow_find_by_id(OGS_POINTER_TO_UINT(xact->data));
     }
 
     ogs_list_copy(&pdr_to_create_list, &xact->pdr_to_create_list);
@@ -496,10 +495,12 @@ void smf_5gc_n4_handle_session_modification_response(
 
             ogs_list_for_each_entry_safe(&sess->qos_flow_to_modify_list,
                     next, qos_flow, to_modify_node) {
+                smf_sess_t *sess = smf_sess_find_by_id(qos_flow->sess_id);
+                ogs_assert(sess);
                 smf_metrics_inst_by_5qi_add(
-                        &qos_flow->sess->serving_plmn_id,
-                        &qos_flow->sess->s_nssai,
-                        qos_flow->sess->session.qos.index,
+                        &sess->serving_plmn_id,
+                        &sess->s_nssai,
+                        sess->session.qos.index,
                         SMF_METR_GAUGE_SM_QOSFLOWNBR, -1);
                 smf_bearer_remove(qos_flow);
             }
@@ -528,10 +529,12 @@ void smf_5gc_n4_handle_session_modification_response(
 
             ogs_list_for_each_entry_safe(&sess->qos_flow_to_modify_list,
                     next, qos_flow, to_modify_node) {
+                smf_sess_t *sess = smf_sess_find_by_id(qos_flow->sess_id);
+                ogs_assert(sess);
                 smf_metrics_inst_by_5qi_add(
-                        &qos_flow->sess->serving_plmn_id,
-                        &qos_flow->sess->s_nssai,
-                        qos_flow->sess->session.qos.index,
+                        &sess->serving_plmn_id,
+                        &sess->s_nssai,
+                        sess->session.qos.index,
                         SMF_METR_GAUGE_SM_QOSFLOWNBR, -1);
                 smf_bearer_remove(qos_flow);
             }
@@ -857,8 +860,7 @@ void smf_epc_n4_handle_session_modification_response(
         /* If smf_epc_pfcp_send_pdr_modification_request() is called */
     } else {
         /* If smf_epc_pfcp_send_bearer_modification_request() is called */
-        bearer = xact->data;
-        ogs_assert(bearer);
+        bearer = smf_bearer_find_by_id(OGS_POINTER_TO_UINT(xact->data));
     }
     flags = xact->modify_flags;
     ogs_assert(flags);
@@ -867,7 +869,7 @@ void smf_epc_n4_handle_session_modification_response(
        PFCP Session Report Request, xact->assoc_xact is not a gtp_xact. No
        need to do anything. */
     if (!(flags & OGS_PFCP_MODIFY_URR)) {
-        gtp_xact = xact->assoc_xact;
+        gtp_xact = ogs_gtp_xact_find_by_id(xact->assoc_xact_id);
         gtp_pti = xact->gtp_pti;
         gtp_cause = xact->gtp_cause;
     }
@@ -1005,7 +1007,7 @@ void smf_epc_n4_handle_session_modification_response(
          *
          * To do this, I saved Bearer Context in Transaction Context.
          */
-            gtp_xact->data = bearer;
+            gtp_xact->data = OGS_UINT_TO_POINTER(bearer->id);
 
             rv = ogs_gtp_xact_commit(gtp_xact);
             ogs_expect(rv == OGS_OK);
@@ -1059,9 +1061,15 @@ void smf_epc_n4_handle_session_modification_response(
 
             /* SMF send Update PDP Context Response (GTPv1C) to SGSN */
             if (gtp_xact->gtp_version == 1) {
+                ogs_pool_id_t bearer_id = OGS_POINTER_TO_UINT(gtp_xact->data);
 
-                bearer = gtp_xact->data;
-                smf_gtp1_send_update_pdp_context_response(bearer, gtp_xact);
+                ogs_assert(bearer_id >= OGS_MIN_POOL_ID &&
+                        bearer_id <= OGS_MAX_POOL_ID);
+                bearer = smf_bearer_find_by_id(bearer_id);
+                if (bearer)
+                    smf_gtp1_send_update_pdp_context_response(bearer, gtp_xact);
+                else
+                    ogs_error("Bearer has already been removed");
 
             } else {
 
@@ -1193,7 +1201,7 @@ uint8_t smf_n4_handle_session_report_request(
     }
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     report_type.value = pfcp_req->report_type.u8;
@@ -1339,7 +1347,8 @@ uint8_t smf_n4_handle_session_report_request(
         switch (smf_use_gy_iface()) {
         case 1:
             if (!sess->gy.final_unit) {
-                smf_gy_send_ccr(sess, pfcp_xact,
+                smf_gy_send_ccr(
+                        sess, pfcp_xact->id,
                         OGS_DIAM_GY_CC_REQUEST_TYPE_UPDATE_REQUEST);
             } else {
                 ogs_debug("[%s:%s] Rx PFCP report after Gy Final Unit Indication",
@@ -1378,7 +1387,7 @@ uint8_t smf_n4_handle_session_report_request(
                 smf_ue->imsi_bcd, sess->session.name);
             ogs_assert(OGS_OK ==
                 smf_epc_pfcp_send_session_deletion_request(
-                    sess, NULL));
+                    sess, OGS_INVALID_POOL_ID));
         } else {
             ogs_warn("[%s:%s] Error Indication from gNB",
                 smf_ue->supi, sess->session.name);

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -258,7 +258,9 @@ void smf_5gc_n4_handle_session_modification_response(
     ogs_assert(flags);
 
     /* 'stream' could be NULL in smf_qos_flow_binding() */
-    stream = xact->assoc_stream;
+    if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+            xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+        stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
 
     if (flags & OGS_PFCP_MODIFY_SESSION) {
         /* If smf_5gc_pfcp_send_all_pdr_modification_request() is called */

--- a/src/smf/namf-build.c
+++ b/src/smf/namf-build.c
@@ -44,7 +44,7 @@ ogs_sbi_request_t *smf_namf_comm_build_n1_n2_message_transfer(
     OpenAPI_ref_to_binary_data_t ngapData;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(smf_ue->supi);
 

--- a/src/smf/namf-handler.c
+++ b/src/smf/namf-handler.c
@@ -29,7 +29,7 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
     OpenAPI_n1_n2_message_transfer_rsp_data_t *N1N2MessageTransferRspData;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(state);
     ogs_assert(recvmsg);

--- a/src/smf/nas-path.c
+++ b/src/smf/nas-path.c
@@ -31,7 +31,7 @@ void nas_5gs_send_to_gsm(
     e = smf_event_new(SMF_EVT_5GSM_MESSAGE);
     ogs_assert(e);
 
-    e->sess = sess;
+    e->sess_id = sess->id;
     e->pkbuf = pkbuf;
 
     if (stream) {

--- a/src/smf/nas-path.c
+++ b/src/smf/nas-path.c
@@ -30,9 +30,17 @@ void nas_5gs_send_to_gsm(
 
     e = smf_event_new(SMF_EVT_5GSM_MESSAGE);
     ogs_assert(e);
+
     e->sess = sess;
-    e->h.sbi.data = stream;
     e->pkbuf = pkbuf;
+
+    if (stream) {
+        ogs_pool_id_t stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+        e->h.sbi.data = OGS_UINT_TO_POINTER(stream_id);;
+    }
+
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
         ogs_error("ogs_queue_push() failed:%d", (int)rv);

--- a/src/smf/ngap-handler.c
+++ b/src/smf/ngap-handler.c
@@ -46,7 +46,7 @@ int ngap_handle_pdu_session_resource_setup_response_transfer(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("PDUSessionResourceSetupResponseTransfer");
@@ -185,7 +185,7 @@ int ngap_handle_pdu_session_resource_setup_unsuccessful_transfer(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("PDUSessionResourceSetupUnsuccessfulTransfer");
@@ -285,7 +285,7 @@ int ngap_handle_pdu_session_resource_modify_response_transfer(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("PDUSessionResourceModifyResponseTransfer");
@@ -390,7 +390,7 @@ int ngap_handle_path_switch_request_transfer(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("PathSwitchRequestTransfer");
@@ -517,7 +517,7 @@ int ngap_handle_handover_required_transfer(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("HandoverRequiredTransfer");
@@ -569,7 +569,7 @@ int ngap_handle_handover_request_ack(
     ogs_assert(stream);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("HandoverRequestAcknowledgeTransfer");

--- a/src/smf/ngap-path.c
+++ b/src/smf/ngap-path.c
@@ -30,7 +30,7 @@ void ngap_send_to_n2sm(smf_sess_t *sess,
 
     e = smf_event_new(SMF_EVT_NGAP_MESSAGE);
     ogs_assert(e);
-    e->sess = sess;
+    e->sess_id = sess->id;
     e->pkbuf = pkbuf;
     e->ngap.type = type;
 

--- a/src/smf/ngap-path.c
+++ b/src/smf/ngap-path.c
@@ -31,9 +31,16 @@ void ngap_send_to_n2sm(smf_sess_t *sess,
     e = smf_event_new(SMF_EVT_NGAP_MESSAGE);
     ogs_assert(e);
     e->sess = sess;
-    e->h.sbi.data = stream;
     e->pkbuf = pkbuf;
     e->ngap.type = type;
+
+    if (stream) {
+        ogs_pool_id_t stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+        e->h.sbi.data = OGS_UINT_TO_POINTER(stream_id);;
+    }
+
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
         ogs_error("ogs_queue_push() failed:%d", (int)rv);

--- a/src/smf/npcf-build.c
+++ b/src/smf/npcf-build.c
@@ -38,7 +38,7 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
     ogs_assert(sess);
     ogs_assert(sess->sm_context_ref);
     ogs_assert(sess->session.name);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     memset(&message, 0, sizeof(message));
@@ -301,7 +301,7 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_delete(
 
     ogs_assert(sess);
     ogs_assert(sess->sm_context_ref);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(sess->policy_association.resource_uri);
 

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -304,7 +304,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_assert(recvmsg);
@@ -699,7 +699,7 @@ bool smf_npcf_smpolicycontrol_handle_update_notify(
 
     ogs_assert(sess);
     ogs_assert(stream);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_assert(recvmsg);
@@ -748,7 +748,7 @@ bool smf_npcf_smpolicycontrol_handle_terminate_notify(
 
     ogs_assert(sess);
     ogs_assert(stream);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_assert(recvmsg);

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -49,7 +49,7 @@ bool smf_nsmf_handle_create_sm_context(
     ogs_assert(message);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     SmContextCreateData = message->SmContextCreateData;
@@ -398,7 +398,7 @@ bool smf_nsmf_handle_update_sm_context(
     ogs_assert(message);
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     SmContextUpdateData = message->SmContextUpdateData;
@@ -818,7 +818,7 @@ bool smf_nsmf_handle_release_sm_context(
     ogs_assert(stream);
     ogs_assert(message);
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     memset(&param, 0, sizeof(param));

--- a/src/smf/nudm-build.c
+++ b/src/smf/nudm-build.c
@@ -26,7 +26,7 @@ ogs_sbi_request_t *smf_nudm_sdm_build_get(smf_sess_t *sess, void *data)
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(smf_ue->supi);
 
@@ -62,7 +62,7 @@ ogs_sbi_request_t *smf_nudm_uecm_build_registration(
 
     ogs_assert(sess);
     ogs_assert(sess->psi);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(smf_ue->supi);
 
@@ -123,7 +123,7 @@ ogs_sbi_request_t *smf_nudm_uecm_build_deregistration(
 
     ogs_assert(sess);
     ogs_assert(sess->psi);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(smf_ue->supi);
 

--- a/src/smf/nudm-handler.c
+++ b/src/smf/nudm-handler.c
@@ -53,7 +53,7 @@ bool smf_nudm_sdm_handle_get(smf_sess_t *sess, ogs_sbi_stream_t *stream,
 
     ogs_assert(sess);
     ogs_assert(stream);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -230,7 +230,10 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
     smf_ue = sess->smf_ue;
     ogs_assert(smf_ue);
 
-    stream = xact->assoc_stream;
+    if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+            xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+        stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
+
     type = xact->seq[0].type;
 
     switch (type) {
@@ -486,7 +489,12 @@ int smf_5gc_pfcp_send_all_pdr_modification_request(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
+
     xact->local_seid = sess->smf_n4_seid;
     xact->modify_flags = flags | OGS_PFCP_MODIFY_SESSION;
 
@@ -516,7 +524,12 @@ int smf_5gc_pfcp_send_qos_flow_list_modification_request(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
+
     xact->local_seid = sess->smf_n4_seid;
     xact->modify_flags = flags | OGS_PFCP_MODIFY_SESSION;
 
@@ -544,7 +557,12 @@ int smf_5gc_pfcp_send_session_deletion_request(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
+
     xact->delete_trigger = trigger;
     xact->local_seid = sess->smf_n4_seid;
 

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -210,6 +210,7 @@ void smf_pfcp_close(void)
 
 static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     smf_ue_t *smf_ue = NULL;
     smf_sess_t *sess = NULL;
     ogs_sbi_stream_t *stream = NULL;
@@ -222,19 +223,22 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
     ogs_assert(xact);
     ogs_assert(data);
 
-    sess = smf_sess_cycle(data);
-    if (!sess) {
-        ogs_warn("Session has already been removed");
-        return;
-    }
-    smf_ue = sess->smf_ue;
-    ogs_assert(smf_ue);
-
     if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
             xact->assoc_stream_id <= OGS_MAX_POOL_ID)
         stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
 
     type = xact->seq[0].type;
+
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = smf_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+    ogs_assert(smf_ue);
 
     switch (type) {
     case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
@@ -242,7 +246,7 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
 
         e = smf_event_new(SMF_EVT_N4_TIMER);
         ogs_assert(e);
-        e->sess = sess;
+        e->sess_id = sess->id;
         e->h.timer_id = SMF_TIMER_PFCP_NO_ESTABLISHMENT_RESPONSE;
         e->pfcp_node = sess->pfcp_node;
 
@@ -301,7 +305,7 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
            removal from pfcp-sm state machine. */
         e = smf_event_new(SMF_EVT_N4_TIMER);
         ogs_assert(e);
-        e->sess = sess;
+        e->sess_id = sess->id;
         e->h.timer_id = SMF_TIMER_PFCP_NO_DELETION_RESPONSE;
         e->pfcp_node = sess->pfcp_node;
 
@@ -319,10 +323,22 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
 
 static void sess_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
+    smf_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     uint8_t type;
 
     ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = smf_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
 
     switch (type) {
     case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
@@ -342,10 +358,22 @@ static void sess_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 
 static void bearer_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
+    smf_bearer_t *bearer = NULL;
+    ogs_pool_id_t bearer_id = OGS_INVALID_POOL_ID;
     uint8_t type;
 
     ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    bearer_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(bearer_id >= OGS_MIN_POOL_ID && bearer_id <= OGS_MAX_POOL_ID);
+
+    bearer = smf_bearer_find_by_id(bearer_id);
+    if (!bearer) {
+        ogs_error("Bearer has already been removed [%d]", type);
+        return;
+    }
 
     switch (type) {
     case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
@@ -410,7 +438,8 @@ int smf_5gc_pfcp_send_session_establishment_request(
 
     ogs_assert(sess);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_5gc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_5gc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
@@ -483,7 +512,8 @@ int smf_5gc_pfcp_send_all_pdr_modification_request(
     if ((flags & OGS_PFCP_MODIFY_ERROR_INDICATION) == 0)
         ogs_assert(stream);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_5gc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_5gc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
@@ -518,7 +548,8 @@ int smf_5gc_pfcp_send_qos_flow_list_modification_request(
 
     ogs_assert(sess);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_5gc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_5gc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
@@ -551,7 +582,8 @@ int smf_5gc_pfcp_send_session_deletion_request(
     ogs_assert(sess);
     ogs_assert(trigger);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_5gc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_5gc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
@@ -589,7 +621,7 @@ int smf_5gc_pfcp_send_session_deletion_request(
 }
 
 int smf_epc_pfcp_send_session_establishment_request(
-        smf_sess_t *sess, void *gtp_xact, uint64_t flags)
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id, uint64_t flags)
 {
     int rv;
     ogs_pkbuf_t *n4buf = NULL;
@@ -598,14 +630,15 @@ int smf_epc_pfcp_send_session_establishment_request(
 
     ogs_assert(sess);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_epc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_epc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
     }
 
     xact->epc = true; /* EPC PFCP transaction */
-    xact->assoc_xact = gtp_xact;
+    xact->assoc_xact_id = gtp_xact_id;
     xact->local_seid = sess->smf_n4_seid;
     xact->create_flags = flags;
 
@@ -662,7 +695,7 @@ int smf_epc_pfcp_send_session_establishment_request(
 }
 
 int smf_epc_pfcp_send_all_pdr_modification_request(
-        smf_sess_t *sess, void *gtp_xact, ogs_pkbuf_t *gtpbuf,
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id, ogs_pkbuf_t *gtpbuf,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause)
 {
     int rv;
@@ -671,14 +704,15 @@ int smf_epc_pfcp_send_all_pdr_modification_request(
 
     ogs_assert(sess);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_epc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_epc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
     }
 
     xact->epc = true; /* EPC PFCP transaction */
-    xact->assoc_xact = gtp_xact;
+    xact->assoc_xact_id = gtp_xact_id;
     xact->local_seid = sess->smf_n4_seid;
     xact->modify_flags = flags | OGS_PFCP_MODIFY_SESSION;
 
@@ -704,7 +738,7 @@ int smf_epc_pfcp_send_all_pdr_modification_request(
 }
 
 int smf_epc_pfcp_send_one_bearer_modification_request(
-        smf_bearer_t *bearer, void *gtp_xact,
+        smf_bearer_t *bearer, ogs_pool_id_t gtp_xact_id,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause)
 {
     int rv;
@@ -712,18 +746,19 @@ int smf_epc_pfcp_send_one_bearer_modification_request(
     smf_sess_t *sess = NULL;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     xact = ogs_pfcp_xact_local_create(
-            sess->pfcp_node, bearer_epc_timeout, bearer);
+            sess->pfcp_node, bearer_epc_timeout,
+            OGS_UINT_TO_POINTER(bearer->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
     }
 
     xact->epc = true; /* EPC PFCP transaction */
-    xact->assoc_xact = gtp_xact;
+    xact->assoc_xact_id = gtp_xact_id;
     xact->local_seid = sess->smf_n4_seid;
     xact->modify_flags = flags;
 
@@ -741,7 +776,7 @@ int smf_epc_pfcp_send_one_bearer_modification_request(
 }
 
 int smf_epc_pfcp_send_session_deletion_request(
-        smf_sess_t *sess, void *gtp_xact)
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id)
 {
     int rv;
     ogs_pkbuf_t *n4buf = NULL;
@@ -750,7 +785,8 @@ int smf_epc_pfcp_send_session_deletion_request(
 
     ogs_assert(sess);
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_epc_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_epc_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;
@@ -779,7 +815,7 @@ int smf_epc_pfcp_send_session_deletion_request(
      * - Bearer Resource Command
      * - Delete Bearer Request/Response with DEDICATED BEARER.
      */
-    xact->assoc_xact = gtp_xact;
+    xact->assoc_xact_id = gtp_xact_id;
     xact->local_seid = sess->smf_n4_seid;
 
     memset(&h, 0, sizeof(ogs_pfcp_header_t));
@@ -811,7 +847,7 @@ int smf_epc_pfcp_send_deactivation(smf_sess_t *sess, uint8_t gtp_cause)
     smf_sess_t *eutran_sess = NULL, *wlan_sess = NULL;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     switch (gtp_cause) {
@@ -830,7 +866,7 @@ int smf_epc_pfcp_send_deactivation(smf_sess_t *sess, uint8_t gtp_cause)
 
         /* Deactivate WLAN Session */
         rv = smf_epc_pfcp_send_all_pdr_modification_request(
-                wlan_sess, NULL, NULL,
+                wlan_sess, OGS_INVALID_POOL_ID, NULL,
                 OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                 OGS_GTP2_CAUSE_ACCESS_CHANGED_FROM_NON_3GPP_TO_3GPP);
@@ -853,7 +889,7 @@ int smf_epc_pfcp_send_deactivation(smf_sess_t *sess, uint8_t gtp_cause)
 
             /* Deactivate EUTRAN Session */
             rv = smf_epc_pfcp_send_all_pdr_modification_request(
-                    eutran_sess, NULL, NULL,
+                    eutran_sess, OGS_INVALID_POOL_ID, NULL,
                     OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
                     OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                     OGS_GTP2_CAUSE_RAT_CHANGED_FROM_3GPP_TO_NON_3GPP);

--- a/src/smf/pfcp-path.h
+++ b/src/smf/pfcp-path.h
@@ -47,15 +47,15 @@ int smf_5gc_pfcp_send_session_deletion_request(
         smf_sess_t *sess, ogs_sbi_stream_t *stream, int trigger);
 
 int smf_epc_pfcp_send_session_establishment_request(
-        smf_sess_t *sess, void *gtp_xact, uint64_t flags);
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id, uint64_t flags);
 int smf_epc_pfcp_send_all_pdr_modification_request(
-        smf_sess_t *sess, void *gtp_xact, ogs_pkbuf_t *gtpbuf,
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id, ogs_pkbuf_t *gtpbuf,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause);
 int smf_epc_pfcp_send_one_bearer_modification_request(
-        smf_bearer_t *bearer, void *gtp_xact,
+        smf_bearer_t *bearer, ogs_pool_id_t gtp_xact_id,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause);
 int smf_epc_pfcp_send_session_deletion_request(
-        smf_sess_t *sess, void *gtp_xact);
+        smf_sess_t *sess, ogs_pool_id_t gtp_xact_id);
 
 int smf_epc_pfcp_send_deactivation(smf_sess_t *sess, uint8_t gtp_cause);
 

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -117,7 +117,7 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
             ogs_pfcp_cp_send_association_setup_request(node, node_timeout);
             break;
         case SMF_TIMER_PFCP_NO_ESTABLISHMENT_RESPONSE:
-            sess = smf_sess_cycle(e->sess);
+            sess = smf_sess_find_by_id(e->sess_id);
             if (!sess) {
                 ogs_warn("Session has already been removed");
                 break;
@@ -125,7 +125,7 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case SMF_TIMER_PFCP_NO_DELETION_RESPONSE:
-            sess = smf_sess_cycle(e->sess);
+            sess = smf_sess_find_by_id(e->sess_id);
             if (!sess) {
                 ogs_warn("Session has already been removed");
                 break;
@@ -141,7 +141,7 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
     case SMF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         switch (message->h.type) {
@@ -223,7 +223,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
     case SMF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         if (message->h.seid_presence && message->h.seid != 0) {
@@ -237,7 +237,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             sess = smf_sess_find_by_seid(xact->local_seid);
         }
         if (sess)
-            e->sess = sess;
+            e->sess_id = sess->id;
 
         switch (message->h.type) {
         case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:
@@ -313,7 +313,8 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             if (!message->h.seid_presence) ogs_error("No SEID");
 
             if (!sess) {
-                ogs_gtp_xact_t *gtp_xact = xact->assoc_xact;
+                ogs_gtp_xact_t *gtp_xact =
+                    ogs_gtp_xact_find_by_id(xact->assoc_xact_id);
                 ogs_error("No Session");
                 if (!gtp_xact) {
                     ogs_error("No associated GTP transaction");
@@ -348,7 +349,8 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             if (!message->h.seid_presence) ogs_error("No SEID");
 
             if (!sess) {
-                ogs_gtp_xact_t *gtp_xact = xact->assoc_xact;
+                ogs_gtp_xact_t *gtp_xact =
+                    ogs_gtp_xact_find_by_id(xact->assoc_xact_id);
                 ogs_error("No Session");
                 if (!gtp_xact) {
                     ogs_error("No associated GTP transaction");
@@ -397,7 +399,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                 ogs_pfcp_send_heartbeat_request(node, node_timeout));
             break;
         case SMF_TIMER_PFCP_NO_ESTABLISHMENT_RESPONSE:
-            sess = smf_sess_cycle(e->sess);
+            sess = smf_sess_find_by_id(e->sess_id);
             if (!sess) {
                 ogs_warn("Session has already been removed");
                 break;
@@ -405,7 +407,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case SMF_TIMER_PFCP_NO_DELETION_RESPONSE:
-            sess = smf_sess_cycle(e->sess);
+            sess = smf_sess_find_by_id(e->sess_id);
             if (!sess) {
                 ogs_warn("Session has already been removed");
                 break;
@@ -482,7 +484,7 @@ static void pfcp_restoration(ogs_pfcp_node_t *node)
                             OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
                     ogs_assert(OGS_OK ==
                         smf_epc_pfcp_send_session_establishment_request(
-                            sess, NULL,
+                            sess, OGS_INVALID_POOL_ID,
                             OGS_PFCP_CREATE_RESTORATION_INDICATION));
                 } else {
                     ogs_info("UE SUPI[%s] DNN[%s] IPv4[%s] IPv6[%s]",

--- a/src/smf/s5c-build.c
+++ b/src/smf/s5c-build.c
@@ -337,7 +337,7 @@ ogs_pkbuf_t *smf_s5c_build_modify_bearer_response(
     smf_bearer_t *bearer = NULL;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(req);
 
@@ -410,7 +410,7 @@ ogs_pkbuf_t *smf_s5c_build_create_bearer_request(
     char tft_buf[OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE];
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
     linked_bearer = smf_default_bearer_in_sess(sess);
     ogs_assert(linked_bearer);
@@ -489,7 +489,7 @@ ogs_pkbuf_t *smf_s5c_build_update_bearer_request(
     char tft_buf[OGS_GTP2_MAX_TRAFFIC_FLOW_TEMPLATE];
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
 
     ogs_debug("[SMF] Update Bearer Request");
@@ -567,7 +567,7 @@ ogs_pkbuf_t *smf_s5c_build_delete_bearer_request(
     ogs_gtp2_cause_t cause;
 
     ogs_assert(bearer);
-    sess = bearer->sess;
+    sess = smf_sess_find_by_id(bearer->sess_id);
     ogs_assert(sess);
     linked_bearer = smf_default_bearer_in_sess(sess);
     ogs_assert(linked_bearer);

--- a/src/smf/s6b-path.c
+++ b/src/smf/s6b-path.c
@@ -26,7 +26,7 @@ struct sess_state {
     smf_sess_t *sess;
     os0_t       s6b_sid;             /* S6B Session-Id */
 
-    ogs_gtp_xact_t *xact;
+    ogs_pool_id_t xact_id;
 
     struct timespec ts; /* Time of sending the message */
 };
@@ -102,7 +102,7 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
 
     ogs_assert(xact);
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("[AA-Request]");
@@ -165,7 +165,7 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
 
     /* Update session state */
     sess_data->sess = sess;
-    sess_data->xact = xact;
+    sess_data->xact_id = xact ? xact->id : OGS_INVALID_POOL_ID;
 
     /* Set Origin-Host & Origin-Realm */
     ret = fd_msg_add_origin(req, 0);
@@ -346,7 +346,6 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
     int new;
 
     smf_sess_t *sess = NULL;
-    ogs_gtp_xact_t *xact = NULL;
     smf_event_t *e = NULL;
     ogs_diam_s6b_message_t *s6b_message = NULL;
 
@@ -371,8 +370,6 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
 
     sess = sess_data->sess;
     ogs_assert(sess);
-    xact = sess_data->xact;
-    ogs_assert(xact);
 
     s6b_message = ogs_calloc(1, sizeof(ogs_diam_s6b_message_t));
     ogs_assert(s6b_message);
@@ -442,8 +439,8 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
     if (error && s6b_message->result_code == ER_DIAMETER_SUCCESS)
             s6b_message->result_code = error;
 
-    e->sess = sess;
-    e->gtp_xact = xact;
+    e->sess_id = sess->id;
+    e->gtp_xact_id = sess_data->xact_id;
     e->s6b_message = s6b_message;
     ret = ogs_queue_push(ogs_app()->queue, e);
     if (ret != OGS_OK) {
@@ -516,9 +513,8 @@ void smf_s6b_send_str(smf_sess_t *sess, ogs_gtp_xact_t *xact, uint32_t cause)
     smf_ue_t *smf_ue = NULL;
     char *user_name = NULL;
 
-    //ogs_assert(xact);
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_debug("[Session-Termination-Request]");
@@ -557,7 +553,7 @@ void smf_s6b_send_str(smf_sess_t *sess, ogs_gtp_xact_t *xact, uint32_t cause)
 
     /* Update session state */
     sess_data->sess = sess;
-    sess_data->xact = xact;
+    sess_data->xact_id = xact ? xact->id : OGS_INVALID_POOL_ID;
 
     /* Set Origin-Host & Origin-Realm */
     ret = fd_msg_add_origin(req, 0);
@@ -666,6 +662,7 @@ static void smf_s6b_sta_cb(void *data, struct msg **msg)
     ogs_debug("    Retrieve its data: [%s]", sess_data->s6b_sid);
 
     sess = sess_data->sess;
+    ogs_assert(sess);
 
     s6b_message = ogs_calloc(1, sizeof(ogs_diam_s6b_message_t));
     ogs_assert(s6b_message);
@@ -736,7 +733,7 @@ static void smf_s6b_sta_cb(void *data, struct msg **msg)
         e = smf_event_new(SMF_EVT_S6B_MESSAGE);
         ogs_assert(e);
 
-        e->sess = sess;
+        e->sess_id = sess->id;
         e->s6b_message = s6b_message;
         rv = ogs_queue_push(ogs_app()->queue, e);
         if (rv != OGS_OK) {

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -198,7 +198,7 @@ int smf_sbi_discover_and_send(
     }
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, service_type, discovery_option,
+            0, &sess->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("smf_sbi_discover_and_send() failed");
@@ -256,7 +256,7 @@ void smf_namf_comm_send_n1_n2_message_transfer(
             discovery_option, sess->serving_nf_id);
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, OGS_SBI_SERVICE_TYPE_NAMF_COMM, discovery_option,
+            0, &sess->sbi, OGS_SBI_SERVICE_TYPE_NAMF_COMM, discovery_option,
             (ogs_sbi_build_f)smf_namf_comm_build_n1_n2_message_transfer,
             sess, param);
     if (!xact) {

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -106,7 +106,7 @@ int smf_sbi_discover_and_send(
     target_nf_type = ogs_sbi_service_type_to_nf_type(service_type);
     ogs_assert(target_nf_type);
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
     ogs_assert(build);
 
@@ -198,7 +198,7 @@ int smf_sbi_discover_and_send(
     }
 
     xact = ogs_sbi_xact_add(
-            0, &sess->sbi, service_type, discovery_option,
+            sess->id, &sess->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("smf_sbi_discover_and_send() failed");
@@ -243,7 +243,7 @@ void smf_namf_comm_send_n1_n2_message_transfer(
     int r;
 
     ogs_assert(sess);
-    smf_ue = sess->smf_ue;
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
     ogs_assert(smf_ue);
 
     ogs_assert(param);
@@ -256,7 +256,8 @@ void smf_namf_comm_send_n1_n2_message_transfer(
             discovery_option, sess->serving_nf_id);
 
     xact = ogs_sbi_xact_add(
-            0, &sess->sbi, OGS_SBI_SERVICE_TYPE_NAMF_COMM, discovery_option,
+            sess->id, &sess->sbi, OGS_SBI_SERVICE_TYPE_NAMF_COMM,
+            discovery_option,
             (ogs_sbi_build_f)smf_namf_comm_build_n1_n2_message_transfer,
             sess, param);
     if (!xact) {

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -211,7 +211,12 @@ int smf_sbi_discover_and_send(
     }
 
     xact->state = state;
-    xact->assoc_stream = stream;
+
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
 
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -79,6 +79,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
     ogs_sbi_message_t sbi_message;
     ogs_sbi_xact_t *sbi_xact = NULL;
     ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
+    ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
 
     ogs_nas_5gs_message_t nas_message;
     ogs_pkbuf_t *pkbuf = NULL;
@@ -118,7 +119,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_pkbuf_free(recvbuf);
             break;
         }
-        e->gtp_xact = gtp_xact;
+        e->gtp_xact_id = gtp_xact ? gtp_xact->id : OGS_INVALID_POOL_ID;
 
         if (gtp2_message.h.teid_presence && gtp2_message.h.teid != 0) {
             sess = smf_sess_find_by_teid(gtp2_message.h.teid);
@@ -164,7 +165,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                     sess->sgw_s5c_teid,
                     gtp2_sender_f_teid.teid_presence, gtp2_sender_f_teid.teid);
 
-            e->sess = sess;
+            e->sess_id = sess->id;
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
@@ -192,7 +193,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                     break;
                 }
             }
-            e->sess = sess;
+            e->sess_id = sess->id;
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case OGS_GTP2_MODIFY_BEARER_REQUEST_TYPE:
@@ -218,7 +219,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 ogs_error("TODO: NACK the message");
                 break;
             }
-            e->sess = sess;
+            e->sess_id = sess->id;
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
@@ -260,7 +261,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_pkbuf_free(recvbuf);
             break;
         }
-        e->gtp_xact = gtp_xact;
+        e->gtp_xact_id = gtp_xact ? gtp_xact->id : OGS_INVALID_POOL_ID;
 
         switch(gtp1_message.h.type) {
         case OGS_GTP1_ECHO_REQUEST_TYPE:
@@ -284,7 +285,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                         OGS_GTP1_CAUSE_CONTEXT_NOT_FOUND);
                 break;
             }
-            e->sess = sess;
+            e->sess_id = sess->id;
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case OGS_GTP1_DELETE_PDP_CONTEXT_REQUEST_TYPE:
@@ -296,7 +297,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                         OGS_GTP1_CAUSE_NON_EXISTENT);
                 break;
             }
-            e->sess = sess;
+            e->sess_id = sess->id;
             ogs_fsm_dispatch(&sess->sm, e);
             break;
         case OGS_GTP1_UPDATE_PDP_CONTEXT_REQUEST_TYPE:
@@ -319,7 +320,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         gx_message = e->gx_message;
         ogs_assert(gx_message);
 
-        sess = e->sess;
+        sess = smf_sess_find_by_id(e->sess_id);
         ogs_assert(sess);
 
         switch(gx_message->cmd_code) {
@@ -354,7 +355,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         gy_message = e->gy_message;
         ogs_assert(gy_message);
 
-        sess = e->sess;
+        sess = smf_sess_find_by_id(e->sess_id);
         ogs_assert(sess);
 
         switch(gy_message->cmd_code) {
@@ -376,7 +377,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         ogs_assert(e);
         s6b_message = e->s6b_message;
         ogs_assert(s6b_message);
-        sess = e->sess;
+        sess = smf_sess_find_by_id(e->sess_id);
         ogs_assert(sess);
 
         switch(s6b_message->cmd_code) {
@@ -421,7 +422,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         }
 
         e->pfcp_message = pfcp_message;
-        e->pfcp_xact = pfcp_xact;
+        e->pfcp_xact_id = pfcp_xact ? pfcp_xact->id : OGS_INVALID_POOL_ID;
 
         e->gtp2_message = NULL;
         if (pfcp_xact->gtpbuf) {
@@ -579,11 +580,11 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 END
 
                 if (sess) {
-                    smf_ue = sess->smf_ue;
+                    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
                     ogs_assert(smf_ue);
                     ogs_assert(OGS_FSM_STATE(&sess->sm));
 
-                    e->sess = sess;
+                    e->sess_id = sess->id;
                     e->h.sbi.message = &sbi_message;
                     ogs_fsm_dispatch(&sess->sm, e);
                 }
@@ -824,8 +825,9 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 break;
             }
 
-            sess = (smf_sess_t *)sbi_xact->sbi_object;
-            ogs_assert(sess);
+            sbi_object_id = sbi_xact->sbi_object_id;
+            ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+                    sbi_object_id <= OGS_MAX_POOL_ID);
 
             if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
                 sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
@@ -835,16 +837,16 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
             ogs_sbi_xact_remove(sbi_xact);
 
-            sess = smf_sess_cycle(sess);
+            sess = smf_sess_find_by_id(sbi_object_id);
             if (!sess) {
                 ogs_error("Session has already been removed");
                 break;
             }
-            smf_ue = smf_ue_cycle(sess->smf_ue);
+            smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
             ogs_assert(smf_ue);
             ogs_assert(OGS_FSM_STATE(&sess->sm));
 
-            e->sess = sess;
+            e->sess_id = sess->id;
             e->h.sbi.message = &sbi_message;
 
             ogs_fsm_dispatch(&sess->sm, e);
@@ -867,8 +869,9 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 break;
             }
 
-            sess = (smf_sess_t *)sbi_xact->sbi_object;
-            ogs_assert(sess);
+            sbi_object_id = sbi_xact->sbi_object_id;
+            ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+                    sbi_object_id <= OGS_MAX_POOL_ID);
 
             if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
                 sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
@@ -879,12 +882,12 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
             ogs_sbi_xact_remove(sbi_xact);
 
-            sess = smf_sess_cycle(sess);
+            sess = smf_sess_find_by_id(sbi_object_id);
             if (!sess) {
                 ogs_error("Session has already been removed");
                 break;
             }
-            smf_ue = smf_ue_cycle(sess->smf_ue);
+            smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
             ogs_assert(smf_ue);
 
             if (state == SMF_UECM_STATE_REGISTERED) {
@@ -1055,8 +1058,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         break;
 
     case SMF_EVT_5GSM_MESSAGE:
-        sess = e->sess;
-        ogs_assert(sess);
         pkbuf = e->pkbuf;
         ogs_assert(pkbuf);
 
@@ -1066,8 +1067,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             return;
         }
 
-        ogs_assert(sess);
-        sess = smf_sess_cycle(sess);
+        sess = smf_sess_find_by_id(e->sess_id);
         if (!sess) {
             ogs_error("Session has already been removed");
             ogs_pkbuf_free(pkbuf);
@@ -1081,14 +1081,11 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         break;
 
     case SMF_EVT_NGAP_MESSAGE:
-        sess = e->sess;
-        ogs_assert(sess);
         pkbuf = e->pkbuf;
         ogs_assert(pkbuf);
         ogs_assert(e->ngap.type);
 
-        ogs_assert(sess);
-        sess = smf_sess_cycle(sess);
+        sess = smf_sess_find_by_id(e->sess_id);
         if (!sess) {
             ogs_error("Session has already been removed");
             ogs_pkbuf_free(pkbuf);

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -70,7 +70,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
     ogs_pfcp_message_t *pfcp_message = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *sbi_request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -78,7 +78,7 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
     ogs_sbi_response_t *sbi_response = NULL;
     ogs_sbi_message_t sbi_message;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     ogs_nas_5gs_message_t nas_message;
     ogs_pkbuf_t *pkbuf = NULL;

--- a/src/udm/context.h
+++ b/src/udm/context.h
@@ -46,6 +46,7 @@ typedef struct udm_context_s {
 
 struct udm_ue_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
     ogs_fsm_t sm;
 
     OpenAPI_auth_event_t *auth_event;
@@ -78,6 +79,7 @@ struct udm_ue_s {
 
 struct udm_sess_s {
     ogs_sbi_object_t sbi;
+    ogs_pool_id_t id;
     ogs_fsm_t sm;
 
     uint8_t psi; /* PDU Session Identity */
@@ -87,7 +89,7 @@ struct udm_sess_s {
     char *smf_instance_id;
 
     /* Related Context */
-    udm_ue_t *udm_ue;
+    ogs_pool_id_t udm_ue_id;
 };
 
 typedef struct udm_sdm_subscription_s {
@@ -118,8 +120,8 @@ void udm_sess_remove(udm_sess_t *sess);
 void udm_sess_remove_all(udm_ue_t *udm_ue);
 udm_sess_t *udm_sess_find_by_psi(udm_ue_t *udm_ue, uint8_t psi);
 
-udm_ue_t *udm_ue_cycle(udm_ue_t *udm_ue);
-udm_sess_t *udm_sess_cycle(udm_sess_t *sess);
+udm_ue_t *udm_ue_find_by_id(ogs_pool_id_t id);
+udm_sess_t *udm_sess_find_by_id(ogs_pool_id_t id);
 
 udm_sdm_subscription_t *udm_sdm_subscription_add(udm_ue_t *udm_ue);
 void udm_sdm_subscription_remove(udm_sdm_subscription_t *subscription);

--- a/src/udm/event.h
+++ b/src/udm/event.h
@@ -32,8 +32,8 @@ typedef struct udm_sess_s udm_sess_t;
 typedef struct udm_event_s {
     ogs_event_t h;
 
-    udm_ue_t *udm_ue;
-    udm_sess_t *sess;
+    ogs_pool_id_t udm_ue_id;
+    ogs_pool_id_t sess_id;
 } udm_event_t;
 
 OGS_STATIC_ASSERT(OGS_EVENT_SIZE >= sizeof(udm_event_t));

--- a/src/udm/nnrf-handler.c
+++ b/src/udm/nnrf-handler.c
@@ -25,6 +25,7 @@ void udm_nnrf_handle_nf_discover(
 {
     ogs_sbi_nf_instance_t *nf_instance = NULL;
     ogs_sbi_object_t *sbi_object = NULL;
+    ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
 
@@ -46,6 +47,10 @@ void udm_nnrf_handle_nf_discover(
     requester_nf_type = xact->requester_nf_type;
     ogs_assert(requester_nf_type);
 
+    sbi_object_id = xact->sbi_object_id;
+    ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+            sbi_object_id <= OGS_MAX_POOL_ID);
+
     discovery_option = xact->discovery_option;
 
     SearchResult = recvmsg->SearchResult;
@@ -55,12 +60,12 @@ void udm_nnrf_handle_nf_discover(
     }
 
     if (sbi_object->type == OGS_SBI_OBJ_UE_TYPE) {
-        udm_ue = (udm_ue_t *)sbi_object;
+        udm_ue = udm_ue_find_by_id(sbi_object_id);
         ogs_assert(udm_ue);
     } else if (sbi_object->type == OGS_SBI_OBJ_SESS_TYPE) {
-        sess = (udm_sess_t *)sbi_object;
+        sess = udm_sess_find_by_id(sbi_object_id);
         ogs_assert(sess);
-        udm_ue = sess->udm_ue;
+        udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
         ogs_assert(udm_ue);
     } else {
         ogs_fatal("(NF discover) Not implemented [%s:%d]",

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -530,7 +530,7 @@ bool udm_nudm_uecm_handle_smf_registration(
     ogs_assert(message);
 
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     SmfRegistration = message->SmfRegistration;
@@ -604,7 +604,7 @@ bool udm_nudm_uecm_handle_smf_deregistration(
     ogs_assert(message);
 
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     r = udm_sess_sbi_discover_and_send(OGS_SBI_SERVICE_TYPE_NUDR_DR, NULL,

--- a/src/udm/nudr-build.c
+++ b/src/udm/nudr-build.c
@@ -256,7 +256,7 @@ ogs_sbi_request_t *udm_nudr_dr_build_update_smf_context(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     memset(&message, 0, sizeof(message));
@@ -301,7 +301,7 @@ ogs_sbi_request_t *udm_nudr_dr_build_delete_smf_context(
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     memset(&message, 0, sizeof(message));

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -754,7 +754,7 @@ bool udm_nudr_dr_handle_smf_registration(
     int status;
 
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);

--- a/src/udm/sbi-path.c
+++ b/src/udm/sbi-path.c
@@ -119,7 +119,11 @@ static int udm_sbi_discover_and_send(
         return OGS_ERROR;
     }
 
-    xact->assoc_stream = stream;
+    if (stream) {
+        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
+        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+    }
 
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {

--- a/src/udm/sbi-path.c
+++ b/src/udm/sbi-path.c
@@ -112,7 +112,7 @@ static int udm_sbi_discover_and_send(
     ogs_assert(build);
 
     xact = ogs_sbi_xact_add(
-            sbi_object, service_type, discovery_option,
+            0, sbi_object, service_type, discovery_option,
             (ogs_sbi_build_f)build, context, data);
     if (!xact) {
         ogs_error("udm_sbi_discover_and_send() failed");

--- a/src/udm/sbi-path.c
+++ b/src/udm/sbi-path.c
@@ -97,6 +97,7 @@ bool udm_sbi_send_request(
 }
 
 static int udm_sbi_discover_and_send(
+        ogs_pool_id_t sbi_object_id,
         ogs_sbi_object_t *sbi_object,
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
@@ -111,8 +112,11 @@ static int udm_sbi_discover_and_send(
     ogs_assert(stream);
     ogs_assert(build);
 
+    ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+            sbi_object_id <= OGS_MAX_POOL_ID);
+
     xact = ogs_sbi_xact_add(
-            0, sbi_object, service_type, discovery_option,
+            sbi_object_id, sbi_object, service_type, discovery_option,
             (ogs_sbi_build_f)build, context, data);
     if (!xact) {
         ogs_error("udm_sbi_discover_and_send() failed");
@@ -143,9 +147,11 @@ int udm_ue_sbi_discover_and_send(
 {
     int r;
 
+    ogs_assert(udm_ue->id >= OGS_MIN_POOL_ID && udm_ue->id <= OGS_MAX_POOL_ID);
+
     r = udm_sbi_discover_and_send(
-                &udm_ue->sbi, service_type, discovery_option,
-                (ogs_sbi_build_f)build, udm_ue, stream, data);
+            udm_ue->id, &udm_ue->sbi, service_type, discovery_option,
+            (ogs_sbi_build_f)build, udm_ue, stream, data);
     if (r != OGS_OK) {
         ogs_error("udm_ue_sbi_discover_and_send() failed");
         ogs_assert(true ==
@@ -166,9 +172,11 @@ int udm_sess_sbi_discover_and_send(
 {
     int r;
 
+    ogs_assert(sess->id >= OGS_MIN_POOL_ID && sess->id <= OGS_MAX_POOL_ID);
+
     r = udm_sbi_discover_and_send(
-                &sess->sbi, service_type, discovery_option,
-                (ogs_sbi_build_f)build, sess, stream, data);
+            sess->id, &sess->sbi, service_type, discovery_option,
+            (ogs_sbi_build_f)build, sess, stream, data);
     if (r != OGS_OK) {
         ogs_error("udm_sess_sbi_discover_and_send() failed");
         ogs_assert(true ==

--- a/src/udm/sess-sm.c
+++ b/src/udm/sess-sm.c
@@ -40,6 +40,7 @@ void udm_sess_state_operational(ogs_fsm_t *s, udm_event_t *e)
     udm_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);
@@ -62,8 +63,16 @@ void udm_sess_state_operational(ogs_fsm_t *s, udm_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_UECM)
@@ -112,8 +121,16 @@ void udm_sess_state_operational(ogs_fsm_t *s, udm_event_t *e)
     case OGS_EVENT_SBI_CLIENT:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDR_DR)

--- a/src/udm/sess-sm.c
+++ b/src/udm/sess-sm.c
@@ -48,9 +48,9 @@ void udm_sess_state_operational(ogs_fsm_t *s, udm_event_t *e)
 
     udm_sm_debug(e);
 
-    sess = e->sess;
+    sess = udm_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     switch (e->h.id) {
@@ -179,9 +179,9 @@ void udm_sess_state_exception(ogs_fsm_t *s, udm_event_t *e)
 
     udm_sm_debug(e);
 
-    sess = e->sess;
+    sess = udm_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    udm_ue = sess->udm_ue;
+    udm_ue = udm_ue_find_by_id(sess->udm_ue_id);
     ogs_assert(udm_ue);
 
     switch (e->h.id) {

--- a/src/udm/sess-sm.c
+++ b/src/udm/sess-sm.c
@@ -40,7 +40,7 @@ void udm_sess_state_operational(ogs_fsm_t *s, udm_event_t *e)
     udm_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
 
     ogs_assert(s);

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -47,6 +47,7 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
+    ogs_pool_id_t sbi_xact_id = 0;
 
     udm_ue_t *udm_ue = NULL;
     udm_sess_t *sess = NULL;
@@ -337,8 +338,17 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_DISC)
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
+
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
+                if (!sbi_xact) {
+                    /* CLIENT_WAIT timer could remove SBI transaction
+                     * before receiving SBI message */
+                    ogs_error("SBI transaction has already been removed");
+                    break;
+                }
 
                 SWITCH(message.h.method)
                 CASE(OGS_SBI_HTTP_METHOD_GET)
@@ -367,10 +377,11 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             CASE(OGS_SBI_RESOURCE_NAME_SUBSCRIPTION_DATA)
                 SWITCH(message.h.resource.component[3])
                 CASE(OGS_SBI_RESOURCE_NAME_SMF_REGISTRATIONS)
-                    sbi_xact = e->h.sbi.data;
-                    ogs_assert(sbi_xact);
+                    sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                    ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                            sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                    sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                    sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
@@ -409,10 +420,11 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                     break;
 
                 DEFAULT
-                    sbi_xact = e->h.sbi.data;
-                    ogs_assert(sbi_xact);
+                    sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                    ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                            sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                    sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                    sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
@@ -534,9 +546,13 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
              * 4. timer expiration event is processed. (double-free SBI xact)
              *
              * To avoid double-free SBI xact,
-             * we need to check ogs_sbi_xact_cycle()
+             * we need to check ogs_sbi_xact_find_by_id()
              */
-            sbi_xact = ogs_sbi_xact_cycle(e->h.sbi.data);
+            sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+            ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact_id <= OGS_MAX_POOL_ID);
+
+            sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
                 ogs_error("SBI transaction has already been removed");
                 break;

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -40,7 +40,7 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     const char *api_version = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -48,7 +48,7 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
-    ogs_pool_id_t sbi_xact_id = 0;
+    ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
 
     udm_ue_t *udm_ue = NULL;
     udm_sess_t *sess = NULL;

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,6 +40,7 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     const char *api_version = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -66,8 +67,16 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {
@@ -346,7 +355,8 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
-                    ogs_error("SBI transaction has already been removed");
+                    ogs_error("SBI transaction has already been removed [%d]",
+                            sbi_xact_id);
                     break;
                 }
 
@@ -385,14 +395,19 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
-                        ogs_error("SBI transaction has already been removed");
+                        ogs_error(
+                                "SBI transaction has already been removed [%d]",
+                                sbi_xact_id);
                         break;
                     }
 
                     sess = (udm_sess_t *)sbi_xact->sbi_object;
                     ogs_assert(sess);
 
-                    e->h.sbi.data = sbi_xact->assoc_stream;
+                    if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                        e->h.sbi.data =
+                            OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
 
                     ogs_sbi_xact_remove(sbi_xact);
 
@@ -428,14 +443,19 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                     if (!sbi_xact) {
                         /* CLIENT_WAIT timer could remove SBI transaction
                          * before receiving SBI message */
-                        ogs_error("SBI transaction has already been removed");
+                        ogs_error(
+                                "SBI transaction has already been removed [%d]",
+                                sbi_xact_id);
                         break;
                     }
 
                     udm_ue = (udm_ue_t *)sbi_xact->sbi_object;
                     ogs_assert(udm_ue);
 
-                    e->h.sbi.data = sbi_xact->assoc_stream;
+                    if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                        e->h.sbi.data =
+                            OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
 
                     ogs_sbi_xact_remove(sbi_xact);
 
@@ -554,16 +574,24 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
 
             sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
-                ogs_error("SBI transaction has already been removed");
+                ogs_error("SBI transaction has already been removed [%d]",
+                        sbi_xact_id);
                 break;
             }
 
-            stream = sbi_xact->assoc_stream;
-            ogs_assert(stream);
+            ogs_assert(sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+            stream = ogs_sbi_stream_find_by_id(sbi_xact->assoc_stream_id);
 
             ogs_sbi_xact_remove(sbi_xact);
 
             ogs_error("Cannot receive SBI message");
+
+            if (!stream) {
+                ogs_error("STREAM has alreadt been removed [%d]",
+                        sbi_xact->assoc_stream_id);
+                break;
+            }
             ogs_assert(true ==
                 ogs_sbi_server_send_error(stream,
                     OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT, NULL,

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -38,7 +38,7 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
     udm_ue_t *udm_ue = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_message_t *message = NULL;
     int r;
 

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -38,6 +38,7 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
     udm_ue_t *udm_ue = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_message_t *message = NULL;
     int r;
 
@@ -59,8 +60,16 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         message = e->h.sbi.message;
         ogs_assert(message);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDM_UEAU)
@@ -266,8 +275,16 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
 
         udm_ue = e->udm_ue;
         ogs_assert(udm_ue);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         SWITCH(message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NUDR_DR)

--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -47,7 +47,7 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
 
     udm_sm_debug(e);
 
-    udm_ue = e->udm_ue;
+    udm_ue = udm_ue_find_by_id(e->udm_ue_id);
     ogs_assert(udm_ue);
 
     switch (e->h.id) {
@@ -273,7 +273,7 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
         message = e->h.sbi.message;
         ogs_assert(message);
 
-        udm_ue = e->udm_ue;
+        udm_ue = udm_ue_find_by_id(e->udm_ue_id);
         ogs_assert(udm_ue);
 
         stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
@@ -346,7 +346,7 @@ void udm_ue_state_exception(ogs_fsm_t *s, udm_event_t *e)
 
     udm_sm_debug(e);
 
-    udm_ue = e->udm_ue;
+    udm_ue = udm_ue_find_by_id(e->udm_ue_id);
     ogs_assert(udm_ue);
 
     switch (e->h.id) {

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -41,7 +41,7 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
-    ogs_pool_id_t stream_id = 0;
+    ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -41,6 +41,7 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
     int rv;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -62,8 +63,16 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -175,9 +175,8 @@ upf_sess_t *upf_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
 
     ogs_assert(cp_f_seid);
 
-    ogs_pool_alloc(&upf_sess_pool, &sess);
+    ogs_pool_id_calloc(&upf_sess_pool, &sess);
     ogs_assert(sess);
-    memset(sess, 0, sizeof *sess);
 
     ogs_pfcp_pool_init(&sess->pfcp);
 
@@ -244,7 +243,7 @@ int upf_sess_remove(upf_sess_t *sess)
     ogs_pfcp_pool_final(&sess->pfcp);
 
     ogs_pool_free(&upf_n4_seid_pool, sess->upf_n4_seid_node);
-    ogs_pool_free(&upf_sess_pool, sess);
+    ogs_pool_id_free(&upf_sess_pool, sess);
     if (sess->apn_dnn)
         ogs_free(sess->apn_dnn);
     upf_metrics_inst_global_dec(UPF_METR_GLOB_GAUGE_UPF_SESSIONNBR);
@@ -350,6 +349,11 @@ upf_sess_t *upf_sess_find_by_ipv6(uint32_t *addr6)
             trie = trie->left;
     }
     return ret;
+}
+
+upf_sess_t *upf_sess_find_by_id(ogs_pool_id_t id)
+{
+    return ogs_pool_find_by_id(&upf_sess_pool, id);
 }
 
 upf_sess_t *upf_sess_add_by_message(ogs_pfcp_message_t *message)

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -100,6 +100,7 @@ typedef struct upf_sess_urr_acc_s {
 #define UPF_SESS(pfcp_sess) ogs_container_of(pfcp_sess, upf_sess_t, pfcp)
 typedef struct upf_sess_s {
     ogs_lnode_t     lnode;
+    ogs_pool_id_t   id;
     ogs_pool_id_t   *upf_n4_seid_node;  /* A node of UPF-N4-SEID */
 
     ogs_pfcp_sess_t pfcp;
@@ -141,6 +142,7 @@ upf_sess_t *upf_sess_find_by_smf_n4_f_seid(ogs_pfcp_f_seid_t *f_seid);
 upf_sess_t *upf_sess_find_by_upf_n4_seid(uint64_t seid);
 upf_sess_t *upf_sess_find_by_ipv4(uint32_t addr);
 upf_sess_t *upf_sess_find_by_ipv6(uint32_t *addr6);
+upf_sess_t *upf_sess_find_by_id(ogs_pool_id_t id);
 
 uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
         uint8_t session_type, ogs_pfcp_pdr_t *pdr);

--- a/src/upf/event.h
+++ b/src/upf/event.h
@@ -49,7 +49,7 @@ typedef struct upf_event_s {
     ogs_pkbuf_t *pkbuf;
 
     ogs_pfcp_node_t *pfcp_node;
-    ogs_pfcp_xact_t *pfcp_xact;
+    ogs_pool_id_t pfcp_xact_id;
     ogs_pfcp_message_t *pfcp_message;
 } upf_event_t;
 

--- a/src/upf/pfcp-path.c
+++ b/src/upf/pfcp-path.c
@@ -270,10 +270,22 @@ int upf_pfcp_send_session_deletion_response(ogs_pfcp_xact_t *xact,
 
 static void sess_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
+    upf_sess_t *sess = NULL;
+    ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     uint8_t type;
 
     ogs_assert(xact);
     type = xact->seq[0].type;
+
+    ogs_assert(data);
+    sess_id = OGS_POINTER_TO_UINT(data);
+    ogs_assert(sess_id >= OGS_MIN_POOL_ID && sess_id <= OGS_MAX_POOL_ID);
+
+    sess = upf_sess_find_by_id(sess_id);
+    if (!sess) {
+        ogs_error("Session has already been removed [%d]", type);
+        return;
+    }
 
     switch (type) {
     case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
@@ -302,7 +314,8 @@ int upf_pfcp_send_session_report_request(
     h.type = OGS_PFCP_SESSION_REPORT_REQUEST_TYPE;
     h.seid = sess->smf_n4_f_seid.seid;
 
-    xact = ogs_pfcp_xact_local_create(sess->pfcp_node, sess_timeout, sess);
+    xact = ogs_pfcp_xact_local_create(
+            sess->pfcp_node, sess_timeout, OGS_UINT_TO_POINTER(sess->id));
     if (!xact) {
         ogs_error("ogs_pfcp_xact_local_create() failed");
         return OGS_ERROR;

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -122,7 +122,7 @@ void upf_pfcp_state_will_associate(ogs_fsm_t *s, upf_event_t *e)
     case UPF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         switch (message->h.type) {
@@ -204,7 +204,7 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
     case UPF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
         ogs_assert(message);
-        xact = e->pfcp_xact;
+        xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
         if (message->h.seid_presence && message->h.seid != 0)

--- a/src/upf/upf-sm.c
+++ b/src/upf/upf-sm.c
@@ -87,7 +87,7 @@ void upf_state_operational(ogs_fsm_t *s, upf_event_t *e)
         }
 
         e->pfcp_message = pfcp_message;
-        e->pfcp_xact = xact;
+        e->pfcp_xact_id = xact ? xact->id : OGS_INVALID_POOL_ID;
         ogs_fsm_dispatch(&node->sm, e);
         if (OGS_FSM_CHECK(&node->sm, upf_pfcp_state_exception)) {
             ogs_error("PFCP state machine exception");

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -52,6 +52,7 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
     ogs_sbi_response_t *response = NULL;
     ogs_sbi_message_t message;
     ogs_sbi_xact_t *sbi_xact = NULL;
+    ogs_pool_id_t sbi_xact_id = 0;
 
     af_sm_debug(e);
 
@@ -278,8 +279,17 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NNRF_DISC)
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
+
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
+                if (!sbi_xact) {
+                    /* CLIENT_WAIT timer could remove SBI transaction
+                     * before receiving SBI message */
+                    ogs_error("SBI transaction has already been removed");
+                    break;
+                }
 
                 SWITCH(message.h.method)
                 CASE(OGS_SBI_HTTP_METHOD_GET)
@@ -306,10 +316,11 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NBSF_MANAGEMENT)
             SWITCH(message.h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_PCF_BINDINGS)
-                sbi_xact = e->h.sbi.data;
-                ogs_assert(sbi_xact);
+                sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+                ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                        sbi_xact_id <= OGS_MAX_POOL_ID);
 
-                sbi_xact = ogs_sbi_xact_cycle(sbi_xact);
+                sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
                 if (!sbi_xact) {
                     /* CLIENT_WAIT timer could remove SBI transaction
                      * before receiving SBI message */
@@ -478,9 +489,13 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
              * 4. timer expiration event is processed. (double-free SBI xact)
              *
              * To avoid double-free SBI xact,
-             * we need to check ogs_sbi_xact_cycle()
+             * we need to check ogs_sbi_xact_find_by_id()
              */
-            sbi_xact = ogs_sbi_xact_cycle(e->h.sbi.data);
+            sbi_xact_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+            ogs_assert(sbi_xact_id >= OGS_MIN_POOL_ID &&
+                    sbi_xact_id <= OGS_MAX_POOL_ID);
+
+            sbi_xact = ogs_sbi_xact_find_by_id(sbi_xact_id);
             if (!sbi_xact) {
                 ogs_error("SBI transaction has already been removed");
                 break;

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -45,6 +45,7 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
     af_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
+    ogs_pool_id_t stream_id = 0;
     ogs_sbi_request_t *request = NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
@@ -68,8 +69,16 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
     case OGS_EVENT_SBI_SERVER:
         request = e->h.sbi.request;
         ogs_assert(request);
-        stream = e->h.sbi.data;
-        ogs_assert(stream);
+
+        stream_id = OGS_POINTER_TO_UINT(e->h.sbi.data);
+        ogs_assert(stream_id >= OGS_MIN_POOL_ID &&
+                stream_id <= OGS_MAX_POOL_ID);
+
+        stream = ogs_sbi_stream_find_by_id(stream_id);
+        if (!stream) {
+            ogs_error("STREAM has already been removed [%d]", stream_id);
+            break;
+        }
 
         rv = ogs_sbi_parse_request(&message, request);
         if (rv != OGS_OK) {
@@ -501,7 +510,9 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
                 break;
             }
 
-            stream = sbi_xact->assoc_stream;
+            if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
+                stream = ogs_sbi_stream_find_by_id(sbi_xact->assoc_stream_id);
             /* Here, we should not use ogs_assert(stream)
              * since 'namf-comm' service has no an associated stream. */
 

--- a/tests/af/sbi-path.c
+++ b/tests/af/sbi-path.c
@@ -74,7 +74,7 @@ void af_sbi_discover_and_send(
     ogs_assert(build);
 
     xact = ogs_sbi_xact_add(
-            &sess->sbi, service_type, discovery_option,
+            0, &sess->sbi, service_type, discovery_option,
             (ogs_sbi_build_f)build, sess, data);
     if (!xact) {
         ogs_error("af_sbi_discover_and_send() failed");

--- a/tests/sctp/abts-main.c
+++ b/tests/sctp/abts-main.c
@@ -33,6 +33,9 @@ static void terminate(void)
 {
     ogs_sctp_final();
 
+    ogs_app_config_final();
+    ogs_app_context_final();
+
     ogs_pkbuf_default_destroy();
     ogs_core_terminate();
 }


### PR DESCRIPTION
Pool library has the following issues with XXX_cycle,
including mme_enb_cycle()/amf_ue_cycle()

```
INIT POOL(SIZE:5)

Alloc Node1
Alloc Node2
Alloc Node3
Alloc Node4
Alloc Node5

Free Node4
Free Node3

PoolCycle(Node4) is NULL (Freed...OK!)
PoolCycle(Node3) is NULL (Freed...OK!)

Alloc Node6
Alloc Node7

PoolCycle(Node4) is Not NULL (Freed...but NOK!)
PoolCycle(Node3) is Not NULL (Freed...but NOK!)
PoolCycle(Node6) is Not NULL (Allocated...OK!)
PoolCycle(Node7) is Not NULL (Allocated...OK!)
```

If we use ogs_poll_alloc() to create and allocate a node,
the correct behavior of calling ogs_pool_free() on this node
and then later calling ogs_pool_cycle() on this node must always return NULL.

However, the behavior of calling ogs_pool_cycle() on this node
in the future may return a “valid” pointer.

To solve the problem, we added hash id to the pool memory and
ogs_pool_find_by_id() function is added.

The event or context connection is also used by linking to the hash id, not the pointer itself.

This requires a lot of code modifications and may have stability issues.

Until all of this is stabilized, we recommend that those unfamiliar with Open5GS use the previous version of this pull request.
