### PR TITLE
[MME] Avoid crash if tx Security Mode Command fails

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -1167,7 +1167,8 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
         CLEAR_MME_UE_TIMER(mme_ue->t3460);
         r = nas_eps_send_security_mode_command(mme_ue);
         ogs_expect(r == OGS_OK);
-        ogs_assert(r != OGS_ERROR);
+        if (r == OGS_ERROR)
+            OGS_FSM_TRAN(s, &emm_state_exception);
         break;
     case OGS_FSM_EXIT_SIG:
         break;


### PR DESCRIPTION
This can happen if a UE never sends the UE Network Capabilities IE (eg Attach or TAU) when coming from 2G to 4G:
```
08/21 11:45:31.476: [emm] DEBUG: emm_state_security_mode(): ENTRY (/open5gs/src/mme/emm-sm.c:1162) 08/21 11:45:31.476: [mme] DEBUG: [262420000000007] Security mode command (/open5gs/src/mme/nas-path.c:336)
08/21 11:45:31.476: [emm] DEBUG:     Replayed UE SEC[LEN:2 EEA:0x0 EIA:0x0 UEA:0x0 UIA:0x0 GEA:0x0] (/open5gs/src/mme/emm-build.c:385)
08/21 11:45:31.476: [emm] DEBUG:     Selected[Integrity:0x0 Encrypt:0x0] (/open5gs/src/mme/emm-build.c:393)
08/21 11:45:31.476: [emm] ERROR: Encrypt[0x0] can be skipped with EEA0, but Integrity[0x0] cannot be bypassed with EIA0 (/open5gs/src/mme/emm-build.c:447)
08/21 11:45:31.476: [mme] ERROR: emm_build_security_mode_command() failed (/open5gs/src/mme/nas-path.c:343)
08/21 11:45:31.476: [emm] ERROR: emm_state_security_mode: Expectation `r == OGS_OK' failed. (/open5gs/src/mme/emm-sm.c:1171)
```

Instead of crashing the MME, fail gracefuly sending a UeContextReleaseCommand.

Reproduced/tested with a WIP ttcn3 test.