### PR TITLE
[TFT] Incrase the number of flows 8->16 (#3339)

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -34,15 +34,28 @@ extern "C" {
 #define OGS_MAX_NUM_OF_PACKET_BUFFER    64  /* Num of PacketBuffer per UE */
 
 /*
- * The array of TLV messages is limited to 8.
- * So, Flow(PDI.SDF_Filter) in PDR is limited to 8.
+ * TS24.008
+ * 10.5.6.12 Traffic Flow Template
+ * Table 10.5.162: Traffic flow template information element
  *
- * However, the number of flow in bearer context seems to need more than 16.
+ * Number of packet filters (octet 3)
+ * The number of packet filters contains the binary coding
+ * for the number of packet filters in the packet filter list.
+ * The number of packet filters field is encoded in bits 4
+ * through 1 of octet 3 where bit 4 is the most significant
+ * and bit 1 is the least significant bit.
  *
- * Therefore, the maximum number of flows of messages is defined as 8,
- * and the maximum number of flows stored by the context is 16.
+ * For the "delete existing TFT" operation and
+ * for the "no TFT operation", the number of packet filters shall be
+ * coded as 0. For all other operations, the number of packet filters
+ * shall be greater than 0 and less than or equal to 15.
+ *
+ * The array of TLV messages is limited to 16.
+ * So, Flow(PDI.SDF_Filter) in PDR is limited to 16.
+ *
+ * Therefore, we defined the maximum number of flows as 16.
  */
-#define OGS_MAX_NUM_OF_FLOW_IN_PDR      8
+#define OGS_MAX_NUM_OF_FLOW_IN_PDR      16
 #define OGS_MAX_NUM_OF_FLOW_IN_GTP      OGS_MAX_NUM_OF_FLOW_IN_PDR
 #define OGS_MAX_NUM_OF_FLOW_IN_NAS      OGS_MAX_NUM_OF_FLOW_IN_PDR
 #define OGS_MAX_NUM_OF_FLOW_IN_PCC_RULE OGS_MAX_NUM_OF_FLOW_IN_PDR

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -1281,12 +1281,16 @@ void smf_s5c_handle_bearer_resource_command(
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
     decoded = ogs_gtp2_parse_tft(&tft, &cmd->traffic_aggregate_description);
-    if (cmd->traffic_aggregate_description.len != decoded) {
-        ogs_fatal("ogs_gtp2_parse_tft() failed");
-        ogs_log_hexdump(OGS_LOG_FATAL,
+    if (cmd->traffic_aggregate_description.len == decoded) {
+        ogs_error("ogs_gtp2_parse_tft() failed");
+        ogs_log_hexdump(OGS_LOG_ERROR,
             cmd->traffic_aggregate_description.data,
             cmd->traffic_aggregate_description.len);
-        ogs_assert_if_reached();
+        ogs_gtp2_send_error_message(
+                xact, get_sender_f_teid(sess, sender_f_teid),
+                OGS_GTP2_BEARER_RESOURCE_FAILURE_INDICATION_TYPE,
+                OGS_GTP2_CAUSE_INVALID_MESSAGE_FORMAT);
+        return;
     }
 
     ogs_assert(cmd->traffic_aggregate_description.len == decoded);

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -210,7 +210,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         case OGS_GTP2_UPDATE_BEARER_RESPONSE_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             if (!sess) {
-                /* Don't have to send NACK the message */
                 ogs_error("No Session");
                 rv = ogs_gtp_xact_commit(gtp_xact);
                 ogs_expect(rv == OGS_OK);
@@ -222,7 +221,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         case OGS_GTP2_DELETE_BEARER_RESPONSE_TYPE:
             if (!gtp2_message.h.teid_presence) ogs_error("No TEID");
             if (!sess) {
-                /* Don't have to send NACK the message */
                 ogs_error("No Session");
                 rv = ogs_gtp_xact_commit(gtp_xact);
                 ogs_expect(rv == OGS_OK);


### PR DESCRIPTION
TS24.008
10.5.6.12 Traffic Flow Template
Table 10.5.162: Traffic flow template information element

Number of packet filters (octet 3)
The number of packet filters contains the binary coding for the number of packet filters in the packet filter list. The number of packet filters field is encoded in bits 4 through 1 of octet 3 where bit 4 is the most significant and bit 1 is the least significant bit.

For the "delete existing TFT" operation and
for the "no TFT operation", the number of packet filters shall be coded as 0. For all other operations, the number of packet filters shall be greater than 0 and less than or equal to 15.

The array of TLV messages is limited to 16.
So, Flow(PDI.SDF_Filter) in PDR is limited to 16.

Therefore, we defined the maximum number of flows as 16.