### PR TITLE
Allow value of 0 for S-NSSAI SST

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -1258,7 +1258,6 @@ ogs_app_slice_conf_t *ogs_app_slice_conf_add(
 
     ogs_assert(policy_conf);
     ogs_assert(s_nssai);
-    ogs_assert(s_nssai->sst);
 
     ogs_pool_alloc(&slice_conf_pool, &slice_conf);
     if (!slice_conf) {
@@ -1289,7 +1288,6 @@ ogs_app_slice_conf_t *ogs_app_slice_conf_find_by_s_nssai(
 
     ogs_assert(policy_conf);
     ogs_assert(s_nssai);
-    ogs_assert(s_nssai->sst);
 
     ogs_list_for_each(&policy_conf->slice_list, slice_conf) {
         if (slice_conf->data.s_nssai.sst == s_nssai->sst &&

--- a/lib/dbi/session.c
+++ b/lib/dbi/session.c
@@ -109,11 +109,6 @@ int ogs_dbi_session_data(char *supi, ogs_s_nssai_t *s_nssai, char *dnn,
                     }
                 }
 
-                if (!sst) {
-                    ogs_error("No SST");
-                    continue;
-                }
-
                 if (s_nssai && s_nssai->sst != sst) continue;
 
                 if (s_nssai &&

--- a/lib/nas/5gs/types.c
+++ b/lib/nas/5gs/types.c
@@ -128,8 +128,7 @@ void ogs_nas_build_s_nssai(
 
     pos = 0;
 
-    if (nas_s_nssai_ie->sst)
-        nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->sst;
+    nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->sst;
 
     if (nas_s_nssai_ie->sd.v != OGS_S_NSSAI_NO_SD_VALUE ||
 
@@ -141,7 +140,6 @@ void ogs_nas_build_s_nssai(
          * "no SD value associated with the SST".
          */
         (nas_s_nssai_ie->sd.v == OGS_S_NSSAI_NO_SD_VALUE &&
-         nas_s_nssai_ie->mapped_hplmn_sst &&
          nas_s_nssai_ie->mapped_hplmn_sd.v != OGS_S_NSSAI_NO_SD_VALUE)) {
 
         v = ogs_htobe24(nas_s_nssai_ie->sd);
@@ -149,8 +147,7 @@ void ogs_nas_build_s_nssai(
         pos += 3;
     }
 
-    if (nas_s_nssai_ie->mapped_hplmn_sst)
-        nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->mapped_hplmn_sst;
+    nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->mapped_hplmn_sst;
 
     if (nas_s_nssai_ie->mapped_hplmn_sd.v != OGS_S_NSSAI_NO_SD_VALUE) {
         v = ogs_htobe24(nas_s_nssai_ie->mapped_hplmn_sd);

--- a/lib/nas/5gs/types.c
+++ b/lib/nas/5gs/types.c
@@ -147,7 +147,8 @@ void ogs_nas_build_s_nssai(
         pos += 3;
     }
 
-    nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->mapped_hplmn_sst;
+    if (nas_s_nssai_ie->mapped_hplmn_sst_presence)
+        nas_s_nssai->buffer[pos++] = nas_s_nssai_ie->mapped_hplmn_sst;
 
     if (nas_s_nssai_ie->mapped_hplmn_sd.v != OGS_S_NSSAI_NO_SD_VALUE) {
         v = ogs_htobe24(nas_s_nssai_ie->mapped_hplmn_sd);
@@ -166,14 +167,19 @@ void ogs_nas_build_s_nssai2(
 
     ogs_assert(nas_s_nssai);
     ogs_assert(s_nssai);
-    ogs_assert(mapped_hplmn);
 
     memset(&ie, 0, sizeof(ie));
 
     ie.sst = s_nssai->sst;
     ie.sd.v = s_nssai->sd.v;
-    ie.mapped_hplmn_sst = mapped_hplmn->sst;
-    ie.mapped_hplmn_sd.v = mapped_hplmn->sd.v;
+
+    if (mapped_hplmn) {
+        ie.mapped_hplmn_sst_presence = true;
+        ie.mapped_hplmn_sst = mapped_hplmn->sst;
+        ie.mapped_hplmn_sd.v = mapped_hplmn->sd.v;
+    } else {
+        ie.mapped_hplmn_sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+    }
 
     ogs_nas_build_s_nssai(nas_s_nssai, &ie);
 }
@@ -237,8 +243,10 @@ int ogs_nas_parse_s_nssai(
         pos += 3;
     }
 
-    if (mapped_hplmn_sst)
+    if (mapped_hplmn_sst) {
         nas_s_nssai_ie->mapped_hplmn_sst = nas_s_nssai->buffer[pos++];
+        nas_s_nssai_ie->mapped_hplmn_sst_presence = true;
+    }
 
     if (mapped_hplmn_sd) {
         memcpy(&v, nas_s_nssai->buffer+pos, 3);

--- a/lib/nas/5gs/types.h
+++ b/lib/nas/5gs/types.h
@@ -66,6 +66,7 @@ typedef struct ogs_nas_s_nssai_ie_s {
     uint8_t sst;
     ogs_uint24_t sd;
     uint8_t mapped_hplmn_sst;
+    bool mapped_hplmn_sst_presence;
     ogs_uint24_t mapped_hplmn_sd;
 } __attribute__ ((packed)) ogs_nas_s_nssai_ie_t;
 

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -612,11 +612,6 @@ ogs_sbi_request_t *ogs_sbi_build_request(ogs_sbi_message_t *message)
         char *v = NULL;
         cJSON *item = NULL;
 
-        if (!message->param.s_nssai.sst) {
-            ogs_error("No S-NSSAI SST");
-            ogs_sbi_request_free(request);
-            return NULL;
-        }
         if (!message->param.roaming_indication) {
             ogs_error("No Roaming Indication");
             ogs_sbi_request_free(request);

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2265,6 +2265,7 @@ amf_sess_t *amf_sess_add(amf_ue_t *amf_ue, uint8_t psi)
 
     sess->s_nssai.sst = 0;
     sess->s_nssai.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+    sess->mapped_hplmn_presence = false;
     sess->mapped_hplmn.sst = 0;
     sess->mapped_hplmn.sd.v = OGS_S_NSSAI_NO_SD_VALUE;
 
@@ -2887,6 +2888,8 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
 
                 allowed->sst = requested->sst;
                 allowed->sd.v = requested->sd.v;
+                allowed->mapped_hplmn_sst_presence =
+                        requested->mapped_hplmn_sst_presence;
                 allowed->mapped_hplmn_sst = requested->mapped_hplmn_sst;
                 allowed->mapped_hplmn_sd.v = requested->mapped_hplmn_sd.v;
 
@@ -2923,6 +2926,7 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
 
                 allowed->sst = slice->s_nssai.sst;
                 allowed->sd.v = slice->s_nssai.sd.v;
+                allowed->mapped_hplmn_sst_presence = false;
                 allowed->mapped_hplmn_sst = 0;
                 allowed->mapped_hplmn_sd.v = OGS_S_NSSAI_NO_SD_VALUE;
 

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -834,6 +834,7 @@ typedef struct amf_sess_s {
 
     ogs_s_nssai_t s_nssai;
     ogs_s_nssai_t mapped_hplmn;
+    bool mapped_hplmn_presence;
     char *dnn;
 
 } amf_sess_t;

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1287,8 +1287,11 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                         if (ie.sst == amf_ue->slice[i].s_nssai.sst &&
                             ie.sd.v == amf_ue->slice[i].s_nssai.sd.v) {
 
-                            sess->mapped_hplmn.sst = ie.mapped_hplmn_sst;
-                            sess->mapped_hplmn.sd.v = ie.mapped_hplmn_sd.v;
+                            if (ie.mapped_hplmn_sst_presence) {
+                                sess->mapped_hplmn_presence = true;
+                                sess->mapped_hplmn.sst = ie.mapped_hplmn_sst;
+                                sess->mapped_hplmn.sd.v = ie.mapped_hplmn_sd.v;
+                            }
 
                             /* PASS */
 

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -133,9 +133,11 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
     SmContextCreateData.s_nssai = &sNssai;
 
-    hplmnSnssai.sst = sess->mapped_hplmn.sst;
-    hplmnSnssai.sd = ogs_s_nssai_sd_to_string(sess->mapped_hplmn.sd);
-    SmContextCreateData.hplmn_snssai = &hplmnSnssai;
+    if (sess->mapped_hplmn_presence) {
+        hplmnSnssai.sst = sess->mapped_hplmn.sst;
+        hplmnSnssai.sd = ogs_s_nssai_sd_to_string(sess->mapped_hplmn.sd);
+        SmContextCreateData.hplmn_snssai = &hplmnSnssai;
+    }
 
     SmContextCreateData.guami = ogs_sbi_build_guami(amf_ue->guami);
     if (!SmContextCreateData.guami) {

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -133,11 +133,9 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
     SmContextCreateData.s_nssai = &sNssai;
 
-    if (sess->mapped_hplmn.sst) {
-        hplmnSnssai.sst = sess->mapped_hplmn.sst;
-        hplmnSnssai.sd = ogs_s_nssai_sd_to_string(sess->mapped_hplmn.sd);
-        SmContextCreateData.hplmn_snssai = &hplmnSnssai;
-    }
+    hplmnSnssai.sst = sess->mapped_hplmn.sst;
+    hplmnSnssai.sd = ogs_s_nssai_sd_to_string(sess->mapped_hplmn.sd);
+    SmContextCreateData.hplmn_snssai = &hplmnSnssai;
 
     SmContextCreateData.guami = ogs_sbi_build_guami(amf_ue->guami);
     if (!SmContextCreateData.guami) {

--- a/src/nssf/context.c
+++ b/src/nssf/context.c
@@ -285,7 +285,6 @@ nssf_nsi_t *nssf_nsi_add(char *nrf_id, uint8_t sst, ogs_uint24_t sd)
     nssf_nsi_t *nsi = NULL;
 
     ogs_assert(nrf_id);
-    ogs_assert(sst);
 
     ogs_pool_alloc(&nssf_nsi_pool, &nsi);
     ogs_assert(nsi);

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -132,12 +132,6 @@ static int parse_slice_conf(
                 const char *v = ogs_yaml_iter_value(&slice_iter);
                 if (v) {
                     s_nssai.sst = atoi(v);
-                    if (s_nssai.sst == 1 || s_nssai.sst == 2 ||
-                            s_nssai.sst == 3 || s_nssai.sst == 4) {
-                    } else {
-                        ogs_error("Unknown SST [%d]", s_nssai.sst);
-                        return OGS_ERROR;
-                    }
                 }
             } else if (!strcmp(slice_key, OGS_SD_STRING)) {
                 const char *v = ogs_yaml_iter_value(&slice_iter);
@@ -147,18 +141,13 @@ static int parse_slice_conf(
             }
         }
 
-        if (s_nssai.sst) {
-            slice_conf = ogs_app_slice_conf_add(policy_conf, &s_nssai);
-            if (!slice_conf) {
-                ogs_error("ogs_app_slice_conf_add() failed [SST:%d,SD:0x%x]",
-                        s_nssai.sst, s_nssai.sd.v);
-                return OGS_ERROR;
-            }
-            slice_conf->data.default_indicator = default_indicator;
-        } else {
-            ogs_error("No SST");
+        slice_conf = ogs_app_slice_conf_add(policy_conf, &s_nssai);
+        if (!slice_conf) {
+            ogs_error("ogs_app_slice_conf_add() failed [SST:%d,SD:0x%x]",
+                    s_nssai.sst, s_nssai.sd.v);
             return OGS_ERROR;
         }
+        slice_conf->data.default_indicator = default_indicator;
 
         OGS_YAML_ARRAY_RECURSE(&slice_array, &slice_iter);
         while (ogs_yaml_iter_next(&slice_iter)) {

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -133,10 +133,6 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
         }
     }
 
-    if (!sess->s_nssai.sst) {
-        ogs_error("No SST");
-        goto end;
-    }
     if (PcfIpEndPointList->count)
         PcfBinding.pcf_ip_end_points = PcfIpEndPointList;
     else

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -299,13 +299,6 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
         goto cleanup;
     }
 
-    if (!sliceInfo->sst) {
-        strerror = ogs_msprintf("[%s:%d] No sliceInfo->sst",
-                pcf_ue->supi, sess->psi);
-        status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-        goto cleanup;
-    }
-
     servingNetwork = SmPolicyContextData->serving_network;
     if (servingNetwork) {
         if (!servingNetwork->mcc) {

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -379,6 +379,7 @@ typedef struct smf_sess_s {
     /* S_NSSAI */
     ogs_s_nssai_t s_nssai;
     ogs_s_nssai_t mapped_hplmn;
+    bool mapped_hplmn_presence;
 
     /* PDN Configuration */
     ogs_session_t session;

--- a/src/smf/gsm-build.c
+++ b/src/smf/gsm-build.c
@@ -186,7 +186,8 @@ ogs_pkbuf_t *gsm_build_pdu_session_establishment_accept(smf_sess_t *sess)
     /* S-NSSAI */
     pdu_session_establishment_accept->presencemask |=
         OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_ACCEPT_S_NSSAI_PRESENT;
-    ogs_nas_build_s_nssai2(nas_s_nssai, &sess->s_nssai, &sess->mapped_hplmn);
+    ogs_nas_build_s_nssai2(nas_s_nssai, &sess->s_nssai,
+        (sess->mapped_hplmn_presence) ? &sess->mapped_hplmn : NULL);
 
     /* QoS flow descriptions */
     memset(&qos_flow_description, 0, sizeof(qos_flow_description));

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -236,6 +236,7 @@ bool smf_nsmf_handle_create_sm_context(
     sess->s_nssai.sst = sNssai->sst;
     sess->s_nssai.sd = ogs_s_nssai_sd_from_string(sNssai->sd);
     if (SmContextCreateData->hplmn_snssai) {
+        sess->mapped_hplmn_presence = true;
         sess->mapped_hplmn.sst = SmContextCreateData->hplmn_snssai->sst;
         sess->mapped_hplmn.sd = ogs_s_nssai_sd_from_string(
                                     SmContextCreateData->hplmn_snssai->sd);

--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -558,7 +558,7 @@ bool udm_nudm_uecm_handle_smf_registration(
         return false;
     }
 
-    if (!SmfRegistration->single_nssai || !SmfRegistration->single_nssai->sst) {
+    if (!SmfRegistration->single_nssai) {
         ogs_error("[%s:%d] No singleNssai", udm_ue->supi, sess->psi);
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -808,8 +808,7 @@ bool udm_nudr_dr_handle_smf_registration(
                 return false;
             }
 
-            if (!SmfRegistration->single_nssai ||
-                    !SmfRegistration->single_nssai->sst) {
+            if (!SmfRegistration->single_nssai) {
                 ogs_error("[%s:%d] No singleNssai", udm_ue->supi, sess->psi);
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(

--- a/tests/af/npcf-build.c
+++ b/tests/af/npcf-build.c
@@ -115,11 +115,9 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
     AscReqData.ev_subsc = &evSubsc;
 
     memset(&sNssai, 0, sizeof(sNssai));
-    if (sess->s_nssai.sst) {
-        sNssai.sst = sess->s_nssai.sst;
-        sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
-        AscReqData.slice_info = &sNssai;
-    }
+    sNssai.sst = sess->s_nssai.sst;
+    sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
+    AscReqData.slice_info = &sNssai;
 
     AscReqData.spon_status = OpenAPI_sponsoring_status_SPONSOR_DISABLED;
 
@@ -709,11 +707,10 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create_video(
     AscReqData.ev_subsc = &evSubsc;
 
     memset(&sNssai, 0, sizeof(sNssai));
-    if (sess->s_nssai.sst) {
-        sNssai.sst = sess->s_nssai.sst;
-        sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
-        AscReqData.slice_info = &sNssai;
-    }
+
+    sNssai.sst = sess->s_nssai.sst;
+    sNssai.sd = ogs_s_nssai_sd_to_string(sess->s_nssai.sd);
+    AscReqData.slice_info = &sNssai;
 
     AscReqData.spon_status = OpenAPI_sponsoring_status_SPONSOR_DISABLED;
 

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -1174,6 +1174,7 @@ test_ue_t *test_ue_add_by_suci(
 
             s_nssai->sst = 0;
             s_nssai->sd.v = OGS_S_NSSAI_NO_SD_VALUE;
+            s_nssai->mapped_hplmn_sst_presence = false;
             s_nssai->mapped_hplmn_sst = 0;
             s_nssai->mapped_hplmn_sd.v = OGS_S_NSSAI_NO_SD_VALUE;
 

--- a/tests/slice/same-dnn-test.c
+++ b/tests/slice/same-dnn-test.c
@@ -427,6 +427,8 @@ static void test2_func(abts_case *tc, void *data)
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
         sd.v = OGS_S_NSSAI_NO_SD_VALUE;
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
+        mapped_hplmn_sst_presence = false;
+    test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
         mapped_hplmn_sst = 0;
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
         mapped_hplmn_sd.v = OGS_S_NSSAI_NO_SD_VALUE;
@@ -436,6 +438,8 @@ static void test2_func(abts_case *tc, void *data)
         sst = 3;
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
         sd.v = 0x000080;
+    test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
+        mapped_hplmn_sst_presence = false;
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].
         mapped_hplmn_sst = 0;
     test_ue->requested_nssai.s_nssai[test_ue->requested_nssai.num_of_s_nssai].


### PR DESCRIPTION
3GPP TS 23.003: 28.4.2 Format of the S-NSSAI

The SST field may have standardized and non-standardized values. Values
0 to 127 belong to the standardized SST range and they are defined in
3GPP TS 23.501 [119]. Values 128 to 255 belong to the Operator-specific
range.
