### PR TITLE
[SMF] Fixed incorrect prefix length in GTPv2 PAA IE (#3495)

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1608,7 +1608,7 @@ uint8_t smf_sess_set_ue_ip(smf_sess_t *sess)
         subnet6 = sess->ipv6->subnet;
         ogs_assert(subnet6);
 
-        sess->paa.len = OGS_IPV6_DEFAULT_PREFIX_LEN >> 3;
+        sess->paa.len = OGS_IPV6_DEFAULT_PREFIX_LEN;
         memcpy(sess->paa.addr6, sess->ipv6->addr, OGS_IPV6_LEN);
         ogs_hash_set(smf_self()->ipv6_hash,
                 sess->ipv6->addr, OGS_IPV6_DEFAULT_PREFIX_LEN >> 3, sess);
@@ -1637,7 +1637,7 @@ uint8_t smf_sess_set_ue_ip(smf_sess_t *sess)
         ogs_assert(subnet6);
 
         sess->paa.both.addr = sess->ipv4->addr[0];
-        sess->paa.both.len = OGS_IPV6_DEFAULT_PREFIX_LEN >> 3;
+        sess->paa.both.len = OGS_IPV6_DEFAULT_PREFIX_LEN;
         memcpy(sess->paa.both.addr6, sess->ipv6->addr, OGS_IPV6_LEN);
         ogs_hash_set(smf_self()->ipv4_hash,
                 sess->ipv4->addr, OGS_IPV4_LEN, sess);


### PR DESCRIPTION
I have modified the PAA's IPv6 prefix length from 8 to 64. This adjustment ensures that the prefix length now correctly reflects the standard /64 notation, in accordance with the specifications.