### PR TITLE
[PFCP] Ensure correct TEID restoration behavior by checking F-TEID.ch…

### DIFF
--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -95,7 +95,17 @@ void sgwu_sxa_handle_session_establishment_request(
             pdr = created_pdr[i];
             ogs_assert(pdr);
 
-            if (pdr->f_teid_len)
+    /*
+     * Only perform TEID restoration via swap when F-TEID.ch is false.
+     *
+     * When F-TEID.ch is false, it means the TEID has already been assigned, and
+     * the restoration process can safely perform the swap.
+     *
+     * If F-TEID.ch is true, it indicates that the UPF needs to assign
+     * a new TEID for the first time, so performing a swap is not appropriate
+     * in this case.
+     */
+            if (pdr->f_teid.ch == false && pdr->f_teid_len)
                 ogs_pfcp_pdr_swap_teid(pdr);
         }
         restoration_indication = true;

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -152,7 +152,17 @@ void upf_n4_handle_session_establishment_request(
             pdr = created_pdr[i];
             ogs_assert(pdr);
 
-            if (pdr->f_teid_len)
+    /*
+     * Only perform TEID restoration via swap when F-TEID.ch is false.
+     *
+     * When F-TEID.ch is false, it means the TEID has already been assigned, and
+     * the restoration process can safely perform the swap.
+     *
+     * If F-TEID.ch is true, it indicates that the UPF needs to assign
+     * a new TEID for the first time, so performing a swap is not appropriate
+     * in this case.
+     */
+            if (pdr->f_teid.ch == false && pdr->f_teid_len)
                 ogs_pfcp_pdr_swap_teid(pdr);
         }
         restoration_indication = true;


### PR DESCRIPTION
… value (#3574)

Added a check to ensure that TEID restoration via swap occurs only when F-TEID.ch is false. In the restoration process, when F-TEID.ch is false, it indicates that the TEID has already been assigned, and the swap operation is necessary to restore the TEID. However, if F-TEID.ch is true, it means that the UPF needs to assign a new TEID for the first time, and performing a swap in this case would be incorrect.

This check ensures that the swap operation is only triggered when the TEID is already assigned and prevents potential issues during the TEID assignment process.