### PR TITLE
[SMF] Fix release in case of 404 to dereg. with UDM

### DIFF
--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -910,7 +910,8 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             } else if (state == SMF_UECM_STATE_DEREGISTERED_BY_AMF ||
                         state == SMF_UECM_STATE_DEREGISTERED_BY_N1_N2_RELEASE) {
                 /* SMF Deregistration */
-                if (sbi_message.res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)
+                if (sbi_message.res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT &&
+                        sbi_message.res_status != OGS_SBI_HTTP_STATUS_NOT_FOUND)
                     unknown_res_status = true;
             } else {
                 ogs_fatal("Unknown state [%d]", state);


### PR DESCRIPTION
Bug:

If SMF has not registered with UDM during PDU session establishment (due to error. e.g. PFCP Session Modification rejection), SMF does not notify AMF about successful resource release when releasing PDU session.
Afterwards the AMF does not complete Deregistration and the next Registration Request is ignored (due to AMF_SESSION_RELEASE_PENDING).

Fix:

SMF treats 404 to dereg. with UDM just like 204 was received. The desired result is reached - no SMF registration with UDM.