### PR TITLE
[MME] Force re-auth of UE during 2g->4g cell reselection

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3354,6 +3354,7 @@ mme_ue_t *mme_ue_add(enb_ue_t *enb_ue)
         ogs_pool_id_free(&mme_ue_pool, mme_ue);
         return NULL;
     }
+    mme_ue->gn.gtp_xact_id = OGS_INVALID_POOL_ID;
 
     mme_ebi_pool_init(mme_ue);
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -402,6 +402,7 @@ struct mme_ue_s {
         ogs_ip_t        sgsn_gn_ip_alt;
         /* Unnamed timer in 3GPP TS 23.401 D.3.5 step 2), see also 3GPP TS 23.060 6.9.1.2.2 */
         ogs_timer_t     *t_gn_holding;
+        ogs_pool_id_t   gtp_xact_id; /* 2g->4g SGSN Context Req/Resp/Ack gtp1c xact */
     } gn;
 
     struct {

--- a/src/mme/mme-event.h
+++ b/src/mme/mme-event.h
@@ -99,6 +99,7 @@ typedef struct mme_event_s {
     ogs_pool_id_t sgw_ue_id;
     ogs_pool_id_t mme_ue_id;
     ogs_pool_id_t bearer_id;
+    ogs_pool_id_t gtp_xact_id;
 
     ogs_timer_t *timer;
 } mme_event_t;

--- a/src/mme/mme-fd-path.h
+++ b/src/mme/mme-fd-path.h
@@ -33,6 +33,9 @@ void mme_fd_final(void);
 void mme_s6a_send_air(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
     ogs_nas_authentication_failure_parameter_t
         *authentication_failure_parameter);
+void mme_s6a_send_air_from_gn(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
+    ogs_gtp_xact_t *gtp_xact);
+
 /* MME Sends Update Location Request to HSS */
 void mme_s6a_send_ulr(enb_ue_t *enb_ue, mme_ue_t *mme_ue);
 /* MME Sends Purge UE Request to HSS */

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -429,11 +429,8 @@ int mme_gn_handle_sgsn_context_response(
         gtp1_cause = OGS_GTP1_CAUSE_SYSTEM_FAILURE;
         goto nack_and_reject;
     }
-
-    rv = mme_gtp1_send_sgsn_context_ack(mme_ue, OGS_GTP1_CAUSE_REQUEST_ACCEPTED, xact);
-
-    mme_gtp_send_create_session_request(
-            enb_ue, sess, OGS_GTP_CREATE_IN_TRACKING_AREA_UPDATE);
+    /* Store sess id to be able to retrieve it later on from xact: */
+    xact->data = OGS_UINT_TO_POINTER(sess->pti);
 
     return ret_cause;
 

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -425,6 +425,10 @@ int mme_gn_handle_sgsn_context_response(
     }
 
     sess = mme_ue_session_from_gtp1_pdp_ctx(mme_ue, &gtp1_pdp_ctx);
+    if (!sess) {
+        gtp1_cause = OGS_GTP1_CAUSE_SYSTEM_FAILURE;
+        goto nack_and_reject;
+    }
 
     rv = mme_gtp1_send_sgsn_context_ack(mme_ue, OGS_GTP1_CAUSE_REQUEST_ACCEPTED, xact);
 

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -39,7 +39,6 @@ static uint8_t mme_ue_session_from_slice_data(mme_ue_t *mme_ue,
 uint8_t mme_s6a_handle_aia(
         mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
 {
-    int r;
     ogs_diam_s6a_aia_message_t *aia_message = NULL;
     ogs_diam_e_utran_vector_t *e_utran_vector = NULL;
 
@@ -66,10 +65,6 @@ uint8_t mme_s6a_handle_aia(
 
     if (mme_ue->nas_eps.ksi == OGS_NAS_KSI_NO_KEY_IS_AVAILABLE)
         mme_ue->nas_eps.ksi = 0;
-
-    r = nas_eps_send_authentication_request(mme_ue);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
 
     return OGS_NAS_EMM_CAUSE_REQUEST_ACCEPTED;
 }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -624,20 +624,10 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
                 break;
             }
 
-            /* TODO: Delay this further until AuthReq below + SecurityModeCommand succeeds against UE */
             if (xact) {
-                rv = mme_gtp1_send_sgsn_context_ack(mme_ue,
-                                                    OGS_GTP1_CAUSE_REQUEST_ACCEPTED,
-                                                    xact);
-                if (rv != OGS_OK) {
-                    ogs_warn("Tx SGSN Context Request failed(%d)", rv);
-                    break;
-                }
-                mme_sess_t *sess = mme_sess_find_by_pti(mme_ue, OGS_POINTER_TO_UINT(xact->data));
-                ogs_assert(sess);
-                mme_gtp_send_create_session_request(enb_ue, sess,
-                                                    OGS_GTP_CREATE_IN_TRACKING_AREA_UPDATE);
-                OGS_FSM_TRAN(&mme_ue->sm, &emm_state_initial_context_setup);
+                /* Subscriber coming from SGSN, store info so we can SGSN
+                 * Context Ack after authenticating the UE: */
+                mme_ue->gn.gtp_xact_id = e->gtp_xact_id;
             }
 
             /* Auth-Info accepted from HSS, now authenticate the UE: */

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -595,7 +595,14 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
                         S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
+                break;
             }
+
+            /* Auth-Info accepted from HSS, now authenticate the UE: */
+            r = nas_eps_send_authentication_request(mme_ue);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+
             break;
         case OGS_DIAM_S6A_CMD_CODE_UPDATE_LOCATION:
             ogs_debug("OGS_DIAM_S6A_CMD_CODE_UPDATE_LOCATION");


### PR DESCRIPTION
As per 3GPP TS 23.401 Annex D.3.6 step 6, "Security functions may be
executed" during TAU (UE cell reselection 2g->4g).

The idea is that the 4G network should check the integrity of the TAU,
and only if iexisting and valid then accept it right away. Otherwise,
an authorization procedure is started.

Until now, during 2g->4g TAU we were retrieving and acking the PDP Context
received from the SGSN and creating the session against the SGW right away.

Tests done so far with real phones ended up in unsuccesful results when
tring to reuse the 4g context derived from 2g, due to yet unknown
reasons.
Hence, with this patchset we simply force for now the re-auth and
recreation of security context before completing the TAU. This showed
good results during testing with real phones.

The security context is recreated through:
* S6a 3gpp-Authentication-Info towards HSS
* S1AP/NAS Authentication Request+Response towards UE
* SecurityModeCommand towards UE.