### PR TITLE
[CSFB] Fix Location Update for non-EPS (#3381)

### DIFF
--- a/lib/asn1c/util/conv.c
+++ b/lib/asn1c/util/conv.c
@@ -205,8 +205,10 @@ int ogs_asn_ip_to_BIT_STRING(ogs_ip_t *ip, BIT_STRING_t *bit_string)
         bit_string->buf = CALLOC(bit_string->size, sizeof(uint8_t));
         memcpy(bit_string->buf, &ip->addr6, OGS_IPV6_LEN);
         ogs_debug("    IPv6[%s]", OGS_INET_NTOP(&ip->addr6, buf));
-    } else
-        ogs_assert_if_reached();
+    } else {
+        ogs_error("No IPv4 or IPv6");
+        return OGS_ERROR;
+    }
 
     return OGS_OK;
 }

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -204,8 +204,6 @@ typedef struct mme_pgw_s {
 #define MME_SGSAP_IS_CONNECTED(__mME) \
     ((__mME) && ((__mME)->csmap) && ((__mME)->csmap->vlr) && \
      (OGS_FSM_CHECK(&(__mME)->csmap->vlr->sm, sgsap_state_connected)))
-#define MME_P_TMSI_IS_AVAILABLE(__mME) \
-    (MME_SGSAP_IS_CONNECTED(__mME) && (__mME)->p_tmsi)
 
 typedef struct mme_vlr_s {
     ogs_lnode_t     lnode;
@@ -363,6 +361,11 @@ struct mme_ue_s {
         ogs_nas_detach_type_t detach;
     } nas_eps;
 
+#define MME_TAU_TYPE_INITIAL_UE_MESSAGE    1
+#define MME_TAU_TYPE_UPLINK_NAS_TRANPORT   2
+#define MME_TAU_TYPE_UNPROTECTED_INGERITY  3
+    uint8_t tracking_area_update_request_type;
+
     /* 1. MME initiated detach request to the UE.
      *    (nas_eps.type = MME_EPS_TYPE_DETACH_REQUEST_TO_UE)
      * 2. If UE is IDLE, Paging sent to the UE
@@ -403,7 +406,6 @@ struct mme_ue_s {
     int             a_msisdn_len;
     char            a_msisdn_bcd[OGS_MAX_MSISDN_BCD_LEN+1];
 
-    mme_p_tmsi_t    p_tmsi;
     struct {
         ogs_pool_id_t   *mme_gn_teid_node; /* A node of MME-Gn-TEID */
         uint32_t        mme_gn_teid;   /* MME-Gn-TEID is derived from NODE */
@@ -416,8 +418,15 @@ struct mme_ue_s {
     } gn;
 
     struct {
+#define MME_NEXT_GUTI_IS_AVAILABLE(__mME) ((__mME)->next.m_tmsi)
+#define MME_CURRENT_GUTI_IS_AVAILABLE(__mME) ((__mME)->current.m_tmsi)
         mme_m_tmsi_t *m_tmsi;
         ogs_nas_eps_guti_t guti;
+#define MME_NEXT_P_TMSI_IS_AVAILABLE(__mME) \
+    (MME_SGSAP_IS_CONNECTED(__mME) && (__mME)->next.p_tmsi)
+#define MME_CURRENT_P_TMSI_IS_AVAILABLE(__mME) \
+    (MME_SGSAP_IS_CONNECTED(__mME) && (__mME)->current.p_tmsi)
+        mme_p_tmsi_t    p_tmsi;
     } current, next;
 
     ogs_pool_id_t   *mme_s11_teid_node; /* A node of MME-S11-TEID */
@@ -659,10 +668,10 @@ struct mme_ue_s {
     } while(0);
 
 #define CS_CALL_SERVICE_INDICATOR(__mME) \
-    (MME_P_TMSI_IS_AVAILABLE(__mME) && \
+    (MME_CURRENT_P_TMSI_IS_AVAILABLE(__mME) && \
      ((__mME)->service_indicator) == SGSAP_CS_CALL_SERVICE_INDICATOR)
 #define SMS_SERVICE_INDICATOR(__mME) \
-    (MME_P_TMSI_IS_AVAILABLE(__mME) && \
+    (MME_CURRENT_P_TMSI_IS_AVAILABLE(__mME) && \
      ((__mME)->service_indicator) == SGSAP_SMS_SERVICE_INDICATOR)
     uint8_t         service_indicator;
 
@@ -980,6 +989,12 @@ sgw_relocation_e sgw_ue_check_if_relocated(mme_ue_t *mme_ue);
 
 void mme_ue_new_guti(mme_ue_t *mme_ue);
 void mme_ue_confirm_guti(mme_ue_t *mme_ue);
+
+#define INVALID_P_TMSI 0
+void mme_ue_set_p_tmsi(
+        mme_ue_t *mme_ue,
+        ogs_nas_mobile_identity_tmsi_t *nas_mobile_identity_tmsi);
+void mme_ue_confirm_p_tmsi(mme_ue_t *mme_ue);
 
 mme_ue_t *mme_ue_add(enb_ue_t *enb_ue);
 void mme_ue_remove(mme_ue_t *mme_ue);

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -302,7 +302,7 @@ void mme_send_after_paging(mme_ue_t *mme_ue, bool failed)
             r = nas_eps_send_detach_request(mme_ue);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
-            if (MME_P_TMSI_IS_AVAILABLE(mme_ue)) {
+            if (MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
                 ogs_assert(OGS_OK == sgsap_send_detach_indication(mme_ue));
             } else {
                 enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -123,10 +123,26 @@ uint8_t mme_s6a_handle_ula(
             return OGS_NAS_EMM_CAUSE_NO_EPS_BEARER_CONTEXT_ACTIVATED;
         }
 
-        r = nas_eps_send_tau_accept(mme_ue,
-                S1AP_ProcedureCode_id_InitialContextSetup);
-        ogs_expect(r == OGS_OK);
-        ogs_assert(r != OGS_ERROR);
+        /* Update CSMAP from Tracking area update request */
+        mme_ue->csmap = mme_csmap_find_by_tai(&mme_ue->tai);
+        if (mme_ue->csmap &&
+            mme_ue->network_access_mode ==
+                OGS_NETWORK_ACCESS_MODE_PACKET_AND_CIRCUIT &&
+            (mme_ue->nas_eps.update.value ==
+             OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING ||
+             mme_ue->nas_eps.update.value ==
+             OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING_WITH_IMSI_ATTACH)) {
+
+            mme_ue->tracking_area_update_request_type =
+                MME_TAU_TYPE_UNPROTECTED_INGERITY;
+            ogs_assert(OGS_OK == sgsap_send_location_update_request(mme_ue));
+
+        } else {
+            r = nas_eps_send_tau_accept(mme_ue,
+                    S1AP_ProcedureCode_id_InitialContextSetup);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+        }
     } else {
         ogs_error("Invalid Type[%d]", mme_ue->nas_eps.type);
         return OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED;
@@ -275,7 +291,7 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
             r = nas_eps_send_detach_request(mme_ue);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
-            if (MME_P_TMSI_IS_AVAILABLE(mme_ue)) {
+            if (MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
                 ogs_assert(OGS_OK == sgsap_send_detach_indication(mme_ue));
             } else {
                 enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
@@ -304,7 +320,7 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
          * There is no need to send NAS or S1AP message to the UE.
          * So, we don't have to check whether UE is IDLE or not.
          */
-        if (MME_P_TMSI_IS_AVAILABLE(mme_ue)) {
+        if (MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
             ogs_assert(OGS_OK == sgsap_send_detach_indication(mme_ue));
         } else {
             enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -857,17 +857,15 @@ int nas_eps_send_tau_accept(
         return OGS_ERROR;
     }
 
-    if (mme_ue->next.m_tmsi) {
-        CLEAR_MME_UE_TIMER(mme_ue->t3450);
-        mme_ue->t3450.pkbuf = ogs_pkbuf_copy(emmbuf);
-        if (!mme_ue->t3450.pkbuf) {
-            ogs_error("ogs_pkbuf_copy(mme_ue->t3450.pkbuf) failed");
-            ogs_pkbuf_free(emmbuf);
-            return OGS_ERROR;
-        }
-        ogs_timer_start(mme_ue->t3450.timer,
-                mme_timer_cfg(MME_TIMER_T3450)->duration);
+    CLEAR_MME_UE_TIMER(mme_ue->t3450);
+    mme_ue->t3450.pkbuf = ogs_pkbuf_copy(emmbuf);
+    if (!mme_ue->t3450.pkbuf) {
+        ogs_error("ogs_pkbuf_copy(mme_ue->t3450.pkbuf) failed");
+        ogs_pkbuf_free(emmbuf);
+        return OGS_ERROR;
     }
+    ogs_timer_start(mme_ue->t3450.timer,
+            mme_timer_cfg(MME_TIMER_T3450)->duration);
 
     if (procedureCode == S1AP_ProcedureCode_id_InitialContextSetup) {
         ogs_pkbuf_t *s1apbuf = NULL;

--- a/src/mme/s1ap-build.c
+++ b/src/mme/s1ap-build.c
@@ -692,7 +692,7 @@ ogs_pkbuf_t *s1ap_build_initial_context_setup_request(
     ogs_log_hexdump(OGS_LOG_DEBUG, SecurityKey->buf, SecurityKey->size);
 
     if (mme_ue->nas_eps.type == MME_EPS_TYPE_EXTENDED_SERVICE_REQUEST &&
-        MME_P_TMSI_IS_AVAILABLE(mme_ue)) {
+        MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
 
         /* Set CS-Fallback */
         S1AP_CSFallbackIndicator_t *CSFallbackIndicator = NULL;
@@ -727,7 +727,7 @@ ogs_pkbuf_t *s1ap_build_initial_context_setup_request(
         ogs_s1ap_buffer_to_OCTET_STRING(
             &mme_ue->tai.plmn_id, sizeof(ogs_plmn_id_t), &LAI->pLMNidentity);
         ogs_assert(mme_ue->csmap);
-        ogs_assert(mme_ue->p_tmsi);
+        ogs_assert(mme_ue->current.p_tmsi);
         ogs_asn_uint16_to_OCTET_STRING(mme_ue->csmap->lai.lac, &LAI->lAC);
 
     }
@@ -891,7 +891,7 @@ ogs_pkbuf_t *s1ap_build_ue_context_modification_request(mme_ue_t *mme_ue)
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 
     if (mme_ue->nas_eps.type == MME_EPS_TYPE_EXTENDED_SERVICE_REQUEST &&
-        MME_P_TMSI_IS_AVAILABLE(mme_ue)) {
+        MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
         ie = CALLOC(1, sizeof(S1AP_UEContextModificationRequestIEs_t));
         ASN_SEQUENCE_ADD(&UEContextModificationRequest->protocolIEs, ie);
 
@@ -919,7 +919,7 @@ ogs_pkbuf_t *s1ap_build_ue_context_modification_request(mme_ue_t *mme_ue)
         ogs_s1ap_buffer_to_OCTET_STRING(
             &mme_ue->tai.plmn_id, sizeof(ogs_plmn_id_t), &LAI->pLMNidentity);
         ogs_assert(mme_ue->csmap);
-        ogs_assert(mme_ue->p_tmsi);
+        ogs_assert(mme_ue->current.p_tmsi);
         ogs_asn_uint16_to_OCTET_STRING(mme_ue->csmap->lai.lac, &LAI->lAC);
 
     } else {

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -101,6 +101,12 @@ void sgsap_handle_location_update_accept(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
         goto error;
     }
 
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
+        ogs_error("!enb_ue");
+        goto error;
+    }
+
     ogs_debug("    IMSI[%s]", mme_ue->imsi_bcd);
     if (lai) {
         ogs_debug("    LAI[PLMN_ID:%06x,LAC:%d]",
@@ -109,38 +115,125 @@ void sgsap_handle_location_update_accept(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
 
     if (nas_mobile_identity_tmsi) {
         if (nas_mobile_identity_tmsi->type == OGS_NAS_MOBILE_IDENTITY_TMSI) {
-            mme_ue->p_tmsi = be32toh(nas_mobile_identity_tmsi->tmsi);
+            mme_ue_set_p_tmsi(mme_ue, nas_mobile_identity_tmsi);
         } else {
             ogs_error("Not supported Identity type[%d]",
                     nas_mobile_identity_tmsi->type);
             goto error;
         }
-        ogs_debug("    P-TMSI[0x%08x]", mme_ue->p_tmsi);
+        ogs_debug("    P-TMSI[0x%08x]", mme_ue->next.p_tmsi);
     }
 
-    r = nas_eps_send_attach_accept(mme_ue);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
+    if (mme_ue->nas_eps.type == MME_EPS_TYPE_ATTACH_REQUEST) {
+        r = nas_eps_send_attach_accept(mme_ue);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    } else if (mme_ue->nas_eps.type == MME_EPS_TYPE_TAU_REQUEST) {
+        if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_INITIAL_UE_MESSAGE) {
+            ogs_debug("    Iniital UE Message");
+            if (mme_ue->nas_eps.update.active_flag) {
+
+/*
+* TS33.401
+* 7 Security procedures between UE and EPS access network elements
+* 7.2 Handling of user-related keys in E-UTRAN
+* 7.2.7 Key handling for the TAU procedure when registered in E-UTRAN
+*
+* If the "active flag" is set in the TAU request message or
+* the MME chooses to establish radio bearers when there is pending downlink
+* UP data or pending downlink signalling, radio bearers will be established
+* as part of the TAU procedure and a KeNB derivation is necessary.
+*/
+                ogs_kdf_kenb(mme_ue->kasme, mme_ue->ul_count.i32,
+                        mme_ue->kenb);
+                ogs_kdf_nh_enb(mme_ue->kasme, mme_ue->kenb, mme_ue->nh);
+                mme_ue->nhcc = 1;
+
+                r = nas_eps_send_tau_accept(mme_ue,
+                        S1AP_ProcedureCode_id_InitialContextSetup);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+            } else {
+                r = nas_eps_send_tau_accept(mme_ue,
+                        S1AP_ProcedureCode_id_downlinkNASTransport);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+            }
+        } else if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_UPLINK_NAS_TRANPORT) {
+            ogs_debug("    Uplink NAS Transport");
+            r = nas_eps_send_tau_accept(mme_ue,
+                    S1AP_ProcedureCode_id_downlinkNASTransport);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+        } else if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_UNPROTECTED_INGERITY) {
+            ogs_debug("    Unprotected Integrity");
+            r = nas_eps_send_tau_accept(mme_ue,
+                    S1AP_ProcedureCode_id_InitialContextSetup);
+            ogs_expect(r == OGS_OK);
+        } else {
+            ogs_error("Invalid TAU Type[%d]",
+                    mme_ue->tracking_area_update_request_type);
+            return;
+        }
+
+        /*
+         * When active_flag is 0, check if the P-TMSI has been updated.
+         * If the P-TMSI has changed, wait to receive the TAU Complete message
+         * from the UE before sending the UEContextReleaseCommand.
+         *
+         * This ensures that the UE has acknowledged the new P-TMSI,
+         * allowing the TAU procedure to complete successfully
+         * and maintaining synchronization between the UE and the network.
+         */
+        if (!mme_ue->nas_eps.update.active_flag &&
+            !MME_NEXT_P_TMSI_IS_AVAILABLE(mme_ue)) {
+            enb_ue->relcause.group = S1AP_Cause_PR_nas;
+            enb_ue->relcause.cause = S1AP_CauseNas_normal_release;
+            mme_send_release_access_bearer_or_ue_context_release(enb_ue);
+        }
+    } else {
+        ogs_fatal("[%s] Invalid EPS-Type[%d]",
+                mme_ue->imsi_bcd, mme_ue->nas_eps.type);
+        ogs_assert_if_reached();
+    }
 
     return;
 
 error:
-    /* Clang scan-build SA: NULL pointer dereference: mme_ue=NULL if root=NULL. */
+    /* Clang scan-build SA:
+     * NULL pointer dereference: mme_ue=NULL if root=NULL. */
     if (!mme_ue) {
         ogs_error("!mme_ue");
         return;
-    }  
+    }
     enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-    if (enb_ue) {
+    if (!enb_ue) {
+        ogs_error("ENB-S1 Context has already been removed");
+        return;
+    }
+
+    if (mme_ue->nas_eps.type == MME_EPS_TYPE_ATTACH_REQUEST) {
         r = nas_eps_send_attach_reject(
                 enb_ue, mme_ue,
                 OGS_NAS_EMM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED,
                 OGS_NAS_ESM_CAUSE_PROTOCOL_ERROR_UNSPECIFIED);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
-        mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
-    } else
-        ogs_error("ENB-S1 Context has already been removed");
+    } else if (mme_ue->nas_eps.type == MME_EPS_TYPE_TAU_REQUEST) {
+        r = nas_eps_send_tau_reject(
+                enb_ue, mme_ue,
+                OGS_NAS_EMM_CAUSE_UE_IDENTITY_CANNOT_BE_DERIVED_BY_THE_NETWORK);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    } else {
+        ogs_fatal("[%s] Invalid EPS-Type[%d]",
+                mme_ue->imsi_bcd, mme_ue->nas_eps.type);
+        ogs_assert_if_reached();
+    }
+    mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
 }
 
 void sgsap_handle_location_update_reject(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
@@ -148,6 +241,7 @@ void sgsap_handle_location_update_reject(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
     int r;
     ogs_tlv_t *root = NULL, *iter = NULL;
     mme_ue_t *mme_ue = NULL;
+    enb_ue_t *enb_ue = NULL;
 
     char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
 
@@ -215,15 +309,94 @@ void sgsap_handle_location_update_reject(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
         return;
     }
 
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
+        ogs_error("!enb_ue");
+        goto error;
+    }
+
     ogs_debug("    IMSI[%s] CAUSE[%d]", mme_ue->imsi_bcd, emm_cause);
     if (lai) {
         ogs_debug("    LAI[PLMN_ID:%06x,LAC:%d]",
                     ogs_plmn_id_hexdump(&lai->nas_plmn_id), lai->lac);
     }
 
-    r = nas_eps_send_attach_accept(mme_ue);
-    ogs_expect(r == OGS_OK);
-    ogs_assert(r != OGS_ERROR);
+    if (mme_ue->nas_eps.type == MME_EPS_TYPE_ATTACH_REQUEST) {
+        r = nas_eps_send_attach_accept(mme_ue);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    } else if (mme_ue->nas_eps.type == MME_EPS_TYPE_TAU_REQUEST) {
+        if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_INITIAL_UE_MESSAGE) {
+            ogs_debug("    Iniital UE Message");
+            if (mme_ue->nas_eps.update.active_flag) {
+
+/*
+* TS33.401
+* 7 Security procedures between UE and EPS access network elements
+* 7.2 Handling of user-related keys in E-UTRAN
+* 7.2.7 Key handling for the TAU procedure when registered in E-UTRAN
+*
+* If the "active flag" is set in the TAU request message or
+* the MME chooses to establish radio bearers when there is pending downlink
+* UP data or pending downlink signalling, radio bearers will be established
+* as part of the TAU procedure and a KeNB derivation is necessary.
+*/
+                ogs_kdf_kenb(mme_ue->kasme, mme_ue->ul_count.i32,
+                        mme_ue->kenb);
+                ogs_kdf_nh_enb(mme_ue->kasme, mme_ue->kenb, mme_ue->nh);
+                mme_ue->nhcc = 1;
+
+                r = nas_eps_send_tau_accept(mme_ue,
+                        S1AP_ProcedureCode_id_InitialContextSetup);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+            } else {
+                r = nas_eps_send_tau_accept(mme_ue,
+                        S1AP_ProcedureCode_id_downlinkNASTransport);
+                ogs_expect(r == OGS_OK);
+                ogs_assert(r != OGS_ERROR);
+            }
+        } else if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_UPLINK_NAS_TRANPORT) {
+            ogs_debug("    Uplink NAS Transport");
+            r = nas_eps_send_tau_accept(mme_ue,
+                    S1AP_ProcedureCode_id_downlinkNASTransport);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+        } else if (mme_ue->tracking_area_update_request_type ==
+                MME_TAU_TYPE_UNPROTECTED_INGERITY) {
+            ogs_debug("    Unprotected Integrity");
+            r = nas_eps_send_tau_accept(mme_ue,
+                    S1AP_ProcedureCode_id_InitialContextSetup);
+            ogs_expect(r == OGS_OK);
+        } else {
+            ogs_error("Invalid TAU Type[%d]",
+                    mme_ue->tracking_area_update_request_type);
+            return;
+        }
+
+        /*
+         * When active_flag is 0, check if the P-TMSI has been updated.
+         * If the P-TMSI has changed, wait to receive the TAU Complete message
+         * from the UE before sending the UEContextReleaseCommand.
+         *
+         * This ensures that the UE has acknowledged the new P-TMSI,
+         * allowing the TAU procedure to complete successfully
+         * and maintaining synchronization between the UE and the network.
+         */
+        if (!mme_ue->nas_eps.update.active_flag &&
+            !MME_NEXT_P_TMSI_IS_AVAILABLE(mme_ue)) {
+            ogs_fatal("NEXT = %d", MME_NEXT_P_TMSI_IS_AVAILABLE(mme_ue));
+            enb_ue->relcause.group = S1AP_Cause_PR_nas;
+            enb_ue->relcause.cause = S1AP_CauseNas_normal_release;
+            mme_send_release_access_bearer_or_ue_context_release(enb_ue);
+        }
+    } else {
+        ogs_fatal("[%s] Invalid EPS-Type[%d]",
+                mme_ue->imsi_bcd, mme_ue->nas_eps.type);
+        ogs_assert_if_reached();
+    }
 
     return;
 

--- a/src/smf/ngap-build.c
+++ b/src/smf/ngap-build.c
@@ -85,7 +85,8 @@ ogs_pkbuf_t *ngap_build_pdu_session_resource_setup_request_transfer(
 
     ogs_assert(OGS_OK == ogs_sockaddr_to_ip(
                 sess->upf_n3_addr, sess->upf_n3_addr6, &upf_n3_ip));
-    ogs_asn_ip_to_BIT_STRING(&upf_n3_ip, &gTPTunnel->transportLayerAddress);
+    ogs_assert(OGS_OK == ogs_asn_ip_to_BIT_STRING(
+                &upf_n3_ip, &gTPTunnel->transportLayerAddress));
     ogs_asn_uint32_to_OCTET_STRING(sess->upf_n3_teid, &gTPTunnel->gTP_TEID);
 
     if (sess->handover.data_forwarding_not_possible == true) {
@@ -477,7 +478,8 @@ ogs_pkbuf_t *ngap_build_path_switch_request_ack_transfer(smf_sess_t *sess)
 
     ogs_assert(OGS_OK == ogs_sockaddr_to_ip(
                 sess->upf_n3_addr, sess->upf_n3_addr6, &upf_n3_ip));
-    ogs_asn_ip_to_BIT_STRING(&upf_n3_ip, &gTPTunnel->transportLayerAddress);
+    ogs_assert(OGS_OK == ogs_asn_ip_to_BIT_STRING(
+                &upf_n3_ip, &gTPTunnel->transportLayerAddress));
     ogs_asn_uint32_to_OCTET_STRING(sess->upf_n3_teid, &gTPTunnel->gTP_TEID);
 
 #endif
@@ -518,7 +520,8 @@ ogs_pkbuf_t *ngap_build_handover_command_transfer(smf_sess_t *sess)
         ogs_assert(OGS_OK == ogs_sockaddr_to_ip(
                 sess->handover.upf_dl_addr, sess->handover.upf_dl_addr6,
                 &upf_dl_ip));
-        ogs_asn_ip_to_BIT_STRING(&upf_dl_ip, &gTPTunnel->transportLayerAddress);
+        ogs_assert(OGS_OK == ogs_asn_ip_to_BIT_STRING(
+                    &upf_dl_ip, &gTPTunnel->transportLayerAddress));
         ogs_asn_uint32_to_OCTET_STRING(
                 sess->handover.upf_dl_teid, &gTPTunnel->gTP_TEID);
 

--- a/tests/app/5gc-init.c
+++ b/tests/app/5gc-init.c
@@ -129,7 +129,7 @@ int app_initialize(const char *const argv[])
      * 
      * If freeDiameter is not used, it uses a delay of less than 4 seconds.
      */
-    ogs_msleep(2000);
+    ogs_msleep(3000);
 
     return OGS_OK;
 }

--- a/tests/common/sgsap-build.c
+++ b/tests/common/sgsap-build.c
@@ -26,13 +26,21 @@ ogs_pkbuf_t *test_sgsap_location_update_accept(int i)
     ogs_pkbuf_t *pkbuf = NULL;
     const char *payload[TEST_SGSAP_MAX_MESSAGE] = {
         "0a01089999073746 000006040509f107 09260e05f49ee88e 64",
+        "0a01089999073746 000006040509f107 09260e05f49ee88e 65",
+        "0a01089999073746 000006040509f107 09260e05f49ee88e 66",
+
         "0a01087942120000 000030040527f412 c9580e05f437ab9c c5",
+        "",
         "",
 
     };
     uint16_t len[TEST_SGSAP_MAX_MESSAGE] = {
         25,
         25,
+        25,
+
+        25,
+        0,
         0,
     };
     char hexbuf[OGS_HUGE_LEN];

--- a/tests/csfb/abts-main.c
+++ b/tests/csfb/abts-main.c
@@ -25,6 +25,7 @@ abts_suite *test_mo_active(abts_suite *suite);
 abts_suite *test_mt_active(abts_suite *suite);
 abts_suite *test_mo_sms(abts_suite *suite);
 abts_suite *test_mt_sms(abts_suite *suite);
+abts_suite *test_tau(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
 
 const struct testlist {
@@ -36,6 +37,7 @@ const struct testlist {
     {test_mt_active},
     {test_mo_sms},
     {test_mt_sms},
+    {test_tau},
     {test_crash},
     {NULL},
 };

--- a/tests/csfb/meson.build
+++ b/tests/csfb/meson.build
@@ -23,6 +23,7 @@ testapp_csfb_sources = files('''
     mt-active-test.c
     mo-sms-test.c
     mt-sms-test.c
+    tau-test.c
     crash-test.c
 '''.split())
 

--- a/tests/csfb/tau-test.c
+++ b/tests/csfb/tau-test.c
@@ -1,0 +1,1538 @@
+/*
+ * Copyright (C) 2024 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "test-common.h"
+
+extern ogs_socknode_t *sgsap;
+
+static void test_simple_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_s1ap_message_t message;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    uint32_t enb_ue_s1ap_id;
+    uint64_t mme_ue_s1ap_id;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "3746000006");
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x54f6401;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* eNB connects to MME */
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    /* eNB connects to SGW */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send S1-Setup Reqeust */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive S1-Setup Response */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.ms_network_feature_support = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, false, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response */
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(1);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Initial Context Setup Request +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Initial Context Setup Response */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    test_ue->nr_cgi.cell_id = 0x1234502;
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send TAU Request */
+    memset(&test_ue->tau_request_param, 0, sizeof(test_ue->tau_request_param));
+    test_ue->tau_request_param.ue_network_capability = 1;
+    test_ue->tau_request_param.last_visited_registered_tai = 1;
+    test_ue->tau_request_param.drx_parameter = 1;
+    test_ue->tau_request_param.eps_bearer_context_status = 1;
+    test_ue->tau_request_param.ms_network_capability = 1;
+    test_ue->tau_request_param.tmsi_status = 1;
+    test_ue->tau_request_param.mobile_station_classmark_2 = 1;
+    test_ue->tau_request_param.ue_usage_setting = 1;
+    test_ue->tau_request_param.device_properties = 1;
+    emmbuf = testemm_build_tau_request(
+            test_ue, true, OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING, true, true);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive OLD UE Context Release Command */
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send OLD UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(1);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupResponse + TAU Accept */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send UE Context Release Request */
+    sendbuf = test_s1ap_build_ue_context_release_request(test_ue,
+            S1AP_Cause_PR_radioNetwork, S1AP_CauseRadioNetwork_user_inactivity);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from MME */
+    testenb_s1ap_close(s1ap);
+
+    /* eNB disonncect from SGW */
+    test_gtpu_close(gtpu);
+
+    test_ue_remove(test_ue);
+}
+
+static void test_no_active_flag_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_s1ap_message_t message;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    uint32_t enb_ue_s1ap_id;
+    uint64_t mme_ue_s1ap_id;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "3746000006");
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x54f6401;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* eNB connects to MME */
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    /* eNB connects to SGW */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send S1-Setup Reqeust */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive S1-Setup Response */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.ms_network_feature_support = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, false, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response */
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(2);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    test_ue->nr_cgi.cell_id = 0x1234502;
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send TAU Request */
+    memset(&test_ue->tau_request_param, 0, sizeof(test_ue->tau_request_param));
+    test_ue->tau_request_param.ue_network_capability = 1;
+    test_ue->tau_request_param.last_visited_registered_tai = 1;
+    test_ue->tau_request_param.drx_parameter = 1;
+    test_ue->tau_request_param.eps_bearer_context_status = 1;
+    test_ue->tau_request_param.ms_network_capability = 1;
+    test_ue->tau_request_param.tmsi_status = 1;
+    test_ue->tau_request_param.mobile_station_classmark_2 = 1;
+    test_ue->tau_request_param.ue_usage_setting = 1;
+    test_ue->tau_request_param.device_properties = 1;
+    emmbuf = testemm_build_tau_request(
+            test_ue, false,
+            OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING_WITH_IMSI_ATTACH,
+            true, true);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive OLD UEContextReleaseCommand */
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send OLD UEContextReleaseComplete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive TAU Accept */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send TAU Complete */
+    emmbuf = testemm_build_tau_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from MME */
+    testenb_s1ap_close(s1ap);
+
+    /* eNB disonncect from SGW */
+    test_gtpu_close(gtpu);
+
+    test_ue_remove(test_ue);
+}
+
+static void test_integrity_unprotected_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_s1ap_message_t message;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    uint32_t enb_ue_s1ap_id;
+    uint64_t mme_ue_s1ap_id;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "3746000006");
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x54f6401;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* eNB connects to MME */
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    /* eNB connects to SGW */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send S1-Setup Reqeust */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive S1-Setup Response */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.ms_network_feature_support = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, false, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response */
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(1);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Initial Context Setup Request +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Initial Context Setup Response */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    test_ue->nr_cgi.cell_id = 0x1234502;
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send TAU Request */
+    memset(&test_ue->tau_request_param, 0, sizeof(test_ue->tau_request_param));
+    test_ue->tau_request_param.ue_network_capability = 1;
+    test_ue->tau_request_param.last_visited_registered_tai = 1;
+    test_ue->tau_request_param.drx_parameter = 1;
+    test_ue->tau_request_param.eps_bearer_context_status = 1;
+    test_ue->tau_request_param.ms_network_capability = 1;
+    test_ue->tau_request_param.tmsi_status = 1;
+    test_ue->tau_request_param.mobile_station_classmark_2 = 1;
+    test_ue->tau_request_param.ue_usage_setting = 1;
+    test_ue->tau_request_param.device_properties = 1;
+    emmbuf = testemm_build_tau_request(
+            test_ue, true,
+            OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING_WITH_IMSI_ATTACH,
+            false, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive OLD UE Context Release Command */
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send OLD UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupResponse + TAU Accept */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send TAU Complete */
+    emmbuf = testemm_build_tau_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send UE Context Release Request */
+    sendbuf = test_s1ap_build_ue_context_release_request(test_ue,
+            S1AP_Cause_PR_radioNetwork, S1AP_CauseRadioNetwork_user_inactivity);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from MME */
+    testenb_s1ap_close(s1ap);
+
+    /* eNB disonncect from SGW */
+    test_gtpu_close(gtpu);
+
+    test_ue_remove(test_ue);
+}
+
+static void test_uplink_transport_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap1, *s1ap2;
+    ogs_socknode_t *gtpu1, *gtpu2;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_pkbuf_t *pkbuf;
+    ogs_s1ap_message_t message;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    uint32_t enb_ue_s1ap_id;
+    uint64_t mme_ue_s1ap_id;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "3746000006");
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x1234560;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* Two eNB connects to MME */
+    s1ap1 = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap1);
+
+    s1ap2 = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap2);
+
+    /* eNB connects to SGW */
+    gtpu1 = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu1);
+
+    gtpu2 = test_gtpu_server(2, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu2);
+
+    /* S1-Setup Reqeust/Response for Source eNB */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x1f2);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /* S1-Setup Reqeust/Response for Target eNB */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x43);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_qos_flow(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.guti = 1;
+    test_ue->attach_request_param.last_visited_registered_tai = 1;
+    test_ue->attach_request_param.drx_parameter = 1;
+    test_ue->attach_request_param.tmsi_status = 1;
+    test_ue->attach_request_param.mobile_station_classmark_2 = 1;
+    test_ue->attach_request_param.additional_update_type = 1;
+    test_ue->attach_request_param.ue_usage_setting = 1;
+    test_ue->attach_request_param.old_guti_type = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    test_ue->initial_ue_param.gummei_id = 1;
+    test_ue->initial_ue_param.gummei.mme_gid = 2;
+    test_ue->initial_ue_param.gummei.mme_code = 1;
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Identity Request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Identity response */
+    emmbuf = testemm_build_identity_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response */
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Initial Context Setup Request +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Initial Context Setup Response */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    test_ue->nr_cgi.cell_id = 0x1234502;
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Receive SGsAP-TMSI-REALLOCATION-COMPLETE */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Receive E-RAB Setup Request +
+     * Activate dedicated EPS bearer context request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send E-RAB Setup Response */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 6);
+    ogs_assert(bearer);
+    sendbuf = test_s1ap_build_e_rab_setup_response(bearer);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Activate dedicated EPS bearer context accept */
+    esmbuf = testesm_build_activate_dedicated_eps_bearer_context_accept(bearer);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send ENB configuration transfer */
+    sendbuf = test_s1ap_build_enb_configuration_transfer(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive MME configuration transfer */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ENB configuration transfer */
+    sendbuf = test_s1ap_build_enb_configuration_transfer(1);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive MME configuration transfer */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* DELAY is needed in dedicated EPS bearer */
+    ogs_msleep(100);
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu1, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 6);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu1, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send Handover Required */
+    sendbuf = test_s1ap_build_handover_required(
+            test_ue, S1AP_HandoverType_intralte,
+            S1AP_ENB_ID_PR_macroENB_ID, 0x43,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_time_critical_handover);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Request */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Request Ack */
+    ogs_list_for_each(&sess->bearer_list, bearer) {
+        bearer->enb_s1u_addr = test_self()->gnb2_addr;
+        bearer->enb_s1u_addr6 = test_self()->gnb2_addr6;
+    }
+    sendbuf = test_s1ap_build_handover_request_ack(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Command */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu1, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+
+    /* Copy ICMP Packet */
+    pkbuf = ogs_pkbuf_alloc(NULL, 200);
+    ogs_assert(pkbuf);
+    ogs_pkbuf_reserve(pkbuf, OGS_GTPV1U_5GC_HEADER_LEN);
+    ogs_pkbuf_put(pkbuf, 200-OGS_GTPV1U_5GC_HEADER_LEN);
+    memset(pkbuf->data, 0, pkbuf->len);
+    memcpy(pkbuf->data, recvbuf->data + 8, recvbuf->len - 8);
+
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send GTP-U Packet with Indirect Data Forwarding */
+    rv = test_gtpu_send_indirect_data_forwarding(gtpu1, bearer, pkbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = testgnb_gtpu_read(gtpu2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send eNB Status Transfer */
+    sendbuf = test_s1ap_build_enb_status_transfer(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive MME Status Transfer */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Notify */
+    test_ue->e_cgi.cell_id = 0xabcdef0;
+    sendbuf = test_s1ap_build_handover_notify(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive End Mark */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Receive End Mark */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send TAU Request */
+    memset(&test_ue->tau_request_param, 0, sizeof(test_ue->tau_request_param));
+    test_ue->tau_request_param.ue_network_capability = 1;
+    test_ue->tau_request_param.last_visited_registered_tai = 1;
+    test_ue->tau_request_param.drx_parameter = 1;
+    test_ue->tau_request_param.eps_bearer_context_status = 1;
+    test_ue->tau_request_param.ms_network_capability = 1;
+    test_ue->tau_request_param.tmsi_status = 1;
+    test_ue->tau_request_param.mobile_station_classmark_2 = 1;
+    test_ue->tau_request_param.ue_usage_setting = 1;
+    emmbuf = testemm_build_tau_request(
+            test_ue, true, OGS_NAS_EPS_UPDATE_TYPE_COMBINED_TA_LA_UPDATING,
+            true, true);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive SGsAP-Location-Update-Request */
+    recvbuf = testvlr_sgsap_read(sgsap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send SGsAP-Location-Update-Accept */
+    sendbuf = test_sgsap_location_update_accept(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testvlr_sgsap_send(sgsap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive TAU Accept */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Receive UE Context Release Command */
+    mme_ue_s1ap_id = test_ue->mme_ue_s1ap_id;
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->mme_ue_s1ap_id = mme_ue_s1ap_id;
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu2, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 6);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu2, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send Handover Required */
+    sendbuf = test_s1ap_build_handover_required(
+            test_ue, S1AP_HandoverType_intralte,
+            S1AP_ENB_ID_PR_macroENB_ID, 0x1f2,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_time_critical_handover);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Request */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Request Ack */
+    ogs_list_for_each(&sess->bearer_list, bearer) {
+        bearer->enb_s1u_addr = test_self()->gnb1_addr;
+        bearer->enb_s1u_addr6 = test_self()->gnb1_addr6;
+    }
+    sendbuf = test_s1ap_build_handover_request_ack(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Command */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send eNB Status Transfer */
+    sendbuf = test_s1ap_build_enb_status_transfer(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive MME Status Transfer */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Notify */
+    test_ue->e_cgi.cell_id = 0x1234560;
+    sendbuf = test_s1ap_build_handover_notify(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive End Mark */
+    recvbuf = test_gtpu_read(gtpu2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Receive End Mark */
+    recvbuf = test_gtpu_read(gtpu2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Receive UE Context Release Command */
+    mme_ue_s1ap_id = test_ue->mme_ue_s1ap_id;
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->mme_ue_s1ap_id = mme_ue_s1ap_id;
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu1, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send GTP-U ICMP Packet */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 6);
+    ogs_assert(bearer);
+    rv = test_gtpu_send_ping(gtpu1, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send Handover Required */
+    sendbuf = test_s1ap_build_handover_required(
+            test_ue, S1AP_HandoverType_intralte,
+            S1AP_ENB_ID_PR_macroENB_ID, 0x43,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_time_critical_handover);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Request */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Request Ack */
+    ogs_list_for_each(&sess->bearer_list, bearer) {
+        bearer->enb_s1u_addr = test_self()->gnb1_addr;
+        bearer->enb_s1u_addr6 = test_self()->gnb1_addr6;
+    }
+    sendbuf = test_s1ap_build_handover_request_ack(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Handover Command */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Handover Cancel */
+    sendbuf = test_s1ap_build_handover_cancel(test_ue,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_tS1relocprep_expiry);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap1, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap2);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap2, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Recv HandoverCancelAcknowledge */
+    recvbuf = testenb_s1ap_read(s1ap1);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from SGW */
+    testgnb_gtpu_close(gtpu2);
+    testgnb_gtpu_close(gtpu1);
+
+    /* Two eNB disonncect from MME */
+    testenb_s1ap_close(s1ap1);
+    testenb_s1ap_close(s1ap2);
+
+    test_ue_remove(test_ue);
+}
+
+abts_suite *test_tau(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite)
+
+    abts_run_test(suite, test_simple_func, NULL);
+    abts_run_test(suite, test_no_active_flag_func, NULL);
+    abts_run_test(suite, test_integrity_unprotected_func, NULL);
+    abts_run_test(suite, test_uplink_transport_func, NULL);
+
+    return suite;
+}


### PR DESCRIPTION
While experimenting with CSFB, it was observed that when the UE returns to E-UTRAN after a CS call, the UE performs a Tracking Area Update with a combined Tracking Area/Location Area update and IMSI attach. Currently, Open5GS's MME simply responds with a TAU Accept message but does not inform the MSC/VLR.

As a result, no further MT (Mobile Terminated) CS/SMS services are possible in cases where the MSC/VLR only attempts paging on GERAN. However, some MSC/VLR implementations with fast fallback may still attempt paging on E-UTRAN, allowing MT CS/SMS services to function intermittently.

According to 3GPP TS 29.118 Section 5.2.2 Procedures in the MME, specifically Section 5.2.2.2.1, if the timer Ts6-1 is not running, the MME shall start the location update for non-EPS services procedure upon receiving a combined Tracking Area Update Request indicating combined TA/LA updating with IMSI attach. However, SGs timers are not implemented in Open5GS, which is a separate issue.

To comply with the specification and ensure that the MSC/VLR is informed when the UE becomes reachable via SGs, the following changes have been implemented:

1. Delay UEContextReleaseCommand:

When the active_flag is set to 0, the UEContextReleaseCommand is now delayed until the MME receives the TAU Complete message from the UE. This ensures that the UE has acknowledged the new P-TMSI before the network releases the context, maintaining proper synchronization between the UE and the network.

2. Include Mobile Identity Only When P-TMSI Changes:

The Mobile Identity is now included in the Attach/TAU Accept messages only when the MSC/VLR updates the P-TMSI. This ensures that the UE receives the Mobile Identity information solely when there is an actual change in the P-TMSI, preventing unnecessary or incorrect handling of TAU Complete messages.

3. Send SGsAP-REALLOCATION-COMPLETE Conditionally:

The SGsAP-REALLOCATION-COMPLETE message is now sent to the MSC/VLR only upon receiving a Attach/TAU Complete message from the UE. This confirmation indicates that the UE has successfully updated its P-TMSI, ensuring that the MSC/VLR is accurately informed of the change.

4. Handle P-TMSI Confirmation:

When the MSC/VLR updates the P-TMSI, Open5GS stores the new P-TMSI in the next field of the mme_ue structure. Upon receiving the TAU Complete message from the UE, indicating acknowledgment of the new P-TMSI, Open5GS confirms the update by transferring the P-TMSI from the next field to the current field. This ensures that the MME maintains an accurate and up-to-date record of the P-TMSI as confirmed by the UE.