### PR TITLE
diameter: Integrate stats into mainloop

### DIFF
--- a/lib/diameter/common/config.c
+++ b/lib/diameter/common/config.c
@@ -105,7 +105,7 @@ static int diam_config_apply(ogs_diam_config_t *fd_config)
                     fd_config->conn[i].addr, errno, strerror(errno));
             return OGS_ERROR;
         }
-        
+
         CHECK_FCT_DO( fd_ep_add_merge(
                 &fddpi.pi_endpoints, ai->ai_addr, ai->ai_addrlen,
                 EP_FL_CONF | (disc ?: EP_ACCEPTALL) ), return OGS_ERROR);
@@ -197,7 +197,7 @@ int ogs_diam_config_init(ogs_diam_config_t *fd_config)
 
     /* Display configuration */
     b = fd_conf_dump(&buf, &len, NULL);
-    LOG_SPLIT(FD_LOG_NOTICE, NULL, 
+    LOG_SPLIT(FD_LOG_NOTICE, NULL,
             b ?: (char*)"<Error during configuration dump...>", NULL);
     free(buf);
 

--- a/lib/diameter/common/init.c
+++ b/lib/diameter/common/init.c
@@ -55,7 +55,10 @@ int ogs_diam_init(int mode, const char *conffile, ogs_diam_config_t *fd_config)
     CHECK_FCT( ogs_diam_message_init() );
 
     /* Initialize FD logger */
-    CHECK_FCT_DO( ogs_diam_logger_init(mode), goto error );
+    CHECK_FCT_DO( ogs_diam_logger_init(), goto error );
+
+    /* Initialize FD stats */
+    CHECK_FCT_DO( ogs_diam_stats_init(mode), goto error );
 
     return 0;
 error:
@@ -72,7 +75,7 @@ int ogs_diam_start(void)
 
     CHECK_FCT_DO( fd_core_waitstartcomplete(), goto error );
 
-    CHECK_FCT( ogs_diam_logger_stats_start() );
+    CHECK_FCT( ogs_diam_stats_start() );
 
     return 0;
 error:
@@ -84,6 +87,7 @@ error:
 
 void ogs_diam_final()
 {
+    ogs_diam_stats_final();
     ogs_diam_logger_final();
 
     CHECK_FCT_DO( fd_core_shutdown(), ogs_error("fd_core_shutdown() failed") );

--- a/lib/diameter/common/init.c
+++ b/lib/diameter/common/init.c
@@ -36,14 +36,14 @@ int ogs_diam_init(int mode, const char *conffile, ogs_diam_config_t *fd_config)
     if (ret != 0) {
         ogs_error("fd_log_handler_register() failed");
         return ret;
-    } 
+    }
 
     ret = fd_core_initialize();
     if (ret != 0) {
         ogs_error("fd_core_initialize() failed");
         return ret;
-    } 
-    
+    }
+
     /* Parse the configuration file */
     if (conffile) {
         CHECK_FCT_DO( fd_core_parseconf(conffile), goto error );
@@ -118,12 +118,12 @@ static void diam_log_func(int printlevel, const char *format, va_list ap)
     ogs_log_printf(level, OGS_LOG_DOMAIN, 0, NULL, 0, NULL, 0, __VA_ARGS__)
 
     switch(printlevel) {
-    case FD_LOG_ANNOYING: 
+    case FD_LOG_ANNOYING:
         diam_log_printf(OGS_LOG_TRACE, "[%d] %s\n", printlevel, buffer);
-        break;  
+        break;
     case FD_LOG_DEBUG:
         diam_log_printf(OGS_LOG_TRACE, "[%d] %s\n", printlevel, buffer);
-        break;  
+        break;
     case FD_LOG_INFO:
         diam_log_printf(OGS_LOG_TRACE, "[%d] %s\n", printlevel, buffer);
         break;

--- a/lib/diameter/common/logger.c
+++ b/lib/diameter/common/logger.c
@@ -19,55 +19,28 @@
 
 #include "ogs-diameter-common.h"
 
-static ogs_diam_logger_t self;
-
 static struct fd_hook_hdl *logger_hdl = NULL;
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
-static pthread_t fd_stats_th = (pthread_t)NULL;
 
 static ogs_diam_logger_user_handler user_handler = NULL;
 
 static void ogs_diam_logger_cb(enum fd_hook_type type, struct msg * msg,
     struct peer_hdr * peer, void * other, struct fd_hook_permsgdata *pmd,
     void * regdata);
-static void * diam_stats_worker(void * arg);
 
-int ogs_diam_logger_init(int mode)
+int ogs_diam_logger_init()
 {
     uint32_t mask_peers = HOOK_MASK( HOOK_PEER_CONNECT_SUCCESS );
 
-    memset(&self, 0, sizeof(ogs_diam_logger_t));
-
-    self.mode = mode;
-    self.duration = 60;       /* 60 seconds */
-
     CHECK_FCT( fd_hook_register(
             mask_peers, ogs_diam_logger_cb, NULL, NULL, &logger_hdl) );
-
-    CHECK_POSIX( pthread_mutex_init(&self.stats_lock, NULL) );
 
     return 0;
 }
 
 void ogs_diam_logger_final()
 {
-    CHECK_FCT_DO( fd_thr_term(&fd_stats_th), );
-    CHECK_POSIX_DO( pthread_mutex_destroy(&self.stats_lock), );
-
     if (logger_hdl) { CHECK_FCT_DO( fd_hook_unregister( logger_hdl ), ); }
-}
-
-ogs_diam_logger_t* ogs_diam_logger_self()
-{
-    return &self;
-}
-
-int ogs_diam_logger_stats_start()
-{
-    /* Start the statistics thread */
-    CHECK_POSIX( pthread_create(&fd_stats_th, NULL, diam_stats_worker, NULL) );
-
-    return 0;
 }
 
 void ogs_diam_logger_register(ogs_diam_logger_user_handler instance)
@@ -114,64 +87,5 @@ static void ogs_diam_logger_cb(enum fd_hook_type type, struct msg * msg,
     }
 
     CHECK_POSIX_DO( pthread_mutex_unlock(&mtx), );
-}
-
-/* Function to display statistics periodically */
-static void * diam_stats_worker(void * arg)
-{
-    struct timespec start, now;
-    struct fd_stats copy;
-
-    /* Get the start time */
-    CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &start), );
-
-    /* Now, loop until canceled */
-    while (1) {
-        /* Display statistics every XX seconds */
-        sleep(self.duration);
-
-        /* Now, get the current stats */
-        CHECK_POSIX_DO( pthread_mutex_lock(&self.stats_lock), );
-        memcpy(&copy, &self.stats, sizeof(struct fd_stats));
-        CHECK_POSIX_DO( pthread_mutex_unlock(&self.stats_lock), );
-
-        /* Get the current execution time */
-        CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &now), );
-
-        /* Now, display everything */
-        ogs_trace("------- fd statistics ---------");
-        if (now.tv_nsec >= start.tv_nsec)
-        {
-            ogs_trace(" Executing for: %d.%06ld sec",
-                    (int)(now.tv_sec - start.tv_sec),
-                    (long)(now.tv_nsec - start.tv_nsec) / 1000);
-        }
-        else
-        {
-            ogs_trace(" Executing for: %d.%06ld sec",
-                    (int)(now.tv_sec - 1 - start.tv_sec),
-                    (long)(now.tv_nsec + 1000000000 - start.tv_nsec) / 1000);
-        }
-
-        if (self.mode & FD_MODE_SERVER) {
-            ogs_trace(" Server: %llu message(s) echoed",
-                    copy.nb_echoed);
-        }
-        if (self.mode & FD_MODE_CLIENT) {
-            ogs_trace(" Client:");
-            ogs_trace("   %llu message(s) sent", copy.nb_sent);
-            ogs_trace("   %llu error(s) received", copy.nb_errs);
-            ogs_trace("   %llu answer(s) received", copy.nb_recv);
-            ogs_trace("     fastest: %ld.%06ld sec.",
-                    copy.shortest / 1000000, copy.shortest % 1000000);
-            ogs_trace("     slowest: %ld.%06ld sec.",
-                    copy.longest / 1000000, copy.longest % 1000000);
-            ogs_trace("     Average: %ld.%06ld sec.",
-                    copy.avg / 1000000, copy.avg % 1000000);
-        }
-        ogs_trace("-------------------------------------");
-    }
-
-    return NULL; /* never called */
 }
 

--- a/lib/diameter/common/logger.c
+++ b/lib/diameter/common/logger.c
@@ -19,7 +19,7 @@
 
 #include "ogs-diameter-common.h"
 
-static struct ogs_diam_logger_t self;
+static ogs_diam_logger_t self;
 
 static struct fd_hook_hdl *logger_hdl = NULL;
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
@@ -36,7 +36,7 @@ int ogs_diam_logger_init(int mode)
 {
     uint32_t mask_peers = HOOK_MASK( HOOK_PEER_CONNECT_SUCCESS );
 
-    memset(&self, 0, sizeof(struct ogs_diam_logger_t));
+    memset(&self, 0, sizeof(ogs_diam_logger_t));
 
     self.mode = mode;
     self.duration = 60;       /* 60 seconds */
@@ -57,7 +57,7 @@ void ogs_diam_logger_final()
     if (logger_hdl) { CHECK_FCT_DO( fd_hook_unregister( logger_hdl ), ); }
 }
 
-struct ogs_diam_logger_t* ogs_diam_logger_self()
+ogs_diam_logger_t* ogs_diam_logger_self()
 {
     return &self;
 }

--- a/lib/diameter/common/logger.h
+++ b/lib/diameter/common/logger.h
@@ -28,7 +28,7 @@
 extern "C" {
 #endif
 
-struct ogs_diam_logger_t {
+typedef struct ogs_diam_logger_s {
 
 #define FD_MODE_SERVER   0x1
 #define FD_MODE_CLIENT   0x2
@@ -46,12 +46,12 @@ struct ogs_diam_logger_t {
     } stats;
 
     pthread_mutex_t stats_lock;
-};
+} ogs_diam_logger_t;
 
 int ogs_diam_logger_init(int mode);
 void ogs_diam_logger_final(void);
 
-struct ogs_diam_logger_t* ogs_diam_logger_self(void);
+ogs_diam_logger_t* ogs_diam_logger_self(void);
 
 int ogs_diam_logger_stats_start(void);
 

--- a/lib/diameter/common/meson.build
+++ b/lib/diameter/common/meson.build
@@ -20,12 +20,14 @@ libdiameter_common_sources = files('''
 
     message.h
     logger.h
+    stats.h
     base.h
 
     libapp_sip.c
     dict.c
     message.c
     logger.c
+    stats.c
     config.c
     util.c
     init.c

--- a/lib/diameter/common/meson.build
+++ b/lib/diameter/common/meson.build
@@ -53,10 +53,10 @@ libdiameter_common = library('ogsdiameter-common',
     version : libogslib_version,
     c_args : libdiameter_common_cc_flags,
     include_directories : [libdiameter_common_inc, libinc],
-    dependencies : [libcore_dep, libfdcore_dep],
+    dependencies : [libcore_dep, libfdcore_dep, libapp_dep],
     install : true)
 
 libdiameter_common_dep = declare_dependency(
     link_with : libdiameter_common,
     include_directories : [libdiameter_common_inc, libinc],
-    dependencies : [libcore_dep, libfdcore_dep])
+    dependencies : [libcore_dep, libfdcore_dep, libapp_dep])

--- a/lib/diameter/common/ogs-diameter-common.h
+++ b/lib/diameter/common/ogs-diameter-common.h
@@ -43,6 +43,7 @@
 
 #include "diameter/common/message.h"
 #include "diameter/common/logger.h"
+#include "diameter/common/stats.h"
 #include "diameter/common/base.h"
 
 #undef OGS_DIAMETER_INSIDE

--- a/lib/diameter/common/stats.c
+++ b/lib/diameter/common/stats.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ogs-diameter-common.h"
+
+static ogs_diam_stats_t self;
+static pthread_t fd_stats_th = (pthread_t)NULL;
+
+static void * diam_stats_worker(void * arg);
+
+int ogs_diam_stats_init(int mode)
+{
+    memset(&self, 0, sizeof(ogs_diam_stats_t));
+
+    self.mode = mode;
+    self.duration = 60;       /* 60 seconds */
+
+    CHECK_POSIX( pthread_mutex_init(&self.stats_lock, NULL) );
+
+    return 0;
+}
+
+void ogs_diam_stats_final()
+{
+    CHECK_FCT_DO( fd_thr_term(&fd_stats_th), );
+    CHECK_POSIX_DO( pthread_mutex_destroy(&self.stats_lock), );
+}
+
+ogs_diam_stats_t* ogs_diam_stats_self()
+{
+    return &self;
+}
+
+int ogs_diam_stats_start()
+{
+    /* Start the statistics thread */
+    CHECK_POSIX( pthread_create(&fd_stats_th, NULL, diam_stats_worker, NULL) );
+
+    return 0;
+}
+
+/* Function to display statistics periodically */
+static void * diam_stats_worker(void * arg)
+{
+    struct timespec start, now;
+    struct fd_stats copy;
+
+    /* Get the start time */
+    CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &start), );
+
+    /* Now, loop until canceled */
+    while (1) {
+        /* Display statistics every XX seconds */
+        sleep(self.duration);
+
+        /* Now, get the current stats */
+        CHECK_POSIX_DO( pthread_mutex_lock(&self.stats_lock), );
+        memcpy(&copy, &self.stats, sizeof(struct fd_stats));
+        CHECK_POSIX_DO( pthread_mutex_unlock(&self.stats_lock), );
+
+        /* Get the current execution time */
+        CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &now), );
+
+        /* Now, display everything */
+        ogs_trace("------- fd statistics ---------");
+        if (now.tv_nsec >= start.tv_nsec)
+        {
+            ogs_trace(" Executing for: %d.%06ld sec",
+                    (int)(now.tv_sec - start.tv_sec),
+                    (long)(now.tv_nsec - start.tv_nsec) / 1000);
+        }
+        else
+        {
+            ogs_trace(" Executing for: %d.%06ld sec",
+                    (int)(now.tv_sec - 1 - start.tv_sec),
+                    (long)(now.tv_nsec + 1000000000 - start.tv_nsec) / 1000);
+        }
+
+        if (self.mode & FD_MODE_SERVER) {
+            ogs_trace(" Server: %llu message(s) echoed",
+                    copy.nb_echoed);
+        }
+        if (self.mode & FD_MODE_CLIENT) {
+            ogs_trace(" Client:");
+            ogs_trace("   %llu message(s) sent", copy.nb_sent);
+            ogs_trace("   %llu error(s) received", copy.nb_errs);
+            ogs_trace("   %llu answer(s) received", copy.nb_recv);
+            ogs_trace("     fastest: %ld.%06ld sec.",
+                    copy.shortest / 1000000, copy.shortest % 1000000);
+            ogs_trace("     slowest: %ld.%06ld sec.",
+                    copy.longest / 1000000, copy.longest % 1000000);
+            ogs_trace("     Average: %ld.%06ld sec.",
+                    copy.avg / 1000000, copy.avg % 1000000);
+        }
+        ogs_trace("-------------------------------------");
+    }
+
+    return NULL; /* never called */
+}
+

--- a/lib/diameter/common/stats.c
+++ b/lib/diameter/common/stats.c
@@ -18,18 +18,21 @@
  */
 
 #include "ogs-diameter-common.h"
+#include "ogs-app.h"
 
 static ogs_diam_stats_t self;
-static pthread_t fd_stats_th = (pthread_t)NULL;
 
-static void * diam_stats_worker(void * arg);
+static void diam_stats_timer_cb(void *data);
 
 int ogs_diam_stats_init(int mode)
 {
     memset(&self, 0, sizeof(ogs_diam_stats_t));
 
     self.mode = mode;
-    self.duration = 60;       /* 60 seconds */
+    self.poll.t_interval = ogs_time_from_sec(60); /* 60 seconds */
+    self.poll.timer = ogs_timer_add(ogs_app()->timer_mgr,
+                diam_stats_timer_cb, 0);
+        ogs_assert(self.poll.timer);
 
     CHECK_POSIX( pthread_mutex_init(&self.stats_lock, NULL) );
 
@@ -38,8 +41,9 @@ int ogs_diam_stats_init(int mode)
 
 void ogs_diam_stats_final()
 {
-    CHECK_FCT_DO( fd_thr_term(&fd_stats_th), );
-    CHECK_POSIX_DO( pthread_mutex_destroy(&self.stats_lock), );
+    if (self.poll.timer)
+        ogs_timer_delete(self.poll.timer);
+    self.poll.timer = NULL;
 }
 
 ogs_diam_stats_t* ogs_diam_stats_self()
@@ -49,68 +53,59 @@ ogs_diam_stats_t* ogs_diam_stats_self()
 
 int ogs_diam_stats_start()
 {
-    /* Start the statistics thread */
-    CHECK_POSIX( pthread_create(&fd_stats_th, NULL, diam_stats_worker, NULL) );
+    /* Get the start time */
+    CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &self.poll.ts_start), );
+    /* Start the statistics timer */
+    ogs_timer_start(self.poll.timer, self.poll.t_interval);
 
     return 0;
 }
 
 /* Function to display statistics periodically */
-static void * diam_stats_worker(void * arg)
+static void diam_stats_timer_cb(void *data)
 {
-    struct timespec start, now;
+    struct timespec now;
     struct fd_stats copy;
 
-    /* Get the start time */
-    CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &start), );
+    /* Now, get the current stats */
+    CHECK_POSIX_DO( pthread_mutex_lock(&self.stats_lock), );
+    memcpy(&copy, &self.stats, sizeof(struct fd_stats));
+    CHECK_POSIX_DO( pthread_mutex_unlock(&self.stats_lock), );
 
-    /* Now, loop until canceled */
-    while (1) {
-        /* Display statistics every XX seconds */
-        sleep(self.duration);
+    /* Get the current execution time */
+    CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &now), );
 
-        /* Now, get the current stats */
-        CHECK_POSIX_DO( pthread_mutex_lock(&self.stats_lock), );
-        memcpy(&copy, &self.stats, sizeof(struct fd_stats));
-        CHECK_POSIX_DO( pthread_mutex_unlock(&self.stats_lock), );
-
-        /* Get the current execution time */
-        CHECK_SYS_DO( clock_gettime(CLOCK_REALTIME, &now), );
-
-        /* Now, display everything */
-        ogs_trace("------- fd statistics ---------");
-        if (now.tv_nsec >= start.tv_nsec)
-        {
-            ogs_trace(" Executing for: %d.%06ld sec",
-                    (int)(now.tv_sec - start.tv_sec),
-                    (long)(now.tv_nsec - start.tv_nsec) / 1000);
-        }
-        else
-        {
-            ogs_trace(" Executing for: %d.%06ld sec",
-                    (int)(now.tv_sec - 1 - start.tv_sec),
-                    (long)(now.tv_nsec + 1000000000 - start.tv_nsec) / 1000);
-        }
-
-        if (self.mode & FD_MODE_SERVER) {
-            ogs_trace(" Server: %llu message(s) echoed",
-                    copy.nb_echoed);
-        }
-        if (self.mode & FD_MODE_CLIENT) {
-            ogs_trace(" Client:");
-            ogs_trace("   %llu message(s) sent", copy.nb_sent);
-            ogs_trace("   %llu error(s) received", copy.nb_errs);
-            ogs_trace("   %llu answer(s) received", copy.nb_recv);
-            ogs_trace("     fastest: %ld.%06ld sec.",
-                    copy.shortest / 1000000, copy.shortest % 1000000);
-            ogs_trace("     slowest: %ld.%06ld sec.",
-                    copy.longest / 1000000, copy.longest % 1000000);
-            ogs_trace("     Average: %ld.%06ld sec.",
-                    copy.avg / 1000000, copy.avg % 1000000);
-        }
-        ogs_trace("-------------------------------------");
+    /* Now, display everything */
+    ogs_trace("------- fd statistics ---------");
+    if (now.tv_nsec >= self.poll.ts_start.tv_nsec) {
+        ogs_trace(" Executing for: %d.%06ld sec",
+                (int)(now.tv_sec - self.poll.ts_start.tv_sec),
+                (long)(now.tv_nsec - self.poll.ts_start.tv_nsec) / 1000);
+    } else {
+        ogs_trace(" Executing for: %d.%06ld sec",
+                (int)(now.tv_sec - 1 - self.poll.ts_start.tv_sec),
+                (long)(now.tv_nsec + 1000000000 - self.poll.ts_start.tv_nsec) / 1000);
     }
 
-    return NULL; /* never called */
+    if (self.mode & FD_MODE_SERVER) {
+        ogs_trace(" Server: %llu message(s) echoed",
+                copy.nb_echoed);
+    }
+    if (self.mode & FD_MODE_CLIENT) {
+        ogs_trace(" Client:");
+        ogs_trace("   %llu message(s) sent", copy.nb_sent);
+        ogs_trace("   %llu error(s) received", copy.nb_errs);
+        ogs_trace("   %llu answer(s) received", copy.nb_recv);
+        ogs_trace("     fastest: %ld.%06ld sec.",
+                copy.shortest / 1000000, copy.shortest % 1000000);
+        ogs_trace("     slowest: %ld.%06ld sec.",
+                copy.longest / 1000000, copy.longest % 1000000);
+        ogs_trace("     Average: %ld.%06ld sec.",
+                copy.avg / 1000000, copy.avg % 1000000);
+    }
+    ogs_trace("-------------------------------------");
+
+    /* Re-schedule timer: */
+    ogs_timer_start(self.poll.timer, self.poll.t_interval);
 }
 

--- a/lib/diameter/common/stats.c
+++ b/lib/diameter/common/stats.c
@@ -20,13 +20,13 @@
 #include "ogs-diameter-common.h"
 #include "ogs-app.h"
 
-static ogs_diam_stats_t self;
+static ogs_diam_stats_ctx_t self;
 
 static void diam_stats_timer_cb(void *data);
 
 int ogs_diam_stats_init(int mode)
 {
-    memset(&self, 0, sizeof(ogs_diam_stats_t));
+    memset(&self, 0, sizeof(ogs_diam_stats_ctx_t));
 
     self.mode = mode;
     self.poll.t_interval = ogs_time_from_sec(60); /* 60 seconds */
@@ -46,7 +46,7 @@ void ogs_diam_stats_final()
     self.poll.timer = NULL;
 }
 
-ogs_diam_stats_t* ogs_diam_stats_self()
+ogs_diam_stats_ctx_t* ogs_diam_stats_self()
 {
     return &self;
 }
@@ -66,11 +66,11 @@ int ogs_diam_stats_start()
 static void diam_stats_timer_cb(void *data)
 {
     ogs_time_t now, since_start, since_prev, next_run;
-    struct fd_stats copy;
+    ogs_diam_stats_t copy;
 
     /* Now, get the current stats */
     CHECK_POSIX_DO( pthread_mutex_lock(&self.stats_lock), );
-    memcpy(&copy, &self.stats, sizeof(struct fd_stats));
+    memcpy(&copy, &self.stats, sizeof(ogs_diam_stats_t));
     CHECK_POSIX_DO( pthread_mutex_unlock(&self.stats_lock), );
 
     /* Get the current execution time */

--- a/lib/diameter/common/stats.c
+++ b/lib/diameter/common/stats.c
@@ -62,6 +62,32 @@ int ogs_diam_stats_start()
     return 0;
 }
 
+static void ogs_diam_stats_log(const ogs_diam_stats_t *stats, ogs_time_t elapsed)
+{
+    ogs_trace("------- fd statistics ---------");
+    ogs_trace(" Executing for: %llu.%06llu sec",
+              (unsigned long long)ogs_time_sec(elapsed),
+              (unsigned long long)ogs_time_usec(elapsed));
+
+    if (self.mode & FD_MODE_SERVER) {
+        ogs_trace(" Server: %llu message(s) echoed",
+                stats->nb_echoed);
+    }
+    if (self.mode & FD_MODE_CLIENT) {
+        ogs_trace(" Client:");
+        ogs_trace("   %llu message(s) sent", stats->nb_sent);
+        ogs_trace("   %llu error(s) received", stats->nb_errs);
+        ogs_trace("   %llu answer(s) received", stats->nb_recv);
+        ogs_trace("     fastest: %ld.%06ld sec.",
+                stats->shortest / 1000000, stats->shortest % 1000000);
+        ogs_trace("     slowest: %ld.%06ld sec.",
+                stats->longest / 1000000, stats->longest % 1000000);
+        ogs_trace("     Average: %ld.%06ld sec.",
+                stats->avg / 1000000, stats->avg % 1000000);
+    }
+    ogs_trace("-------------------------------------");
+}
+
 /* Function to display statistics periodically */
 static void diam_stats_timer_cb(void *data)
 {
@@ -78,28 +104,7 @@ static void diam_stats_timer_cb(void *data)
     since_start = now - self.poll.t_start;
 
     /* Now, display everything */
-    ogs_trace("------- fd statistics ---------");
-    ogs_trace(" Executing for: %llu.%06llu sec",
-              (unsigned long long)ogs_time_sec(since_start),
-              (unsigned long long)ogs_time_usec(since_start));
-
-    if (self.mode & FD_MODE_SERVER) {
-        ogs_trace(" Server: %llu message(s) echoed",
-                copy.nb_echoed);
-    }
-    if (self.mode & FD_MODE_CLIENT) {
-        ogs_trace(" Client:");
-        ogs_trace("   %llu message(s) sent", copy.nb_sent);
-        ogs_trace("   %llu error(s) received", copy.nb_errs);
-        ogs_trace("   %llu answer(s) received", copy.nb_recv);
-        ogs_trace("     fastest: %ld.%06ld sec.",
-                copy.shortest / 1000000, copy.shortest % 1000000);
-        ogs_trace("     slowest: %ld.%06ld sec.",
-                copy.longest / 1000000, copy.longest % 1000000);
-        ogs_trace("     Average: %ld.%06ld sec.",
-                copy.avg / 1000000, copy.avg % 1000000);
-    }
-    ogs_trace("-------------------------------------");
+    ogs_diam_stats_log(&copy, since_start);
 
     /* Re-schedule timer: */
     since_prev = now - self.poll.t_prev;

--- a/lib/diameter/common/stats.h
+++ b/lib/diameter/common/stats.h
@@ -21,25 +21,42 @@
 #error "This header cannot be included directly."
 #endif
 
-#ifndef OGS_DIAM_LOGGER_H
-#define OGS_DIAM_LOGGER_H
+#ifndef OGS_DIAM_STATS_H
+#define OGS_DIAM_STATS_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int ogs_diam_logger_init(void);
-void ogs_diam_logger_final(void);
+typedef struct ogs_diam_stats_s {
 
-typedef void (*ogs_diam_logger_user_handler)(
-    enum fd_hook_type type, struct msg *msg, struct peer_hdr *peer,
-    void *other, struct fd_hook_permsgdata *pmd, void *regdata);
+#define FD_MODE_SERVER   0x1
+#define FD_MODE_CLIENT   0x2
+    int mode;        /* default FD_MODE_SERVER | FD_MODE_CLIENT */
 
-void ogs_diam_logger_register(ogs_diam_logger_user_handler instance);
-void ogs_diam_logger_unregister(void);
+    int duration; /* default 10 */
+    struct fd_stats {
+        unsigned long long nb_echoed; /* server */
+        unsigned long long nb_sent;   /* client */
+        unsigned long long nb_recv;   /* client */
+        unsigned long long nb_errs;   /* client */
+        unsigned long shortest;  /* fastest answer, in microseconds */
+        unsigned long longest;   /* slowest answer, in microseconds */
+        unsigned long avg;       /* average answer time, in microseconds */
+    } stats;
+
+    pthread_mutex_t stats_lock;
+} ogs_diam_stats_t;
+
+int ogs_diam_stats_init(int mode);
+void ogs_diam_stats_final(void);
+
+ogs_diam_stats_t* ogs_diam_stats_self(void);
+
+int ogs_diam_stats_start(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OGS_DIAM_LOGGER_H */
+#endif /* OGS_DIAM_STATS_H */

--- a/lib/diameter/common/stats.h
+++ b/lib/diameter/common/stats.h
@@ -31,6 +31,16 @@ extern "C" {
 #include <sys/time.h>
 
 typedef struct ogs_diam_stats_s {
+    unsigned long long nb_echoed; /* server */
+    unsigned long long nb_sent;   /* client */
+    unsigned long long nb_recv;   /* client */
+    unsigned long long nb_errs;   /* client */
+    unsigned long shortest;  /* fastest answer, in microseconds */
+    unsigned long longest;   /* slowest answer, in microseconds */
+    unsigned long avg;       /* average answer time, in microseconds */
+} ogs_diam_stats_t;
+
+typedef struct ogs_diam_stats_ctx_s {
 
 #define FD_MODE_SERVER   0x1
 #define FD_MODE_CLIENT   0x2
@@ -42,23 +52,15 @@ typedef struct ogs_diam_stats_s {
         ogs_time_t t_prev; /* in usecs */
         ogs_time_t t_interval; /* in usecs */
     } poll;
-    struct fd_stats {
-        unsigned long long nb_echoed; /* server */
-        unsigned long long nb_sent;   /* client */
-        unsigned long long nb_recv;   /* client */
-        unsigned long long nb_errs;   /* client */
-        unsigned long shortest;  /* fastest answer, in microseconds */
-        unsigned long longest;   /* slowest answer, in microseconds */
-        unsigned long avg;       /* average answer time, in microseconds */
-    } stats;
+    ogs_diam_stats_t stats;
 
     pthread_mutex_t stats_lock;
-} ogs_diam_stats_t;
+} ogs_diam_stats_ctx_t;
 
 int ogs_diam_stats_init(int mode);
 void ogs_diam_stats_final(void);
 
-ogs_diam_stats_t* ogs_diam_stats_self(void);
+ogs_diam_stats_ctx_t* ogs_diam_stats_self(void);
 
 int ogs_diam_stats_start(void);
 

--- a/lib/diameter/common/stats.h
+++ b/lib/diameter/common/stats.h
@@ -28,13 +28,19 @@
 extern "C" {
 #endif
 
+#include <sys/time.h>
+
 typedef struct ogs_diam_stats_s {
 
 #define FD_MODE_SERVER   0x1
 #define FD_MODE_CLIENT   0x2
     int mode;        /* default FD_MODE_SERVER | FD_MODE_CLIENT */
 
-    int duration; /* default 10 */
+    struct poll {
+        ogs_timer_t *timer;
+        struct timespec ts_start;
+        ogs_time_t t_interval; /* in usecs */
+    } poll;
     struct fd_stats {
         unsigned long long nb_echoed; /* server */
         unsigned long long nb_sent;   /* client */

--- a/lib/diameter/common/stats.h
+++ b/lib/diameter/common/stats.h
@@ -38,7 +38,8 @@ typedef struct ogs_diam_stats_s {
 
     struct poll {
         ogs_timer_t *timer;
-        struct timespec ts_start;
+        ogs_time_t t_start; /* in usecs */
+        ogs_time_t t_prev; /* in usecs */
         ogs_time_t t_interval; /* in usecs */
     } poll;
     struct fd_stats {

--- a/src/hss/hss-cx-path.c
+++ b/src/hss/hss-cx-path.c
@@ -166,9 +166,9 @@ static int hss_ogs_diam_cx_uar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("User-Authorization-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_free(user_name);
     ogs_free(public_identity);
@@ -555,9 +555,9 @@ static int hss_ogs_diam_cx_mar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Multimedia-Auth-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     if (authentication_scheme)
         ogs_free(authentication_scheme);
@@ -815,9 +815,9 @@ static int hss_ogs_diam_cx_sar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Server-Assignment-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     if (user_data)
         ogs_free(user_data);
@@ -936,9 +936,9 @@ static int hss_ogs_diam_cx_lir_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Location-Info-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_free(public_identity);
 

--- a/src/hss/hss-s6a-path.c
+++ b/src/hss/hss-s6a-path.c
@@ -265,9 +265,9 @@ static int hss_ogs_diam_s6a_air_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Authentication-Information-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     return 0;
 
@@ -971,9 +971,9 @@ static int hss_ogs_diam_s6a_ulr_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Update-Location-Answer");
 
     /* Add this value to the stats */
-    ogs_assert( pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert( pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert( pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert( pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_subscription_data_free(&subscription_data);
 
@@ -1128,9 +1128,9 @@ static int hss_ogs_diam_s6a_pur_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Purge-UE-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_subscription_data_free(&subscription_data);
 
@@ -1284,9 +1284,9 @@ void hss_s6a_send_clr(char *imsi_bcd, char *mme_host, char *mme_realm,
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
 }
 
@@ -1485,9 +1485,9 @@ int hss_s6a_send_idr(char *imsi_bcd, uint32_t idr_flags, uint32_t subdata_mask)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_subscription_data_free(&subscription_data);
 

--- a/src/hss/hss-swx-path.c
+++ b/src/hss/hss-swx-path.c
@@ -334,9 +334,9 @@ static int hss_ogs_diam_swx_mar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Multimedia-Auth-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     if (authentication_scheme)
         ogs_free(authentication_scheme);
@@ -857,9 +857,9 @@ static int hss_ogs_diam_swx_sar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Server-Assignment-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_subscription_data_free(&subscription_data);
     ogs_free(user_name);

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -858,9 +858,9 @@ static void _mme_s6a_send_air(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 void mme_s6a_send_air(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
@@ -1118,30 +1118,30 @@ out:
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1315,9 +1315,9 @@ void mme_s6a_send_ulr(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* MME received Update Location Answer from HSS */
@@ -1543,31 +1543,31 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg =
-            (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg =
+            (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1676,9 +1676,9 @@ void mme_s6a_send_pur(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* MME received Purge UE Answer from HSS */
@@ -1855,31 +1855,31 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg =
-            (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg =
+            (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1991,9 +1991,9 @@ static int mme_ogs_diam_s6a_clr_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Cancel-Location-Answer");
 
     /* Add this value to the stats */
-    ogs_assert( pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert( pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert( pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert( pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     e = mme_event_new(MME_EVENT_S6A_MESSAGE);
     ogs_assert(e);
@@ -2284,9 +2284,9 @@ static int mme_ogs_diam_s6a_idr_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Insert-Subscriber-Data-Answer");
 
     /* Add this value to the stats */
-    ogs_assert( pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert( pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert( pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert( pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     int rv;
     e = mme_event_new(MME_EVENT_S6A_MESSAGE);

--- a/src/pcrf/pcrf-gx-path.c
+++ b/src/pcrf/pcrf-gx-path.c
@@ -621,9 +621,9 @@ static int pcrf_gx_ccr_cb( struct msg **msg, struct avp *avp,
     ogs_debug("[Credit-Control-Answer]");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) ==0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) ==0);
 
     OGS_SESSION_DATA_FREE(&gx_message.session_data);
 
@@ -1013,9 +1013,9 @@ int pcrf_gx_send_rar(
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Set no error */
     rx_message->result_code = ER_DIAMETER_SUCCESS;
@@ -1121,30 +1121,30 @@ static void pcrf_gx_raa_cb(void *data, struct msg **msg)
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)

--- a/src/pcrf/pcrf-rx-path.c
+++ b/src/pcrf/pcrf-rx-path.c
@@ -413,9 +413,9 @@ static int pcrf_rx_aar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("[PCRF] AA-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_ims_data_free(&rx_message.ims_data);
     
@@ -561,9 +561,9 @@ int pcrf_rx_send_asr(uint8_t *rx_sid, uint32_t abort_cause)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     return OGS_OK;
 }
@@ -746,9 +746,9 @@ static int pcrf_rx_str_cb( struct msg **msg, struct avp *avp,
     ogs_debug("[PCRF] Session-Termination-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     state_cleanup(sess_data, NULL, NULL);
     ogs_ims_data_free(&rx_message.ims_data);

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -728,9 +728,9 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* 3GPP TS 29.212 5b.6.5 Credit-Control-Answer */
@@ -1089,30 +1089,30 @@ out:
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1355,9 +1355,9 @@ static int smf_gx_rar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Re-Auth-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     return 0;
 

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -959,9 +959,9 @@ void smf_gy_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
 
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 static void smf_gy_cca_cb(void *data, struct msg **msg)
@@ -1217,30 +1217,30 @@ out:
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1367,9 +1367,9 @@ static int smf_gy_rar_cb( struct msg **msg, struct avp *avp,
     ogs_debug("Re-Auth-Answer");
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     return 0;
 

--- a/src/smf/s6b-path.c
+++ b/src/smf/s6b-path.c
@@ -329,9 +329,9 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_free(user_name);
     ogs_free(visited_network_identifier);
@@ -460,30 +460,30 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -628,9 +628,9 @@ void smf_s6b_send_str(smf_sess_t *sess, ogs_gtp_xact_t *xact, uint32_t cause)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_free(user_name);
 }
@@ -762,30 +762,30 @@ static void smf_s6b_sta_cb(void *data, struct msg **msg)
     }
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)

--- a/tests/non3gpp/diameter-s6b-path.c
+++ b/tests/non3gpp/diameter-s6b-path.c
@@ -178,9 +178,9 @@ static int test_s6b_aar_cb( struct msg **msg, struct avp *avp,
     ogs_assert(ret == 0);
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) ==0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) ==0);
 
     return 0;
 
@@ -278,9 +278,9 @@ static int test_s6b_str_cb( struct msg **msg, struct avp *avp,
     ogs_assert(ret == 0);
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) ==0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) ==0);
 
     return 0;
 

--- a/tests/non3gpp/diameter-swx-path.c
+++ b/tests/non3gpp/diameter-swx-path.c
@@ -273,9 +273,9 @@ static void test_swx_send_mar(struct sess_state *sess_data)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* Callback for incoming Multimedia-Auth-Answer messages */
@@ -358,30 +358,30 @@ static void test_swx_maa_cb(void *data, struct msg **msg)
     ogs_assert(err && !exp_err && result_code == ER_DIAMETER_SUCCESS);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -525,9 +525,9 @@ static void test_swx_send_sar(struct sess_state *sess_data)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* Callback for incoming Server-Assignment-Answer messages */
@@ -618,30 +618,30 @@ static void test_swx_saa_cb(void *data, struct msg **msg)
     ogs_assert(err && !exp_err && result_code == ER_DIAMETER_SUCCESS);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)

--- a/tests/volte/diameter-cx-path.c
+++ b/tests/volte/diameter-cx-path.c
@@ -210,9 +210,9 @@ void test_cx_send_uar(test_ue_t *test_ue, int id_type)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* Callback for incoming User-Authorization-Answer messages */
@@ -300,30 +300,30 @@ static void test_cx_uaa_cb(void *data, struct msg **msg)
     ogs_assert(!err && exp_err);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -531,9 +531,9 @@ static void test_cx_send_mar(struct sess_state *sess_data)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* Callback for incoming Multimedia-Auth-Answer messages */
@@ -621,30 +621,30 @@ static void test_cx_maa_cb(void *data, struct msg **msg)
     ogs_assert(err && !exp_err && result_code == ER_DIAMETER_SUCCESS);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -814,9 +814,9 @@ static void test_cx_send_sar(struct sess_state *sess_data)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 /* Callback for incoming Server-Assignment-Answer messages */
@@ -904,30 +904,30 @@ static void test_cx_saa_cb(void *data, struct msg **msg)
     ogs_assert(err && !exp_err && result_code == ER_DIAMETER_SUCCESS);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1056,9 +1056,9 @@ static void test_cx_send_lir(struct sess_state *sess_data)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     ogs_free(public_identity);
 }
@@ -1148,30 +1148,30 @@ static void test_cx_lia_cb(void *data, struct msg **msg)
     ogs_assert(err && !exp_err && result_code == ER_DIAMETER_SUCCESS);
 
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) +
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg *
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg *
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)

--- a/tests/volte/diameter-rx-path.c
+++ b/tests/volte/diameter-rx-path.c
@@ -561,9 +561,9 @@ void test_rx_send_aar_audio(uint8_t **rx_sid,
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Free string memory */
     ogs_free(sip_uri);
@@ -1239,9 +1239,9 @@ void test_rx_send_aar_video(uint8_t **rx_sid, test_sess_t *sess, int id_type)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Free string memory */
     ogs_free(sip_uri);
@@ -1646,9 +1646,9 @@ void test_rx_send_aar_ctrl(uint8_t **rx_sid, test_sess_t *sess, int id_type)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     /* Free string memory */
     ogs_free(sip_uri);
@@ -1745,30 +1745,30 @@ static void pcscf_rx_aaa_cb(void *data, struct msg **msg)
 
 out:
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) + 
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg * 
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg * 
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else 
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
     
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)
@@ -1866,9 +1866,9 @@ static int pcscf_rx_asr_cb( struct msg **msg, struct avp *avp,
     ogs_assert(ret == 0);
 
     /* Add this value to the stats */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_echoed++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_echoed++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 
     test_rx_send_str(sid);
 
@@ -1977,9 +1977,9 @@ void test_rx_send_str(uint8_t *rx_sid)
     ogs_assert(ret == 0);
 
     /* Increment the counter */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
-    ogs_diam_logger_self()->stats.nb_sent++;
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
+    ogs_diam_stats_self()->stats.nb_sent++;
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
 }
 
 static void pcscf_rx_sta_cb(void *data, struct msg **msg)
@@ -2073,30 +2073,30 @@ static void pcscf_rx_sta_cb(void *data, struct msg **msg)
 
 out:
     /* Free the message */
-    ogs_assert(pthread_mutex_lock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_lock(&ogs_diam_stats_self()->stats_lock) == 0);
     dur = ((ts.tv_sec - sess_data->ts.tv_sec) * 1000000) + 
         ((ts.tv_nsec - sess_data->ts.tv_nsec) / 1000);
-    if (ogs_diam_logger_self()->stats.nb_recv) {
+    if (ogs_diam_stats_self()->stats.nb_recv) {
         /* Ponderate in the avg */
-        ogs_diam_logger_self()->stats.avg = (ogs_diam_logger_self()->stats.avg * 
-            ogs_diam_logger_self()->stats.nb_recv + dur) /
-            (ogs_diam_logger_self()->stats.nb_recv + 1);
+        ogs_diam_stats_self()->stats.avg = (ogs_diam_stats_self()->stats.avg * 
+            ogs_diam_stats_self()->stats.nb_recv + dur) /
+            (ogs_diam_stats_self()->stats.nb_recv + 1);
         /* Min, max */
-        if (dur < ogs_diam_logger_self()->stats.shortest)
-            ogs_diam_logger_self()->stats.shortest = dur;
-        if (dur > ogs_diam_logger_self()->stats.longest)
-            ogs_diam_logger_self()->stats.longest = dur;
+        if (dur < ogs_diam_stats_self()->stats.shortest)
+            ogs_diam_stats_self()->stats.shortest = dur;
+        if (dur > ogs_diam_stats_self()->stats.longest)
+            ogs_diam_stats_self()->stats.longest = dur;
     } else {
-        ogs_diam_logger_self()->stats.shortest = dur;
-        ogs_diam_logger_self()->stats.longest = dur;
-        ogs_diam_logger_self()->stats.avg = dur;
+        ogs_diam_stats_self()->stats.shortest = dur;
+        ogs_diam_stats_self()->stats.longest = dur;
+        ogs_diam_stats_self()->stats.avg = dur;
     }
     if (error)
-        ogs_diam_logger_self()->stats.nb_errs++;
+        ogs_diam_stats_self()->stats.nb_errs++;
     else 
-        ogs_diam_logger_self()->stats.nb_recv++;
+        ogs_diam_stats_self()->stats.nb_recv++;
 
-    ogs_assert(pthread_mutex_unlock(&ogs_diam_logger_self()->stats_lock) == 0);
+    ogs_assert(pthread_mutex_unlock(&ogs_diam_stats_self()->stats_lock) == 0);
     
     /* Display how long it took */
     if (ts.tv_nsec > sess_data->ts.tv_nsec)


### PR DESCRIPTION
This is a preparation PR towards being able to provide diameter metrics updates through the mainloop, as discussed earlier here:
https://github.com/open5gs/open5gs/pull/3121#issuecomment-2044603693

Please merge without squashing, makes following the changes easier.