### PR TITLE
[AMF/MME] Fix handover failing due to GNB/eNBID hash table handling

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1258,7 +1258,8 @@ void amf_gnb_remove(amf_gnb_t *gnb)
 
     ogs_hash_set(self.gnb_addr_hash,
             gnb->sctp.addr, sizeof(ogs_sockaddr_t), NULL);
-    ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
+    if (gnb->gnb_id_presence == true)
+        ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
 
     ogs_sctp_flush_and_destroy(&gnb->sctp);
 
@@ -1294,10 +1295,13 @@ int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id)
 {
     ogs_assert(gnb);
 
-    ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
+    if (gnb->gnb_id_presence == true)
+        ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
 
     gnb->gnb_id = gnb_id;
     ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), gnb);
+
+    gnb->gnb_id_presence = true;
 
     return OGS_OK;
 }

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -139,6 +139,7 @@ typedef struct amf_gnb_s {
 
     ogs_fsm_t       sm;         /* A state machine */
 
+    bool            gnb_id_presence;
     uint32_t        gnb_id;     /* gNB_ID received from gNB */
     ogs_plmn_id_t   plmn_id;    /* gNB PLMN-ID received from gNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2999,7 +2999,8 @@ int mme_enb_remove(mme_enb_t *enb)
 
     ogs_hash_set(self.enb_addr_hash,
             enb->sctp.addr, sizeof(ogs_sockaddr_t), NULL);
-    ogs_hash_set(self.enb_id_hash, &enb->enb_id, sizeof(enb->enb_id), NULL);
+    if (enb->enb_id_presence == true)
+        ogs_hash_set(self.enb_id_hash, &enb->enb_id, sizeof(enb->enb_id), NULL);
 
     /*
      * CHECK:
@@ -3046,10 +3047,13 @@ int mme_enb_set_enb_id(mme_enb_t *enb, uint32_t enb_id)
 {
     ogs_assert(enb);
 
-    ogs_hash_set(self.enb_id_hash, &enb->enb_id, sizeof(enb->enb_id), NULL);
+    if (enb->enb_id_presence == true)
+        ogs_hash_set(self.enb_id_hash, &enb->enb_id, sizeof(enb->enb_id), NULL);
 
     enb->enb_id = enb_id;
     ogs_hash_set(self.enb_id_hash, &enb->enb_id, sizeof(enb->enb_id), enb);
+
+    enb->enb_id_presence = true;
 
     return OGS_OK;
 }

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -246,6 +246,7 @@ typedef struct mme_enb_s {
 
     ogs_fsm_t       sm;         /* A state machine */
 
+    bool            enb_id_presence;
     uint32_t        enb_id;     /* eNB_ID received from eNB */
     ogs_plmn_id_t   plmn_id;    /* eNB PLMN-ID received from eNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */

--- a/tests/handover/5gc-n2-test.c
+++ b/tests/handover/5gc-n2-test.c
@@ -515,7 +515,7 @@ static void direct_complete_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, gtpu2);
 
     /* NG-Setup Reqeust/Response for Source gNB */
-    sendbuf = testngap_build_ng_setup_request(0x4000, 28);
+    sendbuf = testngap_build_ng_setup_request(0, 28);
     ABTS_PTR_NOTNULL(tc, sendbuf);
     rv = testgnb_ngap_send(ngap1, sendbuf);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
@@ -769,7 +769,7 @@ static void direct_complete_func(abts_case *tc, void *data)
 
     /* Send UplinkRANConfigurationTransfer */
     sendbuf = testngap_build_uplink_ran_configuration_transfer(
-            0x4000, 28, 0x4001, 28);
+            0, 28, 0x4001, 28);
     ABTS_PTR_NOTNULL(tc, sendbuf);
     rv = testgnb_ngap_send(ngap1, sendbuf);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
@@ -781,7 +781,7 @@ static void direct_complete_func(abts_case *tc, void *data)
 
     /* Send UplinkRANConfigurationTransfer */
     sendbuf = testngap_build_uplink_ran_configuration_transfer(
-            0x4001, 28, 0x4000, 28);
+            0x4001, 28, 0, 28);
     ABTS_PTR_NOTNULL(tc, sendbuf);
     rv = testgnb_ngap_send(ngap2, sendbuf);
     ABTS_INT_EQUAL(tc, OGS_OK, rv);
@@ -911,7 +911,7 @@ static void direct_complete_func(abts_case *tc, void *data)
     /* Send HandoverRequired */
     sendbuf = testngap_build_handover_required(
             test_ue, NGAP_HandoverType_intra5gs,
-            0x4000, 28,
+            0, 28,
             NGAP_Cause_PR_radioNetwork,
             NGAP_CauseRadioNetwork_handover_desirable_for_radio_reason,
             true);


### PR DESCRIPTION
Resolved an issue where Handover was failing when attempting to handover from GNB-ID/eNB-ID 1 to GNB-ID/eNB-ID 0.

The problem occurred because the hash table managing GNB_ID values would remove any entry with the default GNB-ID/eNB-ID of 0 before re-adding entries.

Consequently, any GNB/eNB configured with a GNB-ID/eNB-ID of 0 would be inadvertently deleted whenever another GNB was added.

This fix modifies the handling of the hash table to prevent the default GNB-ID/eNB-ID (0) from being removed unintentionally, allowing handovers between GNB-ID/eNB-ID 0 and other GNBs/eNBs to proceed without error.