### PR TITLE
[MME] UEContextReleaseCommand cause (#3280)

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -674,8 +674,11 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
                 ogs_fatal("Invalid Procedure Code[%d]", (int)e->s1ap_code);
             }
 
-            if (!mme_ue->nas_eps.update.active_flag)
+            if (!mme_ue->nas_eps.update.active_flag) {
+                enb_ue->relcause.group = S1AP_Cause_PR_nas;
+                enb_ue->relcause.cause = S1AP_CauseNas_normal_release;
                 mme_send_release_access_bearer_or_ue_context_release(enb_ue);
+            }
 
             if (mme_ue->next.m_tmsi) {
                 ogs_fatal("MME does not create new GUTI");
@@ -743,6 +746,8 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
                         OGS_NAS_EMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
+                    enb_ue->relcause.group = S1AP_Cause_PR_nas;
+                    enb_ue->relcause.cause = S1AP_CauseNas_normal_release;
                     mme_send_release_access_bearer_or_ue_context_release(
                             enb_ue);
                     break;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -287,6 +287,12 @@ struct enb_ue_s {
     /* S1 Holding timer for removing this context */
     ogs_timer_t     *t_s1_holding;
 
+    /* UEContextReleaseRequest or InitialContextSetupFailure */
+    struct {
+        S1AP_Cause_PR group;
+        long cause;
+    } relcause;
+
     /* Store by UE Context Release Command
      * Retrieve by UE Context Release Complete */
 #define S1AP_UE_CTX_REL_INVALID_ACTION                      0

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -156,7 +156,7 @@ void mme_send_release_access_bearer_or_ue_context_release(enb_ue_t *enb_ue)
     } else {
         ogs_debug("No UE Context");
         r = s1ap_send_ue_context_release_command(enb_ue,
-                S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
+                enb_ue->relcause.group, enb_ue->relcause.cause,
                 S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE, 0);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -1435,7 +1435,7 @@ void mme_s11_handle_release_access_bearers_response(
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
         if (enb_ue) {
             r = s1ap_send_ue_context_release_command(enb_ue,
-                    S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
+                    enb_ue->relcause.group, enb_ue->relcause.cause,
                     S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK, 0);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -1195,6 +1195,9 @@ void s1ap_handle_initial_context_setup_failure(
         CLEAR_MME_UE_ALL_TIMERS(mme_ue);
     }
 
+    enb_ue->relcause.group = S1AP_Cause_PR_nas;
+    enb_ue->relcause.cause = S1AP_CauseNas_normal_release;
+
     /*
      * 19.2.2.3 in Spec 36.300
      *
@@ -1759,6 +1762,8 @@ void s1ap_handle_ue_context_release_request(
         break;
     }
 
+    enb_ue->relcause.group = Cause->present;
+    enb_ue->relcause.cause = (int)Cause->choice.radioNetwork;
     mme_send_release_access_bearer_or_ue_context_release(enb_ue);
 }
 


### PR DESCRIPTION
On 4G only... when UE sent an inactivity UEContextReleaseRequest, Open5GS sent back UEContextReleaseCommand **with cause=normal-release. This, in turn, does not allow the Samsung UE to return to the low power state in our testing of the scenario.

Comparing the behavior of open5gs to other cores that we have tested the other cores are sending a ** cause=“Radio Network Layer Cause”: User inactivity ** when the UE sends inactivity. And this is what allows other cores to transition the UE to the low power state whereas with open5gs the UE is not entering the low power state.

We've fixed to allow open5gs to come to the same level of compliance in this area as to the other cores.