### PR TITLE
Adding Support for nf-instance-id as Subscription Condition in subscriptions…

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2514,6 +2514,9 @@ void ogs_sbi_subscription_data_remove(
 
     if (subscription_data->subscr_cond.service_name)
         ogs_free(subscription_data->subscr_cond.service_name);
+        
+    if (subscription_data->subscr_cond.nf_instance_id)
+        ogs_free(subscription_data->subscr_cond.nf_instance_id);
 
     if (subscription_data->t_validity)
         ogs_timer_delete(subscription_data->t_validity);

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -299,6 +299,7 @@ typedef struct ogs_sbi_subscription_data_s {
     struct {
         OpenAPI_nf_type_e nf_type;          /* nfType */
         char *service_name;                 /* ServiceName */
+        char *nf_instance_id;               /* NF Instance Id */
     } subscr_cond;
 
     uint64_t requester_features;

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -930,6 +930,9 @@ bool nrf_nnrf_handle_nf_discover(
         if (!NFProfile) {
             ogs_error("No NFProfile");
             continue;
+        } else {
+            //This line is added to not include nfProfileChangesSupportInd in a discovery response which should not have it    
+        	NFProfile->is_nf_profile_changes_support_ind = false;
         }
 
         OpenAPI_list_add(SearchResult->nf_instances, NFProfile);

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -386,6 +386,9 @@ bool nrf_nnrf_handle_nf_status_subscribe(
         else if (SubscrCond->service_name)
             subscription_data->subscr_cond.service_name =
                 ogs_strdup(SubscrCond->service_name);
+        else if (SubscrCond->nf_instance_id)
+            subscription_data->subscr_cond.nf_instance_id = 
+                ogs_strdup(SubscrCond->nf_instance_id);
         else {
             ogs_error("No SubscrCond");
             ogs_sbi_subscription_data_remove(subscription_data);

--- a/src/nrf/sbi-path.c
+++ b/src/nrf/sbi-path.c
@@ -127,6 +127,9 @@ bool nrf_nnrf_nfm_send_nf_status_notify_all(
                 ogs_sbi_nf_service_is_allowed_nf_type(
                     nf_service, subscription_data->req_nf_type) == false)
                 continue;
+        } else if (subscription_data->subscr_cond.nf_instance_id) {
+            if (strcmp(subscription_data->subscr_cond.nf_instance_id, nf_instance->id) != 0)
+                continue;
         }
 
         if (subscription_data->req_nf_type &&


### PR DESCRIPTION
… to notifications from NRF


Its a very simple change that introduces support for NFInstanceIdCond to the SubscrCond for NFs which subscribe to their own NF-Intance-Id (as some vendors do).   Currently the Open5GS NRF only supports NFType and ServiceName as subscription conditions.