### PR TITLE
Support non-integer bitrate strings more accurately

### DIFF
--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -722,12 +722,12 @@ char *ogs_sbi_bitrate_to_string(uint64_t bitrate, int unit)
 uint64_t ogs_sbi_bitrate_from_string(char *str)
 {
     char *unit = NULL;
-    uint64_t bitrate = 0;
+    double bitrate = 0;
     ogs_assert(str);
     uint64_t mul = 1;
 
     unit = strrchr(str, ' ');
-    bitrate = atoll(str);
+    bitrate = atof(str);
 
     if (!unit) {
         ogs_error("No Unit [%s]", str);
@@ -755,7 +755,7 @@ uint64_t ogs_sbi_bitrate_from_string(char *str)
     else
         bitrate *= mul;
 
-    return bitrate;
+    return (uint64_t) bitrate;
 }
 
 #define MAX_TIMESTR_LEN 128


### PR DESCRIPTION
TS 29.571 - 5.5.2 Simple Data Types defines BitRate type as

	String representing a bit rate that shall be formatted as follows:

	Pattern: '^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$'

	Examples: "125 Mbps", "0.125 Gbps", "125000 Kbps"

Taking the "0.125 Gbps" example, rather than round 0.125 down to 0, parse it as a double-float first before multiplying by 10^9, resulting in 1.25e8 (bps).