### PR TITLE
[PFCP] Add Missing 3GPP Interface Type in PFCP Messages

### DIFF
--- a/lib/pfcp/build.c
+++ b/lib/pfcp/build.c
@@ -355,6 +355,11 @@ void ogs_pfcp_build_create_pdr(
     message->pdi.source_interface.presence = 1;
     message->pdi.source_interface.u8 = pdr->src_if;
 
+    if (pdr->src_if_type_presence) {
+        message->pdi.source_interface_type.presence = 1;
+        message->pdi.source_interface_type.u8 = pdr->src_if_type;
+    }
+
     if (pdr->dnn) {
         message->pdi.network_instance.presence = 1;
         message->pdi.network_instance.len = ogs_fqdn_build(
@@ -504,6 +509,11 @@ void ogs_pfcp_build_update_pdr(
         message->pdi.source_interface.presence = 1;
         message->pdi.source_interface.u8 = pdr->src_if;
 
+        if (pdr->src_if_type_presence) {
+            message->pdi.source_interface_type.presence = 1;
+            message->pdi.source_interface_type.u8 = pdr->src_if_type;
+        }
+
         memset(pfcp_sdf_filter, 0, sizeof(pfcp_sdf_filter));
         for (j = 0; j < pdr->num_of_flow && j < OGS_MAX_NUM_OF_FLOW_IN_PDR; j++) {
             ogs_assert(pdr->flow[j].fd || pdr->flow[j].bid);
@@ -565,6 +575,13 @@ void ogs_pfcp_build_create_far(
         message->forwarding_parameters.destination_interface.presence = 1;
         message->forwarding_parameters.destination_interface.u8 =
             far->dst_if;
+
+        if (far->dst_if_type_presence) {
+            message->forwarding_parameters.destination_interface_type.
+                presence = 1;
+            message->forwarding_parameters.destination_interface_type.
+                u8 = far->dst_if_type;
+        }
 
         if (far->dnn) {
             message->forwarding_parameters.network_instance.presence = 1;
@@ -636,6 +653,13 @@ void ogs_pfcp_build_update_far_activate(
     message->update_forwarding_parameters.destination_interface.presence = 1;
     message->update_forwarding_parameters.
         destination_interface.u8 = far->dst_if;
+
+    if (far->dst_if_type_presence) {
+        message->update_forwarding_parameters.destination_interface_type.
+            presence = 1;
+        message->update_forwarding_parameters.destination_interface_type.
+            u8 = far->dst_if_type;
+    }
 
     if (far->dnn) {
         message->update_forwarding_parameters.network_instance.presence = 1;

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -156,6 +156,9 @@ typedef struct ogs_pfcp_pdr_s {
     ogs_pfcp_precedence_t   precedence;
     ogs_pfcp_interface_t    src_if;
 
+    bool src_if_type_presence;
+    ogs_pfcp_3gpp_interface_type_t src_if_type;
+
     union {
         char *apn;
         char *dnn;
@@ -238,6 +241,10 @@ typedef struct ogs_pfcp_far_s {
     ogs_pfcp_far_id_t       id;
     ogs_pfcp_apply_action_t apply_action;
     ogs_pfcp_interface_t    dst_if;
+
+    bool dst_if_type_presence;
+    ogs_pfcp_3gpp_interface_type_t dst_if_type;
+
     ogs_pfcp_outer_header_creation_t outer_header_creation;
     int                     outer_header_creation_len;
 

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -413,6 +413,11 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_create_pdr(ogs_pfcp_sess_t *sess,
 
     pdr->src_if = message->pdi.source_interface.u8;
 
+    if (message->pdi.source_interface_type.presence) {
+        pdr->src_if_type_presence = true;
+        pdr->src_if_type = message->pdi.source_interface_type.u8;
+    }
+
     ogs_pfcp_rule_remove_all(pdr);
 
     for (i = 0; i < OGS_MAX_NUM_OF_FLOW_IN_PDR; i++) {
@@ -758,6 +763,11 @@ ogs_pfcp_pdr_t *ogs_pfcp_handle_update_pdr(ogs_pfcp_sess_t *sess,
 
         pdr->src_if = message->pdi.source_interface.u8;
 
+        if (message->pdi.source_interface_type.presence) {
+            pdr->src_if_type_presence = true;
+            pdr->src_if_type = message->pdi.source_interface_type.u8;
+        }
+
         ogs_pfcp_rule_remove_all(pdr);
 
         for (i = 0; i < OGS_MAX_NUM_OF_FLOW_IN_PDR; i++) {
@@ -971,6 +981,13 @@ ogs_pfcp_far_t *ogs_pfcp_handle_create_far(ogs_pfcp_sess_t *sess,
                 message->forwarding_parameters.destination_interface.u8;
         }
 
+        if (message->forwarding_parameters.destination_interface_type.
+                presence) {
+            far->dst_if_type_presence = true;
+            far->dst_if_type = message->forwarding_parameters.
+                destination_interface_type.u8;
+        }
+
         if (message->forwarding_parameters.network_instance.presence) {
             char dnn[OGS_MAX_DNN_LEN+1];
 
@@ -1076,6 +1093,13 @@ ogs_pfcp_far_t *ogs_pfcp_handle_update_far(ogs_pfcp_sess_t *sess,
                 destination_interface.presence) {
             far->dst_if =
                 message->update_forwarding_parameters.destination_interface.u8;
+        }
+
+        if (message->update_forwarding_parameters.destination_interface_type.
+                presence) {
+            far->dst_if_type_presence = true;
+            far->dst_if_type = message->update_forwarding_parameters.
+                destination_interface_type.u8;
         }
 
         if (message->update_forwarding_parameters.network_instance.presence) {

--- a/lib/pfcp/message.c
+++ b/lib/pfcp/message.c
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by pfcp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2024-01-19 23:36:01.346970 by acetcom
+ * Created on: 2024-10-20 22:37:02.550243 by acetcom
  * from 29244-h71-modified.docx
  ******************************************************************************/
 
@@ -1348,10 +1348,10 @@ ogs_tlv_desc_t ogs_pfcp_tlv_desc_apn_dnn =
 
 ogs_tlv_desc_t ogs_pfcp_tlv_desc__interface_type =
 {
-    OGS_TLV_VAR_STR,
+    OGS_TLV_UINT8,
     "3GPP Interface Type",
     OGS_PFCP__INTERFACE_TYPE_TYPE,
-    0,
+    1,
     0,
     sizeof(ogs_pfcp_tlv__interface_type_t),
     { NULL }

--- a/lib/pfcp/message.h
+++ b/lib/pfcp/message.h
@@ -20,7 +20,7 @@
 /*******************************************************************************
  * This file had been created by pfcp-tlv.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2024-01-19 23:36:01.327925 by acetcom
+ * Created on: 2024-10-20 22:37:02.530796 by acetcom
  * from 29244-h71-modified.docx
  ******************************************************************************/
 
@@ -885,7 +885,7 @@ typedef ogs_tlv_octet_t ogs_pfcp_tlv_time_stamp_t;
 typedef ogs_tlv_uint32_t ogs_pfcp_tlv_averaging_window_t;
 typedef ogs_tlv_uint8_t ogs_pfcp_tlv_paging_policy_indicator_t;
 typedef ogs_tlv_octet_t ogs_pfcp_tlv_apn_dnn_t;
-typedef ogs_tlv_octet_t ogs_pfcp_tlv__interface_type_t;
+typedef ogs_tlv_uint8_t ogs_pfcp_tlv__interface_type_t;
 typedef ogs_tlv_uint8_t ogs_pfcp_tlv_pfcpsrreq_flags_t;
 typedef ogs_tlv_uint8_t ogs_pfcp_tlv_pfcpaureq_flags_t;
 typedef ogs_tlv_octet_t ogs_pfcp_tlv_activation_time_t;

--- a/lib/pfcp/support/pfcp-tlv.py
+++ b/lib/pfcp/support/pfcp-tlv.py
@@ -516,6 +516,7 @@ type_list["Event Quota"]["size"] = 4                        # Type 148
 type_list["Event Threshold"]["size"] = 4                    # Type 149
 type_list["Averaging Window"]["size"] = 4                   # Type 157
 type_list["Paging Policy Indicator"]["size"] = 1            # Type 158
+type_list["3GPP Interface Type"]["size"] = 1                # Type 160
 type_list["PFCPSRReq-Flags"]["size"] = 1                    # Type 161
 type_list["PFCPAUReq-Flags"]["size"] = 1                    # Type 162
 type_list["Quota Validity Time"]["size"] = 4                # Type 181

--- a/lib/pfcp/types.h
+++ b/lib/pfcp/types.h
@@ -441,8 +441,6 @@ ED7(uint8_t spare:2;,
 #define OGS_PFCP_APPLY_ACTION_MBSU                          (1<<4)
 typedef uint16_t  ogs_pfcp_apply_action_t;
 
-
-
 /* 8.2.58 CP Function Features */
 typedef struct ogs_pfcp_cp_function_features_s {
     union {
@@ -1650,6 +1648,54 @@ ED8(uint8_t spare:1;,
 int16_t ogs_pfcp_build_user_id(
         ogs_tlv_octet_t *octet, ogs_pfcp_user_id_t *user_id,
         void *data, int data_len);
+
+/*
+ * 8.2.118 3GPP Interface Type
+ *
+ * NOTE 1: If separation of roaming and non-roaming traffic is desired
+ * this value should only be used for the S5-U interface
+ * and "S8-U" (decimal 19) should be used for the S8-U interface.
+ * NOTE 2: If separation of roaming and non-roaming traffic is desired
+ * this value should only be used for the Gn-U interface
+ * and "Gp-U" (decimal 20) should be used for the Gp-U interface.
+ * NOTE 3: If separation of roaming and non-roaming traffic is desired,
+ * this value should only be used for N9 non-roaming interfaces
+ * and (decimal value "21") should be used for N9 roaming interfaces.
+ */
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S1_U       0
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S5_S8_U    1  /* NOTE 1 */
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S4_U       2
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S11_U      3
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S12        4
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_GN_GP_U    5  /* NOTE 2 */
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S2A_U      6
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S2B_U      7
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_ENB_GTP_U_FOR_DL_DATA_FORWARDING 8
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_ENB_GTP_U_FOR_UL_DATA_FORWARDING 9
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_DL_DATA_FORWARDING 10
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS 11
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N3_TRUSTED_NON_3GPP_ACCESS 12
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N3_UNTRUSTED_NON_3GPP_ACCESS 13
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N3_FOR_DATA_FORWARDING 14
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N9         15 /* NOTE 3 */
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SGI        16
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N6         17
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N19        18
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_S8_U       19
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_GP_U       20
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N9_FOR_ROAMING 21
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_IU_U       22
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N9_FOR_DATA_FORWARDING 23
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SXA_U      24
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SXB_U      25
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SXC_U      26
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N4_U       27
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_UL_DATA_FORWARDING 28
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N6MB_NMB9  29
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N3MB       30
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_N19MB      31
+#define OGS_PFCP_3GPP_INTERFACE_TYPE_UNKNOWN    0xff
+typedef uint8_t ogs_pfcp_3gpp_interface_type_t;
 
 /*
  * 8.2.136 PFCPSEReq-Flags

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -648,8 +648,12 @@ sgwc_tunnel_t *sgwc_tunnel_add(
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
 
-    uint8_t src_if = OGS_PFCP_INTERFACE_UNKNOWN;
-    uint8_t dst_if = OGS_PFCP_INTERFACE_UNKNOWN;
+    ogs_pfcp_interface_t src_if = OGS_PFCP_INTERFACE_UNKNOWN;
+    ogs_pfcp_interface_t dst_if = OGS_PFCP_INTERFACE_UNKNOWN;
+    ogs_pfcp_3gpp_interface_type_t src_if_type =
+        OGS_PFCP_3GPP_INTERFACE_TYPE_UNKNOWN;
+    ogs_pfcp_3gpp_interface_type_t dst_if_type =
+        OGS_PFCP_3GPP_INTERFACE_TYPE_UNKNOWN;
 
     ogs_assert(bearer);
     sess = sgwc_sess_find_by_id(bearer->sess_id);
@@ -659,20 +663,28 @@ sgwc_tunnel_t *sgwc_tunnel_add(
     /* Downlink */
     case OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U:
         src_if = OGS_PFCP_INTERFACE_CORE;
+        src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_S5_S8_U;
         dst_if = OGS_PFCP_INTERFACE_ACCESS;
+        dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_S1_U;
         break;
 
     /* Uplink */
     case OGS_GTP2_F_TEID_S1_U_SGW_GTP_U:
         src_if = OGS_PFCP_INTERFACE_ACCESS;
+        src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_S1_U;
         dst_if = OGS_PFCP_INTERFACE_CORE;
+        dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_S5_S8_U;
         break;
 
     /* Indirect */
     case OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING:
     case OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING:
         src_if = OGS_PFCP_INTERFACE_ACCESS;
+        src_if_type =
+            OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_UL_DATA_FORWARDING;
         dst_if = OGS_PFCP_INTERFACE_ACCESS;
+        dst_if_type =
+            OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_DL_DATA_FORWARDING;
         break;
     default:
         ogs_fatal("Invalid interface type = %d", interface_type);
@@ -693,6 +705,9 @@ sgwc_tunnel_t *sgwc_tunnel_add(
 
     pdr->src_if = src_if;
 
+    pdr->src_if_type_presence = true;
+    pdr->src_if_type = src_if_type;
+
     far = ogs_pfcp_far_add(&sess->pfcp);
     ogs_assert(far);
 
@@ -701,6 +716,10 @@ sgwc_tunnel_t *sgwc_tunnel_add(
     ogs_assert(far->apn);
 
     far->dst_if = dst_if;
+
+    far->dst_if_type_presence = true;
+    far->dst_if_type = dst_if_type;
+
     ogs_pfcp_pdr_associate_far(pdr, far);
 
     far->apply_action =

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1955,6 +1955,9 @@ smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess)
 
     dl_pdr->src_if = OGS_PFCP_INTERFACE_CORE;
 
+    dl_pdr->src_if_type_presence = true;
+    dl_pdr->src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N6;
+
     ul_pdr = ogs_pfcp_pdr_add(&sess->pfcp);
     ogs_assert(ul_pdr);
     qos_flow->ul_pdr = ul_pdr;
@@ -1964,6 +1967,9 @@ smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess)
     ogs_assert(ul_pdr->apn);
 
     ul_pdr->src_if = OGS_PFCP_INTERFACE_ACCESS;
+
+    ul_pdr->src_if_type_presence = true;
+    ul_pdr->src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS;
 
     ul_pdr->outer_header_removal_len = 1;
     if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
@@ -1990,6 +1996,10 @@ smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess)
     ogs_assert(dl_far->apn);
 
     dl_far->dst_if = OGS_PFCP_INTERFACE_ACCESS;
+
+    dl_far->dst_if_type_presence = true;
+    dl_far->dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS;
+
     ogs_pfcp_pdr_associate_far(dl_pdr, dl_far);
 
     dl_far->apply_action =
@@ -2005,6 +2015,10 @@ smf_bearer_t *smf_qos_flow_add(smf_sess_t *sess)
     ogs_assert(ul_far->apn);
 
     ul_far->dst_if = OGS_PFCP_INTERFACE_CORE;
+
+    ul_far->dst_if_type_presence = true;
+    ul_far->dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N6;
+
     ogs_pfcp_pdr_associate_far(ul_pdr, ul_far);
 
     ul_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
@@ -2067,6 +2081,10 @@ void smf_sess_create_indirect_data_forwarding(smf_sess_t *sess)
 
         pdr->src_if = OGS_PFCP_INTERFACE_ACCESS;
 
+        pdr->src_if_type_presence = true;
+        pdr->src_if_type =
+            OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_UL_DATA_FORWARDING;
+
         pdr->outer_header_removal_len = 1;
         if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
             pdr->outer_header_removal.description =
@@ -2090,6 +2108,11 @@ void smf_sess_create_indirect_data_forwarding(smf_sess_t *sess)
         ogs_assert(far->apn);
 
         far->dst_if = OGS_PFCP_INTERFACE_ACCESS;
+
+        far->dst_if_type_presence = true;
+        far->dst_if_type =
+            OGS_PFCP_3GPP_INTERFACE_TYPE_SGW_UPF_GTP_U_FOR_DL_DATA_FORWARDING;
+
         ogs_pfcp_pdr_associate_far(pdr, far);
 
         far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
@@ -2284,6 +2307,9 @@ void smf_sess_create_cp_up_data_forwarding(smf_sess_t *sess)
 
     up2cp_pdr->src_if = OGS_PFCP_INTERFACE_ACCESS;
 
+    up2cp_pdr->src_if_type_presence = true;
+    up2cp_pdr->src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS;
+
     up2cp_pdr->outer_header_removal_len = 1;
     if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
         up2cp_pdr->outer_header_removal.description =
@@ -2421,6 +2447,9 @@ smf_bearer_t *smf_bearer_add(smf_sess_t *sess)
 
     dl_pdr->src_if = OGS_PFCP_INTERFACE_CORE;
 
+    dl_pdr->src_if_type_presence = true;
+    dl_pdr->src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N6;
+
     ul_pdr = ogs_pfcp_pdr_add(&sess->pfcp);
     ogs_assert(ul_pdr);
     bearer->ul_pdr = ul_pdr;
@@ -2430,6 +2459,9 @@ smf_bearer_t *smf_bearer_add(smf_sess_t *sess)
     ogs_assert(ul_pdr->apn);
 
     ul_pdr->src_if = OGS_PFCP_INTERFACE_ACCESS;
+
+    ul_pdr->src_if_type_presence = true;
+    ul_pdr->src_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS;
 
     ul_pdr->outer_header_removal_len = 1;
     if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
@@ -2456,6 +2488,10 @@ smf_bearer_t *smf_bearer_add(smf_sess_t *sess)
     ogs_assert(dl_far->apn);
 
     dl_far->dst_if = OGS_PFCP_INTERFACE_ACCESS;
+
+    dl_far->dst_if_type_presence = true;
+    dl_far->dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N3_3GPP_ACCESS;
+
     ogs_pfcp_pdr_associate_far(dl_pdr, dl_far);
 
     dl_far->apply_action =
@@ -2471,6 +2507,10 @@ smf_bearer_t *smf_bearer_add(smf_sess_t *sess)
     ogs_assert(ul_far->apn);
 
     ul_far->dst_if = OGS_PFCP_INTERFACE_CORE;
+
+    ul_far->dst_if_type_presence = true;
+    ul_far->dst_if_type = OGS_PFCP_3GPP_INTERFACE_TYPE_N6;
+
     ogs_pfcp_pdr_associate_far(ul_pdr, ul_far);
 
     ul_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;


### PR DESCRIPTION
This field was previously omitted, which could lead to improper handling of interface-specific logic in certain scenarios.

The addition of the 3GPP Interface Type ensures correct behavior in compliance with the 3GPP standards for PFCP message handling.