### PR TITLE
[SBI] Added support for custom port numbers in SBI configuration with FQDN(#3385)

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -59,18 +59,31 @@ amf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-amf.svc.local
 #  sbi:
 #    server:
 #      - dev:eth0
 #        advertise: open5gs-amf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: amf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.5 and advertise as open5gs-amf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.5
+#        port: 7777
+#        advertise: open5gs-amf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.5
+#        port: 7777
+#        advertise: open5gs-amf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -22,18 +22,31 @@ ausf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-ausf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-ausf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: ausf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.11 and advertise as open5gs-ausf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.11
+#        port: 7777
+#        advertise: open5gs-ausf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.11
+#        port: 7777
+#        advertise: open5gs-ausf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -22,18 +22,31 @@ bsf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-bsf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-bsf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: bsf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.15 and advertise as open5gs-bsf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.15
+#        port: 7777
+#        advertise: open5gs-bsf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.15
+#        port: 7777
+#        advertise: open5gs-bsf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/nrf.yaml.in
+++ b/configs/open5gs/nrf.yaml.in
@@ -21,18 +21,31 @@ nrf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-nrf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-nrf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: nrf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.10 and advertise as open5gs-nrf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.10
+#        port: 7777
+#        advertise: open5gs-nrf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.10
+#        port: 7777
+#        advertise: open5gs-nrf.svc.local:8888
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -25,18 +25,31 @@ nssf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-nssf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-nssf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: nssf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.14 and advertise as open5gs-nssf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.14
+#        port: 7777
+#        advertise: open5gs-nssf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.14
+#        port: 7777
+#        advertise: open5gs-nssf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -148,18 +148,31 @@ pcf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-pcf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-pcf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: pcf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.13 and advertise as open5gs-pcf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.13
+#        port: 7777
+#        advertise: open5gs-pcf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.13
+#        port: 7777
+#        advertise: open5gs-pcf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -63,18 +63,31 @@ scp:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-scp.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-scp.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: scp.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.200 and advertise as open5gs-scp.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.200
+#        port: 7777
+#        advertise: open5gs-scp.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.200
+#        port: 7777
+#        advertise: open5gs-scp.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -186,18 +186,31 @@ smf:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-smf.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-smf.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: smf.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.4 and advertise as open5gs-smf.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.4
+#        port: 7777
+#        advertise: open5gs-smf.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.4
+#        port: 7777
+#        advertise: open5gs-smf.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -81,18 +81,31 @@ udm:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-udm.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-udm.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: udm.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.12 and advertise as open5gs-udm.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.12
+#        port: 7777
+#        advertise: open5gs-udm.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.12
+#        port: 7777
+#        advertise: open5gs-udm.svc.local:8888
 #
 ################################################################################
 # SBI Client

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -23,18 +23,31 @@ udr:
 ################################################################################
 # SBI Server
 ################################################################################
-#  o Override SBI address to be advertised to NRF
+#  o Bind to the address on the eth0 and advertise as open5gs-udr.svc.local
 #  sbi:
 #    server:
-#      - dev: eth0
+#      - dev:eth0
 #        advertise: open5gs-udr.svc.local
 #
+#  o Specify a custom port number 7777 while binding to the given address
 #  sbi:
 #    server:
-#      - address: localhost
-#        advertise:
-#          - 127.0.0.99
-#          - ::1
+#      - address: udr.localdomain
+#        port: 7777
+#
+#  o Bind to 127.0.0.20 and advertise as open5gs-udr.svc.local
+#  sbi:
+#    server:
+#      - address: 127.0.0.20
+#        port: 7777
+#        advertise: open5gs-udr.svc.local
+#
+#  o Bind to port 7777 but advertise with a different port number 8888
+#  sbi:
+#    server:
+#      - address: 127.0.0.20
+#        port: 7777
+#        advertise: open5gs-udr.svc.local:8888
 #
 ################################################################################
 # SBI Client


### PR DESCRIPTION
This update allows the parsing and handling of user-defined port numbers in the `advertise` field or explicitly in the `server` configuration for SBI. Users can now specify non-default ports for both binding and advertising while maintaining compatibility with existing configurations. The feature includes logic to handle FQDNs with embedded port numbers (e.g., `example.com:8080`) and ensures proper memory management during parsing. Updated the client association logic to utilize custom ports when specified.

Examples:
- Bind to the address on the eth0 and advertise as open5gs-amf.svc.local
```
  sbi:
    server:
      - dev:eth0
        advertise: open5gs-amf.svc.local
```

- Specify a custom port number 7777 while binding to the given address
```
  sbi:
    server:
      - address: amf.localdomain
        port: 7777
```

- Bind to 127.0.0.5 and advertise as open5gs-amf.svc.local
```
  sbi:
    server:
      - address: 127.0.0.5
        port: 7777
        advertise: open5gs-amf.svc.local
```

- Bind to port 7777 but advertise with a different port number 8888
```
  sbi:
    server:
      - address: 127.0.0.5
        port: 7777
        advertise: open5gs-amf.svc.local:8888
```