### PR TITLE
[SMF] Update QoS parameters even when only PFs needs to be added to QoS flow

### DIFF
--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -599,19 +599,19 @@ void smf_qos_flow_binding(smf_sess_t *sess)
             } else {
                 ogs_assert(strcmp(qos_flow->pcc_rule.id, pcc_rule->id) == 0);
 
-                if ((pcc_rule->qos.mbr.downlink &&
-                    qos_flow->qos.mbr.downlink != pcc_rule->qos.mbr.downlink) ||
-                    (pcc_rule->qos.mbr.uplink &&
-                     qos_flow->qos.mbr.uplink != pcc_rule->qos.mbr.uplink) ||
-                    (pcc_rule->qos.gbr.downlink &&
-                    qos_flow->qos.gbr.downlink != pcc_rule->qos.gbr.downlink) ||
-                    (pcc_rule->qos.gbr.uplink &&
-                    qos_flow->qos.gbr.uplink != pcc_rule->qos.gbr.uplink)) {
-                    /* Update QoS parameter */
-                    memcpy(&qos_flow->qos, &pcc_rule->qos, sizeof(ogs_qos_t));
+                if (pcc_rule->qos.mbr.downlink || pcc_rule->qos.mbr.uplink ||
+                    pcc_rule->qos.gbr.downlink || pcc_rule->qos.gbr.uplink) {
 
-                    /* Update Bearer Request encodes updated QoS parameter */
-                    qos_presence = true;
+                    if ((ogs_list_count(&qos_flow->pf_to_add_list) > 0) ||
+                        (qos_flow->qos.mbr.downlink != pcc_rule->qos.mbr.downlink) ||
+                        (qos_flow->qos.mbr.uplink != pcc_rule->qos.mbr.uplink) ||
+                        (qos_flow->qos.gbr.downlink != pcc_rule->qos.gbr.downlink) ||
+                        (qos_flow->qos.gbr.uplink != pcc_rule->qos.gbr.uplink)) {
+                        /* Update QoS parameter */
+                        memcpy(&qos_flow->qos, &pcc_rule->qos, sizeof(ogs_qos_t));
+                        /* Update Bearer Request encodes updated QoS parameter */
+                        qos_presence = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
TS 38.413 version 16.2.0, clause 8.2.3.4, states below

"If the NG-RAN node receives a PDU SESSION RESOURCE MODIFY REQUEST message containing a QoS Flow
Level QoS Parameters IE in the PDU Session Resource Modify Request Transfer IE for a GBR QoS flow but the GBR
QoS Flow Information IE is not present, the NG-RAN node shall report the addition or modification of the
corresponding QoS flow as failed in the PDU Session Resource Modify Response Transfer IE of the PDU SESSION
RESOURCE MODIFY RESPONSE message with an appropriate cause value."

This PR facilitates adding of GBR QoS Flow Information IE in PDU SESSION RESOURCE MODIFY REQUEST for GBR QoS flows
