### PR TITLE
[all] allow value of 0 for S-NSSAI SST

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -1252,7 +1252,6 @@ ogs_app_slice_conf_t *ogs_app_slice_conf_add(
 
     ogs_assert(policy_conf);
     ogs_assert(s_nssai);
-    ogs_assert(s_nssai->sst);
 
     ogs_pool_alloc(&slice_conf_pool, &slice_conf);
     if (!slice_conf) {
@@ -1283,7 +1282,6 @@ ogs_app_slice_conf_t *ogs_app_slice_conf_find_by_s_nssai(
 
     ogs_assert(policy_conf);
     ogs_assert(s_nssai);
-    ogs_assert(s_nssai->sst);
 
     ogs_list_for_each(&policy_conf->slice_list, slice_conf) {
         if (slice_conf->data.s_nssai.sst == s_nssai->sst &&

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -613,11 +613,6 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
         char *v = NULL;
         cJSON *item = NULL;
 
-        if (!message->param.s_nssai.sst) {
-            ogs_error("No S-NSSAI SST");
-            ogs_sbi_request_free(request);
-            return NULL;
-        }
         if (!message->param.roaming_indication) {
             ogs_error("No Roaming Indication");
             ogs_sbi_request_free(request);

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -132,12 +132,6 @@ static int parse_slice_conf(
                 const char *v = ogs_yaml_iter_value(&slice_iter);
                 if (v) {
                     s_nssai.sst = atoi(v);
-                    if (s_nssai.sst == 1 || s_nssai.sst == 2 ||
-                            s_nssai.sst == 3 || s_nssai.sst == 4) {
-                    } else {
-                        ogs_error("Unknown SST [%d]", s_nssai.sst);
-                        return OGS_ERROR;
-                    }
                 }
             } else if (!strcmp(slice_key, OGS_SD_STRING)) {
                 const char *v = ogs_yaml_iter_value(&slice_iter);
@@ -147,18 +141,13 @@ static int parse_slice_conf(
             }
         }
 
-        if (s_nssai.sst) {
-            slice_conf = ogs_app_slice_conf_add(policy_conf, &s_nssai);
-            if (!slice_conf) {
-                ogs_error("ogs_app_slice_conf_add() failed [SST:%d,SD:0x%x]",
-                        s_nssai.sst, s_nssai.sd.v);
-                return OGS_ERROR;
-            }
-            slice_conf->data.default_indicator = default_indicator;
-        } else {
-            ogs_error("No SST");
+        slice_conf = ogs_app_slice_conf_add(policy_conf, &s_nssai);
+        if (!slice_conf) {
+            ogs_error("ogs_app_slice_conf_add() failed [SST:%d,SD:0x%x]",
+                    s_nssai.sst, s_nssai.sd.v);
             return OGS_ERROR;
         }
+        slice_conf->data.default_indicator = default_indicator;
 
         OGS_YAML_ARRAY_RECURSE(&slice_array, &slice_iter);
         while (ogs_yaml_iter_next(&slice_iter)) {

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -127,10 +127,6 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
         }
     }
 
-    if (!sess->s_nssai.sst) {
-        ogs_error("No SST");
-        goto end;
-    }
     if (PcfIpEndPointList->count)
         PcfBinding.pcf_ip_end_points = PcfIpEndPointList;
     else

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -299,13 +299,6 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
         goto cleanup;
     }
 
-    if (!sliceInfo->sst) {
-        strerror = ogs_msprintf("[%s:%d] No sliceInfo->sst",
-                pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-        goto cleanup;
-    }
-
     servingNetwork = SmPolicyContextData->serving_network;
     if (servingNetwork) {
         if (!servingNetwork->mcc) {

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -558,7 +558,7 @@ bool udm_nudm_uecm_handle_smf_registration(
         return false;
     }
 
-    if (!SmfRegistration->single_nssai || !SmfRegistration->single_nssai->sst) {
+    if (!SmfRegistration->single_nssai) {
         ogs_error("[%s:%d] No singleNssai", udm_ue->supi, sess->psi);
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -808,8 +808,7 @@ bool udm_nudr_dr_handle_smf_registration(
                 return false;
             }
 
-            if (!SmfRegistration->single_nssai ||
-                    !SmfRegistration->single_nssai->sst) {
+            if (!SmfRegistration->single_nssai) {
                 ogs_error("[%s:%d] No singleNssai", udm_ue->supi, sess->psi);
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(

--- a/tests/af/npcf-build.c
+++ b/tests/af/npcf-build.c
@@ -115,11 +115,9 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
     AscReqData.ev_subsc = &evSubsc;
 
     memset(&sNssai, 0, sizeof(sNssai));
-    if (sess->s_nssai.sst) {
-        sNssai.sst = sess->s_nssai.sst;
-        sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
-        AscReqData.slice_info = &sNssai;
-    }
+    sNssai.sst = sess->s_nssai.sst;
+    sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
+    AscReqData.slice_info = &sNssai;
 
     AscReqData.spon_status = OpenAPI_sponsoring_status_SPONSOR_DISABLED;
 
@@ -709,11 +707,10 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create_video(
     AscReqData.ev_subsc = &evSubsc;
 
     memset(&sNssai, 0, sizeof(sNssai));
-    if (sess->s_nssai.sst) {
-        sNssai.sst = sess->s_nssai.sst;
-        sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
-        AscReqData.slice_info = &sNssai;
-    }
+
+    sNssai.sst = sess->s_nssai.sst;
+    sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
+    AscReqData.slice_info = &sNssai;
 
     AscReqData.spon_status = OpenAPI_sponsoring_status_SPONSOR_DISABLED;
 


### PR DESCRIPTION
3GPP TS 23.003: 28.4.2 Format of the S-NSSAI

The SST field may have standardized and non-standardized values. Values 0 to 127 belong to the standardized SST range and they are defined in 3GPP TS 23.501 [119]. Values 128 to 255 belong to the Operator-specific range.