### PR TITLE
[MME] Gn/2G to 4G mobility: Fix QoS values

### DIFF
--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -460,7 +460,7 @@ struct mme_ue_s {
     uint8_t         kenb[OGS_SHA256_DIGEST_SIZE];
     uint8_t         hash_mme[OGS_HASH_MME_LEN];
     uint32_t        nonceue, noncemme;
-    uint8_t gprs_ciphering_key_sequence_number;
+    uint8_t         gprs_ciphering_key_sequence_number;
 
     struct {
     ED2(uint8_t nhcc_spare:5;,

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -243,8 +243,8 @@ static mme_sess_t *mme_ue_session_from_gtp1_pdp_ctx(mme_ue_t *mme_ue, const ogs_
     ogs_gtp1_qos_profile_to_qci(qos_pdec, &qci);
     ogs_sess->qos.index = qci;
     ogs_sess->qos.arp.priority_level = qos_pdec->qos_profile.arp; /* 3GPP TS 23.401 Annex E Table E.2 */
-    ogs_sess->qos.arp.pre_emption_capability = 0; /* ignored as per 3GPP TS 23.401 Annex E */
-    ogs_sess->qos.arp.pre_emption_vulnerability = 0; /* ignored as per 3GPP TS 23.401 Annex E */
+    ogs_sess->qos.arp.pre_emption_capability = 0; /* operator policy, hardcoded, 3GPP TS 23.401 Annex E */
+    ogs_sess->qos.arp.pre_emption_vulnerability = 1; /* operator policy, hardcoded, 3GPP TS 23.401 Annex E */
     if (qos_pdec->data_octet6_to_13_present) {
         ogs_sess->ambr.downlink = qos_pdec->dec_mbr_kbps_dl * 1000;
         ogs_sess->ambr.uplink = qos_pdec->dec_mbr_kbps_ul * 1000;

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -289,6 +289,10 @@ static mme_sess_t *mme_ue_session_from_gtp1_pdp_ctx(mme_ue_t *mme_ue, const ogs_
     bearer->enb_s1u_ip.ipv4 = 1;
     bearer->enb_s1u_ip.addr = 0;
     bearer->enb_s1u_teid = 0xffffffff;
+    bearer->qos.index = ogs_sess->qos.index;
+    bearer->qos.arp.priority_level = ogs_sess->qos.arp.priority_level;
+    bearer->qos.arp.pre_emption_capability = ogs_sess->qos.arp.pre_emption_capability;
+    bearer->qos.arp.pre_emption_vulnerability = ogs_sess->qos.arp.pre_emption_vulnerability;
 
     return sess;
 }


### PR DESCRIPTION
Correct the Quality of Service values for a translated bearer when a UE comes from 2G to 4G.
Without the commits, the MME requests a bearer with QCI 0.
Certain eNodeBs will reject such bearer (Ericsson rbs6402).