### PR TITLE
Log improvments for NRF subscriptions. (#3360)

### DIFF
--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -865,13 +865,20 @@ static void handle_validity_time(
         ogs_assert(validity_time_string);
     }
 
-    ogs_info("[%s] Subscription %s until %s "
-            "[duration:%lld,validity:%d.%06d,patch:%d.%06d]",
-            subscription_data->id, action, validity_time_string,
-            (long long)subscription_data->validity_duration,
-            (int)ogs_time_sec(subscription_data->validity_duration),
-            (int)ogs_time_usec(subscription_data->validity_duration),
-            (int)ogs_time_sec(patch), (int)ogs_time_usec(patch));
+    char* subscriptionTarget;
+    if (subscription_data->subscr_cond.nf_type) {
+        subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+    } else if (subscription_data->subscr_cond.service_name) {
+        subscriptionTarget = subscription_data->subscr_cond.service_name;
+    }
+    ogs_info("[%s] Subscription for %s %s until %s "
+        "[duration:%lld,validity:%d.%06d,patch:%d.%06d]",
+        subscription_data->id, subscriptionTarget, action,
+        validity_time_string,
+        (long long)subscription_data->validity_duration,
+        (int)ogs_time_sec(subscription_data->validity_duration),
+        (int)ogs_time_usec(subscription_data->validity_duration),
+        (int)ogs_time_sec(patch), (int)ogs_time_usec(patch));
 
     ogs_free(validity_time_string);
 }

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -870,6 +870,8 @@ static void handle_validity_time(
         subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
     } else if (subscription_data->subscr_cond.service_name) {
         subscriptionTarget = subscription_data->subscr_cond.service_name;
+    } else {
+        subscriptionTarget = "Unknown";
     }
     ogs_info("[%s] Subscription for %s %s until %s "
         "[duration:%lld,validity:%d.%06d,patch:%d.%06d]",

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -865,7 +865,7 @@ static void handle_validity_time(
         ogs_assert(validity_time_string);
     }
 
-    char* subscriptionTarget;
+    const char* subscriptionTarget = NULL;
     if (subscription_data->subscr_cond.nf_type) {
         subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
     } else if (subscription_data->subscr_cond.service_name) {

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -672,9 +672,10 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -669,8 +669,15 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -627,6 +627,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
+        
+        const char* subscriptionTarget = NULL;
 
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
@@ -657,8 +659,17 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -668,8 +679,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
-
-            char* subscriptionTarget;
+            
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -409,8 +409,15 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -368,6 +368,8 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -397,8 +399,17 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -409,7 +420,6 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -412,9 +412,10 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -386,9 +386,10 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -342,6 +342,8 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -371,8 +373,17 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -383,7 +394,6 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -383,8 +383,15 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -322,9 +322,10 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -278,6 +278,8 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -307,8 +309,17 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -319,7 +330,6 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/nssf/nssf-sm.c
+++ b/src/nssf/nssf-sm.c
@@ -319,8 +319,15 @@ void nssf_state_operational(ogs_fsm_t *s, nssf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -693,8 +693,15 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -696,9 +696,10 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -652,6 +652,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -681,8 +683,17 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -693,7 +704,6 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -280,9 +280,10 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                     subscription_data->id, subscriptionTarget);

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -277,8 +277,15 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                    subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/scp/scp-sm.c
+++ b/src/scp/scp-sm.c
@@ -238,6 +238,8 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -265,8 +267,17 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -277,7 +288,6 @@ void scp_state_operational(ogs_fsm_t *s, scp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -417,9 +417,10 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -414,8 +414,15 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:

--- a/src/sepp/sepp-sm.c
+++ b/src/sepp/sepp-sm.c
@@ -364,6 +364,8 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case SEPP_TIMER_PEER_ESTABLISH:
             sepp_node = e->sepp_node;
@@ -402,8 +404,17 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -414,7 +425,6 @@ void sepp_state_operational(ogs_fsm_t *s, sepp_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -998,8 +998,15 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -957,6 +957,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -986,8 +988,17 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -998,7 +1009,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -1001,9 +1001,10 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -540,8 +540,15 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -543,9 +543,10 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -499,6 +499,8 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -528,8 +530,17 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
             
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -540,7 +551,6 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -336,8 +336,15 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         default:

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -298,6 +298,8 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -324,8 +326,17 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -336,7 +347,6 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/src/udr/udr-sm.c
+++ b/src/udr/udr-sm.c
@@ -339,9 +339,10 @@ void udr_state_operational(ogs_fsm_t *s, udr_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -468,8 +468,15 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            ogs_info("[%s] Need to update Subscription",
-                    subscription_data->id);
+            char* subscriptionTarget;
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            ogs_info("[%s] Need to update Subscription for %s",
+                subscription_data->id, subscriptionTarget);
             break;
 
         case OGS_TIMER_SBI_CLIENT_WAIT:

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -431,6 +431,8 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
     case OGS_EVENT_SBI_TIMER:
         ogs_assert(e);
 
+        const char* subscriptionTarget = NULL;
+
         switch(e->h.timer_id) {
         case OGS_TIMER_NF_INSTANCE_REGISTRATION_INTERVAL:
         case OGS_TIMER_NF_INSTANCE_HEARTBEAT_INTERVAL:
@@ -456,8 +458,17 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
                     subscription_data->subscr_cond.nf_type,
                     subscription_data->subscr_cond.service_name));
 
-            ogs_error("[%s] Subscription validity expired",
-                subscription_data->id);
+            if (subscription_data->subscr_cond.nf_type) {
+                subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
+            }
+            else if (subscription_data->subscr_cond.service_name) {
+                subscriptionTarget = subscription_data->subscr_cond.service_name;
+            }
+            else {
+                subscriptionTarget = "Unknown";
+            }
+            ogs_error("[%s] Subscription for %s validity expired",
+                subscription_data->id, subscriptionTarget);
             ogs_sbi_subscription_data_remove(subscription_data);
             break;
 
@@ -468,7 +479,6 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
             ogs_assert(true ==
                 ogs_nnrf_nfm_send_nf_status_update(subscription_data));
 
-            char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
             } else if (subscription_data->subscr_cond.service_name) {

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -471,9 +471,10 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
             char* subscriptionTarget;
             if (subscription_data->subscr_cond.nf_type) {
                 subscriptionTarget = OpenAPI_nf_type_ToString(subscription_data->subscr_cond.nf_type);
-            }
-            else if (subscription_data->subscr_cond.service_name) {
+            } else if (subscription_data->subscr_cond.service_name) {
                 subscriptionTarget = subscription_data->subscr_cond.service_name;
+            } else {
+                subscriptionTarget = "Unknown";
             }
             ogs_info("[%s] Need to update Subscription for %s",
                 subscription_data->id, subscriptionTarget);


### PR DESCRIPTION
NfTypes have been added for updated subscription decision logs and subscription response received logs.
Below are the example

**Before:**
08/04 21:19:18.295: [scp] INFO: [clzg2emky000blr4243hgqsbc] Need to update Subscription (../src/scp/scp-sm.c:280)
08/04 21:19:18.302: [sbi] INFO: [clzg2emky000blr4243hgqsbc] Subscription updated(200 OK) until 2024-08-05T00:21:18.306+03:00 [duration:121000000,validity:121.000000,patch:60.500000] (../lib/sbi/nnrf-handler.c:868)

**After:**
08/04 22:10:30.390: [scp] INFO: [clzg48h160013lr42spzk5fod] Need to update Subscription for **BSF** (../src/scp/scp-sm.c:287)
08/04 22:10:30.393: [sbi] INFO: [clzg48h160014lr42kjhdpph3] Subscription for **NSSF** updated(200 OK) until 2024-08-05T01:12:30.396+03:00 [duration:121000000,validity:121.000000,patch:60.500000] (../lib/sbi/nnrf-handler.c:877)