### PR TITLE
[AMF] Order AN release after per. or mob. registration

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2474,10 +2474,21 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                 amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_INIT_SUCC);
                 break;
             case OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING:
-                amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_MOB_SUCC);
-                break;
             case OGS_NAS_5GS_REGISTRATION_TYPE_PERIODIC_UPDATING:
-                amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_PERIOD_SUCC);
+                if (amf_ue->nas.registration.value ==
+                        OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING)
+                    amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_MOB_SUCC);
+                else
+                    amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_PERIOD_SUCC);
+
+                if (!amf_ue->nas.registration.follow_on_request) {
+                    r = ngap_send_ran_ue_context_release_command(
+                            ran_ue_find_by_id(amf_ue->ran_ue_id),
+                            NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release,
+                            NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+                }
                 break;
             case OGS_NAS_5GS_REGISTRATION_TYPE_EMERGENCY:
                 amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_RM_REG_EMERG_SUCC);


### PR DESCRIPTION
If there is no Follow-on request included in the Registration Request, the AMF releases the NAS signaling connection after the completion of the Registration procedure  (mobility and periodic) to save the resources.

In standards there is no explicit request for AMF to release the NAS signaling connection.

But it is implicitly expected that the network releases the connection:

- TS 24.501 – 5.5.1.3.4 Mobility and periodic registration update accepted by the network
If the UE has set the Follow-on request indicator to "Follow-on request pending" in the REGISTRATION REQUEST
message, or the network has downlink signaling pending, the AMF shall not immediately release the NAS signaling
connection after the completion of the registration procedure.

- TS 23.501, 5.3.3.2.3 CM-CONNECTED state:
Upon completion of a NAS signalling procedure, the AMF may decide to release the NAS signalling connection with the UE.

- TS 24.501, 5.3.1.3 Release of the N1 NAS signalling connection
The signalling procedure for the release of the N1 NAS signalling connection is initiated by the network.
...
To allow the network to release the N1 NAS signalling connection, the UE:
a) shall start the timer T3540
...
Table 10.2.1: Timers of 5GS mobility management – UE side:
T3540 NORMAL STOP: N1 NAS signalling connection released, ON EXPIRY: Release the NAS signalling connection for the cases a), b), f) and g) as described in subclause 5.3.1.3

So AMF is aware that UE has no need to maintain the signaling connection therefore it shall release it to save the resources.

There are cases in which the AMF may keep the connection, but currently there is no need:
- TS 23.501, 5.3.3.3  NAS signalling connection management
5.3.3.3.2  NAS signalling connection establishment
Based on UE preferences, UE subscription, Mobility Pattern and network configuration, the AMF may keep the NAS signalling connection until the UE de-registers from the network.
