### PR TITLE
[AMF] Fix a possible heap-buffer-overflow in ngap_send_to_nas

### DIFF
--- a/src/amf/ngap-path.c
+++ b/src/amf/ngap-path.c
@@ -168,6 +168,11 @@ int ngap_send_to_nas(ran_ue_t *ran_ue,
     ogs_assert(ran_ue);
     ogs_assert(nasPdu);
 
+    if (nasPdu->size == 0) {
+        ogs_error("Empty NAS PDU");
+        return OGS_ERROR;
+    }
+
     amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
 
     /* The Packet Buffer(pkbuf_t) for NAS message MUST make a HEADROOM. 


### PR DESCRIPTION
This PR fixes a possible heap-buffer-overflow issue in ngap_send_to_nas function when handling empty NAS PDUs.