### PR TITLE
[PFCP] Fix memory free issue causing crash (#3497)

### DIFF
--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -108,7 +108,7 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
         if (!node) {
             ogs_error("No memory: ogs_pfcp_node_add() failed");
             ogs_pkbuf_free(e->pkbuf);
-            ogs_event_free(e);
+            sgwc_event_free(e);
             return;
         }
 

--- a/src/sgwu/pfcp-path.c
+++ b/src/sgwu/pfcp-path.c
@@ -108,7 +108,7 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
         if (!node) {
             ogs_error("No memory: ogs_pfcp_node_add() failed");
             ogs_pkbuf_free(e->pkbuf);
-            ogs_event_free(e);
+            sgwu_event_free(e);
             return;
         }
 

--- a/src/upf/pfcp-path.c
+++ b/src/upf/pfcp-path.c
@@ -111,7 +111,7 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
         if (!node) {
             ogs_error("No memory: ogs_pfcp_node_add() failed");
             ogs_pkbuf_free(e->pkbuf);
-            ogs_event_free(e);
+            upf_event_free(e);
             return;
         }
 


### PR DESCRIPTION
This commit fixes an issue where the system would crash due to improper memory release after receiving crafted PFCP packets from UEs.