### PR TITLE
Log improvments for NRF subscriptions. (#3360)

### DIFF
--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -817,8 +817,8 @@ static void handle_validity_time(
         validity = time - ogs_time_now();
         if (validity < 0) {
             ogs_error("[%s] Subscription %s until %s [validity:%d.%06d]",
-                subscription_data->id, action, validity_time,
-                (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
+                    subscription_data->id, action, validity_time,
+                    (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
             return;
         }
 

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -817,8 +817,8 @@ static void handle_validity_time(
         validity = time - ogs_time_now();
         if (validity < 0) {
             ogs_error("[%s] Subscription %s until %s [validity:%d.%06d]",
-                    subscription_data->id, action, validity_time,
-                    (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
+                subscription_data->id, action, validity_time,
+                (int)ogs_time_sec(validity), (int)ogs_time_usec(validity));
             return;
         }
 
@@ -865,13 +865,20 @@ static void handle_validity_time(
         ogs_assert(validity_time_string);
     }
 
-    ogs_info("[%s] Subscription %s until %s "
-            "[duration:%lld,validity:%d.%06d,patch:%d.%06d]",
-            subscription_data->id, action, validity_time_string,
-            (long long)subscription_data->validity_duration,
-            (int)ogs_time_sec(subscription_data->validity_duration),
-            (int)ogs_time_usec(subscription_data->validity_duration),
-            (int)ogs_time_sec(patch), (int)ogs_time_usec(patch));
+    char* subscriptionTarget;
+    if (subscription_data->subscr_cond.nf_type) {
+        subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+    } else if (subscription_data->subscr_cond.service_name) {
+        subscriptionTarget = subscription_data->subscr_cond.service_name;
+    }
+    ogs_info("[%s] Subscription for %s %s until %s "
+        "[duration:%lld,validity:%d.%06d,patch:%d.%06d]",
+        subscription_data->id, subscriptionTarget, action,
+        validity_time_string,
+        (long long)subscription_data->validity_duration,
+        (int)ogs_time_sec(subscription_data->validity_duration),
+        (int)ogs_time_usec(subscription_data->validity_duration),
+        (int)ogs_time_sec(patch), (int)ogs_time_usec(patch));
 
     ogs_free(validity_time_string);
 }

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -669,8 +669,15 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -409,8 +409,15 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -383,8 +383,15 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -319,8 +319,15 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -693,8 +693,15 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -277,8 +277,15 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                    subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -414,8 +414,15 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -998,8 +998,15 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -540,8 +540,15 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -336,8 +336,15 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:


### PR DESCRIPTION
NfTypes have been added for updated subscription decision logs and subscription response received logs.
Below are the example

Before:
08/04 21:19:18.295: [scp] INFO: [clzg2emky000blr4243hgqsbc] Need to update Subscription (../src/scp/scp-sm.c:280)
08/04 21:19:18.302: [sbi] INFO: [clzg2emky000blr4243hgqsbc] Subscription updated(200 OK) until 2024-08-05T00:21:18.306+03:00 [duration:121000000,validity:121.000000,patch:60.500000] (../lib/sbi/nnrf-handler.c:868)
After:
08/04 22:10:30.390: [scp] INFO: [clzg48h160013lr42spzk5fod] Need to update Subscription for **BSF** (../src/scp/scp-sm.c:287)
08/04 22:10:30.393: [sbi] INFO: [clzg48h160014lr42kjhdpph3] Subscription for **NSSF** updated(200 OK) until 2024-08-05T01:12:30.396+03:00 [duration:121000000,validity:121.000000,patch:60.500000] (../lib/sbi/nnrf-handler.c:877)
