### PR TITLE
[MME] Add fake combined attach

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -250,6 +250,9 @@ int ogs_app_parse_global_conf(ogs_yaml_iter_t *parent)
                 } else if (!strcmp(parameter_key, "use_upg_vpp")) {
                     global_conf.parameter.use_upg_vpp =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(parameter_key, "fake_csfb")) {
+                    global_conf.parameter.fake_csfb =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else if (!strcmp(parameter_key,
                             "no_ipv4v6_local_addr_in_packet_filter")) {
                     global_conf.parameter.

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -69,6 +69,7 @@ typedef struct ogs_global_conf_s {
         int multicast;
 
         int use_openair;
+        int fake_csfb;
         int use_upg_vpp;
         int no_ipv4v6_local_addr_in_packet_filter;
 

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -83,6 +83,11 @@ ogs_pkbuf_t *emm_build_attach_accept(
     if (mme_ue->network_access_mode == OGS_NETWORK_ACCESS_MODE_ONLY_PACKET) {
         /* permit only EPS_ATTACH */
         eps_attach_result->result = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
+        if (ogs_global_conf()->parameter.fake_csfb == true)
+            eps_attach_result->result =
+                OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+        else
+            eps_attach_result->result = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
     } else {
         eps_attach_result->result = mme_ue->nas_eps.attach.value;
     }


### PR DESCRIPTION
In case an external HSS is used, and the NAM field is set to 0 (PACKET_ONLY), Open5GS MME will only respond with an "EPS_ONLY" attach accept. This behavior causes a lot of UEs (mainly phones) to disconnect after 1-2 seconds without further signalling.

To resolve this, a new flag is introduced:

```
global:
  parameter:
    fake_csfb: true
```

If this flag is set to 'ture', the MME will respond with a combined EPS/IMSI attach accept even if the HSS NAM field is set to "PACKET_ONLY", or if the MME has no SGs connection towards a CS core.

By default this flag is false, thus not modifying the original behavior.

Note: some commercial core network vendors do include the LAI part in a "fake" combined EPS/IMSI attach accept message. As that field is optional, and testing also indicates that it is not needed, this patch does not implement it.