### PR TITLE
[SBI] Allow direct NRF communication in Model C by configuring delegation modes (#3399)

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -88,27 +88,54 @@ amf:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -51,27 +51,54 @@ ausf:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -51,27 +51,54 @@ bsf:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -77,27 +77,55 @@ nssf:
 #            sst: 1
 #            sd: 009000
 #
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
+#
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -177,27 +177,54 @@ pcf:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/scp.yaml.in
+++ b/configs/open5gs/scp.yaml.in
@@ -92,11 +92,48 @@ scp:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
+#
+#  o Indirect Communication by Delegating to Next-SCP
+#  sbi:
+#    client:
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#
+#  o Indirect Communication without Delegation
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegation
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the Next-SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -215,27 +215,54 @@ smf:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -110,27 +110,54 @@ udm:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -52,27 +52,54 @@ udr:
 ################################################################################
 # SBI Client
 ################################################################################
-#  o Direct communication with NRF interaction
+#  o Direct Communication with NRF
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #
-#  o Indirect communication with delegated discovery
+#  o Indirect Communication by Delegating to SCP
 #  sbi:
 #    client:
 #      scp:
 #        - uri: http://127.0.0.200:7777
 #
-#  o Indirect communication without delegated discovery
+#  o Indirect Communication without Delegation
 #  sbi:
 #    client:
 #      nrf:
 #        - uri: http://127.0.0.10:7777
 #      scp:
 #        - uri: http://127.0.0.200:7777
-#  discovery:
-#    delegated: no
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: no   # Directly communicate NRF discovery
+#        scp:
+#          next: no   # Do not delegate to SCP for next-hop
+#
+#  o Indirect Communication with Delegated Discovery
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      delegated:
+#        nrf:
+#          nfm: no    # Directly communicate NRF management functions
+#          disc: yes  # Delegate discovery to SCP
+#        scp:
+#          next: yes  # Delegate to SCP for next-hop communications
+#
+#  o Default delegation: all communications are delegated to the SCP
+#  sbi:
+#    client:
+#      nrf:
+#        - uri: http://127.0.0.10:7777
+#      scp:
+#        - uri: http://127.0.0.200:7777
+#      # No 'delegated' section; defaults to AUTO delegation
 #
 ################################################################################
 # HTTPS scheme with TLS

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -36,19 +36,25 @@ typedef struct ogs_sbi_smf_info_s ogs_sbi_smf_info_t;
 typedef struct ogs_sbi_nf_instance_s ogs_sbi_nf_instance_t;
 
 typedef enum {
-    OGS_SBI_DISCOVERY_DELEGATED_AUTO = 0,
-    OGS_SBI_DISCOVERY_DELEGATED_YES,
-    OGS_SBI_DISCOVERY_DELEGATED_NO,
-} ogs_sbi_discovery_delegated_mode;
+    OGS_SBI_CLIENT_DELEGATED_AUTO = 0,
+    OGS_SBI_CLIENT_DELEGATED_YES,
+    OGS_SBI_CLIENT_DELEGATED_NO,
+} ogs_sbi_client_delegated_mode_e;
 
-typedef struct ogs_sbi_discovery_config_s {
-    ogs_sbi_discovery_delegated_mode delegated;
-    bool no_service_names;
-    bool prefer_requester_nf_instance_id;
-} ogs_sbi_discovery_config_t;
+/* To hold all delegated config under sbi.client.delegated */
+typedef struct ogs_sbi_client_delegated_config_s {
+    struct {
+        ogs_sbi_client_delegated_mode_e nfm;  /* e.g. Registration, Heartbeat */
+        ogs_sbi_client_delegated_mode_e disc; /* NF discovery */
+    } nrf;
+    struct {
+        ogs_sbi_client_delegated_mode_e next; /* Next-hop SCP delegation */
+    } scp;
+} ogs_sbi_client_delegated_config_t;
 
 typedef struct ogs_sbi_context_s {
-    ogs_sbi_discovery_config_t discovery_config; /* SCP Discovery Delegated */
+    /* For sbi.client.delegated */
+    ogs_sbi_client_delegated_config_t client_delegated_config;
 
 #define OGS_HOME_NETWORK_PKI_VALUE_MIN 1
 #define OGS_HOME_NETWORK_PKI_VALUE_MAX 254

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -412,8 +412,7 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
                                 &discovery_option->guami.amf_id));
             }
         }
-        if (ogs_sbi_self()->discovery_config.no_service_names == false &&
-            discovery_option->num_of_service_names) {
+        if (discovery_option->num_of_service_names) {
 
     /*
      * Issues #1730

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -273,11 +273,11 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
     discovery_option = xact->discovery_option;
 
     /* SCP Availability */
-    if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_AUTO) {
+    if (ogs_sbi_self()->client_delegated_config.nrf.disc ==
+            OGS_SBI_CLIENT_DELEGATED_AUTO) {
         scp_client = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
-    } else if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_YES) {
+    } else if (ogs_sbi_self()->client_delegated_config.nrf.disc ==
+            OGS_SBI_CLIENT_DELEGATED_YES) {
         scp_client = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
         ogs_assert(scp_client);
     }
@@ -787,6 +787,7 @@ bool ogs_sbi_send_request_to_nrf(
 {
     bool rc;
     ogs_sbi_client_t *nrf_client = NULL, *scp_client = NULL;
+    ogs_sbi_client_delegated_mode_e mode = OGS_SBI_CLIENT_DELEGATED_AUTO;
 
     ogs_assert(nrf_service_type);
     ogs_assert(request);
@@ -794,39 +795,72 @@ bool ogs_sbi_send_request_to_nrf(
     scp_client = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
     nrf_client = NF_INSTANCE_CLIENT(ogs_sbi_self()->nrf_instance);
 
-    if (scp_client) {
-        /*************************
-         * INDIRECT COMMUNICATION
-         *************************/
-        build_default_discovery_parameter(
-            request, nrf_service_type, discovery_option);
+    /* Decide which delegated mode to use */
+    if (nrf_service_type == OGS_SBI_SERVICE_TYPE_NNRF_NFM)
+        mode = ogs_sbi_self()->client_delegated_config.nrf.nfm;
+    else if (nrf_service_type == OGS_SBI_SERVICE_TYPE_NNRF_DISC)
+        mode = ogs_sbi_self()->client_delegated_config.nrf.disc;
+    /* else if it's some other Nnrf service, fallback to AUTO or keep default */
 
-        rc = ogs_sbi_client_send_via_scp_or_sepp(
-                scp_client, client_cb, request, data);
-        ogs_expect(rc == true);
-
-    } else if (nrf_client) {
-
-        /***********************
-         * DIRECT COMMUNICATION
-         ***********************/
-
-        /* NRF is available */
-        rc = ogs_sbi_client_send_request(nrf_client, client_cb, request, data);
-        ogs_expect(rc == true);
-
-
-    } else {
-        ogs_fatal("[%s:%s] Cannot send request [%s:%s:%s]",
-                nrf_client ? "NRF" : "No-NRF",
-                scp_client ? "SCP" : "No-SCP",
+    switch (mode) {
+    case OGS_SBI_CLIENT_DELEGATED_NO:
+        /* NO => Direct communication (NRF must exist) */
+        if (!nrf_client) {
+            ogs_fatal("[No-NRF] Cannot send request [%s:%s:%s]",
                 ogs_sbi_service_type_to_name(nrf_service_type),
                 request->h.service.name, request->h.api.version);
-        rc = false;
-        ogs_assert_if_reached();
+            ogs_assert_if_reached();
+            return false;
+        }
+        /* Send directly to NRF */
+        rc = ogs_sbi_client_send_request(nrf_client, client_cb,
+                                         request, data);
+        ogs_expect(rc == true);
+        break;
+
+    case OGS_SBI_CLIENT_DELEGATED_YES:
+        /* YES => Indirect communication (SCP must exist) */
+        if (!scp_client) {
+            ogs_fatal("[No-SCP] Cannot send request [%s:%s:%s]",
+                ogs_sbi_service_type_to_name(nrf_service_type),
+                request->h.service.name, request->h.api.version);
+            ogs_assert_if_reached();
+            return false;
+        }
+        /* Indirect via SCP, build discovery parameter if needed */
+        build_default_discovery_parameter(request, nrf_service_type,
+                                          discovery_option);
+        rc = ogs_sbi_client_send_via_scp_or_sepp(scp_client, client_cb,
+                                                 request, data);
+        ogs_expect(rc == true);
+        break;
+
+    case OGS_SBI_CLIENT_DELEGATED_AUTO:
+    default:
+        /*
+         * AUTO => If SCP is present, use it; otherwise direct.
+         */
+        if (scp_client) {
+            build_default_discovery_parameter(request, nrf_service_type,
+                                              discovery_option);
+            rc = ogs_sbi_client_send_via_scp_or_sepp(scp_client, client_cb,
+                                                     request, data);
+            ogs_expect(rc == true);
+        } else if (nrf_client) {
+            rc = ogs_sbi_client_send_request(nrf_client, client_cb,
+                                             request, data);
+            ogs_expect(rc == true);
+        } else {
+            ogs_fatal("[No-NRF:No-SCP] Cannot send request [%s:%s:%s]",
+                ogs_sbi_service_type_to_name(nrf_service_type),
+                request->h.service.name, request->h.api.version);
+            ogs_assert_if_reached();
+            return false;
+        }
+        break;
     }
 
-    return true;
+    return rc;
 }
 
 bool ogs_sbi_send_response(ogs_sbi_stream_t *stream, int status)
@@ -1000,9 +1034,7 @@ static void build_default_discovery_parameter(
                     OGS_SBI_CUSTOM_DISCOVERY_REQUESTER_NF_INSTANCE_ID,
                     discovery_option->requester_nf_instance_id);
         }
-        if (ogs_sbi_self()->discovery_config.
-                no_service_names == false &&
-            discovery_option->num_of_service_names) {
+        if (discovery_option->num_of_service_names) {
             bool rc = false;
 
             /* send array items separated by a comma */

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -68,11 +68,11 @@ int scp_sbi_open(void)
     }
 
     /* Check if Next-SCP's client */
-    if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_AUTO) {
+    if (ogs_sbi_self()->client_delegated_config.scp.next ==
+            OGS_SBI_CLIENT_DELEGATED_AUTO) {
         next_scp = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
-    } else if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_YES) {
+    } else if (ogs_sbi_self()->client_delegated_config.scp.next ==
+            OGS_SBI_CLIENT_DELEGATED_YES) {
         next_scp = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
         ogs_assert(next_scp);
     }
@@ -153,11 +153,11 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
     }
 
     /* Next-SCP client */
-    if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_AUTO) {
+    if (ogs_sbi_self()->client_delegated_config.scp.next ==
+            OGS_SBI_CLIENT_DELEGATED_AUTO) {
         next_scp = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
-    } else if (ogs_sbi_self()->discovery_config.delegated ==
-            OGS_SBI_DISCOVERY_DELEGATED_YES) {
+    } else if (ogs_sbi_self()->client_delegated_config.scp.next ==
+            OGS_SBI_CLIENT_DELEGATED_YES) {
         next_scp = NF_INSTANCE_CLIENT(ogs_sbi_self()->scp_instance);
         ogs_assert(next_scp);
     }


### PR DESCRIPTION
Introduce client_delegated_config to manage delegation settings for NRF and SCP separately. This ensures that in Model C, all NRF-related procedures (registration, heartbeat, deregistration, etc.) communicate directly with the NRF without routing through the SCP. This change aligns Open5GS behavior with 3GPP standards, providing consistent direct communication for both discovery and management in Model C, and maintaining indirect communication in Model D.

- Direct Communication with NRF
```
sbi:
  client:
    nrf:
      - uri: http://127.0.0.10:7777
```

- Indirect Communication by Delegating to SCP
```
sbi:
  client:
    scp:
      - uri: http://127.0.0.200:7777
```

- Indirect Communication without Delegation
```
sbi:
  client:
    nrf:
      - uri: http://127.0.0.10:7777
    scp:
      - uri: http://127.0.0.200:7777
    delegated:
      nrf:
        nfm: no    # Directly communicate NRF management functions
        disc: no   # Directly communicate NRF discovery
      scp:
        next: no   # Do not delegate to SCP for next-hop
```

- Indirect Communication with Delegated Discovery
```
sbi:
  client:
    nrf:
      - uri: http://127.0.0.10:7777
    scp:
      - uri: http://127.0.0.200:7777
    delegated:
      nrf:
        nfm: no    # Directly communicate NRF management functions
        disc: yes  # Delegate discovery to SCP
      scp:
        next: yes  # Delegate to SCP for next-hop communications
```

- Default delegation: all communications are delegated to the SCP
```
sbi:
  client:
    nrf:
      - uri: http://127.0.0.10:7777
    scp:
      - uri: http://127.0.0.200:7777
    # No 'delegated' section; defaults to AUTO delegation
```