### PR TITLE
[SBI] Enable SSL Key Logging for Enhanced Debugging and Analysis (#3647)

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -117,6 +117,24 @@ amf:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/nrf.key
+#        cert: @sysconfdir@/open5gs/tls/nrf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/amf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/amf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -80,6 +80,27 @@ ausf:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/ausf.key
+#        cert: @sysconfdir@/open5gs/tls/ausf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/ausf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/ausf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: ausf.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -80,6 +80,27 @@ bsf:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/bsf.key
+#        cert: @sysconfdir@/open5gs/tls/bsf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/bsf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/bsf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: bsf.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/nrf.yaml.in
+++ b/configs/open5gs/nrf.yaml.in
@@ -51,6 +51,24 @@ nrf:
 #    server:
 #      - address: nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/nrf.key
+#        cert: @sysconfdir@/open5gs/tls/nrf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/nrf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/nrf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -110,6 +110,31 @@ nssf:
 #          s_nssai:
 #            sst: 1
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/nssf.key
+#        cert: @sysconfdir@/open5gs/tls/nssf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/nssf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/nssf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: nssf.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#      nsi:
+#        - uri: https://nrf.localdomain
+#          s_nssai:
+#            sst: 1
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -206,6 +206,27 @@ pcf:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/pcf.key
+#        cert: @sysconfdir@/open5gs/tls/pcf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/pcf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/pcf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: pcf.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -105,6 +105,27 @@ scp:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/scp.key
+#        cert: @sysconfdir@/open5gs/tls/scp.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/scp-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/scp-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: scp.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/sepp1.yaml.in
+++ b/configs/open5gs/sepp1.yaml.in
@@ -148,6 +148,36 @@ sepp:
 #          uri: https://sepp2.localdomain
 #          resolve: 127.0.2.251
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        private_key: @sysconfdir@/open5gs/tls/sepp1.key
+#        cert: @sysconfdir@/open5gs/tls/sepp1.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp1-server-sslkeylog.log
+#      client:
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp1-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: 127.0.1.250
+#        port: 7777
+#    client:
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#  n32:
+#    server:
+#      - sender: sepp1.localdomain
+#        scheme: https
+#        address: 127.0.1.251
+#    client:
+#      sepp:
+#        - receiver: sepp2.localdomain
+#          uri: https://sepp2.localdomain
+#          resolve: 127.0.2.251
+#
 #  o Add client TLS verification to N32 interface
 #  default:
 #    tls:

--- a/configs/open5gs/sepp2.yaml.in
+++ b/configs/open5gs/sepp2.yaml.in
@@ -14,8 +14,10 @@ sepp:
       server:
         private_key: @sysconfdir@/open5gs/tls/sepp2.key
         cert: @sysconfdir@/open5gs/tls/sepp2.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp2-server-sslkeylog.log
       client:
         cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp2-client-sslkeylog.log
   sbi:
     server:
       - address: 127.0.2.250
@@ -130,6 +132,36 @@ sepp:
 #        cert: @sysconfdir@/open5gs/tls/sepp2.crt
 #      client:
 #        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#  sbi:
+#    server:
+#      - address: 127.0.2.250
+#        port: 7777
+#    client:
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#  n32:
+#    server:
+#      - sender: sepp2.localdomain
+#        scheme: https
+#        address: 127.0.2.251
+#    client:
+#      sepp:
+#        - receiver: sepp1.localdomain
+#          uri: https://sepp1.localdomain
+#          resolve: 127.0.1.251
+#
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        private_key: @sysconfdir@/open5gs/tls/sepp2.key
+#        cert: @sysconfdir@/open5gs/tls/sepp2.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp2-server-sslkeylog.log
+#      client:
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/sepp2-client-sslkeylog.log
 #  sbi:
 #    server:
 #      - address: 127.0.2.250

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -244,6 +244,27 @@ smf:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/smf.key
+#        cert: @sysconfdir@/open5gs/tls/smf.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/smf-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/smf-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: smf.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -38,7 +38,6 @@ udm:
       scp:
         - uri: http://127.0.0.200:7777
 
-#
 ################################################################################
 # Home Network Public Key
 ################################################################################
@@ -133,6 +132,27 @@ udm:
 #      client:
 #        scheme: https
 #        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#  sbi:
+#    server:
+#      - address: udm.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/udm.key
+#        cert: @sysconfdir@/open5gs/tls/udm.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/udm-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/udm-client-sslkeylog.log
 #  sbi:
 #    server:
 #      - address: udm.localdomain

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -81,6 +81,27 @@ udr:
 #      nrf:
 #        - uri: https://nrf.localdomain
 #
+#  o Enable SSL key logging for Wireshark
+#    - This configuration allows capturing SSL/TLS session keys
+#      for debugging or analysis purposes using Wireshark.
+#  default:
+#    tls:
+#      server:
+#        scheme: https
+#        private_key: @sysconfdir@/open5gs/tls/udr.key
+#        cert: @sysconfdir@/open5gs/tls/udr.crt
+#        sslkeylogfile: @localstatedir@/log/open5gs/tls/udr-server-sslkeylog.log
+#      client:
+#        scheme: https
+#        cacert: @sysconfdir@/open5gs/tls/ca.crt
+#        client_sslkeylogfile: @localstatedir@/log/open5gs/tls/udr-client-sslkeylog.log
+#  sbi:
+#    server:
+#      - address: udr.localdomain
+#    client:
+#      nrf:
+#        - uri: https://nrf.localdomain
+#
 #  o Add client TLS verification
 #  default:
 #    tls:

--- a/debian/open5gs-common.dirs
+++ b/debian/open5gs-common.dirs
@@ -1,1 +1,1 @@
-var/log/open5gs
+var/log/open5gs/tls

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -129,6 +129,9 @@ ogs_sbi_client_t *ogs_sbi_client_add(
             ogs_strdup(ogs_sbi_self()->tls.client.private_key);
     if (ogs_sbi_self()->tls.client.cert)
         client->cert = ogs_strdup(ogs_sbi_self()->tls.client.cert);
+    if (ogs_sbi_self()->tls.client.sslkeylog)
+        client->sslkeylog =
+            ogs_strdup(ogs_sbi_self()->tls.client.sslkeylog);
 
     ogs_debug("ogs_sbi_client_add [%s]", OpenAPI_uri_scheme_ToString(scheme));
     OGS_OBJECT_REF(client);
@@ -212,6 +215,8 @@ void ogs_sbi_client_remove(ogs_sbi_client_t *client)
         ogs_free(client->private_key);
     if (client->cert)
         ogs_free(client->cert);
+    if (client->sslkeylog)
+        ogs_free(client->sslkeylog);
 
     if (client->fqdn)
         ogs_free(client->fqdn);
@@ -369,6 +374,24 @@ static char *add_params_to_uri(CURL *easy, char *uri, ogs_hash_t *params)
     return uri;
 }
 
+/* User-defined SSL_CTX callback function */
+static CURLcode sslctx_callback(CURL *curl, void *sslctx, void *userdata)
+{
+    SSL_CTX *ctx = (SSL_CTX *)sslctx;
+    ogs_sbi_client_t *client = userdata;
+
+    ogs_assert(ctx);
+    ogs_assert(userdata);
+
+    /* Ensure app data is set for SSL objects */
+    SSL_CTX_set_app_data(ctx, client->sslkeylog);
+
+    /* Set the SSL Key Log callback */
+    SSL_CTX_set_keylog_callback(ctx, ogs_sbi_keylog_callback);
+
+    return CURLE_OK;
+}
+
 static connection_t *connection_add(
         ogs_sbi_client_t *client, ogs_sbi_client_cb_f client_cb,
         ogs_sbi_request_t *request, void *data)
@@ -459,6 +482,7 @@ static connection_t *connection_add(
 
     curl_easy_setopt(conn->easy, CURLOPT_BUFFERSIZE, OGS_MAX_SDU_LEN);
 
+    /* HTTPS certificate-related settings */
     if (client->scheme == OpenAPI_uri_scheme_https) {
         if (client->insecure_skip_verify) {
             curl_easy_setopt(conn->easy, CURLOPT_SSL_VERIFYPEER, 0);
@@ -468,13 +492,23 @@ static connection_t *connection_add(
                 curl_easy_setopt(conn->easy, CURLOPT_CAINFO, client->cacert);
         }
 
+        /* Set private key & certificate */
         if (client->private_key && client->cert) {
             curl_easy_setopt(conn->easy, CURLOPT_SSLKEY, client->private_key);
             curl_easy_setopt(conn->easy, CURLOPT_SSLCERT, client->cert);
         }
+
+        if (client->sslkeylog) {
+            /* Set SSL_CTX callback */
+            curl_easy_setopt(conn->easy, CURLOPT_SSL_CTX_FUNCTION,
+                    sslctx_callback);
+
+            /* Optionally set additional user data */
+            curl_easy_setopt(conn->easy, CURLOPT_SSL_CTX_DATA, client);
+        }
     }
 
-    /* HTTP Method */
+    /* Configure HTTP Method */
     if (strcmp(request->h.method, OGS_SBI_HTTP_METHOD_PUT) == 0 ||
         strcmp(request->h.method, OGS_SBI_HTTP_METHOD_PATCH) == 0 ||
         strcmp(request->h.method, OGS_SBI_HTTP_METHOD_DELETE) == 0 ||

--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -80,7 +80,7 @@ typedef struct ogs_sbi_client_s {
 
     OpenAPI_uri_scheme_e scheme;
     bool insecure_skip_verify;
-    char *cacert, *private_key, *cert;
+    char *cacert, *private_key, *cert, *sslkeylog;
 
     char *fqdn;
     uint16_t fqdn_port;

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -65,6 +65,7 @@ typedef struct ogs_sbi_context_s {
 
             const char *private_key;
             const char *cert;
+            const char *sslkeylog;
 
             bool verify_client;
             const char *verify_client_cacert;
@@ -77,6 +78,7 @@ typedef struct ogs_sbi_context_s {
 
             const char *private_key;
             const char *cert;
+            const char *sslkeylog;
         } client;
     } tls;
 
@@ -569,6 +571,8 @@ ogs_sbi_subscription_data_t *ogs_sbi_subscription_data_find(char *id);
 bool ogs_sbi_supi_in_vplmn(char *supi);
 bool ogs_sbi_plmn_id_in_vplmn(ogs_plmn_id_t *plmn_id);
 bool ogs_sbi_fqdn_in_vplmn(char *fqdn);
+
+void ogs_sbi_keylog_callback(const SSL *ssl, const char *line);
 
 #ifdef __cplusplus
 }

--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -196,7 +196,9 @@ static int ssl_ctx_set_proto_versions(SSL_CTX *ssl_ctx, int min, int max)
 #endif /* OPENSSL_VERSION_NUMBER >= 0x1010000fL */
 }
 
-static SSL_CTX *create_ssl_ctx(const char *key_file, const char *cert_file)
+static SSL_CTX *create_ssl_ctx(
+        const char *key_file, const char *cert_file,
+        const char *sslkeylog_file)
 {
     SSL_CTX *ssl_ctx;
     uint64_t ssl_opts;
@@ -208,6 +210,14 @@ static SSL_CTX *create_ssl_ctx(const char *key_file, const char *cert_file)
     if (!ssl_ctx) {
         ogs_error("Could not create SSL/TLS context: %s", ERR_error_string(ERR_get_error(), NULL));
         return NULL;
+    }
+
+    /* Set key log files for each SSL_CTX */
+    if (sslkeylog_file) {
+        /* Ensure app data is set for SSL objects */
+        SSL_CTX_set_app_data(ssl_ctx, sslkeylog_file);
+        /* Set the SSL Key Log callback */
+        SSL_CTX_set_keylog_callback(ssl_ctx, ogs_sbi_keylog_callback);
     }
 
     ssl_opts = (SSL_OP_ALL & ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) |
@@ -322,7 +332,8 @@ static int server_start(ogs_sbi_server_t *server,
     /* Create SSL CTX */
     if (server->scheme == OpenAPI_uri_scheme_https) {
 
-        server->ssl_ctx = create_ssl_ctx(server->private_key, server->cert);
+        server->ssl_ctx = create_ssl_ctx(
+                server->private_key, server->cert, server->sslkeylog);
         if (!server->ssl_ctx) {
             ogs_error("Cannot create SSL CTX");
             return OGS_ERROR;

--- a/lib/sbi/server.c
+++ b/lib/sbi/server.c
@@ -75,6 +75,8 @@ ogs_sbi_server_t *ogs_sbi_server_add(
             ogs_strdup(ogs_sbi_self()->tls.server.private_key);
     if (ogs_sbi_self()->tls.server.cert)
         server->cert = ogs_strdup(ogs_sbi_self()->tls.server.cert);
+    if (ogs_sbi_self()->tls.server.sslkeylog)
+        server->sslkeylog = ogs_strdup(ogs_sbi_self()->tls.server.sslkeylog);
 
     server->verify_client = ogs_sbi_self()->tls.server.verify_client;
     if (ogs_sbi_self()->tls.server.verify_client_cacert)
@@ -112,6 +114,8 @@ void ogs_sbi_server_remove(ogs_sbi_server_t *server)
         ogs_free(server->private_key);
     if (server->cert)
         ogs_free(server->cert);
+    if (server->sslkeylog)
+        ogs_free(server->sslkeylog);
 
     ogs_pool_id_free(&server_pool, server);
 }

--- a/lib/sbi/server.h
+++ b/lib/sbi/server.h
@@ -41,7 +41,7 @@ typedef struct ogs_sbi_server_s {
 
     char *interface;
     OpenAPI_uri_scheme_e scheme;
-    char *private_key, *cert;
+    char *private_key, *cert, *sslkeylog;
     bool verify_client;
     char *verify_client_cacert;
 

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ if clangtidy.found() != true
 endif
 
 meson.add_install_script(python3_exe, '-c',
-        mkdir_p.format(join_paths(localstatedir, 'log', 'open5gs')))
+        mkdir_p.format(join_paths(localstatedir, 'log', 'open5gs', 'tls')))
 
 # Compiler flags
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'


### PR DESCRIPTION
- Add `sslkeylogfile` configuration options to `*.yaml.in` in NFs.
- Update `open5gs-common.dirs` to include `var/log/open5gs/tls` directory
- Extend `ogs_sbi_context_s` structure in `context.h` to include `sslkeylog`
- Modify `context.c` to parse and handle `sslkeylogfile` settings
- Update `server.c` and `server.h` to manage the `sslkeylog` field in server structures
- Update `ogs_sbi_client_add` and `ogs_sbi_client_remove` functions to handle `sslkeylog` field.
- Adjust `meson.build` to create the TLS log directory during installation

This commit introduces SSL key logging functionality to Open5GS, enabling the capture of SSL/TLS keys. This feature is essential for debugging encrypted traffic and allows integration with tools like Wireshark for decrypting TLS sessions.