### PR TITLE
[BSF] Remove mandatory BSF dependency for PDU session establishment (#3626)

### DIFF
--- a/lib/sbi/nnrf-path.c
+++ b/lib/sbi/nnrf-path.c
@@ -32,8 +32,9 @@ bool ogs_nnrf_nfm_send_nf_register(ogs_sbi_nf_instance_t *nf_instance)
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, nf_instance);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, nf_instance);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);
@@ -54,8 +55,9 @@ bool ogs_nnrf_nfm_send_nf_update(ogs_sbi_nf_instance_t *nf_instance)
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, nf_instance);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, nf_instance);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);
@@ -76,8 +78,9 @@ bool ogs_nnrf_nfm_send_nf_de_register(ogs_sbi_nf_instance_t *nf_instance)
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, nf_instance);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, nf_instance);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);
@@ -120,8 +123,9 @@ bool ogs_nnrf_nfm_send_nf_status_subscribe(
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, subscription_data);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, subscription_data);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);
@@ -143,8 +147,9 @@ bool ogs_nnrf_nfm_send_nf_status_update(
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, subscription_data);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, subscription_data);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);
@@ -166,8 +171,9 @@ bool ogs_nnrf_nfm_send_nf_status_unsubscribe(
         return false;
     }
 
-    rc = ogs_sbi_send_notification_request(
-            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL, request, subscription_data);
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, subscription_data);
     ogs_expect(rc == true);
 
     ogs_sbi_request_free(request);

--- a/lib/sbi/path.h
+++ b/lib/sbi/path.h
@@ -38,9 +38,10 @@ bool ogs_sbi_send_request_to_nf_instance(
 bool ogs_sbi_send_request_to_client(
         ogs_sbi_client_t *client, ogs_sbi_client_cb_f client_cb,
         ogs_sbi_request_t *request, void *data);
-bool ogs_sbi_send_notification_request(
-        ogs_sbi_service_type_e service_type,
+bool ogs_sbi_send_request_to_nrf(
+        ogs_sbi_service_type_e nrf_service_type,
         ogs_sbi_discovery_option_t *discovery_option,
+        ogs_sbi_client_cb_f client_cb,
         ogs_sbi_request_t *request, void *data);
 
 #define ogs_sbi_send_http_status_no_content(__sTREAM) \

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2365,7 +2365,6 @@ void amf_sbi_select_nf(
 {
     OpenAPI_nf_type_e target_nf_type = OpenAPI_nf_type_NULL;
     ogs_sbi_nf_instance_t *nf_instance = NULL;
-    amf_sess_t *sess = NULL;
 
     ogs_assert(sbi_object);
     ogs_assert(service_type);
@@ -2373,35 +2372,11 @@ void amf_sbi_select_nf(
     ogs_assert(target_nf_type);
     ogs_assert(requester_nf_type);
 
-    switch(sbi_object->type) {
-    case OGS_SBI_OBJ_UE_TYPE:
-        nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
-                        target_nf_type, requester_nf_type, discovery_option);
-        if (nf_instance)
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
-        break;
-    case OGS_SBI_OBJ_SESS_TYPE:
-        sess = (amf_sess_t *)sbi_object;
-        ogs_assert(sess);
-
-        ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance) {
-            if (ogs_sbi_discovery_param_is_matched(
-                    nf_instance,
-                    target_nf_type, requester_nf_type, discovery_option) ==
-                        false)
-                continue;
-
-            OGS_SBI_SETUP_NF_INSTANCE(
-                    sbi_object->service_type_array[service_type], nf_instance);
-            break;
-        }
-        break;
-    default:
-        ogs_fatal("(NF discover search result) Not implemented [%d]",
-                    sbi_object->type);
-        ogs_assert_if_reached();
-    }
+    nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
+                    target_nf_type, requester_nf_type, discovery_option);
+    if (nf_instance)
+        OGS_SBI_SETUP_NF_INSTANCE(
+                sbi_object->service_type_array[service_type], nf_instance);
 }
 
 int amf_sess_xact_count(amf_ue_t *amf_ue)

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -35,14 +35,13 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     ogs_sbi_nf_instance_t *nf_instance = NULL;
     ogs_sbi_nf_service_t *nf_service = NULL;
 
+    OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
+
     int i;
 
     ogs_assert(sess);
     pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
     ogs_assert(pcf_ue);
-
-    nf_instance = data;
-    ogs_assert(nf_instance);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
@@ -68,6 +67,13 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
         goto end;
     }
     PcfBinding.dnn = sess->dnn;
+
+    requester_nf_type = NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
+    ogs_assert(requester_nf_type);
+    nf_instance = ogs_sbi_nf_instance_find_by_service_type(
+                    OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION,
+                    requester_nf_type);
+    ogs_assert(nf_instance);
 
     nf_service = ogs_sbi_nf_service_find_by_name(
             nf_instance, (char *)OGS_SBI_SERVICE_NAME_NPCF_POLICYAUTHORIZATION);

--- a/src/pcf/nbsf-handler.c
+++ b/src/pcf/nbsf-handler.c
@@ -24,43 +24,15 @@
 bool pcf_nbsf_management_handle_register(
     pcf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {
-    int i, rv, status = 0;
+    int rv, status = 0;
     char *strerror = NULL;
     pcf_ue_t *pcf_ue = NULL;
     ogs_sbi_server_t *server = NULL;
 
-    ogs_sbi_message_t sendmsg;
     ogs_sbi_header_t header;
-    ogs_sbi_response_t *response = NULL;
-
     ogs_sbi_message_t message;
 
-    ogs_session_data_t session_data;
-
-    ogs_session_t *session = NULL;
-
     OpenAPI_pcf_binding_t *PcfBinding = NULL;
-
-    OpenAPI_sm_policy_decision_t SmPolicyDecision;
-
-    OpenAPI_lnode_t *node = NULL;
-
-    OpenAPI_list_t *SessRuleList = NULL;
-    OpenAPI_map_t *SessRuleMap = NULL;
-    OpenAPI_session_rule_t *SessionRule = NULL;
-
-    OpenAPI_ambr_t AuthSessAmbr;
-    OpenAPI_authorized_default_qos_t AuthDefQos;
-
-    OpenAPI_list_t *PccRuleList = NULL;
-    OpenAPI_map_t *PccRuleMap = NULL;
-    OpenAPI_pcc_rule_t *PccRule = NULL;
-
-    OpenAPI_list_t *QosDecisionList = NULL;
-    OpenAPI_map_t *QosDecisionMap = NULL;
-    OpenAPI_qos_data_t *QosData = NULL;
-
-    OpenAPI_list_t *PolicyCtrlReqTriggers = NULL;
 
     bool rc;
     ogs_sbi_client_t *client = NULL;
@@ -77,8 +49,6 @@ bool pcf_nbsf_management_handle_register(
     ogs_assert(server);
 
     ogs_assert(recvmsg);
-
-    memset(&session_data, 0, sizeof(ogs_session_data_t));
 
     ogs_assert(pcf_ue->supi);
     ogs_assert(sess->dnn);
@@ -158,288 +128,19 @@ bool pcf_nbsf_management_handle_register(
 
     ogs_sbi_header_free(&header);
 
-    rv = pcf_db_qos_data(
-            pcf_ue->supi,
-            sess->home.presence == true ? &sess->home.plmn_id : NULL,
-            &sess->s_nssai, sess->dnn, &session_data);
-    if (rv != OGS_OK) {
-        strerror = ogs_msprintf("[%s:%d] Cannot find SUPI in DB",
-                pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
-        goto cleanup;
-    }
+    /* Send Response for SM Policy Association establishment */
+    rc = pcf_sbi_send_smpolicycontrol_create_response(sess, stream);
+    ogs_expect(rc == true);
 
-    session = &session_data.session;
-
-    if (!session->qos.index) {
-        strerror = ogs_msprintf("[%s:%d] No 5QI", pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-        goto cleanup;
-    }
-    if (!session->qos.arp.priority_level) {
-        strerror = ogs_msprintf("[%s:%d] No Priority Level",
-                pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-        goto cleanup;
-    }
-
-    if (!session->ambr.uplink && !session->ambr.downlink) {
-        strerror = ogs_msprintf("[%s:%d] No Session-AMBR",
-                pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-        goto cleanup;
-    }
-
-    memset(&SmPolicyDecision, 0, sizeof(SmPolicyDecision));
-
-    PolicyCtrlReqTriggers = OpenAPI_list_create();
-    ogs_assert(PolicyCtrlReqTriggers);
-
-    /**************************************************************
-     * Session Rule
-     *************************************************************/
-    SessRuleList = OpenAPI_list_create();
-    ogs_assert(SessRuleList);
-
-    SessionRule = ogs_calloc(1, sizeof(*SessionRule));
-    ogs_assert(SessionRule);
-
-    /* Only 1 SessionRule is used */
-    SessionRule->sess_rule_id = (char *)"1";
-
-    if (OGS_SBI_FEATURES_IS_SET(sess->smpolicycontrol_features,
-                OGS_SBI_NPCF_SMPOLICYCONTROL_DN_AUTHORIZATION)) {
-        if (sess->subscribed_sess_ambr) {
-            ogs_bitrate_t subscribed_sess_ambr;
-
-            subscribed_sess_ambr.uplink = ogs_sbi_bitrate_from_string(
-                    sess->subscribed_sess_ambr->uplink);
-            subscribed_sess_ambr.downlink = ogs_sbi_bitrate_from_string(
-                    sess->subscribed_sess_ambr->downlink);
-            if (((subscribed_sess_ambr.uplink / 1000) !=
-                 (session->ambr.uplink / 1000)) ||
-                ((subscribed_sess_ambr.downlink / 1000) !=
-                 (session->ambr.downlink / 1000))) {
-
-                OpenAPI_list_add(PolicyCtrlReqTriggers,
-                    (void *)OpenAPI_policy_control_request_trigger_SE_AMBR_CH);
-            }
-
-            memset(&AuthSessAmbr, 0, sizeof(AuthSessAmbr));
-            AuthSessAmbr.uplink = ogs_sbi_bitrate_to_string(
-                    session->ambr.uplink, OGS_SBI_BITRATE_KBPS);
-            AuthSessAmbr.downlink = ogs_sbi_bitrate_to_string(
-                    session->ambr.downlink, OGS_SBI_BITRATE_KBPS);
-            SessionRule->auth_sess_ambr = &AuthSessAmbr;
-        }
-    }
-
-    if (sess->subscribed_default_qos) {
-        bool triggered = false;
-
-        memset(&AuthDefQos, 0, sizeof(AuthDefQos));
-        AuthDefQos.arp = ogs_calloc(1, sizeof(OpenAPI_arp_t));
-        ogs_assert(AuthDefQos.arp);
-
-        AuthDefQos.is__5qi = true;
-        AuthDefQos._5qi = session->qos.index;
-        AuthDefQos.is_priority_level = true;
-        AuthDefQos.priority_level = session->qos.arp.priority_level;
-
-        if (session->qos.arp.pre_emption_capability ==
-                OGS_5GC_PRE_EMPTION_ENABLED)
-            AuthDefQos.arp->preempt_cap =
-                OpenAPI_preemption_capability_MAY_PREEMPT;
-        else if (session->qos.arp.pre_emption_capability ==
-                OGS_5GC_PRE_EMPTION_DISABLED)
-            AuthDefQos.arp->preempt_cap =
-                OpenAPI_preemption_capability_NOT_PREEMPT;
-        ogs_assert(AuthDefQos.arp->preempt_cap);
-
-        if (session->qos.arp.pre_emption_vulnerability ==
-                OGS_5GC_PRE_EMPTION_ENABLED)
-            AuthDefQos.arp->preempt_vuln =
-                OpenAPI_preemption_vulnerability_PREEMPTABLE;
-        else if (session->qos.arp.pre_emption_vulnerability ==
-                OGS_5GC_PRE_EMPTION_DISABLED)
-            AuthDefQos.arp->preempt_vuln =
-                OpenAPI_preemption_vulnerability_NOT_PREEMPTABLE;
-        ogs_assert(AuthDefQos.arp->preempt_vuln);
-        AuthDefQos.arp->priority_level = session->qos.arp.priority_level;
-
-        SessionRule->auth_def_qos = &AuthDefQos;
-
-        if (sess->subscribed_default_qos->_5qi != AuthDefQos._5qi)
-            triggered = true;
-        if (sess->subscribed_default_qos->priority_level !=
-                AuthDefQos.priority_level)
-            triggered = true;
-        if (sess->subscribed_default_qos->arp) {
-            if (sess->subscribed_default_qos->arp->priority_level !=
-                    AuthDefQos.arp->priority_level)
-                triggered = true;
-            if (sess->subscribed_default_qos->arp->preempt_cap !=
-                    AuthDefQos.arp->preempt_cap)
-                triggered = true;
-            if (sess->subscribed_default_qos->arp->preempt_vuln !=
-                    AuthDefQos.arp->preempt_vuln)
-                triggered = true;
-
-        }
-
-        if (triggered)
-            OpenAPI_list_add(PolicyCtrlReqTriggers,
-                (void *)OpenAPI_policy_control_request_trigger_DEF_QOS_CH);
-
-    }
-
-    SessRuleMap = OpenAPI_map_create(
-            SessionRule->sess_rule_id, SessionRule);
-    ogs_assert(SessRuleMap);
-
-    OpenAPI_list_add(SessRuleList, SessRuleMap);
-
-    if (SessRuleList->count)
-        SmPolicyDecision.sess_rules = SessRuleList;
-
-    /**************************************************************
-     * PCC Rule & QoS Decision
-     *************************************************************/
-    PccRuleList = OpenAPI_list_create();
-    ogs_assert(PccRuleList);
-
-    QosDecisionList = OpenAPI_list_create();
-    ogs_assert(QosDecisionList);
-
-    for (i = 0; i < session_data.num_of_pcc_rule; i++) {
-        ogs_pcc_rule_t *pcc_rule = &session_data.pcc_rule[i];
-
-        ogs_assert(pcc_rule);
-        ogs_assert(pcc_rule->id);
-
-        if (!pcc_rule->num_of_flow) {
-            /* No Flow */
-            continue;
-        }
-
-        PccRule = ogs_sbi_build_pcc_rule(pcc_rule, 1);
-        ogs_assert(PccRule->pcc_rule_id);
-
-        PccRuleMap = OpenAPI_map_create(PccRule->pcc_rule_id, PccRule);
-        ogs_assert(PccRuleMap);
-
-        OpenAPI_list_add(PccRuleList, PccRuleMap);
-
-        QosData = ogs_sbi_build_qos_data(pcc_rule);
-        ogs_assert(QosData);
-        ogs_assert(QosData->qos_id);
-
-        QosDecisionMap = OpenAPI_map_create(QosData->qos_id, QosData);
-        ogs_assert(QosDecisionMap);
-
-        OpenAPI_list_add(QosDecisionList, QosDecisionMap);
-    }
-
-    if (PccRuleList->count)
-        SmPolicyDecision.pcc_rules = PccRuleList;
-
-    if (QosDecisionList->count)
-        SmPolicyDecision.qos_decs = QosDecisionList;
-
-    /* Policy Control Request Triggers */
-    if (PolicyCtrlReqTriggers->count)
-        SmPolicyDecision.policy_ctrl_req_triggers = PolicyCtrlReqTriggers;
-
-    /* Supported Features */
-    if (sess->smpolicycontrol_features) {
-        SmPolicyDecision.supp_feat =
-            ogs_uint64_to_string(sess->smpolicycontrol_features);
-        ogs_assert(SmPolicyDecision.supp_feat);
-    }
-
-    memset(&header, 0, sizeof(header));
-    header.service.name = (char *)OGS_SBI_SERVICE_NAME_NPCF_SMPOLICYCONTROL;
-    header.api.version = (char *)OGS_SBI_API_V1;
-    header.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_SM_POLICIES;
-    header.resource.component[1] = sess->sm_policy_id;
-
-    memset(&sendmsg, 0, sizeof(sendmsg));
-    sendmsg.SmPolicyDecision = &SmPolicyDecision;
-    sendmsg.http.location = ogs_sbi_server_uri(server, &header);
-
-    response = ogs_sbi_build_response(
-            &sendmsg, OGS_SBI_HTTP_STATUS_CREATED);
-    ogs_assert(response);
-    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-
-    ogs_free(sendmsg.http.location);
-
-    OpenAPI_list_for_each(SessRuleList, node) {
-        SessRuleMap = node->data;
-        if (SessRuleMap) {
-            SessionRule = SessRuleMap->value;
-            if (SessionRule) {
-                if (SessionRule->auth_sess_ambr) {
-                    if (SessionRule->auth_sess_ambr->uplink)
-                        ogs_free(SessionRule->auth_sess_ambr->uplink);
-                    if (SessionRule->auth_sess_ambr->downlink)
-                        ogs_free(SessionRule->auth_sess_ambr->downlink);
-                }
-                if (SessionRule->auth_def_qos) {
-                    ogs_free(SessionRule->auth_def_qos->arp);
-
-                }
-                ogs_free(SessionRule);
-            }
-            ogs_free(SessRuleMap);
-        }
-    }
-    OpenAPI_list_free(SessRuleList);
-
-    OpenAPI_list_for_each(PccRuleList, node) {
-        PccRuleMap = node->data;
-        if (PccRuleMap) {
-            PccRule = PccRuleMap->value;
-            if (PccRule)
-                ogs_sbi_free_pcc_rule(PccRule);
-            ogs_free(PccRuleMap);
-        }
-    }
-    OpenAPI_list_free(PccRuleList);
-
-    OpenAPI_list_for_each(QosDecisionList, node) {
-        QosDecisionMap = node->data;
-        if (QosDecisionMap) {
-            QosData = QosDecisionMap->value;
-            if (QosData)
-                ogs_sbi_free_qos_data(QosData);
-            ogs_free(QosDecisionMap);
-        }
-    }
-    OpenAPI_list_free(QosDecisionList);
-
-    OpenAPI_list_free(PolicyCtrlReqTriggers);
-
-    if (SmPolicyDecision.supp_feat)
-        ogs_free(SmPolicyDecision.supp_feat);
-
-    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
-            &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOSUCC, 1);
-
-    OGS_SESSION_DATA_FREE(&session_data);
-
-    return true;
+    return rc;
 
 cleanup:
     ogs_assert(strerror);
     ogs_assert(status);
     ogs_error("%s", strerror);
-    ogs_assert(true ==
-        ogs_sbi_server_send_error(stream, status, recvmsg, strerror, NULL,
-                NULL));
+    ogs_assert(true == ogs_sbi_server_send_error(
+                stream, status, recvmsg, strerror, NULL, NULL));
     ogs_free(strerror);
-
-    OGS_SESSION_DATA_FREE(&session_data);
 
     return false;
 }
@@ -447,18 +148,13 @@ cleanup:
 bool pcf_nbsf_management_handle_de_register(
     pcf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {
-    ogs_sbi_message_t sendmsg;
-    ogs_sbi_response_t *response = NULL;
+    bool rc;
 
     ogs_assert(sess);
     ogs_assert(stream);
 
-    memset(&sendmsg, 0, sizeof(sendmsg));
+    rc = ogs_sbi_send_response(stream, OGS_SBI_HTTP_STATUS_NO_CONTENT);
+    ogs_expect(rc == true);
 
-    response = ogs_sbi_build_response(
-            &sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
-    ogs_assert(response);
-    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-
-    return true;
+    return rc;
 }

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -23,13 +23,11 @@
 void pcf_nnrf_handle_nf_discover(
         ogs_sbi_xact_t *xact, ogs_sbi_message_t *recvmsg)
 {
-    int r;
     ogs_sbi_nf_instance_t *nf_instance = NULL;
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
-    ogs_sbi_stream_t *stream = NULL;
 
     pcf_ue_t *pcf_ue = NULL;
     pcf_sess_t *sess = NULL;
@@ -54,10 +52,6 @@ void pcf_nnrf_handle_nf_discover(
             sbi_object_id <= OGS_MAX_POOL_ID);
 
     discovery_option = xact->discovery_option;
-
-    if (xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
-        xact->assoc_stream_id <= OGS_MAX_POOL_ID)
-        stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
 
     SearchResult = recvmsg->SearchResult;
     if (!SearchResult) {
@@ -89,28 +83,28 @@ void pcf_nnrf_handle_nf_discover(
                     sess ? sess->psi : 0,
                     ogs_sbi_service_type_to_name(service_type),
                     OpenAPI_nf_type_ToString(requester_nf_type));
+
+        /* If BSF is not reachable, we ignore NBSF_MANAGMENT service */
+        if (service_type == OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT) {
+            ogs_sbi_stream_t *stream = NULL;
+
+            ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
+                    xact->assoc_stream_id <= OGS_MAX_POOL_ID);
+            stream = ogs_sbi_stream_find_by_id(xact->assoc_stream_id);
+            ogs_assert(stream);
+
+            /* Send Response for SM Policy Association establishment */
+            ogs_expect(true ==
+                    pcf_sbi_send_smpolicycontrol_create_response(sess, stream));
+
+            ogs_sbi_xact_remove(xact);
+        }
         return;
     }
 
     OGS_SBI_SETUP_NF_INSTANCE(
             sbi_object->service_type_array[service_type], nf_instance);
 
-    switch (service_type) {
-    case OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION:
-        ogs_sbi_xact_remove(xact);
-
-        ogs_assert(sess);
-        ogs_assert(stream);
-        r = pcf_sess_sbi_discover_and_send(
-                    OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
-                    pcf_nbsf_management_build_register,
-                    sess, stream, nf_instance);
-        ogs_expect(r == OGS_OK);
-        ogs_assert(r != OGS_ERROR);
-        break;
-    default:
-        ogs_assert(xact->request);
-        ogs_expect(true == pcf_sbi_send_request(nf_instance, xact));
-        break;
-    }
+    ogs_assert(xact->request);
+    ogs_expect(true == pcf_sbi_send_request(nf_instance, xact));
 }

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -500,37 +500,12 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
 
     if (ogs_sbi_supi_in_vplmn(pcf_ue->supi) == true) {
         /* Visited PLMN */
-        ogs_sbi_nf_instance_t *nf_instance = NULL;
-        ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
-
-        service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
-
-        nf_instance = OGS_SBI_GET_NF_INSTANCE(
-                sess->sbi.service_type_array[service_type]);
-        if (!nf_instance) {
-            OpenAPI_nf_type_e requester_nf_type =
-                        NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
-            ogs_assert(requester_nf_type);
-            nf_instance = ogs_sbi_nf_instance_find_by_service_type(
-                            service_type, requester_nf_type);
-            if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE(
-                        sess->sbi.service_type_array[service_type],
-                        nf_instance);
-        }
-
-        if (nf_instance) {
-            r = pcf_sess_sbi_discover_and_send(
-                        OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
-                        pcf_nbsf_management_build_register,
-                        sess, stream, nf_instance);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
-        } else {
-            r = pcf_sess_sbi_discover_only(sess, stream, service_type);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
-        }
+        r = pcf_sess_sbi_discover_and_send(
+                    OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
+                    pcf_nbsf_management_build_register,
+                    sess, stream, NULL);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
 
         return (r == OGS_OK);
     } else {
@@ -598,19 +573,17 @@ bool pcf_npcf_smpolicycontrol_handle_delete(pcf_sess_t *sess,
 
     if (pcf_sessions_number_by_snssai_and_dnn(
                 pcf_ue, &sess->s_nssai, sess->dnn) > 1) {
-        ogs_sbi_message_t sendmsg;
-        memset(&sendmsg, 0, sizeof(sendmsg));
-
-        ogs_sbi_response_t *response = ogs_sbi_build_response(
-                &sendmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
-        ogs_assert(response);
-        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-    } else {
+        ogs_expect(true ==
+                ogs_sbi_send_response(stream, OGS_SBI_HTTP_STATUS_NO_CONTENT));
+    } else if (sess->binding.resource_uri) {
         r = pcf_sess_sbi_discover_and_send(
                 OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
                 pcf_nbsf_management_build_de_register, sess, stream, NULL);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
+    } else {
+        ogs_expect(true ==
+                ogs_sbi_send_response(stream, OGS_SBI_HTTP_STATUS_NO_CONTENT));
     }
 
     return true;

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -203,9 +203,6 @@ bool pcf_nudr_dr_handle_query_sm_data(
 
     SWITCH(recvmsg->h.resource.component[3])
     CASE(OGS_SBI_RESOURCE_NAME_SM_DATA)
-        ogs_sbi_nf_instance_t *nf_instance = NULL;
-        ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
-
         if (!recvmsg->SmPolicyData) {
             strerror = ogs_msprintf("[%s:%d] No SmPolicyData",
                     pcf_ue->supi, sess->psi);
@@ -213,34 +210,12 @@ bool pcf_nudr_dr_handle_query_sm_data(
             goto cleanup;
         }
 
-        service_type = OGS_SBI_SERVICE_TYPE_NPCF_POLICYAUTHORIZATION;
-
-        nf_instance = OGS_SBI_GET_NF_INSTANCE(
-                sess->sbi.service_type_array[service_type]);
-        if (!nf_instance) {
-            OpenAPI_nf_type_e requester_nf_type =
-                        NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance);
-            ogs_assert(requester_nf_type);
-            nf_instance = ogs_sbi_nf_instance_find_by_service_type(
-                            service_type, requester_nf_type);
-            if (nf_instance)
-                OGS_SBI_SETUP_NF_INSTANCE(
-                        sess->sbi.service_type_array[service_type],
-                        nf_instance);
-        }
-
-        if (nf_instance) {
-            r = pcf_sess_sbi_discover_and_send(
-                        OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
-                        pcf_nbsf_management_build_register,
-                        sess, stream, nf_instance);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
-        } else {
-            r = pcf_sess_sbi_discover_only(sess, stream, service_type);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
-        }
+        r = pcf_sess_sbi_discover_and_send(
+                    OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT, NULL,
+                    pcf_nbsf_management_build_register,
+                    sess, stream, NULL);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
 
         return true;
 

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -189,31 +189,6 @@ int pcf_ue_sbi_discover_and_send(
     return OGS_OK;
 }
 
-int pcf_sess_sbi_discover_only(
-        pcf_sess_t *sess, ogs_sbi_stream_t *stream,
-        ogs_sbi_service_type_e service_type)
-{
-    ogs_sbi_xact_t *xact = NULL;
-
-    ogs_assert(sess);
-    ogs_assert(service_type);
-
-    xact = ogs_sbi_xact_add(
-            0, &sess->sbi, service_type, NULL, NULL, NULL, NULL);
-    if (!xact) {
-        ogs_error("ogs_sbi_xact_add() failed");
-        return OGS_ERROR;
-    }
-
-    if (stream) {
-        xact->assoc_stream_id = ogs_sbi_id_from_stream(stream);
-        ogs_assert(xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
-                xact->assoc_stream_id <= OGS_MAX_POOL_ID);
-    }
-
-    return ogs_sbi_discover_only(xact);
-}
-
 int pcf_sess_sbi_discover_and_send(
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
@@ -305,6 +280,340 @@ bool pcf_sbi_send_am_policy_control_notify(pcf_ue_t *pcf_ue)
     ogs_sbi_request_free(request);
 
     return rc;
+}
+
+bool pcf_sbi_send_smpolicycontrol_create_response(
+        pcf_sess_t *sess, ogs_sbi_stream_t *stream)
+{
+    int i, rv, status = 0;
+    char *strerror = NULL;
+    pcf_ue_t *pcf_ue = NULL;
+    ogs_sbi_server_t *server = NULL;
+
+    ogs_sbi_message_t sendmsg;
+    ogs_sbi_header_t header;
+    ogs_sbi_response_t *response = NULL;
+
+    ogs_session_data_t session_data;
+
+    ogs_session_t *session = NULL;
+
+    OpenAPI_sm_policy_decision_t SmPolicyDecision;
+
+    OpenAPI_lnode_t *node = NULL;
+
+    OpenAPI_list_t *SessRuleList = NULL;
+    OpenAPI_map_t *SessRuleMap = NULL;
+    OpenAPI_session_rule_t *SessionRule = NULL;
+
+    OpenAPI_ambr_t AuthSessAmbr;
+    OpenAPI_authorized_default_qos_t AuthDefQos;
+
+    OpenAPI_list_t *PccRuleList = NULL;
+    OpenAPI_map_t *PccRuleMap = NULL;
+    OpenAPI_pcc_rule_t *PccRule = NULL;
+
+    OpenAPI_list_t *QosDecisionList = NULL;
+    OpenAPI_map_t *QosDecisionMap = NULL;
+    OpenAPI_qos_data_t *QosData = NULL;
+
+    OpenAPI_list_t *PolicyCtrlReqTriggers = NULL;
+
+    ogs_assert(sess);
+    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
+    ogs_assert(pcf_ue);
+    ogs_assert(stream);
+    server = ogs_sbi_server_from_stream(stream);
+    ogs_assert(server);
+
+    memset(&session_data, 0, sizeof(ogs_session_data_t));
+
+    ogs_assert(pcf_ue->supi);
+    ogs_assert(sess->dnn);
+
+    rv = pcf_db_qos_data(
+            pcf_ue->supi,
+            sess->home.presence == true ? &sess->home.plmn_id : NULL,
+            &sess->s_nssai, sess->dnn, &session_data);
+    if (rv != OGS_OK) {
+        strerror = ogs_msprintf("[%s:%d] Cannot find SUPI in DB",
+                pcf_ue->supi, sess->psi);
+        status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
+        goto cleanup;
+    }
+
+    session = &session_data.session;
+
+    if (!session->qos.index) {
+        strerror = ogs_msprintf("[%s:%d] No 5QI", pcf_ue->supi, sess->psi);
+        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        goto cleanup;
+    }
+    if (!session->qos.arp.priority_level) {
+        strerror = ogs_msprintf("[%s:%d] No Priority Level",
+                pcf_ue->supi, sess->psi);
+        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        goto cleanup;
+    }
+
+    if (!session->ambr.uplink && !session->ambr.downlink) {
+        strerror = ogs_msprintf("[%s:%d] No Session-AMBR",
+                pcf_ue->supi, sess->psi);
+        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        goto cleanup;
+    }
+
+    memset(&SmPolicyDecision, 0, sizeof(SmPolicyDecision));
+
+    PolicyCtrlReqTriggers = OpenAPI_list_create();
+    ogs_assert(PolicyCtrlReqTriggers);
+
+    /**************************************************************
+     * Session Rule
+     *************************************************************/
+    SessRuleList = OpenAPI_list_create();
+    ogs_assert(SessRuleList);
+
+    SessionRule = ogs_calloc(1, sizeof(*SessionRule));
+    ogs_assert(SessionRule);
+
+    /* Only 1 SessionRule is used */
+    SessionRule->sess_rule_id = (char *)"1";
+
+    if (OGS_SBI_FEATURES_IS_SET(sess->smpolicycontrol_features,
+                OGS_SBI_NPCF_SMPOLICYCONTROL_DN_AUTHORIZATION)) {
+        if (sess->subscribed_sess_ambr) {
+            ogs_bitrate_t subscribed_sess_ambr;
+
+            subscribed_sess_ambr.uplink = ogs_sbi_bitrate_from_string(
+                    sess->subscribed_sess_ambr->uplink);
+            subscribed_sess_ambr.downlink = ogs_sbi_bitrate_from_string(
+                    sess->subscribed_sess_ambr->downlink);
+            if (((subscribed_sess_ambr.uplink / 1000) !=
+                 (session->ambr.uplink / 1000)) ||
+                ((subscribed_sess_ambr.downlink / 1000) !=
+                 (session->ambr.downlink / 1000))) {
+
+                OpenAPI_list_add(PolicyCtrlReqTriggers,
+                    (void *)OpenAPI_policy_control_request_trigger_SE_AMBR_CH);
+            }
+
+            memset(&AuthSessAmbr, 0, sizeof(AuthSessAmbr));
+            AuthSessAmbr.uplink = ogs_sbi_bitrate_to_string(
+                    session->ambr.uplink, OGS_SBI_BITRATE_KBPS);
+            AuthSessAmbr.downlink = ogs_sbi_bitrate_to_string(
+                    session->ambr.downlink, OGS_SBI_BITRATE_KBPS);
+            SessionRule->auth_sess_ambr = &AuthSessAmbr;
+        }
+    }
+
+    if (sess->subscribed_default_qos) {
+        bool triggered = false;
+
+        memset(&AuthDefQos, 0, sizeof(AuthDefQos));
+        AuthDefQos.arp = ogs_calloc(1, sizeof(OpenAPI_arp_t));
+        ogs_assert(AuthDefQos.arp);
+
+        AuthDefQos.is__5qi = true;
+        AuthDefQos._5qi = session->qos.index;
+        AuthDefQos.is_priority_level = true;
+        AuthDefQos.priority_level = session->qos.arp.priority_level;
+
+        if (session->qos.arp.pre_emption_capability ==
+                OGS_5GC_PRE_EMPTION_ENABLED)
+            AuthDefQos.arp->preempt_cap =
+                OpenAPI_preemption_capability_MAY_PREEMPT;
+        else if (session->qos.arp.pre_emption_capability ==
+                OGS_5GC_PRE_EMPTION_DISABLED)
+            AuthDefQos.arp->preempt_cap =
+                OpenAPI_preemption_capability_NOT_PREEMPT;
+        ogs_assert(AuthDefQos.arp->preempt_cap);
+
+        if (session->qos.arp.pre_emption_vulnerability ==
+                OGS_5GC_PRE_EMPTION_ENABLED)
+            AuthDefQos.arp->preempt_vuln =
+                OpenAPI_preemption_vulnerability_PREEMPTABLE;
+        else if (session->qos.arp.pre_emption_vulnerability ==
+                OGS_5GC_PRE_EMPTION_DISABLED)
+            AuthDefQos.arp->preempt_vuln =
+                OpenAPI_preemption_vulnerability_NOT_PREEMPTABLE;
+        ogs_assert(AuthDefQos.arp->preempt_vuln);
+        AuthDefQos.arp->priority_level = session->qos.arp.priority_level;
+
+        SessionRule->auth_def_qos = &AuthDefQos;
+
+        if (sess->subscribed_default_qos->_5qi != AuthDefQos._5qi)
+            triggered = true;
+        if (sess->subscribed_default_qos->priority_level !=
+                AuthDefQos.priority_level)
+            triggered = true;
+        if (sess->subscribed_default_qos->arp) {
+            if (sess->subscribed_default_qos->arp->priority_level !=
+                    AuthDefQos.arp->priority_level)
+                triggered = true;
+            if (sess->subscribed_default_qos->arp->preempt_cap !=
+                    AuthDefQos.arp->preempt_cap)
+                triggered = true;
+            if (sess->subscribed_default_qos->arp->preempt_vuln !=
+                    AuthDefQos.arp->preempt_vuln)
+                triggered = true;
+
+        }
+
+        if (triggered)
+            OpenAPI_list_add(PolicyCtrlReqTriggers,
+                (void *)OpenAPI_policy_control_request_trigger_DEF_QOS_CH);
+
+    }
+
+    SessRuleMap = OpenAPI_map_create(
+            SessionRule->sess_rule_id, SessionRule);
+    ogs_assert(SessRuleMap);
+
+    OpenAPI_list_add(SessRuleList, SessRuleMap);
+
+    if (SessRuleList->count)
+        SmPolicyDecision.sess_rules = SessRuleList;
+
+    /**************************************************************
+     * PCC Rule & QoS Decision
+     *************************************************************/
+    PccRuleList = OpenAPI_list_create();
+    ogs_assert(PccRuleList);
+
+    QosDecisionList = OpenAPI_list_create();
+    ogs_assert(QosDecisionList);
+
+    for (i = 0; i < session_data.num_of_pcc_rule; i++) {
+        ogs_pcc_rule_t *pcc_rule = &session_data.pcc_rule[i];
+
+        ogs_assert(pcc_rule);
+        ogs_assert(pcc_rule->id);
+
+        if (!pcc_rule->num_of_flow) {
+            /* No Flow */
+            continue;
+        }
+
+        PccRule = ogs_sbi_build_pcc_rule(pcc_rule, 1);
+        ogs_assert(PccRule->pcc_rule_id);
+
+        PccRuleMap = OpenAPI_map_create(PccRule->pcc_rule_id, PccRule);
+        ogs_assert(PccRuleMap);
+
+        OpenAPI_list_add(PccRuleList, PccRuleMap);
+
+        QosData = ogs_sbi_build_qos_data(pcc_rule);
+        ogs_assert(QosData);
+        ogs_assert(QosData->qos_id);
+
+        QosDecisionMap = OpenAPI_map_create(QosData->qos_id, QosData);
+        ogs_assert(QosDecisionMap);
+
+        OpenAPI_list_add(QosDecisionList, QosDecisionMap);
+    }
+
+    if (PccRuleList->count)
+        SmPolicyDecision.pcc_rules = PccRuleList;
+
+    if (QosDecisionList->count)
+        SmPolicyDecision.qos_decs = QosDecisionList;
+
+    /* Policy Control Request Triggers */
+    if (PolicyCtrlReqTriggers->count)
+        SmPolicyDecision.policy_ctrl_req_triggers = PolicyCtrlReqTriggers;
+
+    /* Supported Features */
+    if (sess->smpolicycontrol_features) {
+        SmPolicyDecision.supp_feat =
+            ogs_uint64_to_string(sess->smpolicycontrol_features);
+        ogs_assert(SmPolicyDecision.supp_feat);
+    }
+
+    memset(&header, 0, sizeof(header));
+    header.service.name = (char *)OGS_SBI_SERVICE_NAME_NPCF_SMPOLICYCONTROL;
+    header.api.version = (char *)OGS_SBI_API_V1;
+    header.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_SM_POLICIES;
+    header.resource.component[1] = sess->sm_policy_id;
+
+    memset(&sendmsg, 0, sizeof(sendmsg));
+    sendmsg.SmPolicyDecision = &SmPolicyDecision;
+    sendmsg.http.location = ogs_sbi_server_uri(server, &header);
+
+    response = ogs_sbi_build_response(
+            &sendmsg, OGS_SBI_HTTP_STATUS_CREATED);
+    ogs_assert(response);
+    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    ogs_free(sendmsg.http.location);
+
+    OpenAPI_list_for_each(SessRuleList, node) {
+        SessRuleMap = node->data;
+        if (SessRuleMap) {
+            SessionRule = SessRuleMap->value;
+            if (SessionRule) {
+                if (SessionRule->auth_sess_ambr) {
+                    if (SessionRule->auth_sess_ambr->uplink)
+                        ogs_free(SessionRule->auth_sess_ambr->uplink);
+                    if (SessionRule->auth_sess_ambr->downlink)
+                        ogs_free(SessionRule->auth_sess_ambr->downlink);
+                }
+                if (SessionRule->auth_def_qos) {
+                    ogs_free(SessionRule->auth_def_qos->arp);
+
+                }
+                ogs_free(SessionRule);
+            }
+            ogs_free(SessRuleMap);
+        }
+    }
+    OpenAPI_list_free(SessRuleList);
+
+    OpenAPI_list_for_each(PccRuleList, node) {
+        PccRuleMap = node->data;
+        if (PccRuleMap) {
+            PccRule = PccRuleMap->value;
+            if (PccRule)
+                ogs_sbi_free_pcc_rule(PccRule);
+            ogs_free(PccRuleMap);
+        }
+    }
+    OpenAPI_list_free(PccRuleList);
+
+    OpenAPI_list_for_each(QosDecisionList, node) {
+        QosDecisionMap = node->data;
+        if (QosDecisionMap) {
+            QosData = QosDecisionMap->value;
+            if (QosData)
+                ogs_sbi_free_qos_data(QosData);
+            ogs_free(QosDecisionMap);
+        }
+    }
+    OpenAPI_list_free(QosDecisionList);
+
+    OpenAPI_list_free(PolicyCtrlReqTriggers);
+
+    if (SmPolicyDecision.supp_feat)
+        ogs_free(SmPolicyDecision.supp_feat);
+
+    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+            &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOSUCC, 1);
+
+    OGS_SESSION_DATA_FREE(&session_data);
+
+    return true;
+
+cleanup:
+    ogs_assert(strerror);
+    ogs_assert(status);
+    ogs_error("%s", strerror);
+    ogs_assert(true == ogs_sbi_server_send_error(
+                stream, status, NULL, strerror, NULL, NULL));
+    ogs_free(strerror);
+
+    OGS_SESSION_DATA_FREE(&session_data);
+
+    return false;
 }
 
 bool pcf_sbi_send_smpolicycontrol_update_notify(

--- a/src/pcf/sbi-path.h
+++ b/src/pcf/sbi-path.h
@@ -45,11 +45,10 @@ int pcf_sess_sbi_discover_and_send(
         ogs_sbi_discovery_option_t *discovery_option,
         ogs_sbi_request_t *(*build)(pcf_sess_t *sess, void *data),
         pcf_sess_t *sess, ogs_sbi_stream_t *stream, void *data);
-int pcf_sess_sbi_discover_only(
-        pcf_sess_t *sess, ogs_sbi_stream_t *stream,
-        ogs_sbi_service_type_e service_type);
 
 bool pcf_sbi_send_am_policy_control_notify(pcf_ue_t *pcf_ue);
+bool pcf_sbi_send_smpolicycontrol_create_response(
+        pcf_sess_t *sess, ogs_sbi_stream_t *stream);
 bool pcf_sbi_send_smpolicycontrol_update_notify(
         pcf_sess_t *sess, OpenAPI_sm_policy_decision_t *SmPolicyDecision);
 bool pcf_sbi_send_smpolicycontrol_delete_notify(

--- a/src/pcf/sm-sm.c
+++ b/src/pcf/sm-sm.c
@@ -291,8 +291,22 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 } else {
                     SWITCH(message->h.method)
                     CASE(OGS_SBI_HTTP_METHOD_POST)
-                        pcf_nbsf_management_handle_register(
-                                sess, stream, message);
+                        if (message->res_status ==
+                                OGS_SBI_HTTP_STATUS_CREATED) {
+                            pcf_nbsf_management_handle_register(
+                                    sess, stream, message);
+                        } else {
+                            ogs_error("[%s:%d] HTTP response error [%d]",
+                                pcf_ue->supi, sess->psi, message->res_status);
+
+                            /*
+                             * Send Response
+                             * for SM Policy Association establishment
+                             */
+                            ogs_expect(true ==
+                                pcf_sbi_send_smpolicycontrol_create_response(
+                                    sess, stream));
+                        }
                         break;
                     DEFAULT
                         ogs_error("[%s:%d] Unknown method [%s]",

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -584,16 +584,6 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
             return OGS_ERROR;
         }
 
-        assoc->request = request;
-        ogs_assert(assoc->request);
-        assoc->service_type = service_type;
-        ogs_assert(assoc->service_type);
-
-        assoc->target_nf_type = target_nf_type;
-        ogs_assert(assoc->target_nf_type);
-        assoc->requester_nf_type = requester_nf_type;
-        ogs_assert(assoc->requester_nf_type);
-
         if (!discovery_option->num_of_service_names) {
             ogs_error("No service names");
             scp_assoc_remove(assoc);
@@ -623,6 +613,16 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
                     "corresponds to the first service name in the header "
                     "in TS29.500");
         }
+
+        assoc->request = request;
+        ogs_assert(assoc->request);
+        assoc->service_type = service_type;
+        ogs_assert(assoc->service_type);
+
+        assoc->target_nf_type = target_nf_type;
+        ogs_assert(assoc->target_nf_type);
+        assoc->requester_nf_type = requester_nf_type;
+        ogs_assert(assoc->requester_nf_type);
 
         if (false == send_discover(nrf_client, nf_discover_handler, assoc)) {
             ogs_error("send_discover() failed");
@@ -715,7 +715,7 @@ static int response_handler(
 static int nf_discover_handler(
         int status, ogs_sbi_response_t *response, void *data)
 {
-    int rv;
+    int rv, res_status;
     char *strerror = NULL;
     ogs_sbi_message_t message;
 
@@ -775,16 +775,19 @@ static int nf_discover_handler(
     rv = ogs_sbi_parse_response(&message, response);
     if (rv != OGS_OK) {
         strerror = ogs_msprintf("cannot parse HTTP response");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
     if (message.res_status != OGS_SBI_HTTP_STATUS_OK) {
         strerror = ogs_msprintf("NF-Discover failed [%d]", message.res_status);
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
     if (!message.SearchResult) {
         strerror = ogs_msprintf("No SearchResult");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
@@ -796,7 +799,7 @@ static int nf_discover_handler(
         strerror = ogs_msprintf("(NF discover) No NF-Instance [%s:%s]",
                     ogs_sbi_service_type_to_name(service_type),
                     OpenAPI_nf_type_ToString(requester_nf_type));
-
+        res_status = OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT;
         goto cleanup;
     }
 
@@ -809,7 +812,7 @@ static int nf_discover_handler(
         strerror = ogs_msprintf("(NF discover) No client [%s:%s]",
                     ogs_sbi_service_type_to_name(service_type),
                     OpenAPI_nf_type_ToString(requester_nf_type));
-
+        res_status = OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT;
         goto cleanup;
     }
 
@@ -823,6 +826,7 @@ static int nf_discover_handler(
         if (!sepp_client) {
             ogs_error("No SEPP [%s]", client->fqdn);
             strerror = ogs_msprintf("No SEPP [%s]", client->fqdn);
+            res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
 
@@ -837,6 +841,7 @@ static int nf_discover_handler(
     if (false == send_request(
                 client, response_handler, request, false, assoc)) {
         strerror = ogs_msprintf("send_request() failed");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
@@ -852,10 +857,8 @@ cleanup:
     scp_assoc_remove(assoc);
 
     if (stream) {
-        ogs_assert(true ==
-            ogs_sbi_server_send_error(
-                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, NULL, strerror, NULL,
-                NULL));
+        ogs_assert(true == ogs_sbi_server_send_error(
+                stream, res_status, NULL, strerror, NULL, NULL));
     } else
         ogs_error("STREAM has already been removed [%d]", stream_id);
 
@@ -870,7 +873,7 @@ cleanup:
 static int sepp_discover_handler(
         int status, ogs_sbi_response_t *response, void *data)
 {
-    int rv;
+    int rv, res_status;
     char *strerror = NULL;
     ogs_sbi_message_t message;
 
@@ -912,16 +915,19 @@ static int sepp_discover_handler(
     rv = ogs_sbi_parse_response(&message, response);
     if (rv != OGS_OK) {
         strerror = ogs_msprintf("cannot parse HTTP response");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
     if (message.res_status != OGS_SBI_HTTP_STATUS_OK) {
         strerror = ogs_msprintf("NF-Discover failed [%d]", message.res_status);
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
     if (!message.SearchResult) {
         strerror = ogs_msprintf("No SearchResult");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
@@ -933,6 +939,7 @@ static int sepp_discover_handler(
     sepp_client = NF_INSTANCE_CLIENT(ogs_sbi_self()->sepp_instance);
     if (!sepp_client) {
         strerror = ogs_msprintf("No SEPP");
+        res_status = OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT;
         goto cleanup;
     }
 
@@ -943,6 +950,7 @@ static int sepp_discover_handler(
     if (false == send_request(
                 sepp_client, response_handler, request, false, assoc)) {
         strerror = ogs_msprintf("send_request() failed");
+        res_status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
@@ -958,10 +966,8 @@ cleanup:
     scp_assoc_remove(assoc);
 
     if (stream) {
-        ogs_assert(true ==
-            ogs_sbi_server_send_error(
-                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, NULL, strerror, NULL,
-                NULL));
+        ogs_assert(true == ogs_sbi_server_send_error(
+                stream, res_status, NULL, strerror, NULL, NULL));
     } else
         ogs_error("STREAM has already been removed [%d]", stream_id);
 


### PR DESCRIPTION
Modified the PCF logic to bypass the BSF dependency when it is not available. This change ensures that the 5G Core can operate without requiring a BSF, allowing PDU sessions to be established successfully in setups where only a single PCF is used.