### PR TITLE
[SMF] Fix Packet Filter Identifier handling in SMF (#3505)

### DIFF
--- a/src/smf/gsm-build.c
+++ b/src/smf/gsm-build.c
@@ -113,7 +113,7 @@ ogs_pkbuf_t *gsm_build_pdu_session_establishment_accept(smf_sess_t *sess)
     qos_rule[0].num_of_packet_filter = 1;
 
     qos_rule[0].pf[0].direction = OGS_NAS_QOS_DIRECTION_BIDIRECTIONAL;
-    qos_rule[0].pf[0].identifier = 1;
+    qos_rule[0].pf[0].identifier = 0;
     qos_rule[0].pf[0].content.length = 1;
     qos_rule[0].pf[0].content.num_of_component = 1;
     qos_rule[0].pf[0].content.component[0].type = OGS_PACKET_FILTER_MATCH_ALL;
@@ -299,7 +299,7 @@ static void encode_qos_rule_packet_filter(
         ogs_list_for_each_entry(&qos_flow->pf_to_add_list, pf, to_add_node) {
             ogs_assert(i < OGS_MAX_NUM_OF_FLOW_IN_NAS);
             qos_rule->pf[i].direction = pf->direction;
-            qos_rule->pf[i].identifier = pf->identifier;
+            qos_rule->pf[i].identifier = pf->identifier-1;
 
             ogs_pf_content_from_ipfw_rule(
                     pf->direction, &qos_rule->pf[i].content, &pf->ipfw_rule,

--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -410,7 +410,7 @@ int gsm_handle_pdu_session_modification_request(
                     if (pf) {
                         qos_flow->pf_to_delete
                             [qos_flow->num_of_pf_to_delete++] =
-                                qos_rule[i].pf[j].identifier;
+                                qos_rule[i].pf[j].identifier-1;
                         smf_pf_remove(pf);
                     }
                 }

--- a/tests/app/5gc-init.c
+++ b/tests/app/5gc-init.c
@@ -129,7 +129,7 @@ int app_initialize(const char *const argv[])
      * 
      * If freeDiameter is not used, it uses a delay of less than 4 seconds.
      */
-    ogs_msleep(1000);
+    ogs_msleep(2000);
 
     return OGS_OK;
 }


### PR DESCRIPTION
Decrement the Packet Filter Identifier by 1 before sending it to the UE during GSM message construction. This correction ensures proper synchronization between the UE and SMF, allowing `smf_pf_find_by_identifier()` to accurately locate the corresponding `pf` context without adjusting the identifier during the search.

This fix aligns the 5GC implementation with the EPC behavior, where the identifier was correctly decremented before transmission to the UE, preventing mismatches and synchronization issues.