### PR TITLE
[AMF] Send 5GMM cause in request to SMF on AMF-initiated session release

### DIFF
--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -437,7 +437,10 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_release_sm_context(
             ngApCause.value = param->ngApCause.value;
         }
 
-        SmContextReleaseData._5g_mm_cause_value = param->gmm_cause;
+        if (param->gmm_cause) {
+            SmContextReleaseData._5g_mm_cause_value = param->gmm_cause;
+            SmContextReleaseData.is__5g_mm_cause_value = true;
+        }
     }
 
     memset(&ueLocation, 0, sizeof(ueLocation));


### PR DESCRIPTION
Previously, 5GMM cause was not being sent due to missing "is_x_value" not being set to true.