### PR TITLE
[AMF] Fix crash due to incorrect handling of UE registration requests(#3608)

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2815,6 +2815,53 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(ran_ue);
 
         SWITCH(sbi_message->h.service.name)
+        CASE(OGS_SBI_SERVICE_NAME_NAUSF_AUTH)
+            SWITCH(sbi_message->h.resource.component[0])
+            CASE(OGS_SBI_RESOURCE_NAME_UE_AUTHENTICATIONS)
+
+                if (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED &&
+                    sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK &&
+                    sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT) {
+                    if (sbi_message->res_status ==
+                            OGS_SBI_HTTP_STATUS_NOT_FOUND) {
+                        ogs_warn("[%s] Cannot find SUCI [%d]",
+                            amf_ue->suci, sbi_message->res_status);
+                    } else {
+                        ogs_error("[%s] HTTP response error [%d]",
+                            amf_ue->suci, sbi_message->res_status);
+                    }
+                }
+
+                SWITCH(sbi_message->h.method)
+                CASE(OGS_SBI_HTTP_METHOD_POST)
+                    ogs_warn("[%s] Ignore SBI message", amf_ue->suci);
+                    break;
+                CASE(OGS_SBI_HTTP_METHOD_PUT)
+                    ogs_warn("[%s] Ignore SBI message", amf_ue->suci);
+                    break;
+                CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                    ogs_warn("[%s] Ignore SBI message", amf_ue->suci);
+                    break;
+                DEFAULT
+                    ogs_error("[%s] Invalid HTTP method [%s]",
+                            amf_ue->suci, sbi_message->h.method);
+                    ogs_assert_if_reached();
+                END
+                break;
+
+            CASE(OGS_SBI_RESOURCE_NAME_5G_AKA)
+            CASE(OGS_SBI_RESOURCE_NAME_5G_AKA_CONFIRMATION)
+            CASE(OGS_SBI_RESOURCE_NAME_EAP_SESSION)
+                ogs_warn("[%s] Ignore SBI message", amf_ue->supi);
+                break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[0]);
+                ogs_assert_if_reached();
+            END
+            break;
+
         CASE(OGS_SBI_SERVICE_NAME_NAMF_COMM)
             SWITCH(sbi_message->h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)


### PR DESCRIPTION
This pull request addresses an issue in the AMF where it crashes upon receiving the Nausf_UEAuthentication_Authenticate response in the gmm_state_exception function.

The crash occurs when the same UE continuously sends registration requests while the previous UE context is released before the AUSF response is received, leading to incorrect states in the gmm state machine.

The root cause was a lack of proper handling in the gmm_state_exception function for the scenario where multiple registration requests from the same UE cause the AMF to process outdated authentication vectors.

This update introduces a fix to handle this edge case and prevent the AMF from crashing.