### PR TITLE
[AMF] save mapped HPLMN from Session Est Req

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1287,6 +1287,9 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                         if (ie.sst == amf_ue->slice[i].s_nssai.sst &&
                             ie.sd.v == amf_ue->slice[i].s_nssai.sd.v) {
 
+                            sess->mapped_hplmn.sst = ie.mapped_hplmn_sst;
+                            sess->mapped_hplmn.sd.v = ie.mapped_hplmn_sd.v;
+
                             /* PASS */
 
                         } else {


### PR DESCRIPTION
In case that UE sends "mapped HPLMN" in the Session Establishment Request, AMF did not save it and forward it in the request to SMF.