### PR TITLE
[NRF] Fix the subscription valdityTime (#3360 #3361 #3363 #3364)

### DIFF
--- a/lib/core/ogs-time.h
+++ b/lib/core/ogs-time.h
@@ -84,8 +84,11 @@ typedef int64_t ogs_time_t;
 /** @return ogs_time_t as a msec */
 #define ogs_time_msec(time) (((time) / 1000) % 1000)
 
-/** @return ogs_time_t as a msec */
+/** @return ogs_time_t to msec */
 #define ogs_time_to_msec(time) ((time) ? (1 + ((time) - 1) / 1000) : 0)
+/** @return ogs_time_t to sec */
+#define ogs_time_to_sec(time) \
+    ((time) ? (1 + ((time) - 1) / OGS_USEC_PER_SEC) : 0)
 
 /** @return milliseconds as an ogs_time_t */
 #define ogs_time_from_msec(msec) ((ogs_time_t)(msec) * 1000)

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -285,12 +285,7 @@ typedef struct ogs_sbi_subscription_spec_s {
 typedef struct ogs_sbi_subscription_data_s {
     ogs_lnode_t lnode;
 
-#define OGS_SBI_VALIDITY_SEC(v) \
-        ogs_time_sec(v) + (ogs_time_usec(v) ? 1 : 0)
-    struct {
-        int validity_duration;
-    } time;
-
+    ogs_time_t validity_duration;           /* valditiyTime(unit: usec) */
     ogs_timer_t *t_validity;                /* check validation */
     ogs_timer_t *t_patch;                   /* for sending PATCH */
 

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -1722,10 +1722,9 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_update(
         goto end;
     }
 
-    ogs_assert(subscription_data->time.validity_duration);
+    ogs_assert(subscription_data->validity_duration);
     validity_time = ogs_sbi_localtime_string(
-            ogs_time_now() +
-            ogs_time_from_sec(subscription_data->time.validity_duration));
+            ogs_time_now() + subscription_data->validity_duration);
     ogs_assert(validity_time);
 
     ValidityItem.op = OpenAPI_patch_operation_replace;

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -794,31 +794,43 @@ static void handle_validity_time(
 {
     ogs_time_t time, validity, patch;
 
-    ogs_assert(validity_time);
     ogs_assert(subscription_data);
     ogs_assert(action);
 
-    if (ogs_sbi_time_from_string(&time, validity_time) == false) {
-        ogs_error("[%s] Subscription %s until %s [parser error]",
-                subscription_data->id, action, validity_time);
-        return;
-    }
-
-    validity = time - ogs_time_now();
-    if (validity < 0) {
-        ogs_error("[%s] Subscription %s until %s [validity:%d.%06d]",
-                subscription_data->id, action, validity_time,
-                (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
-        return;
-    }
-
     /*
-     * Store subscription_data->time.validity_duration to derive NRF validity.
-     * It will be used in ogs_nnrf_nfm_build_status_update().
+     * If there is a validity_time, then the NRF is updating
+     * the validity_time by sending HTTP_STATUS to 200.
+     * Therefore, change subscription_data->valdity_duration
+     * according to this value.
      *
-     * So, you should not remove the following lines.
+     * If validity_time is NULL, NRF sent an HTTP_STATUS of 204 (No content).
+     * In this case, use the existing subscription_data->validity_duration.
      */
-    subscription_data->time.validity_duration = OGS_SBI_VALIDITY_SEC(validity);
+    if (validity_time) {
+        if (ogs_sbi_time_from_string(&time, validity_time) == false) {
+            ogs_error("[%s] Subscription %s until %s [parser error]",
+                    subscription_data->id, action, validity_time);
+            return;
+        }
+
+        validity = time - ogs_time_now();
+        if (validity < 0) {
+            ogs_error("[%s] Subscription %s until %s [validity:%d.%06d]",
+                    subscription_data->id, action, validity_time,
+                    (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
+            return;
+        }
+
+        /*
+         * Store subscription_data->validity_duration to derive NRF validity.
+         * It will be used in ogs_nnrf_nfm_build_status_update().
+         *
+         * So, you should not remove the following lines.
+         */
+        subscription_data->validity_duration =
+            /* Normalize seconds */
+            ogs_time_from_sec(ogs_time_to_sec(validity));
+    }
 
     if (!subscription_data->t_validity) {
         subscription_data->t_validity =
@@ -826,13 +838,14 @@ static void handle_validity_time(
                 ogs_timer_subscription_validity, subscription_data);
         ogs_assert(subscription_data->t_validity);
     }
-    ogs_timer_start(subscription_data->t_validity, validity);
+    ogs_timer_start(subscription_data->t_validity,
+            subscription_data->validity_duration);
 
     /*
      * PATCH request will be sent before VALIDITY is expired.
      */
 #define PATCH_TIME_FROM_VALIDITY(x) ((x) / 2)
-    patch = PATCH_TIME_FROM_VALIDITY(validity);
+    patch = PATCH_TIME_FROM_VALIDITY(subscription_data->validity_duration);
 
     if (!subscription_data->t_patch) {
         subscription_data->t_patch =
@@ -843,10 +856,11 @@ static void handle_validity_time(
     ogs_timer_start(subscription_data->t_patch, patch);
 
     ogs_info("[%s] Subscription %s until %s "
-            "[duration:%d,validity:%d.%06d,patch:%d.%06d]",
+            "[duration:%ld,validity:%d.%06d,patch:%d.%06d]",
             subscription_data->id, action, validity_time,
-            subscription_data->time.validity_duration,
-            (int)ogs_time_sec(validity), (int)ogs_time_usec(validity),
+            subscription_data->validity_duration,
+            (int)ogs_time_sec(subscription_data->validity_duration),
+            (int)ogs_time_usec(subscription_data->validity_duration),
             (int)ogs_time_sec(patch), (int)ogs_time_usec(patch));
 }
 
@@ -952,20 +966,34 @@ void ogs_nnrf_nfm_handle_nf_status_update(
         ogs_sbi_message_t *recvmsg)
 {
     OpenAPI_subscription_data_t *SubscriptionData = NULL;
+    char *validity_time = NULL;
 
     ogs_assert(recvmsg);
     ogs_assert(subscription_data);
 
-    SubscriptionData = recvmsg->SubscriptionData;
-    if (!SubscriptionData) {
-        ogs_error("No SubscriptionData");
-        return;
+    if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_OK) {
+        SubscriptionData = recvmsg->SubscriptionData;
+        if (!SubscriptionData) {
+            ogs_error("No SubscriptionData");
+            return;
+        }
+        if (!SubscriptionData->validity_time) {
+            ogs_error("No validityTime");
+            return;
+        }
+
+        validity_time = SubscriptionData->validity_time;
+    } else if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_NO_CONTENT) {
+        /* No valdityTime. Re-use current subscription_data->valdity_duration */
+    } else {
+        ogs_fatal("[%s] HTTP response error [%d]",
+                subscription_data->id ?  subscription_data->id : "Unknown",
+                recvmsg->res_status);
+        ogs_assert_if_reached();
     }
 
-    /* Subscription Validity Time */
-    if (SubscriptionData->validity_time)
-        handle_validity_time(
-                subscription_data, SubscriptionData->validity_time, "updated");
+    /* Update Subscription Validity Time */
+    handle_validity_time(subscription_data, validity_time, "updated");
 }
 
 bool ogs_nnrf_nfm_handle_nf_status_notify(

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -424,13 +424,13 @@ bool nrf_nnrf_handle_nf_status_subscribe(
     /*
      * The NRF validity is initially set in configuration.
      */
-    subscription_data->time.validity_duration =
-            ogs_local_conf()->time.subscription.validity_duration;
+    subscription_data->validity_duration =
+        ogs_time_from_sec(
+                ogs_local_conf()->time.subscription.validity_duration);
 
-    if (subscription_data->time.validity_duration) {
+    if (subscription_data->validity_duration) {
         SubscriptionData->validity_time = ogs_sbi_localtime_string(
-            ogs_time_now() + ogs_time_from_sec(
-                subscription_data->time.validity_duration));
+            ogs_time_now() + subscription_data->validity_duration);
         ogs_assert(SubscriptionData->validity_time);
 
         if (!subscription_data->t_validity) {
@@ -440,13 +440,16 @@ bool nrf_nnrf_handle_nf_status_subscribe(
             ogs_assert(subscription_data->t_validity);
         }
         ogs_timer_start(subscription_data->t_validity,
-                ogs_time_from_sec(subscription_data->time.validity_duration));
+                subscription_data->validity_duration);
     }
 
-    ogs_info("[%s] Subscription created until %s [validity_duration:%d]",
+    ogs_info("[%s] Subscription created until %s "
+            "[duration:%ld,validity:%d.%06d]",
             subscription_data->id,
             SubscriptionData->validity_time,
-            subscription_data->time.validity_duration);
+            subscription_data->validity_duration,
+            (int)ogs_time_sec(subscription_data->validity_duration),
+            (int)ogs_time_usec(subscription_data->validity_duration));
 
     /* Location */
     server = ogs_sbi_server_from_stream(stream);
@@ -486,6 +489,8 @@ bool nrf_nnrf_handle_nf_status_update(
     char *validity_time = NULL;
 
     ogs_sbi_subscription_data_t *subscription_data = NULL;
+
+    ogs_time_t time, validity;
 
     ogs_assert(stream);
     ogs_assert(recvmsg);
@@ -553,72 +558,86 @@ bool nrf_nnrf_handle_nf_status_update(
         END
     }
 
-    if (validity_time) {
-        ogs_time_t time, validity;
-
-        if (ogs_sbi_time_from_string(&time, validity_time) == false) {
-            ogs_error("[%s] Subscription updated until %s [parser error]",
-                    subscription_data->id, validity_time);
-            goto end;
-        }
-
-        validity = time - ogs_time_now();
-        if (validity < 0) {
-            ogs_error("[%s] Subscription updated until %s [validity:%d.%06d]",
-                    subscription_data->id, validity_time,
-                    (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
-            goto end;
-        }
-
-        /*
-         * The NRF validity is updated if NF sent the PATCH Request.
-         */
-        subscription_data->time.validity_duration =
-                    OGS_SBI_VALIDITY_SEC(validity);
-
-        if (!subscription_data->t_validity) {
-            subscription_data->t_validity =
-                ogs_timer_add(ogs_app()->timer_mgr,
-                    nrf_timer_subscription_validity, subscription_data);
-            ogs_assert(subscription_data->t_validity);
-        }
-        ogs_timer_start(subscription_data->t_validity,
-                ogs_time_from_sec(subscription_data->time.validity_duration));
-
-        ogs_info("[%s] Subscription updated until %s "
-                "[duration:%d,validity:%d.%06d]",
-                subscription_data->id, validity_time,
-                subscription_data->time.validity_duration,
-                (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
-
-        /* To send SubscriptionData to the NF */
-        memset(&sendmsg, 0, sizeof(sendmsg));
-        sendmsg.SubscriptionData = &SubscriptionData;
-
-        /* Mandatory */
-        SubscriptionData.nf_status_notification_uri =
-            subscription_data->notification_uri;
-
-        /* Validity Time */
-        SubscriptionData.validity_time = ogs_sbi_localtime_string(
-            ogs_time_now() + ogs_time_from_sec(
-                subscription_data->time.validity_duration));
-        ogs_assert(SubscriptionData.validity_time);
-
-        response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_OK);
-        ogs_assert(response);
-        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-
-        ogs_free(SubscriptionData.validity_time);
-
-        return true;
+    if (!validity_time) {
+        ogs_error("[%s] No validityTime", subscription_data->id);
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "No validityTime", subscription_data->id,
+                NULL));
+        return false;
     }
 
-end:
-    response = ogs_sbi_build_response(
-            recvmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+    if (ogs_sbi_time_from_string(&time, validity_time) == false) {
+        ogs_error("[%s] Subscription updated until %s [parser error]",
+                subscription_data->id, validity_time);
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "parse error", subscription_data->id,
+                validity_time));
+        return false;
+    }
+
+    validity = time - ogs_time_now();
+    if (validity < 0) {
+        ogs_error("[%s] Subscription updated until %s [validity:%d.%06d]",
+                subscription_data->id, validity_time,
+                (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "invalid validity", subscription_data->id,
+                validity_time));
+        return false;
+    }
+
+    /*
+     * The NRF validity is updated if NF sent the PATCH Request.
+     */
+    subscription_data->validity_duration =
+        /* Normalize seconds */
+        ogs_time_from_sec(ogs_time_to_sec(validity));
+
+    if (!subscription_data->t_validity) {
+        subscription_data->t_validity =
+            ogs_timer_add(ogs_app()->timer_mgr,
+                nrf_timer_subscription_validity, subscription_data);
+        ogs_assert(subscription_data->t_validity);
+    }
+    ogs_timer_start(subscription_data->t_validity,
+            subscription_data->validity_duration);
+
+    ogs_info("[%s] Subscription updated until %s "
+            "[duration:%ld,validity:%d.%06d]",
+            subscription_data->id, validity_time,
+            subscription_data->validity_duration,
+            (int)ogs_time_sec(subscription_data->validity_duration),
+            (int)ogs_time_usec(subscription_data->validity_duration));
+
+    /* To send SubscriptionData to the NF */
+    memset(&sendmsg, 0, sizeof(sendmsg));
+
+#if 0 /* Use HTTP_STATUS_NO_CONTENT(204) instead of HTTP_STATUS_OK(200) */
+    sendmsg.SubscriptionData = &SubscriptionData;
+
+    /* Mandatory */
+    SubscriptionData.nf_status_notification_uri =
+        subscription_data->notification_uri;
+
+    /* Validity Time */
+    SubscriptionData.validity_time = ogs_sbi_localtime_string(
+        ogs_time_now() + subscription_data->validity_duration);
+    ogs_assert(SubscriptionData.validity_time);
+
+    response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_OK);
+#else
+    response = ogs_sbi_build_response(&sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+#endif
     ogs_assert(response);
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    ogs_free(SubscriptionData.validity_time);
 
     return true;
 }

--- a/tests/app/5gc-init.c
+++ b/tests/app/5gc-init.c
@@ -85,7 +85,7 @@ int app_initialize(const char *const argv[])
      * 
      * If freeDiameter is not used, it uses a delay of less than 4 seconds.
      */
-    ogs_msleep(500);
+    ogs_msleep(1000);
 
     return OGS_OK;;
 }


### PR DESCRIPTION
NF should accept 204 No Content for Update Subscription requests. According to 3GPP 29.510 NRF specification document in figure 5.2.2.5.6.1 NRF may return 204 or 200 for success update operations.

2a. On success, if the NRF accepts the extension of the lifetime of the subscription, and it accepts the requested value for the "validityTime" attribute, a response with status code "204 No Content" shall be returned.

2b. On success, if the NRF accepts the extension of the lifetime of the subscription, but it assigns a validity time different than the value suggested by the NF Service Consumer, a "200 OK" response code shall be returned. The response shall contain the new resource representation of the "subscription" resource, which includes the new validity time, as determined by the NRF, after which the subscription becomes invalid.

I changed it so that all NFs can receive both 200 and 204 STATUS. I also changed the default behavior of NRFs to respond with 204, which is NO CONTEXT.