### PR TITLE
[SMF] Fix Packet Filter Identifier handling and limit maximum number (#3505)

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -50,17 +50,29 @@ extern "C" {
  * coded as 0. For all other operations, the number of packet filters
  * shall be greater than 0 and less than or equal to 15.
  *
- * The array of TLV messages is limited to 16.
- * So, Flow(PDI.SDF_Filter) in PDR is limited to 16.
+ * TS24.501
+ * 9.11.4.13 QoS rules
+ * Table 9.11.4.13.1: QoS rules information element
  *
- * Therefore, we defined the maximum number of flows as 16.
+ * For the "delete existing QoS rule" operation and for the "modify existing
+ * QoS rule without modifying packet filters" operation, the number of packet
+ * filters shall be coded as 0. For the "create new QoS rule" operation
+ * and the "modify existing QoS rule and replace all packet filters" operation,
+ * the number of packet filters shall be greater than or equal to 0
+ * and less than or equal to 15. For all other operations, the number of packet
+ * filters shall be greater than 0 and less than or equal to 15.
+ *
+ * The array of TLV messages is limited to 15.
+ * So, Flow(PDI.SDF_Filter) in PDR is limited to 15.
+ *
+ * Therefore, we defined the maximum number of flows as 15.
  */
-#define OGS_MAX_NUM_OF_FLOW_IN_PDR      16
+#define OGS_MAX_NUM_OF_FLOW_IN_PDR      15
 #define OGS_MAX_NUM_OF_FLOW_IN_GTP      OGS_MAX_NUM_OF_FLOW_IN_PDR
 #define OGS_MAX_NUM_OF_FLOW_IN_NAS      OGS_MAX_NUM_OF_FLOW_IN_PDR
 #define OGS_MAX_NUM_OF_FLOW_IN_PCC_RULE OGS_MAX_NUM_OF_FLOW_IN_PDR
 #define OGS_MAX_NUM_OF_FLOW_IN_MEDIA_SUB_COMPONENT OGS_MAX_NUM_OF_FLOW_IN_PDR
-#define OGS_MAX_NUM_OF_FLOW_IN_BEARER   16
+#define OGS_MAX_NUM_OF_FLOW_IN_BEARER   15
 
 #define OGS_MAX_NUM_OF_GTPU_RESOURCE    4
 #define OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI 8

--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -257,7 +257,7 @@ int gsm_handle_pdu_session_modification_request(
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
                     pf = smf_pf_find_by_identifier(
-                            qos_flow, qos_rule[i].pf[j].identifier+1);
+                            qos_flow, qos_rule[i].pf[j].identifier);
                     if (pf) {
                         ogs_assert(
                             reconfigure_packet_filter(pf, &qos_rule[i], i) > 0);
@@ -329,7 +329,7 @@ int gsm_handle_pdu_session_modification_request(
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
                     pf = smf_pf_find_by_identifier(
-                            qos_flow, qos_rule[i].pf[j].identifier+1);
+                            qos_flow, qos_rule[i].pf[j].identifier);
                     if (!pf)
                         pf = smf_pf_add(qos_flow);
                     ogs_assert(pf);
@@ -406,7 +406,7 @@ int gsm_handle_pdu_session_modification_request(
                             j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
 
                     pf = smf_pf_find_by_identifier(
-                            qos_flow, qos_rule[i].pf[j].identifier+1);
+                            qos_flow, qos_rule[i].pf[j].identifier);
                     if (pf) {
                         qos_flow->pf_to_delete
                             [qos_flow->num_of_pf_to_delete++] =

--- a/tests/app/5gc-init.c
+++ b/tests/app/5gc-init.c
@@ -129,7 +129,7 @@ int app_initialize(const char *const argv[])
      * 
      * If freeDiameter is not used, it uses a delay of less than 4 seconds.
      */
-    ogs_msleep(1000);
+    ogs_msleep(2000);
 
     return OGS_OK;
 }

--- a/tests/common/gsm-build.c
+++ b/tests/common/gsm-build.c
@@ -159,7 +159,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
             qos_rule[0].num_of_packet_filter = 1;
 
             qos_rule[0].pf[0].direction = OGS_NAS_QOS_DIRECTION_UPLINK;
-            qos_rule[0].pf[0].identifier = 4;
+            qos_rule[0].pf[0].identifier = 5;
 
             qos_rule[0].pf[0].content.length = 18;
             qos_rule[0].pf[0].content.num_of_component = 1;
@@ -180,7 +180,7 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
             qos_rule[0].num_of_packet_filter = 1;
 
             qos_rule[0].pf[0].direction = OGS_NAS_QOS_DIRECTION_DOWNLINK;
-            qos_rule[0].pf[0].identifier = 0;
+            qos_rule[0].pf[0].identifier = 1;
 
             qos_rule[0].pf[0].content.length = 9;
             qos_rule[0].pf[0].content.num_of_component = 1;
@@ -198,10 +198,10 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
             qos_rule[0].DQR_bit = 0;
             qos_rule[0].num_of_packet_filter = 4;
 
-            qos_rule[0].pf[0].identifier = 0;
-            qos_rule[0].pf[1].identifier = 1;
-            qos_rule[0].pf[2].identifier = 2;
-            qos_rule[0].pf[3].identifier = 3;
+            qos_rule[0].pf[0].identifier = 1;
+            qos_rule[0].pf[1].identifier = 2;
+            qos_rule[0].pf[2].identifier = 3;
+            qos_rule[0].pf[3].identifier = 4;
 
         } else {
             ogs_fatal("Unknown qos_rule_code[%d]", qos_rule_code);


### PR DESCRIPTION
- **Correct Packet Filter Identifier Handling:** Remove the addition of +1 when searching for the packet filter context using `smf_pf_find_by_identifier()` in the 5G Core SMF. According to 3GPP TS24.008 Section 10.5.6.12 and TS24.501 Section 9.11.4.13, the Packet Filter Identifier should range from 1 to 15 (or 0 to 15) depending on the operation and should be used directly as received from the UE.

- **Adjust Maximum Number of Packet Filter Identifiers:** Change the maximum number of Packet Filter Identifiers from **16** to **15** in the SMF to comply with the 3GPP specifications. The standards specify that the number of packet filters shall be greater than 0 and less than or equal to 15 for certain operations.

**Background:**

In the current 5GC implementation, the SMF incorrectly adds +1 to the identifier received from the UE and allows up to 16 identifiers, leading to mismatches and potential communication issues. These discrepancies cause the SMF to fail in correctly locating the packet filter context, resulting in improper QoS rule enforcement.

**Changes Made:**

- **For Packet Filter Identifier Handling:**
  - Updated the SMF code to use the identifier received from the UE directly without modification: 

```c
   // Corrected code for 5GC: 
   pf = smf_pf_find_by_identifier( qos_flow, qos_rule[i].pf[j].identifier); 
```

- **For Maximum Number of Packet Filter Identifiers:**
  - Adjusted the code to enforce a maximum of 15 packet filters as per the specifications.

**Impact:**

- **Compliance:**
  - Ensures that the 5GC implementation of Open5GS adheres to the 3GPP TS24.008 and TS24.501 specifications regarding Packet Filter Identifier handling and limits.

- **Functionality:**
  - Corrects the mapping and management of packet filters between the UE and SMF in 5GC, preventing potential communication issues and misconfigurations.

- **EPC Implementation:**
  - The EPC implementation remains unaffected by these changes. EPC correctly handles the Packet Filter Identifier by decrementing it by 1 before sending it to the UE and adding +1 when searching for the packet filter context.

**Conclusion:**

By making these adjustments, we ensure proper synchronization between the UE and SMF in the 5G Core and maintain compliance with the 3GPP specifications. This fix resolves the mismatches caused by incorrect identifier handling and enforces the correct limit on the number of packet filters, enhancing the reliability and standards compliance of the 5GC implementation without impacting the existing correct behavior in EPC.