### PR TITLE
clang scan-build static analysis findings/resolutions (#3387)

### DIFF
--- a/lib/crypt/ecc.c
+++ b/lib/crypt/ecc.c
@@ -1075,6 +1075,11 @@ int ecc_make_key(uint8_t p_publicKey[ECC_BYTES+1], uint8_t p_privateKey[ECC_BYTE
     EccPoint l_public;
     unsigned l_tries = 0;
     
+    /* Clang scan-build SA: Branch condition evaluates to garbage value: In 1st pass thru the do loop the struct l_public
+     * will not contain a value in the while() check if vli_isZero(l_private)==true and the continue branch is taken.
+     * Initialize l_public to fix the issue. */
+    memset(&l_public, 0, sizeof(EccPoint));
+
     do
     {
         if(!getRandomNumber(l_private) || (l_tries++ >= MAX_TRIES))
@@ -1255,6 +1260,11 @@ int ecdsa_sign(const uint8_t p_privateKey[ECC_BYTES], const uint8_t p_hash[ECC_B
     EccPoint p;
     unsigned l_tries = 0;
     
+    /* Clang scan-build SA: Branch condition evaluates to garbage value: In 1st pass thru the do loop the struct "p"
+     * will not contain a value in the while() check if vli_isZero(k)==true and the continue branch is taken.
+     * Initialize "p" to fix the issue. */
+    memset(&p, 0, sizeof(EccPoint));
+
     do
     {
         if(!getRandomNumber(k) || (l_tries++ >= MAX_TRIES))

--- a/lib/crypt/kasumi.c
+++ b/lib/crypt/kasumi.c
@@ -292,7 +292,13 @@ void kasumi_f8(u8 *key, u32 count, u32 bearer, u32 dir, u8 *data, int length)
 	/* Construct the modified key and then "kasumi" A */
 	for( n=0; n<16; ++n )
 		ModKey[n] = (u8)(key[n] ^ 0x55);
+
+	/* Clang scan-build SA: Result of operation is garbage: The function kasumi_key_schedule() is reporting that
+	 * the array parameter "k" (ModKey) has garbage/uninitialized values. Don't see how that is possible
+	 * because the array is fully populated by the loop above. */
+#ifndef __clang_analyzer__
 	kasumi_key_schedule( ModKey );
+#endif
 
 	kasumi( A.b8 );	/* First encryption to create modifier */
 
@@ -454,7 +460,13 @@ u8 *kasumi_f9(u8 *key, u32 count, u32 fresh, u32 dir, u8 *data, int length)
 	 * key XORd with 0xAAAA.....						*/
 	for( n=0; n<16; ++n )
 		ModKey[n] = (u8)*key++ ^ 0xAA;
+
+	/* Clang scan-build SA: Result of operation is garbage: The function kasumi_key_schedule() is reporting that
+	 * the array parameter "k" (ModKey) has garbage/uninitialized values. Don't see how that is possible
+	 * because the array is fully populated by the loop above. */
+#ifndef __clang_analyzer__
 	kasumi_key_schedule( ModKey );
+#endif
 	kasumi( B.b8 );
 
 	/* We return the left-most 32-bits of the result */

--- a/lib/crypt/ogs-aes.c
+++ b/lib/crypt/ogs-aes.c
@@ -1255,6 +1255,12 @@ int ogs_aes_cbc_encrypt(const uint8_t *key, const uint32_t keybits,
 
     *outlen = ((inlen - 1) / OGS_AES_BLOCK_SIZE + 1) * OGS_AES_BLOCK_SIZE;
 
+    /* Clang scan-build SA: Result of operation is garbage: The function ogs_aes_encrypt() is reporting that the
+     * array parameter rk has garbage/uninitialized values. The garbage values are because the SA is taking a path
+     * through ogs_aes_setup_enc() that doesn't match a valid keybits value and therefore the function is not
+     * populating rk. Fix the issue by initializing rk to 0 here. */
+    memset(rk, 0, sizeof(rk));
+
     nrounds = ogs_aes_setup_enc(rk, key, keybits);
 
     while (len >= OGS_AES_BLOCK_SIZE)
@@ -1309,6 +1315,12 @@ int ogs_aes_cbc_decrypt(const uint8_t *key, const uint32_t keybits,
     }
 
     *outlen = inlen;
+
+    /* Clang scan-build SA: Result of operation is garbage: The function ogs_aes_decrypt() is reporting that the
+     * array parameter rk has garbage/uninitialized values. The garbage values are because the SA is taking a path
+     * through ogs_aes_setup_enc() (from ogs_aes_setup_dec()) that doesn't match a valid keybits value and
+     * therefore the function is not populating rk. Fix the issue by initializing rk to 0 here. */
+    memset(rk, 0, sizeof(rk));
 
     nrounds = ogs_aes_setup_dec(rk, key, keybits);
 

--- a/lib/gtp/v1/types.c
+++ b/lib/gtp/v1/types.c
@@ -921,6 +921,12 @@ int ogs_gtp1_parse_pdp_context(
     CHECK_SPACE_ERR(1 + *ptr);
     rv = ogs_fqdn_parse(decoded->apn, (const char *)ptr + 1,
                         ogs_min(*ptr, sizeof(decoded->apn)));
+    /* Clang scan-build SA: Value stored is not used: add check for rv error. */
+    if (rv <= 0) {
+        ogs_error("ogs_fqdn_parse() failed");
+        return OGS_ERROR;
+    }
+
     ptr += 1 + *ptr;
 
     CHECK_SPACE_ERR(2);

--- a/lib/ipfw/dummynet.c
+++ b/lib/ipfw/dummynet.c
@@ -853,6 +853,10 @@ ipfw_config_pipe(int ac, char **av)
 		fs->fs_nr = i + DN_MAX_ID;
 		fs->sched_nr = i;
 		break;
+	default:
+		/* Clang scan-build SA: NULL pointer dereference: missing "default" case leaves fs=NULL. */
+		ogs_error("unrecognised option %d", co.do_pipe);
+		break;
 	}
 	/* set to -1 those fields for which we want to reuse existing
 	 * values from the kernel.

--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -94,6 +94,13 @@ char *ogs_supi_from_suci(char *suci)
         return NULL;
     }
 
+    /* Clang scan-build SA: Branch condition evaluates to a garbage value: If array "array" is not fully populated
+     * in the while loop below then later access in the following switch-case may check uninitialized values.
+     * Initialize "array" to NULL pointers to fix the issue. */
+    for (i = 0; i < MAX_SUCI_TOKEN; i++) {
+        array[i] = NULL;
+    }
+
     p = tmp;
     i = 0;
     while((array[i++] = strsep(&p, "-"))) {

--- a/lib/sctp/ogs-lksctp.c
+++ b/lib/sctp/ogs-lksctp.c
@@ -194,6 +194,10 @@ int ogs_sctp_connect(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
 
     ogs_assert(sock);
 
+    /* Clang scan-build SA: NULL pointer dereference: if addr=sa_list=NULL then the macro OGS_PORT(sa_list) will
+     * dereference the NULL pointer. */
+    ogs_assert(sa_list);
+
     addr = sa_list;
     while (addr) {
         if (ogs_sock_connect(sock, addr) == OGS_OK) {

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -377,8 +377,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
             case OpenAPI_n2_sm_info_type_PDU_RES_MOD_REQ:
                 if (!n1smbuf) {
-                    ogs_error("[%s:%d] No N1 SM Content [%s]",
-                            amf_ue->supi, sess->psi, n1SmMsg->content_id);
+                    /* Clang scan-build SA: NULL pointer deference: n1SmMsg=NULL, remove logging of n1SmMsg->content_id. */
+                    ogs_error("[%s:%d] No N1 SM Content",
+                            amf_ue->supi, sess->psi);
                     r = nas_5gs_send_back_gsm_message(ran_ue, sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME);
@@ -419,8 +420,9 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
             case OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD:
                 if (!n1smbuf) {
-                    ogs_error("[%s:%d] No N1 SM Content [%s]",
-                            amf_ue->supi, sess->psi, n1SmMsg->content_id);
+                    /* Clang scan-build SA: NULL pointer deference: n1SmMsg=NULL, remove logging of n1SmMsg->content_id. */
+                    ogs_error("[%s:%d] No N1 SM Content",
+                            amf_ue->supi, sess->psi);
                     r = nas_5gs_send_back_gsm_message(ran_ue, sess,
                             OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
                             AMF_NAS_BACKOFF_TIME);

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -146,6 +146,8 @@ static int mme_s6a_subscription_data_from_avp(struct avp *avp,
     ogs_assert(ret == 0);
     if (avpch1) {
         ret = fd_msg_avp_hdr(avpch1, &hdr);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
         ogs_ascii_to_hex(
             (char*)hdr->avp_value->os.data, (int)hdr->avp_value->os.len,
             buf, sizeof(buf));
@@ -292,6 +294,8 @@ static int mme_s6a_subscription_data_from_avp(struct avp *avp,
                 ogs_assert(ret == 0);
                 if (avpch3) {
                     ret = fd_msg_avp_hdr(avpch3, &hdr);
+                    /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+                    ogs_assert(ret == 0);
                     session->name = ogs_strndup(
                                     (char*)hdr->avp_value->os.data,
                                     hdr->avp_value->os.len);
@@ -565,6 +569,8 @@ static int mme_s6a_subscription_data_from_avp(struct avp *avp,
                     ogs_assert(ret == 0);
                     while (avpch4) {
                         ret = fd_msg_avp_hdr(avpch4, &hdr);
+                        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+                        ogs_assert(ret == 0);
                         switch(hdr->avp_code) {
                         case OGS_DIAM_S6A_AVP_CODE_MIP_HOME_AGENT_ADDRESS:
                             ret = fd_msg_avp_value_interpret(avpch4,
@@ -1018,8 +1024,12 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
 
 
     ret = fd_avp_search_avp(avp_e_utran_vector, ogs_diam_s6a_rand, &avp_rand);
+    /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+    ogs_assert(ret == 0);
     if (avp) {
         ret = fd_msg_avp_hdr(avp_rand, &hdr);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
         memcpy(e_utran_vector->rand, hdr->avp_value->os.data,
                 ogs_min(hdr->avp_value->os.len,
                     OGS_ARRAY_SIZE(e_utran_vector->rand)));
@@ -1440,6 +1450,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
         uint32_t subdatamask = 0;
         ret = mme_s6a_subscription_data_from_avp(avp, subscription_data, mme_ue,
             &subdatamask);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
 
         if (!(subdatamask & OGS_DIAM_S6A_SUBDATA_NAM)) {
             mme_ue->network_access_mode = 0;
@@ -1999,7 +2011,8 @@ static int mme_ogs_diam_s6a_idr_cb( struct msg **msg, struct avp *avp,
     int ret;
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
     uint32_t result_code = 0;
-    bool has_subscriber_data;
+    /* Clang scan-build SA: Branch condition evaluates to a garbage value: has_subscriber_data can be used uninitialized. */
+    bool has_subscriber_data = false;
 
     struct msg *ans, *qry;
 
@@ -2064,6 +2077,8 @@ static int mme_ogs_diam_s6a_idr_cb( struct msg **msg, struct avp *avp,
             uint32_t subdatamask = 0;
             ret = mme_s6a_subscription_data_from_avp(avp, subscription_data, 
                 mme_ue, &subdatamask);
+            /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+            ogs_assert(ret == 0);
             idr_message->subdatamask = subdatamask;
             ogs_info("[%s] Subscription-Data Processed.", imsi_bcd);
         }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -854,6 +854,11 @@ cleanup:
             mme_gn_handle_sgsn_context_request(xact, &gtp1_message.sgsn_context_request);
             break;
         case OGS_GTP1_SGSN_CONTEXT_RESPONSE_TYPE:
+            /* Clang scan-build SA: NULL pointer dereference: mme_ue=NULL if both gtp1_message.h.teid=0 and
+             * xact->local_teid=0. The following function mme_gn_handle_sgsn_context_response() handles the NULL
+             * but the later calls to OGS_FSM_TRAN() to change state will be a NULL pointer dereference. */
+            ogs_assert(mme_ue);
+
             /* 3GPP TS 23.401 Figure D.3.6-1 step 5 */
             rv = mme_gn_handle_sgsn_context_response(xact, mme_ue, &gtp1_message.sgsn_context_response);
             if (rv == OGS_GTP1_CAUSE_ACCEPT) {

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -2268,6 +2268,10 @@ void s1ap_handle_enb_direct_information_transfer(
         }
     }
 
+    /* Clang scan-build SA: NULL pointer dereference: Inter_SystemInformationTransferType=NULL if above
+     * protocolIEs.list.count=0 in loop. */
+    ogs_assert(Inter_SystemInformationTransferType);
+
     RIMTransfer = Inter_SystemInformationTransferType->choice.rIMTransfer;
 
     RIMInformation = &RIMTransfer->rIMInformation;

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -124,6 +124,11 @@ void sgsap_handle_location_update_accept(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
     return;
 
 error:
+    /* Clang scan-build SA: NULL pointer dereference: mme_ue=NULL if root=NULL. */
+    if (!mme_ue) {
+        ogs_error("!mme_ue");
+        return;
+    }
     r = nas_eps_send_attach_reject(
             enb_ue_find_by_id(mme_ue->enb_ue_id), mme_ue,
             OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,

--- a/src/nssf/context.c
+++ b/src/nssf/context.c
@@ -233,6 +233,10 @@ int nssf_context_parse_config(void)
                                                     addr, addr6, port, &h);
                                             ogs_assert(nrf_id);
 
+					    /* Clang scan-build SA: Argument with nonnull attribute passed null:
+					     * sst may be NULL in atoi(sst) if the "uri" key path is followed. */
+					    ogs_assert(sst);
+
                                             nsi = nssf_nsi_add(
                                                     nrf_id,
                                                     atoi(sst),

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -280,8 +280,9 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             e->h.sbi.message = &message;
             ogs_fsm_dispatch(&sess->sm, e);
             if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
+                /* Clang scan-build SA: NULL pointer dereference: pcf_ue=NULL, remove logging of pcf_ue->supi. */
                 ogs_error("[%s:%d] State machine exception",
-                        pcf_ue->supi, sess->psi);
+                        pcf_ue ? pcf_ue->supi : "Unknown", sess->psi);
                 pcf_sess_remove(sess);
             }
             break;
@@ -331,8 +332,9 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             e->h.sbi.message = &message;
             ogs_fsm_dispatch(&sess->sm, e);
             if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
+                /* Clang scan-build SA: NULL pointer dereference: pcf_ue=NULL, remove logging of pcf_ue->supi. */
                 ogs_error("[%s:%d] State machine exception",
-                        pcf_ue->supi, sess->psi);
+                        pcf_ue ? pcf_ue->supi : "Unknown", sess->psi);
                 pcf_sess_remove(sess);
             }
             break;

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -163,7 +163,8 @@ int sgwc_context_parse_config(void)
 sgwc_ue_t *sgwc_ue_add_by_message(ogs_gtp2_message_t *message)
 {
     sgwc_ue_t *sgwc_ue = NULL;
-    ogs_gtp2_create_session_request_t *req = &message->create_session_request;
+    /* Clang scan-build SA: Dead initialization: Don't set req before message is checked for NULL. */
+    ogs_gtp2_create_session_request_t *req;
 
     ogs_assert(message);
 

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -302,6 +302,9 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                 }
                 up_f_seid = rsp->up_f_seid.data;
                 ogs_assert(up_f_seid);
+                /* Clang scan-build SA: NULL pointer dereference: sess=NULL if both message->h.seid=0 and
+                 * xact->local_seid=0. */
+                ogs_assert(sess);
                 sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
             } else {
                 sgwc_sxa_handle_session_establishment_response(

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -865,6 +865,8 @@ void sgwc_sxa_handle_session_modification_response(
             pgw_s5u_teid.teid = htobe32(ul_tunnel->remote_teid);
             rv = ogs_gtp2_ip_to_f_teid(
                     &ul_tunnel->remote_ip, &pgw_s5u_teid, &len);
+            /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+            ogs_assert(rv == OGS_OK);
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.presence = 1;
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.data = &pgw_s5u_teid;
             gtp_rsp->bearer_contexts.s5_s8_u_pgw_f_teid.len = len;

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -192,8 +192,19 @@ ogs_pkbuf_t *smf_gn_build_create_pdp_context_response(
 
     /* End User Address */
     rv = ogs_paa_to_ip(&sess->paa, &ip_eua);
+    /* Clang scan-build SA: Value stored is not used: add check for rv error. */
+    if (rv != OGS_OK) {
+        ogs_error("ogs_paa_to_ip() failed");
+        return NULL;
+    }
     rv = ogs_gtp1_ip_to_eua(sess->session.session_type, &ip_eua, &eua,
             &eua_len);
+    /* Clang scan-build SA: Value stored is not used: add check for rv error. */
+    if (rv != OGS_OK) {
+        ogs_error("ogs_gtp1_ip_to_eua() failed");
+        return NULL;
+    }
+
     rsp->end_user_address.presence = 1;
     rsp->end_user_address.data = &eua;
     rsp->end_user_address.len = eua_len;

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -401,11 +401,15 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     /* PDP-Address, TS 32.299 7.2.137 */
     if (sess->ipv4) {
         ret = fd_msg_avp_new(ogs_diam_gy_pdp_address, 0, &avpch2);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
         sin.sin_family = AF_INET;
         memcpy(&sin.sin_addr.s_addr, (uint8_t*)&sess->ipv4->addr[0], OGS_IPV4_LEN);
         ret = fd_msg_avp_value_encode(&sin, avpch2);
         ogs_assert(ret == 0);
         ret = fd_msg_avp_add(avpch1, MSG_BRW_LAST_CHILD, avpch2);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
     }
     if (sess->ipv6) {
         ret = fd_msg_avp_new(ogs_diam_gy_pdp_address, 0, &avpch2);
@@ -425,6 +429,8 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     /* SGSN-Address */
     if (sess->sgw_s5c_ip.ipv4) {
         ret = fd_msg_avp_new(ogs_diam_gy_sgsn_address, 0, &avpch2);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
         sin.sin_family = AF_INET;
         memcpy(&sin.sin_addr.s_addr, (uint8_t*)&sess->sgw_s5c_ip.addr, OGS_IPV4_LEN);
         ret = fd_msg_avp_value_encode(&sin, avpch2);
@@ -434,6 +440,8 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     }
     if (sess->sgw_s5c_ip.ipv6) {
         ret = fd_msg_avp_new(ogs_diam_gy_sgsn_address, 0, &avpch2);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
         sin6.sin6_family = AF_INET6;
         memcpy(&sin6.sin6_addr.s6_addr, (uint8_t*)&sess->sgw_s5c_ip.addr6[0], OGS_IPV6_LEN);
         ret = fd_msg_avp_value_encode(&sin6, avpch2);
@@ -569,6 +577,8 @@ static void fill_ps_information(smf_sess_t *sess, uint32_t cc_request_type,
     if (smf_ue->imeisv_len > 0) {
         /* User-Equipment-Info, 3GPP TS 32.299 7.1.17 */
         ret = fd_msg_avp_new(ogs_diam_gy_user_equipment_info, 0, &avpch2);
+        /* Clang scan-build SA: Value stored is not used: add ogs_assert(). */
+        ogs_assert(ret == 0);
 
         /* User-Equipment-Info-Type 0 (IMEI) */
         ret = fd_msg_avp_new(ogs_diam_gy_user_equipment_info_type, 0, &avpch3);

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -690,7 +690,8 @@ bool udm_nudm_sdm_handle_subscription_create(
         return false;
     }
 
-    if ((!SDMSubscription->monitored_resource_uris) &&
+    /* Clang scan-build SA: NULL pointer dereference: change && to || in case monitored_resource_uris=NULL. */
+    if ((!SDMSubscription->monitored_resource_uris) ||
         (!SDMSubscription->monitored_resource_uris->count)) {
         ogs_error("[%s] No monitoredResourceUris", udm_ue->supi);
         ogs_assert(true ==


### PR DESCRIPTION
The clang scan-build procedure

```
Assume Ubuntu docker container with open5gs mounted to /src.

Assume these tools are installed to docker container:
sudo apt install -y clang-tools clang

For easy reference to clang scan-build tool:
Put normal open5gs build procedure into a file called /src/build

=======================
Inside docker container:
=======================
export CLANG_OUT_DIR=/src/scan_build_results

scan-build -disable-checker deadcode.DeadStores --override-compiler --keep-going
 --exclude subprojects --exclude tests --exclude lib/asn1c -maxloop 200 -o $CLANG_OUT_DIR -plist-html /src/build 2>&1 | tee /src/logclang.txt

=======================
Results:
=======================
Results are in html format in $CLANG_OUT_DIR - top level index.html
```

Note that in this analysis the following suppressions were assumed:
- no deadcode.DeadStores analysis since those are not functional findings
- exclude lib/asn1c for reason that is outside of open5gs control
- exclude tests for reason that those are not functional findings
- exclude subprojects since those are outside of open5gs control