### PR TITLE
Support for MS_SUPPORT_LOCAL_ADDR_TFT_INDICATOR

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3116,7 +3116,10 @@ int smf_pco_build(uint8_t *pco_buf, uint8_t *buffer, int length)
             /* TODO */
             break;
         case OGS_PCO_ID_MS_SUPPORT_LOCAL_ADDR_TFT_INDICATOR:
-            /* TODO */
+            smf.ids[smf.num_of_id].id = ue.ids[i].id;
+            smf.ids[smf.num_of_id].len = 0;
+            smf.ids[smf.num_of_id].data = 0;
+            smf.num_of_id++;
             break;
         case OGS_PCO_ID_P_CSCF_RE_SELECTION_SUPPORT:
             /* TODO */


### PR DESCRIPTION
Newer phones reject the type of TFTs that SMF sends because they include the local address.

With this patch the SMF will reply with Network support of Local address in TFT indicator, which is the same 0011H value in the PCO; if the UE has advertised support for the local address in TFT (by including the corresponding 0011H PCO in the PDN Connectivity Request or in the corresponding ESM Information Response

For phones which do not indicate support for MS_SUPPORT_LOCAL_ADDR_TFT_INDICATOR there is no problem since they also don't complaint about the TFTs with local address and they seem to apply them (without the local address but they work).

This patch is necessary for VoLTE/VoNR with newer phones