### PR TITLE
[SMF] Add check for relay peer in ogs_diam_is_relay_or_app_advertised function (#3589)

### DIFF
--- a/lib/diameter/common/base.h
+++ b/lib/diameter/common/base.h
@@ -90,7 +90,7 @@ int ogs_diam_start(void);
 void ogs_diam_final(void);
 
 int ogs_diam_config_init(ogs_diam_config_t *fd_config);
-bool ogs_diam_app_connected(uint32_t app_id);
+bool ogs_diam_is_relay_or_app_advertised(uint32_t app_id);
 
 int fd_avp_search_avp ( struct avp * groupedavp,
         struct dict_object * what, struct avp ** avp );

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -53,9 +53,11 @@ int smf_use_gy_iface(void)
 {
     switch (smf_self()->ctf_config.enabled) {
     case SMF_CTF_ENABLED_AUTO:
-        return ogs_diam_app_connected(OGS_DIAM_GY_APPLICATION_ID) ? 1 : 0;
+        return ogs_diam_is_relay_or_app_advertised(
+                OGS_DIAM_GY_APPLICATION_ID) ? 1 : 0;
     case SMF_CTF_ENABLED_YES:
-        return ogs_diam_app_connected(OGS_DIAM_GY_APPLICATION_ID) ? 1 : -1;
+        return ogs_diam_is_relay_or_app_advertised(
+                OGS_DIAM_GY_APPLICATION_ID) ? 1 : -1;
     case SMF_CTF_ENABLED_NO:
         return 0;
     default:

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -110,7 +110,7 @@ uint8_t smf_gn_handle_create_pdp_context_request(
         cause_value = OGS_GTP1_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
+    if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
         cause_value = OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE;
     }
@@ -309,7 +309,7 @@ uint8_t smf_gn_handle_delete_pdp_context_request(
 {
     ogs_debug("Delete PDP Context Request");
 
-    if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
+    if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
         return OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE;
     }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -155,7 +155,7 @@ uint8_t smf_s5c_handle_create_session_request(
         cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
     }
 
-    if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
+    if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
         cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
     }
@@ -172,7 +172,7 @@ uint8_t smf_s5c_handle_create_session_request(
         }
         break;
     case OGS_GTP2_RAT_TYPE_WLAN:
-        if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
+        if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_S6B_APPLICATION_ID)) {
             ogs_error("No S6b Diameter Peer");
             cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
         }
@@ -485,13 +485,13 @@ uint8_t smf_s5c_handle_delete_session_request(
     ogs_assert(xact);
     ogs_assert(req);
 
-    if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
+    if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
         return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
     }
 
     if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_WLAN) {
-        if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
+        if (!ogs_diam_is_relay_or_app_advertised(OGS_DIAM_S6B_APPLICATION_ID)) {
             ogs_error("No S6b Diameter Peer");
             return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
         }


### PR DESCRIPTION
Modify the function to return true if the peer is a relay, otherwise check for advertised application.