### PR TITLE
Refactor PFCP Address Handling and Enable Multi-Address Server Binding (#3431)

### DIFF
--- a/lib/core/ogs-sockaddr.c
+++ b/lib/core/ogs-sockaddr.c
@@ -667,9 +667,9 @@ char *ogs_ipstrdup(ogs_sockaddr_t *addr)
     return ogs_strdup(buf);
 }
 
-char *ogs_sockaddr_strdup(ogs_sockaddr_t *sa_list)
+char *ogs_sockaddr_to_string_static(ogs_sockaddr_t *sa_list)
 {
-    char dumpstr[OGS_HUGE_LEN];
+    static char dumpstr[OGS_HUGE_LEN];
     char *p, *last;
     ogs_sockaddr_t *addr = NULL;
 
@@ -688,7 +688,7 @@ char *ogs_sockaddr_strdup(ogs_sockaddr_t *sa_list)
         /* If there is more than one addr, remove the last character */
         *(p-1) = 0;
 
-        return ogs_strdup(dumpstr);
+        return dumpstr;
     }
 
     /* No address */

--- a/lib/core/ogs-sockaddr.c
+++ b/lib/core/ogs-sockaddr.c
@@ -55,6 +55,10 @@
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __ogs_sock_domain
 
+static bool ogs_sockaddr_compare(const ogs_sockaddr_t *a,
+                                 const ogs_sockaddr_t *b,
+                                 bool compare_port);
+
 /* If you want to use getnameinfo,
  * you need to consider DNS query delay (about 10 seconds) */
 #if 0
@@ -264,6 +268,60 @@ int ogs_sortaddrinfo(ogs_sockaddr_t **sa_list, int family)
     return OGS_OK;
 }
 
+/*--------------------------------------------------------------------------
+ * Merge a single node if not already in "dest" list
+ *--------------------------------------------------------------------------
+ */
+void ogs_merge_single_addrinfo(
+        ogs_sockaddr_t **dest, const ogs_sockaddr_t *item)
+{
+    ogs_sockaddr_t *p;
+    ogs_sockaddr_t *new_sa;
+
+    ogs_assert(dest);
+    ogs_assert(item);
+
+    p = *dest;
+
+    while (p) {
+        if (ogs_sockaddr_is_equal(p, item)) {
+            /* Already exists */
+            return;
+        }
+        p = p->next;
+    }
+    new_sa = (ogs_sockaddr_t *)ogs_malloc(sizeof(*new_sa));
+    ogs_assert(new_sa);
+    memcpy(new_sa, item, sizeof(*new_sa));
+    if (item->hostname) {
+        new_sa->hostname = ogs_strdup(item->hostname);
+        ogs_assert(new_sa->hostname);
+    }
+    new_sa->next = NULL;
+    if (!(*dest)) {
+        *dest = new_sa;
+    } else {
+        p = *dest;
+        while (p->next)
+            p = p->next;
+        p->next = new_sa;
+    }
+}
+
+/*--------------------------------------------------------------------------
+ * Merge an entire src list into dest
+ *--------------------------------------------------------------------------
+ */
+void ogs_merge_addrinfo(ogs_sockaddr_t **dest, const ogs_sockaddr_t *src)
+{
+    const ogs_sockaddr_t *cur;
+    cur = src;
+    while (cur) {
+        ogs_merge_single_addrinfo(dest, cur);
+        cur = cur->next;
+    }
+}
+
 ogs_sockaddr_t *ogs_link_local_addr(const char *dev, const ogs_sockaddr_t *sa)
 {
 #if defined(HAVE_GETIFADDRS)
@@ -419,13 +477,16 @@ socklen_t ogs_sockaddr_len(const void *sa)
     }
 }
 
-bool ogs_sockaddr_is_equal(const void *p, const void *q)
+/*
+ * Helper function to compare two addresses.
+ * If compare_port is true, compare both port and address.
+ * Otherwise, compare address only.
+ */
+static bool ogs_sockaddr_compare(const ogs_sockaddr_t *a,
+                                 const ogs_sockaddr_t *b,
+                                 bool compare_port)
 {
-    const ogs_sockaddr_t *a, *b;
-
-    a = p;
     ogs_assert(a);
-    b = q;
     ogs_assert(b);
 
     if (a->ogs_sa_family != b->ogs_sa_family)
@@ -433,21 +494,40 @@ bool ogs_sockaddr_is_equal(const void *p, const void *q)
 
     switch (a->ogs_sa_family) {
     case AF_INET:
-        if (a->sin.sin_port != b->sin.sin_port)
+        if (compare_port && (a->sin.sin_port != b->sin.sin_port))
             return false;
-        if (memcmp(&a->sin.sin_addr, &b->sin.sin_addr, sizeof(struct in_addr)) != 0)
+        if (memcmp(&a->sin.sin_addr, &b->sin.sin_addr,
+                   sizeof(struct in_addr)) != 0)
             return false;
         return true;
     case AF_INET6:
-        if (a->sin6.sin6_port != b->sin6.sin6_port)
+        if (compare_port && (a->sin6.sin6_port != b->sin6.sin6_port))
             return false;
-        if (memcmp(&a->sin6.sin6_addr, &b->sin6.sin6_addr, sizeof(struct in6_addr)) != 0)
+        if (memcmp(&a->sin6.sin6_addr, &b->sin6.sin6_addr,
+                   sizeof(struct in6_addr)) != 0)
             return false;
         return true;
     default:
-        ogs_error("Unexpected address faimily %u", a->ogs_sa_family);
+        ogs_error("Unexpected address family %u", a->ogs_sa_family);
         ogs_abort();
+        return false; /* Defensive return */
     }
+}
+
+/* Compare addresses including port */
+bool ogs_sockaddr_is_equal(const void *p, const void *q)
+{
+    const ogs_sockaddr_t *a = (const ogs_sockaddr_t *)p;
+    const ogs_sockaddr_t *b = (const ogs_sockaddr_t *)q;
+    return ogs_sockaddr_compare(a, b, true);
+}
+
+/* Compare addresses without considering port */
+bool ogs_sockaddr_is_equal_addr(const void *p, const void *q)
+{
+    const ogs_sockaddr_t *a = (const ogs_sockaddr_t *)p;
+    const ogs_sockaddr_t *b = (const ogs_sockaddr_t *)q;
+    return ogs_sockaddr_compare(a, b, false);
 }
 
 static int parse_network(ogs_ipsubnet_t *ipsub, const char *network)
@@ -669,7 +749,7 @@ char *ogs_ipstrdup(ogs_sockaddr_t *addr)
 
 char *ogs_sockaddr_to_string_static(ogs_sockaddr_t *sa_list)
 {
-    static char dumpstr[OGS_HUGE_LEN];
+    static char dumpstr[OGS_HUGE_LEN] = { 0, };
     char *p, *last;
     ogs_sockaddr_t *addr = NULL;
 

--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -125,7 +125,7 @@ int ogs_ipsubnet(ogs_ipsubnet_t *ipsub,
 
 char *ogs_gethostname(ogs_sockaddr_t *addr);
 char *ogs_ipstrdup(ogs_sockaddr_t *addr);
-char *ogs_sockaddr_strdup(ogs_sockaddr_t *sa_list);
+char *ogs_sockaddr_to_string_static(ogs_sockaddr_t *sa_list);
 
 #ifdef __cplusplus
 }

--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -67,20 +67,8 @@ struct ogs_sockaddr_s {
      * If there is a name in the configuration file,
      * it is set in the 'hostname' of ogs_sockaddr_t.
      * Then, it immediately call getaddrinfo() to fill addr in ogs_sockaddr_t.
-     *
-     * When it was always possible to convert DNS to addr, that was no problem.
-     * However, in some environments, such as Roaming, there are situations
-     * where it is difficult to always change the DNS to addr.
-     *
-     * So, 'fqdn' was created for the purpose of first use in ogs_sbi_client_t.
-     * 'fqdn' always do not change with addr.
-     * This value is used as it is in the actual client connection.
-     *
-     * Note that 'hostname' is still in use for server or other client
-     * except for ogs_sbi_client_t.
      */
     char *hostname;
-    char *fqdn;
 
     ogs_sockaddr_t *next;
 };
@@ -103,6 +91,10 @@ int ogs_copyaddrinfo(
 int ogs_filteraddrinfo(ogs_sockaddr_t **sa_list, int family);
 int ogs_sortaddrinfo(ogs_sockaddr_t **sa_list, int family);
 
+void ogs_merge_single_addrinfo(
+        ogs_sockaddr_t **dest, const ogs_sockaddr_t *item);
+void ogs_merge_addrinfo(ogs_sockaddr_t **dest, const ogs_sockaddr_t *src);
+
 ogs_sockaddr_t *ogs_link_local_addr(const char *dev, const ogs_sockaddr_t *sa);
 ogs_sockaddr_t *ogs_link_local_addr_by_dev(const char *dev);
 ogs_sockaddr_t *ogs_link_local_addr_by_sa(const ogs_sockaddr_t *sa);
@@ -119,6 +111,7 @@ int ogs_inet_pton(int family, const char *src, void *sa);
 
 socklen_t ogs_sockaddr_len(const void *sa);
 bool ogs_sockaddr_is_equal(const void *p, const void *q);
+bool ogs_sockaddr_is_equal_addr(const void *p, const void *q);
 
 int ogs_ipsubnet(ogs_ipsubnet_t *ipsub,
         const char *ipstr, const char *mask_or_numbits);

--- a/lib/gtp/context.c
+++ b/lib/gtp/context.c
@@ -200,6 +200,7 @@ int ogs_gtp_context_parse_config(const char *local, const char *remote)
                                                 server_key);
                                 }
 
+                                /* Add address information */
                                 addr = NULL;
                                 for (i = 0; i < num; i++) {
                                     rv = ogs_addaddrinfo(&addr,
@@ -207,17 +208,30 @@ int ogs_gtp_context_parse_config(const char *local, const char *remote)
                                     ogs_assert(rv == OGS_OK);
                                 }
 
+                                /* Add each address as a separate socknode */
                                 if (addr) {
-                                    if (ogs_global_conf()->parameter.
-                                            no_ipv4 == 0)
-                                        ogs_socknode_add(
-                                            &self.gtpc_list, AF_INET, addr,
-                                            is_option ? &option : NULL);
-                                    if (ogs_global_conf()->parameter.
-                                            no_ipv6 == 0)
-                                        ogs_socknode_add(
-                                            &self.gtpc_list6, AF_INET6, addr,
-                                            is_option ? &option : NULL);
+                                    ogs_sockaddr_t *current = addr;
+                                    while (current) {
+                                        if (current->ogs_sa_family ==
+                                                AF_INET &&
+                                            ogs_global_conf()->
+                                                parameter.no_ipv4 == 0) {
+                                            ogs_socknode_add(&self.gtpc_list,
+                                                             AF_INET, current,
+                                                             is_option ?
+                                                             &option : NULL);
+                                        }
+                                        if (current->ogs_sa_family ==
+                                                AF_INET6 &&
+                                            ogs_global_conf()->
+                                                parameter.no_ipv6 == 0) {
+                                            ogs_socknode_add(&self.gtpc_list6,
+                                                             AF_INET6, current,
+                                                             is_option ?
+                                                             &option : NULL);
+                                        }
+                                        current = current->next;
+                                    }
                                     ogs_freeaddrinfo(addr);
                                 }
 
@@ -417,16 +431,28 @@ int ogs_gtp_context_parse_config(const char *local, const char *remote)
                                 ogs_list_init(&list6);
 
                                 if (addr) {
-                                    if (ogs_global_conf()->parameter.
-                                            no_ipv4 == 0)
-                                        ogs_socknode_add(
-                                            &list, AF_INET, addr,
-                                            is_option ? &option : NULL);
-                                    if (ogs_global_conf()->parameter.
-                                            no_ipv6 == 0)
-                                        ogs_socknode_add(
-                                            &list6, AF_INET6, addr,
-                                            is_option ? &option : NULL);
+                                    ogs_sockaddr_t *current = addr;
+                                    while (current) {
+                                        if (current->ogs_sa_family ==
+                                                AF_INET &&
+                                            ogs_global_conf()->
+                                                parameter.no_ipv4 == 0) {
+                                            ogs_socknode_add(&list,
+                                                             AF_INET, current,
+                                                             is_option ?
+                                                             &option : NULL);
+                                        }
+                                        if (current->ogs_sa_family ==
+                                                AF_INET6 &&
+                                            ogs_global_conf()->
+                                                parameter.no_ipv6 == 0) {
+                                            ogs_socknode_add(&list6,
+                                                             AF_INET6, current,
+                                                             is_option ?
+                                                             &option : NULL);
+                                        }
+                                        current = current->next;
+                                    }
                                     ogs_freeaddrinfo(addr);
                                 }
 

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -84,10 +84,17 @@ typedef struct ogs_pfcp_context_s {
 typedef struct ogs_pfcp_node_s {
     ogs_lnode_t     lnode;          /* A node of list_t */
 
-    ogs_sockaddr_t  *sa_list;       /* Socket Address List Candidate */
+    ogs_sockaddr_t    *config_addr; /* Configured addresses */
+    ogs_pfcp_node_id_t node_id;     /* PFCP node ID */
 
-    ogs_sock_t      *sock;          /* Socket Instance */
-    ogs_sockaddr_t  addr;           /* Remote Address */
+    /* List of addresses:: final merged address list */
+    ogs_sockaddr_t    *addr_list;
+
+     /*
+     * Iterator for round-robin sendto operations.
+     * Points to the current address in the round-robin sequence.
+     */
+    ogs_sockaddr_t *current_addr;
 
     ogs_list_t      local_list;
     ogs_list_t      remote_list;
@@ -399,15 +406,19 @@ void ogs_pfcp_context_final(void);
 ogs_pfcp_context_t *ogs_pfcp_self(void);
 int ogs_pfcp_context_parse_config(const char *local, const char *remote);
 
-ogs_pfcp_node_t *ogs_pfcp_node_new(ogs_sockaddr_t *sa_list);
+ogs_pfcp_node_t *ogs_pfcp_node_new(ogs_sockaddr_t *config_addr);
 void ogs_pfcp_node_free(ogs_pfcp_node_t *node);
 
-ogs_pfcp_node_t *ogs_pfcp_node_add(
-        ogs_list_t *list, ogs_sockaddr_t *addr);
-ogs_pfcp_node_t *ogs_pfcp_node_find(
-        ogs_list_t *list, ogs_sockaddr_t *addr);
+ogs_pfcp_node_t *ogs_pfcp_node_add(ogs_list_t *list,
+    ogs_pfcp_node_id_t *node_id, ogs_sockaddr_t *from);
+ogs_pfcp_node_t *ogs_pfcp_node_find(ogs_list_t *list,
+    ogs_pfcp_node_id_t *node_id, ogs_sockaddr_t *from);
+int ogs_pfcp_node_merge(ogs_pfcp_node_t *node,
+    ogs_pfcp_node_id_t *node_id, ogs_sockaddr_t *from);
 void ogs_pfcp_node_remove(ogs_list_t *list, ogs_pfcp_node_t *node);
 void ogs_pfcp_node_remove_all(ogs_list_t *list);
+int ogs_pfcp_node_id_compare(
+        const ogs_pfcp_node_id_t *id1, const ogs_pfcp_node_id_t *id2);
 
 ogs_gtpu_resource_t *ogs_pfcp_find_gtpu_resource(ogs_list_t *list,
         char *dnn, ogs_pfcp_interface_t source_interface);

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -130,14 +130,9 @@ bool ogs_pfcp_cp_handle_association_setup_request(
         }
     }
 
-    if (node->up_function_features.ftup == 0) {
-        char buf[OGS_ADDRSTRLEN];
-        ogs_sockaddr_t *addr = node->sa_list;
-        ogs_assert(addr);
-
-        ogs_warn("F-TEID allocation/release not supported with peer [%s]:%d",
-                OGS_ADDR(addr, buf), OGS_PORT(addr));
-    }
+    if (node->up_function_features.ftup == 0)
+        ogs_warn("F-TEID allocation/release not supported with peer %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
 
     return true;
 }
@@ -182,14 +177,9 @@ bool ogs_pfcp_cp_handle_association_setup_response(
         }
     }
 
-    if (node->up_function_features.ftup == 0) {
-        char buf[OGS_ADDRSTRLEN];
-        ogs_sockaddr_t *addr = node->sa_list;
-        ogs_assert(addr);
-
-        ogs_warn("F-TEID allocation/release not supported with peer [%s]:%d",
-                OGS_ADDR(addr, buf), OGS_PORT(addr));
-    }
+    if (node->up_function_features.ftup == 0)
+        ogs_warn("F-TEID allocation/release not supported with peer %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
 
     return true;
 }

--- a/lib/pfcp/meson.build
+++ b/lib/pfcp/meson.build
@@ -45,6 +45,7 @@ libpfcp_sources = files('''
     xact.h
     context.h
     rule-match.h
+    util.h
 
     message.c
     types.c
@@ -55,6 +56,7 @@ libpfcp_sources = files('''
     xact.c
     context.c
     rule-match.c
+    util.c
 '''.split())
 
 libpfcp_inc = include_directories('.')

--- a/lib/pfcp/ogs-pfcp.h
+++ b/lib/pfcp/ogs-pfcp.h
@@ -43,6 +43,7 @@
 #include "pfcp/path.h"
 #include "pfcp/xact.h"
 #include "pfcp/handler.h"
+#include "pfcp/util.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/pfcp/path.h
+++ b/lib/pfcp/path.h
@@ -56,10 +56,6 @@ extern "C" {
 typedef struct ogs_pfcp_xact_s ogs_pfcp_xact_t;
 
 ogs_sock_t *ogs_pfcp_server(ogs_socknode_t *node);
-int ogs_pfcp_connect(
-    ogs_sock_t *ipv4, ogs_sock_t *ipv6, ogs_pfcp_node_t *node);
-
-int ogs_pfcp_send(ogs_pfcp_node_t *node, ogs_pkbuf_t *pkbuf);
 int ogs_pfcp_sendto(ogs_pfcp_node_t *node, ogs_pkbuf_t *pkbuf);
 
 ogs_pkbuf_t *ogs_pfcp_handle_echo_req(ogs_pkbuf_t *pkt);

--- a/lib/pfcp/util.c
+++ b/lib/pfcp/util.c
@@ -19,116 +19,180 @@
 
 #include "ogs-pfcp.h"
 
-/**
- * Extracts the `node_id` from a PFCP message.
- *
- * @param node_id Pointer to store the extracted node_id.
- * @param msg Pointer to the parsed PFCP message.
- * @return ogs_pfcp_status_e Status of the operation.
+/*
+ * Requirements of Node ID:
+ * NONE      : Node ID must not be present
+ * OPTIONAL  : Node ID may or may not be present
+ * MANDATORY : Node ID must be present
  */
-ogs_pfcp_status_e ogs_pfcp_get_node_id(
-        ogs_pfcp_node_id_t *node_id, ogs_pfcp_message_t *message)
+#define OGS_PFCP_NODE_ID_NONE      0
+#define OGS_PFCP_NODE_ID_OPTIONAL  1
+#define OGS_PFCP_NODE_ID_MANDATORY 2
+
+/*
+ * This function extracts the PFCP Node ID from the given PFCP message.
+ * It determines the Node ID field location and requirement based on
+ * the message type. Then it validates presence and copies data into
+ * 'node_id'. If Node ID is not consistent with the requirement, an
+ * error status is returned.
+ */
+ogs_pfcp_status_e
+ogs_pfcp_extract_node_id(ogs_pfcp_message_t *message,
+                         ogs_pfcp_node_id_t *node_id)
 {
+
+    /* For C89 compliance, all variables are declared upfront. */
     ogs_pfcp_tlv_node_id_t *tlv_node_id = NULL;
+    int requirement = OGS_PFCP_NODE_ID_NONE;
+    ogs_pfcp_status_e status = OGS_PFCP_STATUS_SUCCESS;
 
-    ogs_assert(node_id);
+    /* Validate input pointers */
     ogs_assert(message);
+    ogs_assert(node_id);
 
+    /* Initialize the output structure */
+    memset(node_id, 0, sizeof(*node_id));
+
+    /* Determine the location of node_id TLV and requirement */
     switch (message->h.type) {
-        /* Message Types with node_id */
-        case OGS_PFCP_PFD_MANAGEMENT_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_pfd_management_request.node_id;
-            break;
+    case OGS_PFCP_PFD_MANAGEMENT_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_pfd_management_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_OPTIONAL;
+        break;
 
-        case OGS_PFCP_PFD_MANAGEMENT_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_pfd_management_response.node_id;
-            break;
+    case OGS_PFCP_PFD_MANAGEMENT_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_pfd_management_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_OPTIONAL;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_association_setup_request.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_association_setup_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_association_setup_response.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_association_setup_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_UPDATE_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_association_update_request.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_UPDATE_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_association_update_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_UPDATE_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_association_update_response.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_UPDATE_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_association_update_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_RELEASE_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_association_release_request.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_RELEASE_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_association_release_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_ASSOCIATION_RELEASE_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_association_release_response.node_id;
-            break;
+    case OGS_PFCP_ASSOCIATION_RELEASE_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_association_release_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_NODE_REPORT_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_node_report_request.node_id;
-            break;
+    case OGS_PFCP_NODE_REPORT_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_node_report_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_NODE_REPORT_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_node_report_response.node_id;
-            break;
+    case OGS_PFCP_NODE_REPORT_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_node_report_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_SET_DELETION_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_session_set_deletion_request.node_id;
-            break;
+    case OGS_PFCP_SESSION_SET_DELETION_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_session_set_deletion_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_SET_DELETION_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_session_set_deletion_response.node_id;
-            break;
+    case OGS_PFCP_SESSION_SET_DELETION_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_session_set_deletion_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_SET_MODIFICATION_REQUEST_TYPE:
-            tlv_node_id =
-                &message->pfcp_session_set_modification_request.node_id;
-            break;
+    case OGS_PFCP_SESSION_SET_MODIFICATION_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_session_set_modification_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_SET_MODIFICATION_RESPONSE_TYPE:
-            tlv_node_id =
-                &message->pfcp_session_set_modification_response.node_id;
-            break;
+    case OGS_PFCP_SESSION_SET_MODIFICATION_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_session_set_modification_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_session_establishment_request.node_id;
-            break;
+    case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_session_establishment_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
-            tlv_node_id = &message->pfcp_session_establishment_response.node_id;
-            break;
+    case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
+        tlv_node_id = &message->pfcp_session_establishment_response.node_id;
+        requirement = OGS_PFCP_NODE_ID_MANDATORY;
+        break;
 
-        case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
-            tlv_node_id = &message->pfcp_session_modification_request.node_id;
-            break;
+    case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
+        tlv_node_id = &message->pfcp_session_modification_request.node_id;
+        requirement = OGS_PFCP_NODE_ID_OPTIONAL;
+        break;
 
-        /* Add other message types with node_id here as needed */
+    /* Add other message types with node_id here as needed */
 
-        /* Message Types without node_id */
-        case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:
-        case OGS_PFCP_HEARTBEAT_RESPONSE_TYPE:
-        case OGS_PFCP_VERSION_NOT_SUPPORTED_RESPONSE_TYPE:
-        case OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE:
-        case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
-        case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
-        case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
-        case OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE:
-            break;
+    case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:
+    case OGS_PFCP_HEARTBEAT_RESPONSE_TYPE:
+    case OGS_PFCP_VERSION_NOT_SUPPORTED_RESPONSE_TYPE:
+    case OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE:
+    case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
+    case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
+    case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
+    case OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE:
+        /* Node ID must not be present for these messages */
+        requirement = OGS_PFCP_NODE_ID_NONE;
+        break;
 
-        default:
-            ogs_error("Unknown message type %d", message->h.type);
-            return OGS_PFCP_ERROR_UNKNOWN_MESSAGE;
+    default:
+        /* Unknown message type */
+        ogs_error("Unknown message type %d", message->h.type);
+        return OGS_PFCP_ERROR_UNKNOWN_MESSAGE;
     }
 
-    if (!tlv_node_id)
-        return OGS_PFCP_ERROR_NODE_ID_NOT_FOUND;
+    /* Check requirement vs. tlv_node_id existence */
+    switch (requirement) {
+    case OGS_PFCP_NODE_ID_MANDATORY:
+        /* Must have tlv_node_id. presence must be 1. */
+        ogs_assert(tlv_node_id);
+        if (!tlv_node_id->presence) {
+            status = OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT;
+            goto done;
+        }
+        break;
 
-    if (!tlv_node_id->presence)
-        return OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT;
+    case OGS_PFCP_NODE_ID_OPTIONAL:
+        /*
+         * Must have tlv_node_id. presence=1 => real Node ID
+         * presence=0 => no Node ID
+         */
+        ogs_assert(tlv_node_id);
+        if (!tlv_node_id->presence) {
+            status = OGS_PFCP_STATUS_NODE_ID_OPTIONAL_ABSENT;
+            goto done;
+        }
+        break;
+
+    case OGS_PFCP_NODE_ID_NONE:
+        /* Must be NULL => no Node ID field */
+        ogs_assert(tlv_node_id == NULL);
+        status = OGS_PFCP_STATUS_NODE_ID_NONE;
+        goto done;
+
+    default:
+        status = OGS_PFCP_ERROR_UNKNOWN_MESSAGE;
+        goto done;
+    }
 
     memcpy(node_id, tlv_node_id->data, tlv_node_id->len);
 
@@ -140,5 +204,113 @@ ogs_pfcp_status_e ogs_pfcp_get_node_id(
         return OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE;
     }
 
-    return OGS_PFCP_STATUS_SUCCESS;
+     /* Node ID is valid */
+    status = OGS_PFCP_STATUS_SUCCESS;
+
+done:
+    return status;
+}
+
+ogs_sockaddr_t *ogs_pfcp_node_id_to_addrinfo(const ogs_pfcp_node_id_t *node_id)
+{
+    ogs_sockaddr_t *p;
+    int ret;
+    uint16_t port = ogs_pfcp_self()->pfcp_port;
+    char fqdn[OGS_MAX_FQDN_LEN+1];
+
+    ogs_assert(node_id);
+    switch (node_id->type) {
+
+    /*------------------------------------------------
+     * 1) IPv4
+     *-----------------------------------------------*/
+    case OGS_PFCP_NODE_ID_IPV4:
+        p = (ogs_sockaddr_t *)ogs_calloc(1, sizeof(*p));
+        if (!p) {
+            ogs_error("ogs_calloc() failed");
+            return NULL;
+        }
+        p->sa.sa_family = AF_INET;
+        p->sin.sin_port = htobe16(port);
+        p->sin.sin_addr.s_addr = node_id->addr;
+        p->next = NULL;
+        return p;
+
+    /*------------------------------------------------
+     * 2) IPv6
+     *-----------------------------------------------*/
+    case OGS_PFCP_NODE_ID_IPV6:
+        p = (ogs_sockaddr_t *)ogs_calloc(1, sizeof(*p));
+        if (!p) {
+            ogs_error("ogs_calloc() failed");
+            return NULL;
+        }
+        p->sa.sa_family = AF_INET6;
+        p->sin6.sin6_port = htobe16(port);
+        /* Copy 16 bytes of IPv6 address */
+        memcpy(&p->sin6.sin6_addr, node_id->addr6, 16);
+        p->next = NULL;
+        return OGS_OK;
+
+    /*------------------------------------------------
+     * 3) FQDN
+     *-----------------------------------------------*/
+    case OGS_PFCP_NODE_ID_FQDN:
+        /* If the FQDN is not empty, we attempt DNS resolution.
+         *  ogs_addaddrinfo() is a placeholder for your actual
+         *  DNS -> ogs_sockaddr_t function (often wraps getaddrinfo).
+         */
+        /* Port=0 or set as needed, family=AF_UNSPEC, flags=0. */
+        if (ogs_fqdn_parse(fqdn, node_id->fqdn, strlen(node_id->fqdn)) <= 0) {
+            ogs_error("ogs_fqdn_parse() error [%s]", node_id->fqdn);
+            return NULL;
+        }
+        ret = ogs_getaddrinfo(&p, AF_UNSPEC, fqdn, port, 0);
+        if (ret != 0) {
+            /* DNS resolution failed => *out remains NULL */
+            ogs_error("ogs_addaddrinfo() failed");
+            return NULL;
+        }
+        /* If FQDN is empty, just return with no addresses. */
+        return p;
+
+    /*------------------------------------------------
+     * 4) Unsupported type or default
+     *-----------------------------------------------*/
+    default:
+        /* Optionally handle an error or just return success
+         * with no addresses.
+         */
+        ogs_error("Unknown type [%d]", node_id->type);
+        return NULL;
+    }
+}
+
+/* Utility function to convert node_id to string for logging */
+const char *ogs_pfcp_node_id_to_string_static(
+        const ogs_pfcp_node_id_t *node_id)
+{
+    static char buffer[OGS_MAX_FQDN_LEN+1] = { 0, };
+
+    if (node_id) {
+        switch (node_id->type) {
+        case OGS_PFCP_NODE_ID_IPV4:
+            inet_ntop(AF_INET, &node_id->addr, buffer, sizeof(buffer));
+            break;
+        case OGS_PFCP_NODE_ID_IPV6:
+            inet_ntop(AF_INET6, node_id->addr6, buffer, sizeof(buffer));
+            break;
+        case OGS_PFCP_NODE_ID_FQDN:
+            if (ogs_fqdn_parse(buffer,
+                               node_id->fqdn,
+                               strlen(node_id->fqdn)) <= 0)
+                snprintf(buffer, sizeof(buffer), "%s", node_id->fqdn);
+            break;
+        default:
+            snprintf(buffer, sizeof(buffer), "Unknown");
+            break;
+        }
+    }
+
+    return buffer;
 }

--- a/lib/pfcp/util.c
+++ b/lib/pfcp/util.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ogs-pfcp.h"
+
+/**
+ * Extracts the `node_id` from a PFCP message.
+ *
+ * @param node_id Pointer to store the extracted node_id.
+ * @param msg Pointer to the parsed PFCP message.
+ * @return ogs_pfcp_status_e Status of the operation.
+ */
+ogs_pfcp_status_e ogs_pfcp_get_node_id(
+        ogs_pfcp_node_id_t *node_id, ogs_pfcp_message_t *message)
+{
+    ogs_pfcp_tlv_node_id_t *tlv_node_id = NULL;
+
+    ogs_assert(node_id);
+    ogs_assert(message);
+
+    switch (message->h.type) {
+        /* Message Types with node_id */
+        case OGS_PFCP_PFD_MANAGEMENT_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_pfd_management_request.node_id;
+            break;
+
+        case OGS_PFCP_PFD_MANAGEMENT_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_pfd_management_response.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_association_setup_request.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_association_setup_response.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_UPDATE_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_association_update_request.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_UPDATE_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_association_update_response.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_RELEASE_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_association_release_request.node_id;
+            break;
+
+        case OGS_PFCP_ASSOCIATION_RELEASE_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_association_release_response.node_id;
+            break;
+
+        case OGS_PFCP_NODE_REPORT_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_node_report_request.node_id;
+            break;
+
+        case OGS_PFCP_NODE_REPORT_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_node_report_response.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_SET_DELETION_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_session_set_deletion_request.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_SET_DELETION_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_session_set_deletion_response.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_SET_MODIFICATION_REQUEST_TYPE:
+            tlv_node_id =
+                &message->pfcp_session_set_modification_request.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_SET_MODIFICATION_RESPONSE_TYPE:
+            tlv_node_id =
+                &message->pfcp_session_set_modification_response.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_session_establishment_request.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
+            tlv_node_id = &message->pfcp_session_establishment_response.node_id;
+            break;
+
+        case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
+            tlv_node_id = &message->pfcp_session_modification_request.node_id;
+            break;
+
+        /* Add other message types with node_id here as needed */
+
+        /* Message Types without node_id */
+        case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:
+        case OGS_PFCP_HEARTBEAT_RESPONSE_TYPE:
+        case OGS_PFCP_VERSION_NOT_SUPPORTED_RESPONSE_TYPE:
+        case OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE:
+        case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
+        case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
+        case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
+        case OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE:
+            break;
+
+        default:
+            ogs_error("Unknown message type %d", message->h.type);
+            return OGS_PFCP_ERROR_UNKNOWN_MESSAGE;
+    }
+
+    if (!tlv_node_id)
+        return OGS_PFCP_ERROR_NODE_ID_NOT_FOUND;
+
+    if (!tlv_node_id->presence)
+        return OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT;
+
+    memcpy(node_id, tlv_node_id->data, tlv_node_id->len);
+
+    if (node_id->type != OGS_PFCP_NODE_ID_IPV4 &&
+        node_id->type != OGS_PFCP_NODE_ID_IPV6 &&
+        node_id->type != OGS_PFCP_NODE_ID_FQDN) {
+        ogs_error("Semantic incorrect message[%d] type[%d]",
+                message->h.type, node_id->type);
+        return OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE;
+    }
+
+    return OGS_PFCP_STATUS_SUCCESS;
+}

--- a/lib/pfcp/util.h
+++ b/lib/pfcp/util.h
@@ -29,26 +29,30 @@ extern "C" {
 #endif
 
 typedef enum {
-    /* Operation was successful */
+    /* Success with actual Node ID */
     OGS_PFCP_STATUS_SUCCESS = 0,
 
-    /* The message type is unknown */
-    OGS_PFCP_ERROR_UNKNOWN_MESSAGE,
+    /* Success with no Node ID (NONE type) */
+    OGS_PFCP_STATUS_NODE_ID_NONE,
 
-    /* The message is semantically incorrect */
+    /* Success with OPTIONAL node_id_tlv, but presence=0 */
+    OGS_PFCP_STATUS_NODE_ID_OPTIONAL_ABSENT,
+
+    /* Error codes */
     OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE,
-
-    /* The node ID is not present in the message */
     OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT,
-
-    /* The node ID was not found in the expected location */
     OGS_PFCP_ERROR_NODE_ID_NOT_FOUND,
+    OGS_PFCP_ERROR_UNKNOWN_MESSAGE
 
-    /* Add additional error codes as needed */
 } ogs_pfcp_status_e;
 
-ogs_pfcp_status_e ogs_pfcp_get_node_id(
-        ogs_pfcp_node_id_t *node_id, ogs_pfcp_message_t *message);
+ogs_pfcp_status_e
+ogs_pfcp_extract_node_id(ogs_pfcp_message_t *message,
+                         ogs_pfcp_node_id_t *node_id);
+
+ogs_sockaddr_t *ogs_pfcp_node_id_to_addrinfo(const ogs_pfcp_node_id_t *node_id);
+const char *ogs_pfcp_node_id_to_string_static(
+        const ogs_pfcp_node_id_t *node_id);
 
 #ifdef __cplusplus
 }

--- a/lib/pfcp/util.h
+++ b/lib/pfcp/util.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if !defined(OGS_PFCP_INSIDE) && !defined(OGS_PFCP_COMPILATION)
+#error "This header cannot be included directly."
+#endif
+
+#ifndef OGS_PFCP_UTIL_H
+#define OGS_PFCP_UTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    /* Operation was successful */
+    OGS_PFCP_STATUS_SUCCESS = 0,
+
+    /* The message type is unknown */
+    OGS_PFCP_ERROR_UNKNOWN_MESSAGE,
+
+    /* The message is semantically incorrect */
+    OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE,
+
+    /* The node ID is not present in the message */
+    OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT,
+
+    /* The node ID was not found in the expected location */
+    OGS_PFCP_ERROR_NODE_ID_NOT_FOUND,
+
+    /* Add additional error codes as needed */
+} ogs_pfcp_status_e;
+
+ogs_pfcp_status_e ogs_pfcp_get_node_id(
+        ogs_pfcp_node_id_t *node_id, ogs_pfcp_message_t *message);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OGS_PFCP_UTIL_H */

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -70,7 +70,6 @@ void ogs_pfcp_xact_final(void)
 ogs_pfcp_xact_t *ogs_pfcp_xact_local_create(ogs_pfcp_node_t *node,
         void (*cb)(ogs_pfcp_xact_t *xact, void *data), void *data)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pfcp_xact_t *xact = NULL;
 
     ogs_assert(node);
@@ -109,11 +108,10 @@ ogs_pfcp_xact_t *ogs_pfcp_xact_local_create(ogs_pfcp_node_t *node,
 
     ogs_list_init(&xact->pdr_to_create_list);
 
-    ogs_debug("[%d] %s Create  peer [%s]:%d",
+    ogs_debug("[%d] %s Create  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+            ogs_sockaddr_to_string_static(node->addr_list));
 
     return xact;
 }
@@ -121,7 +119,6 @@ ogs_pfcp_xact_t *ogs_pfcp_xact_local_create(ogs_pfcp_node_t *node,
 static ogs_pfcp_xact_t *ogs_pfcp_xact_remote_create(
         ogs_pfcp_node_t *node, uint32_t sqn)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pfcp_xact_t *xact = NULL;
 
     ogs_assert(node);
@@ -156,11 +153,10 @@ static ogs_pfcp_xact_t *ogs_pfcp_xact_remote_create(
     ogs_list_add(xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
             &xact->node->local_list : &xact->node->remote_list, xact);
 
-    ogs_debug("[%d] %s Create  peer [%s]:%d",
+    ogs_debug("[%d] %s Create  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+            ogs_sockaddr_to_string_static(node->addr_list));
 
     return xact;
 }
@@ -183,7 +179,6 @@ ogs_pfcp_xact_t *ogs_pfcp_xact_find_by_id(ogs_pool_id_t id)
 int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
         ogs_pfcp_header_t *hdesc, ogs_pkbuf_t *pkbuf)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pfcp_xact_stage_t stage;
     ogs_pfcp_header_t *h = NULL;
     int pfcp_hlen = 0;
@@ -193,12 +188,11 @@ int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
     ogs_assert(hdesc);
     ogs_assert(pkbuf);
 
-    ogs_debug("[%d] %s UPD TX-%d  peer [%s]:%d",
+    ogs_debug("[%d] %s UPD TX-%d  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             hdesc->type,
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     stage = ogs_pfcp_xact_get_stage(hdesc->type, xact->xid);
     if (xact->org == OGS_PFCP_LOCAL_ORIGINATOR) {
@@ -290,15 +284,13 @@ int ogs_pfcp_xact_update_tx(ogs_pfcp_xact_t *xact,
 
 static int ogs_pfcp_xact_update_rx(ogs_pfcp_xact_t *xact, uint8_t type)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pfcp_xact_stage_t stage;
 
-    ogs_debug("[%d] %s UPD RX-%d  peer [%s]:%d",
+    ogs_debug("[%d] %s UPD RX-%d  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             type,
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     stage = ogs_pfcp_xact_get_stage(type, xact->xid);
     if (xact->org == OGS_PFCP_LOCAL_ORIGINATOR) {
@@ -325,25 +317,23 @@ static int ogs_pfcp_xact_update_rx(ogs_pfcp_xact_t *xact, uint8_t type)
                                     pfcp.t1_holding_duration);
 
                     ogs_warn("[%d] %s Request Duplicated. Retransmit!"
-                            " for step %d type %d peer [%s]:%d",
+                            " for step %d type %d peer %s",
                             xact->xid,
                             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
                                 "LOCAL " : "REMOTE",
                             xact->step, type,
-                            OGS_ADDR(&xact->node->addr,
-                                buf),
-                            OGS_PORT(&xact->node->addr));
+                            ogs_sockaddr_to_string_static(
+                                xact->node->addr_list));
                     ogs_expect(OGS_OK == ogs_pfcp_sendto(xact->node, pkbuf));
                 } else {
                     ogs_warn("[%d] %s Request Duplicated. Discard!"
-                            " for step %d type %d peer [%s]:%d",
+                            " for step %d type %d peer %s",
                             xact->xid,
                             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
                                 "LOCAL " : "REMOTE",
                             xact->step, type,
-                            OGS_ADDR(&xact->node->addr,
-                                buf),
-                            OGS_PORT(&xact->node->addr));
+                            ogs_sockaddr_to_string_static(
+                                xact->node->addr_list));
                 }
 
                 return OGS_RETRY;
@@ -391,25 +381,23 @@ static int ogs_pfcp_xact_update_rx(ogs_pfcp_xact_t *xact, uint8_t type)
                                     pfcp.t1_holding_duration);
 
                     ogs_warn("[%d] %s Request Duplicated. Retransmit!"
-                            " for step %d type %d peer [%s]:%d",
+                            " for step %d type %d peer %s",
                             xact->xid,
                             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
                                 "LOCAL " : "REMOTE",
                             xact->step, type,
-                            OGS_ADDR(&xact->node->addr,
-                                buf),
-                            OGS_PORT(&xact->node->addr));
+                            ogs_sockaddr_to_string_static(
+                                xact->node->addr_list));
                     ogs_expect(OGS_OK == ogs_pfcp_sendto(xact->node, pkbuf));
                 } else {
                     ogs_warn("[%d] %s Request Duplicated. Discard!"
-                            " for step %d type %d peer [%s]:%d",
+                            " for step %d type %d peer %s",
                             xact->xid,
                             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ?
                                 "LOCAL " : "REMOTE",
                             xact->step, type,
-                            OGS_ADDR(&xact->node->addr,
-                                buf),
-                            OGS_PORT(&xact->node->addr));
+                            ogs_sockaddr_to_string_static(
+                                xact->node->addr_list));
                 }
 
                 return OGS_RETRY;
@@ -462,8 +450,6 @@ static int ogs_pfcp_xact_update_rx(ogs_pfcp_xact_t *xact, uint8_t type)
 
 int ogs_pfcp_xact_commit(ogs_pfcp_xact_t *xact)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     uint8_t type;
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_pfcp_xact_stage_t stage;
@@ -471,11 +457,10 @@ int ogs_pfcp_xact_commit(ogs_pfcp_xact_t *xact)
     ogs_assert(xact);
     ogs_assert(xact->node);
 
-    ogs_debug("[%d] %s Commit  peer [%s]:%d",
+    ogs_debug("[%d] %s Commit  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     type = xact->seq[xact->step-1].type;
     stage = ogs_pfcp_xact_get_stage(type, xact->xid);
@@ -581,7 +566,6 @@ void ogs_pfcp_xact_delayed_commit(ogs_pfcp_xact_t *xact, ogs_time_t duration)
 
 static void response_timeout(void *data)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pool_id_t xact_id = OGS_INVALID_POOL_ID;
     ogs_pfcp_xact_t *xact = NULL;
 
@@ -597,12 +581,11 @@ static void response_timeout(void *data)
     ogs_assert(xact->node);
 
     ogs_debug("[%d] %s Response Timeout "
-            "for step %d type %d peer [%s]:%d",
+            "for step %d type %d peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             xact->step, xact->seq[xact->step-1].type,
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     if (--xact->response_rcount > 0) {
         ogs_pkbuf_t *pkbuf = NULL;
@@ -617,12 +600,11 @@ static void response_timeout(void *data)
         ogs_expect(OGS_OK == ogs_pfcp_sendto(xact->node, pkbuf));
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "
-                "for step %d type %d peer [%s]:%d",
+                "for step %d type %d peer %s",
                 xact->xid,
                 xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
                 xact->step, xact->seq[xact->step-1].type,
-                OGS_ADDR(&xact->node->addr, buf),
-                OGS_PORT(&xact->node->addr));
+                ogs_sockaddr_to_string_static(xact->node->addr_list));
 
         if (xact->cb)
             xact->cb(xact, xact->data);
@@ -633,7 +615,6 @@ static void response_timeout(void *data)
 
 static void holding_timeout(void *data)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pool_id_t xact_id = OGS_INVALID_POOL_ID;
     ogs_pfcp_xact_t *xact = NULL;
 
@@ -649,12 +630,11 @@ static void holding_timeout(void *data)
     ogs_assert(xact->node);
 
     ogs_debug("[%d] %s Holding Timeout "
-            "for step %d type %d peer [%s]:%d",
+            "for step %d type %d peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             xact->step, xact->seq[xact->step-1].type,
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     if (--xact->holding_rcount > 0) {
         if (xact->tm_holding)
@@ -662,19 +642,17 @@ static void holding_timeout(void *data)
                     ogs_local_conf()->time.message.pfcp.t1_holding_duration);
     } else {
         ogs_debug("[%d] %s Delete Transaction "
-                "for step %d type %d peer [%s]:%d",
+                "for step %d type %d peer %s",
                 xact->xid,
                 xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
                 xact->step, xact->seq[xact->step-1].type,
-                OGS_ADDR(&xact->node->addr, buf),
-                OGS_PORT(&xact->node->addr));
+                ogs_sockaddr_to_string_static(xact->node->addr_list));
         ogs_pfcp_xact_delete(xact);
     }
 }
 
 static void delayed_commit_timeout(void *data)
 {
-    char buf[OGS_ADDRSTRLEN];
     ogs_pool_id_t xact_id = OGS_INVALID_POOL_ID;
     ogs_pfcp_xact_t *xact = NULL;
 
@@ -690,12 +668,11 @@ static void delayed_commit_timeout(void *data)
     ogs_assert(xact->node);
 
     ogs_debug("[%d] %s Delayed Send Timeout "
-            "for step %d type %d peer [%s]:%d",
+            "for step %d type %d peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
             xact->step, xact->seq[xact->step-1].type,
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     ogs_pfcp_xact_commit(xact);
 }
@@ -704,7 +681,6 @@ int ogs_pfcp_xact_receive(
         ogs_pfcp_node_t *node, ogs_pfcp_header_t *h, ogs_pfcp_xact_t **xact)
 {
     int rv;
-    char buf[OGS_ADDRSTRLEN];
 
     uint8_t type;
     uint32_t sqn, xid;
@@ -731,35 +707,33 @@ int ogs_pfcp_xact_receive(
         list = &node->local_list;
         break;
     default:
-        ogs_error("[%d] Unexpected type %u from PFCP peer [%s]:%d",
-                xid, type, OGS_ADDR(&node->addr, buf), OGS_PORT(&node->addr));
+        ogs_error("[%d] Unexpected type %u from PFCP peer %s",
+                xid, type, ogs_sockaddr_to_string_static(node->addr_list));
         return OGS_ERROR;
     }
 
     ogs_assert(list);
     ogs_list_for_each(list, new) {
         if (new->xid == xid) {
-            ogs_debug("[%d] %s Find    peer [%s]:%d",
+            ogs_debug("[%d] %s Find    peer %s",
                 new->xid,
                 new->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-                OGS_ADDR(&node->addr, buf),
-                OGS_PORT(&node->addr));
+                ogs_sockaddr_to_string_static(node->addr_list));
             break;
         }
     }
 
     if (!new) {
-        ogs_debug("[%d] Cannot find new type %u from PFCP peer [%s]:%d",
-                  xid, type, OGS_ADDR(&node->addr, buf), OGS_PORT(&node->addr));
+        ogs_debug("[%d] Cannot find new type %u from PFCP peer %s",
+                xid, type, ogs_sockaddr_to_string_static(node->addr_list));
         new = ogs_pfcp_xact_remote_create(node, sqn);
     }
     ogs_assert(new);
 
-    ogs_debug("[%d] %s Receive peer [%s]:%d",
+    ogs_debug("[%d] %s Receive peer %s",
             new->xid,
             new->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+            ogs_sockaddr_to_string_static(node->addr_list));
 
     rv = ogs_pfcp_xact_update_rx(new, type);
     if (rv == OGS_ERROR) {
@@ -811,16 +785,13 @@ static ogs_pfcp_xact_stage_t ogs_pfcp_xact_get_stage(uint8_t type, uint32_t xid)
 
 int ogs_pfcp_xact_delete(ogs_pfcp_xact_t *xact)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_assert(xact);
     ogs_assert(xact->node);
 
-    ogs_debug("[%d] %s Delete  peer [%s]:%d",
+    ogs_debug("[%d] %s Delete  peer %s",
             xact->xid,
             xact->org == OGS_PFCP_LOCAL_ORIGINATOR ? "LOCAL " : "REMOTE",
-            OGS_ADDR(&xact->node->addr, buf),
-            OGS_PORT(&xact->node->addr));
+            ogs_sockaddr_to_string_static(xact->node->addr_list));
 
     if (xact->seq[0].pkbuf)
         ogs_pkbuf_free(xact->seq[0].pkbuf);

--- a/lib/sctp/ogs-lksctp.c
+++ b/lib/sctp/ogs-lksctp.c
@@ -164,7 +164,6 @@ ogs_sock_t *ogs_sctp_server(
     ogs_sockopt_t *socket_option)
 {
     int rv;
-    char *sa_list_str = NULL;
     int sa_family;
     ogs_sock_t *new_sock = NULL;
     ogs_sockopt_t option;
@@ -175,7 +174,6 @@ ogs_sock_t *ogs_sctp_server(
     int total_len = 0;
 
     ogs_assert(sa_list);
-    sa_list_str = ogs_sockaddr_strdup(sa_list);
 
     /* Initialize socket options. */
     ogs_sockopt_init(&option);
@@ -249,8 +247,8 @@ ogs_sock_t *ogs_sctp_server(
     /*
      * Log debug info: only the first address is shown here as an example.
      */
-    ogs_debug("sctp_server() %s (bound %d addresses)", sa_list_str, addr_count);
-    ogs_free(sa_list_str);
+    ogs_debug("sctp_server() %s (bound %d addresses)",
+            ogs_sockaddr_to_string_static(sa_list), addr_count);
 
     /* Start listening for connections. */
     rv = ogs_sock_listen(new_sock);
@@ -271,8 +269,8 @@ err:
      * in sa_list (customize as needed).
      */
     ogs_log_message(OGS_LOG_ERROR, ogs_socket_errno,
-                    "sctp_server() %s failed", sa_list_str);
-    ogs_free(sa_list_str);
+                    "sctp_server() %s failed",
+                    ogs_sockaddr_to_string_static(sa_list));
 
     return NULL;
 }
@@ -284,7 +282,6 @@ ogs_sock_t *ogs_sctp_client(
     ogs_sockopt_t *socket_option)
 {
     int rv;
-    char *sa_list_str = NULL;
     int sa_family;
     ogs_sock_t *new_sock = NULL;
     ogs_sockopt_t option;
@@ -300,7 +297,6 @@ ogs_sock_t *ogs_sctp_client(
     int local_len = 0;
 
     ogs_assert(sa_list);
-    sa_list_str = ogs_sockaddr_strdup(sa_list);
 
     /* Initialize socket options and copy user-provided options if present. */
     ogs_sockopt_init(&option);
@@ -391,8 +387,8 @@ ogs_sock_t *ogs_sctp_client(
     }
 
     /* Debug log for the first remote address. */
-    ogs_debug("sctp_client() connected to %s", sa_list_str);
-    ogs_free(sa_list_str);
+    ogs_debug("sctp_client() connected to %s",
+            ogs_sockaddr_to_string_static(sa_list));
 
     /* Success: free buffers and return the new socket. */
     if (local_buf)
@@ -414,8 +410,8 @@ err:
      * Adjust to your needs, e.g., log local too if necessary.
      */
     ogs_log_message(OGS_LOG_ERROR, ogs_socket_errno,
-                    "sctp_client() %s failed", sa_list_str);
-    ogs_free(sa_list_str);
+                    "sctp_client() %s failed",
+                    ogs_sockaddr_to_string_static(sa_list));
 
     return NULL;
 }
@@ -423,7 +419,6 @@ err:
 int ogs_sctp_connect(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
 {
     ogs_sockaddr_t *addr;
-    char *sa_list_str = NULL;
     char buf[OGS_ADDRSTRLEN];
 
     ogs_assert(sock);
@@ -444,10 +439,9 @@ int ogs_sctp_connect(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
     }
 
     if (addr == NULL) {
-        sa_list_str = ogs_sockaddr_strdup(sa_list);
         ogs_log_message(OGS_LOG_ERROR, ogs_socket_errno,
-                "sctp_connect() %s failed", sa_list_str);
-        ogs_free(sa_list_str);
+                "sctp_connect() %s failed",
+                ogs_sockaddr_to_string_static(sa_list));
 
         return OGS_ERROR;
     }

--- a/lib/sctp/ogs-usrsctp.c
+++ b/lib/sctp/ogs-usrsctp.c
@@ -93,7 +93,6 @@ ogs_sock_t *ogs_sctp_server(
         int type, ogs_sockaddr_t *sa_list, ogs_sockopt_t *socket_option)
 {
     int rv;
-    char *sa_list_str = NULL;
     char buf[OGS_ADDRSTRLEN];
 
     ogs_sock_t *new = NULL;
@@ -143,10 +142,8 @@ ogs_sock_t *ogs_sctp_server(
     }
 
     if (addr == NULL) {
-        sa_list_str = ogs_sockaddr_strdup(sa_list);
-        ogs_error("sctp_server %s failed", sa_list_str);
-        ogs_free(sa_list_str);
-
+        ogs_error("sctp_server %s failed",
+                ogs_sockaddr_to_string_static(sa_list));
         return NULL;
     }
 
@@ -164,7 +161,6 @@ ogs_sock_t *ogs_sctp_client(
         ogs_sockopt_t *socket_option)
 {
     int rv;
-    char *sa_list_str = NULL;
     char buf[OGS_ADDRSTRLEN];
 
     ogs_sock_t *new = NULL;
@@ -214,10 +210,8 @@ ogs_sock_t *ogs_sctp_client(
     }
 
     if (addr == NULL) {
-        sa_list_str = ogs_sockaddr_strdup(sa_list);
-        ogs_error("sctp_client %s failed", sa_list_str);
-        ogs_free(sa_list_str);
-
+        ogs_error("sctp_client %s failed",
+                ogs_sockaddr_to_string_static(sa_list));
         return NULL;
     }
 
@@ -227,7 +221,6 @@ ogs_sock_t *ogs_sctp_client(
 int ogs_sctp_bind(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
 {
     struct socket *socket = (struct socket *)sock;
-    char *sa_list_str = NULL;
     socklen_t addrlen;
 
     ogs_assert(socket);
@@ -237,16 +230,13 @@ int ogs_sctp_bind(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
     ogs_assert(addrlen);
 
     if (usrsctp_bind(socket, &sa_list->sa, addrlen) != 0) {
-        sa_list_str = ogs_sockaddr_strdup(sa_list);
-        ogs_error("sctp_bind() %s failed", sa_list_str);
-        ogs_free(sa_list_str);
+        ogs_error("sctp_bind() %s failed",
+                ogs_sockaddr_to_string_static(sa_list));
 
         return OGS_ERROR;
     }
 
-    sa_list_str = ogs_sockaddr_strdup(sa_list);
-    ogs_debug("sctp_bind() %s", sa_list_str);
-    ogs_free(sa_list_str);
+    ogs_debug("sctp_bind() %s", ogs_sockaddr_to_string_static(sa_list));
 
     return OGS_OK;
 }
@@ -254,7 +244,6 @@ int ogs_sctp_bind(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
 int ogs_sctp_connect(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
 {
     struct socket *socket = (struct socket *)sock;
-    char *sa_list_str = NULL;
     socklen_t addrlen;
 
     ogs_assert(socket);
@@ -264,16 +253,11 @@ int ogs_sctp_connect(ogs_sock_t *sock, ogs_sockaddr_t *sa_list)
     ogs_assert(addrlen);
 
     if (usrsctp_connect(socket, &sa_list->sa, addrlen) != 0) {
-        sa_list_str = ogs_sockaddr_strdup(sa_list);
-        ogs_error("sctp_connect() %s", sa_list_str);
-        ogs_free(sa_list_str);
-
+        ogs_error("sctp_connect() %s", ogs_sockaddr_to_string_static(sa_list));
         return OGS_ERROR;
     }
 
-    sa_list_str = ogs_sockaddr_strdup(sa_list);
-    ogs_debug("sctp_connect() %s", sa_list_str);
-    ogs_free(sa_list_str);
+    ogs_debug("sctp_connect() %s", ogs_sockaddr_to_string_static(sa_list));
 
     return OGS_OK;
 }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -54,7 +54,6 @@ void mme_state_final(ogs_fsm_t *s, mme_event_t *e)
 void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
 {
     int rv;
-    char *sa_list_str = NULL;
     char buf[OGS_ADDRSTRLEN];
 
     ogs_sock_t *sock = NULL;
@@ -981,10 +980,9 @@ cleanup:
         vlr->max_num_of_ostreams =
                 ogs_min(max_num_of_ostreams, vlr->max_num_of_ostreams);
 
-        sa_list_str = ogs_sockaddr_strdup(vlr->sa_list);
         ogs_debug("VLR-SGs SCTP_COMM_UP %s Max Num of Outbound Streams[%d]",
-                sa_list_str, vlr->max_num_of_ostreams);
-        ogs_free(sa_list_str);
+                ogs_sockaddr_to_string_static(vlr->sa_list),
+                vlr->max_num_of_ostreams);
 
         e->vlr = vlr;
         ogs_fsm_dispatch(&vlr->sm, e);
@@ -998,18 +996,17 @@ cleanup:
         ogs_assert(vlr);
         ogs_assert(OGS_FSM_STATE(&vlr->sm));
 
-        sa_list_str = ogs_sockaddr_strdup(vlr->sa_list);
         if (OGS_FSM_CHECK(&vlr->sm, sgsap_state_connected)) {
             e->vlr = vlr;
             ogs_fsm_dispatch(&vlr->sm, e);
 
-            ogs_info("VLR-SGs %s connection refused!!!", sa_list_str);
+            ogs_info("VLR-SGs %s connection refused!!!",
+                    ogs_sockaddr_to_string_static(vlr->sa_list));
 
         } else {
             ogs_warn("VLR-SGs %s connection refused, Already Removed!",
-                    sa_list_str);
+                    ogs_sockaddr_to_string_static(vlr->sa_list));
         }
-        ogs_free(sa_list_str);
 
         break;
     case MME_EVENT_SGSAP_MESSAGE:

--- a/src/mme/sgsap-path.c
+++ b/src/mme/sgsap-path.c
@@ -76,7 +76,6 @@ int sgsap_send(ogs_sock_t *sock, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
 int sgsap_send_to_vlr_with_sid(
         mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
 {
-    char *sa_list_str = NULL;
     ogs_sock_t *sock = NULL;;
 
     ogs_assert(vlr);
@@ -84,9 +83,8 @@ int sgsap_send_to_vlr_with_sid(
     sock = vlr->sock;
     ogs_assert(sock);
 
-    sa_list_str = ogs_sockaddr_strdup(vlr->sa_list);
-    ogs_debug("    StreamNO[%d] VLR-IP[%s]", stream_no, sa_list_str);
-    ogs_free(sa_list_str);
+    ogs_debug("    StreamNO[%d] VLR-IP[%s]",
+            stream_no, ogs_sockaddr_to_string_static(vlr->sa_list));
 
     return sgsap_send(sock, pkbuf, stream_no);
 }

--- a/src/mme/sgsap-sctp.c
+++ b/src/mme/sgsap-sctp.c
@@ -34,7 +34,6 @@ static void recv_handler(ogs_sock_t *sock);
 
 ogs_sock_t *sgsap_client(mme_vlr_t *vlr)
 {
-    char *sa_list_str = NULL;
     ogs_sock_t *sock = NULL;
 
     ogs_assert(vlr);
@@ -51,9 +50,8 @@ ogs_sock_t *sgsap_client(mme_vlr_t *vlr)
                 OGS_POLLIN, sock->fd, lksctp_recv_handler, sock);
         ogs_assert(vlr->poll);
 #endif
-        sa_list_str = ogs_sockaddr_strdup(vlr->sa_list);
-        ogs_info("sgsap client() %s", sa_list_str);
-        ogs_free(sa_list_str);
+        ogs_info("sgsap client() %s",
+                ogs_sockaddr_to_string_static(vlr->sa_list));
     }
 
     return sock;

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -408,8 +408,6 @@ static ogs_pfcp_node_t *selected_sgwu_node(
 
 void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_assert(sess);
 
     /*
@@ -425,8 +423,9 @@ void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
         selected_sgwu_node(ogs_pfcp_self()->pfcp_node, sess);
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
-    ogs_debug("UE using SGW-U on IP[%s]",
-            OGS_ADDR(&ogs_pfcp_self()->pfcp_node->addr, buf));
+    ogs_debug("UE using SGW-U on IP %s",
+            ogs_sockaddr_to_string_static(
+                ogs_pfcp_self()->pfcp_node->addr_list));
 }
 
 int sgwc_sess_remove(sgwc_sess_t *sess)
@@ -761,14 +760,15 @@ sgwc_tunnel_t *sgwc_tunnel_add(
             else
                 tunnel->local_teid = pdr->teid;
         } else {
-            if (sess->pfcp_node->addr.ogs_sa_family == AF_INET)
+            ogs_assert(sess->pfcp_node->addr_list);
+            if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &tunnel->local_addr, &sess->pfcp_node->addr));
-            else if (sess->pfcp_node->addr.ogs_sa_family == AF_INET6)
+                        &tunnel->local_addr, sess->pfcp_node->addr_list));
+            else if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET6)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &tunnel->local_addr6, &sess->pfcp_node->addr));
+                        &tunnel->local_addr6, sess->pfcp_node->addr_list));
             else
                 ogs_assert_if_reached();
 

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -61,7 +61,11 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t from;
     ogs_pfcp_node_t *node = NULL;
+    ogs_pfcp_message_t *message = NULL;
     ogs_pfcp_header_t *h = NULL;
+
+    ogs_pfcp_status_e pfcp_status;;
+    ogs_pfcp_node_id_t node_id;
 
     ogs_assert(fd != INVALID_SOCKET);
 
@@ -102,28 +106,105 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     e = sgwc_event_new(SGWC_EVT_SXA_MESSAGE);
     ogs_assert(e);
 
-    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list, &from);
-    if (!node) {
-        node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list, &from);
-        if (!node) {
-            ogs_error("No memory: ogs_pfcp_node_add() failed");
-            ogs_pkbuf_free(e->pkbuf);
-            sgwc_event_free(e);
-            return;
-        }
-
-        node->sock = data;
-        pfcp_node_fsm_init(node, false);
+    /*
+     * Issue #1911
+     *
+     * Because ogs_pfcp_message_t is over 80kb in size,
+     * it can cause stack overflow.
+     * To avoid this, the pfcp_message structure uses heap memory.
+     */
+    if ((message = ogs_pfcp_parse_msg(pkbuf)) == NULL) {
+        ogs_error("ogs_pfcp_parse_msg() failed");
+        ogs_pkbuf_free(pkbuf);
+        sgwc_event_free(e);
+        return;
     }
+
+    pfcp_status = ogs_pfcp_extract_node_id(message, &node_id);
+    switch (pfcp_status) {
+    case OGS_PFCP_STATUS_SUCCESS:
+    case OGS_PFCP_STATUS_NODE_ID_NONE:
+    case OGS_PFCP_STATUS_NODE_ID_OPTIONAL_ABSENT:
+        ogs_debug("ogs_pfcp_extract_node_id() "
+                "type [%d] pfcp_status [%d] node_id [%s] from %s",
+                message->h.type, pfcp_status,
+                pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                    ogs_pfcp_node_id_to_string_static(&node_id) :
+                    "NULL",
+                ogs_sockaddr_to_string_static(&from));
+        break;
+
+    case OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_FOUND:
+    case OGS_PFCP_ERROR_UNKNOWN_MESSAGE:
+        ogs_error("ogs_pfcp_extract_node_id() failed "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+
+    default:
+        ogs_error("Unexpected pfcp_status "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+    }
+
+    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list,
+            pfcp_status == OGS_PFCP_STATUS_SUCCESS ? &node_id : NULL, &from);
+    if (!node) {
+        if (message->h.type == OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE ||
+            message->h.type == OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE) {
+            ogs_assert(pfcp_status == OGS_PFCP_STATUS_SUCCESS);
+            node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list,
+                    &node_id, &from);
+            if (!node) {
+                ogs_error("No memory: ogs_pfcp_node_add() failed");
+                goto cleanup;
+            }
+            ogs_debug("Added PFCP-Node: addr_list %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
+
+            pfcp_node_fsm_init(node, false);
+
+        } else {
+            ogs_error("Cannot find PFCP-Node: type [%d] node_id %s from %s",
+                    message->h.type,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                        ogs_pfcp_node_id_to_string_static(&node_id) :
+                        "NULL",
+                    ogs_sockaddr_to_string_static(&from));
+            goto cleanup;
+        }
+    } else {
+        ogs_debug("Found PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+        ogs_expect(OGS_OK == ogs_pfcp_node_merge(
+                    node,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?  &node_id : NULL,
+                    &from));
+        ogs_debug("Merged PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+    }
+
     e->pfcp_node = node;
     e->pkbuf = pkbuf;
+    e->pfcp_message = message;
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
         ogs_error("ogs_queue_push() failed:%d", (int)rv);
-        ogs_pkbuf_free(e->pkbuf);
-        sgwc_event_free(e);
+        goto cleanup;
     }
+
+    return;
+
+cleanup:
+    ogs_pkbuf_free(pkbuf);
+    ogs_pfcp_message_free(message);
+    sgwc_event_free(e);
 }
 
 int sgwc_pfcp_open(void)

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -25,7 +25,6 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data);
 
 void sgwc_pfcp_state_initial(ogs_fsm_t *s, sgwc_event_t *e)
 {
-    int rv;
     ogs_pfcp_node_t *node = NULL;
 
     ogs_assert(s);
@@ -35,10 +34,6 @@ void sgwc_pfcp_state_initial(ogs_fsm_t *s, sgwc_event_t *e)
 
     node = e->pfcp_node;
     ogs_assert(node);
-
-    rv = ogs_pfcp_connect(
-            ogs_pfcp_self()->pfcp_sock, ogs_pfcp_self()->pfcp_sock6, node);
-    ogs_assert(rv == OGS_OK);
 
     node->t_no_heartbeat = ogs_timer_add(ogs_app()->timer_mgr,
             sgwc_timer_pfcp_no_heartbeat, node);
@@ -63,13 +58,9 @@ void sgwc_pfcp_state_final(ogs_fsm_t *s, sgwc_event_t *e)
 
 void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_pfcp_node_t *node = NULL;
     ogs_pfcp_xact_t *xact = NULL;
     ogs_pfcp_message_t *message = NULL;
-
-    ogs_sockaddr_t *addr = NULL;
 
     ogs_assert(s);
     ogs_assert(e);
@@ -78,8 +69,6 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
 
     node = e->pfcp_node;
     ogs_assert(node);
-    addr = node->sa_list;
-    ogs_assert(addr);
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
@@ -103,8 +92,8 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
             node = e->pfcp_node;
             ogs_assert(node);
 
-            ogs_warn("Retry association with peer [%s]:%d failed",
-                        OGS_ADDR(addr, buf), OGS_PORT(addr));
+            ogs_warn("Retry association with peer failed %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
 
             ogs_assert(node->t_association);
             ogs_timer_start(node->t_association,
@@ -159,13 +148,10 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
 
 void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_pfcp_node_t *node = NULL;
     ogs_pfcp_xact_t *xact = NULL;
     ogs_pfcp_message_t *message = NULL;
 
-    ogs_sockaddr_t *addr = NULL;
     sgwc_sess_t *sess = NULL;
 
     ogs_assert(s);
@@ -175,14 +161,11 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
 
     node = e->pfcp_node;
     ogs_assert(node);
-    addr = node->sa_list;
-    ogs_assert(addr);
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated [%s]:%d",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+        ogs_info("PFCP associated %s",
+            ogs_sockaddr_to_string_static(node->addr_list));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_local_conf()->time.message.pfcp.no_heartbeat_duration);
         ogs_assert(OGS_OK ==
@@ -195,9 +178,8 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
         }
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated [%s]:%d",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+        ogs_info("PFCP de-associated %s",
+            ogs_sockaddr_to_string_static(node->addr_list));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case SGWC_EVT_SXA_MESSAGE:
@@ -274,16 +256,14 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
-                OGS_ADDR(&node->addr, buf),
-                OGS_PORT(&node->addr));
+            ogs_warn("PFCP[REQ] has already been associated %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
-                OGS_ADDR(&node->addr, buf),
-                OGS_PORT(&node->addr));
+            ogs_warn("PFCP[RSP] has already been associated %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;
@@ -359,8 +339,8 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
         }
         break;
     case SGWC_EVT_SXA_NO_HEARTBEAT:
-        ogs_warn("No Heartbeat from SGW-U [%s]:%d",
-                    OGS_ADDR(addr, buf), OGS_PORT(addr));
+        ogs_warn("No Heartbeat from SGW-U %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
         OGS_FSM_TRAN(s, sgwc_pfcp_state_will_associate);
         break;
     default:

--- a/src/sgwc/sgwc-sm.c
+++ b/src/sgwc/sgwc-sm.c
@@ -89,22 +89,11 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
         ogs_assert(e);
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
+        pfcp_message = e->pfcp_message;
+        ogs_assert(pfcp_message);
         pfcp_node = e->pfcp_node;
         ogs_assert(pfcp_node);
         ogs_assert(OGS_FSM_STATE(&pfcp_node->sm));
-
-        /*
-         * Issue #1911
-         *
-         * Because ogs_pfcp_message_t is over 80kb in size,
-         * it can cause stack overflow.
-         * To avoid this, the pfcp_message structure uses heap memory.
-         */
-        if ((pfcp_message = ogs_pfcp_parse_msg(recvbuf)) == NULL) {
-            ogs_error("ogs_pfcp_parse_msg() failed");
-            ogs_pkbuf_free(recvbuf);
-            break;
-        }
 
         rv = ogs_pfcp_xact_receive(pfcp_node, &pfcp_message->h, &pfcp_xact);
         if (rv != OGS_OK) {
@@ -113,7 +102,6 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
             break;
         }
 
-        e->pfcp_message = pfcp_message;
         e->pfcp_xact_id = pfcp_xact ? pfcp_xact->id : OGS_INVALID_POOL_ID;
 
         e->gtp_message = NULL;

--- a/src/sgwu/pfcp-path.c
+++ b/src/sgwu/pfcp-path.c
@@ -61,7 +61,11 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t from;
     ogs_pfcp_node_t *node = NULL;
+    ogs_pfcp_message_t *message = NULL;
     ogs_pfcp_header_t *h = NULL;
+
+    ogs_pfcp_status_e pfcp_status;;
+    ogs_pfcp_node_id_t node_id;
 
     ogs_assert(fd != INVALID_SOCKET);
 
@@ -102,28 +106,105 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     e = sgwu_event_new(SGWU_EVT_SXA_MESSAGE);
     ogs_assert(e);
 
-    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list, &from);
-    if (!node) {
-        node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list, &from);
-        if (!node) {
-            ogs_error("No memory: ogs_pfcp_node_add() failed");
-            ogs_pkbuf_free(e->pkbuf);
-            sgwu_event_free(e);
-            return;
-        }
-
-        node->sock = data;
-        pfcp_node_fsm_init(node, false);
+    /*
+     * Issue #1911
+     *
+     * Because ogs_pfcp_message_t is over 80kb in size,
+     * it can cause stack overflow.
+     * To avoid this, the pfcp_message structure uses heap memory.
+     */
+    if ((message = ogs_pfcp_parse_msg(pkbuf)) == NULL) {
+        ogs_error("ogs_pfcp_parse_msg() failed");
+        ogs_pkbuf_free(pkbuf);
+        sgwu_event_free(e);
+        return;
     }
+
+    pfcp_status = ogs_pfcp_extract_node_id(message, &node_id);
+    switch (pfcp_status) {
+    case OGS_PFCP_STATUS_SUCCESS:
+    case OGS_PFCP_STATUS_NODE_ID_NONE:
+    case OGS_PFCP_STATUS_NODE_ID_OPTIONAL_ABSENT:
+        ogs_debug("ogs_pfcp_extract_node_id() "
+                "type [%d] pfcp_status [%d] node_id [%s] from %s",
+                message->h.type, pfcp_status,
+                pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                    ogs_pfcp_node_id_to_string_static(&node_id) :
+                    "NULL",
+                ogs_sockaddr_to_string_static(&from));
+        break;
+
+    case OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_FOUND:
+    case OGS_PFCP_ERROR_UNKNOWN_MESSAGE:
+        ogs_error("ogs_pfcp_extract_node_id() failed "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+
+    default:
+        ogs_error("Unexpected pfcp_status "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+    }
+
+    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list,
+            pfcp_status == OGS_PFCP_STATUS_SUCCESS ? &node_id : NULL, &from);
+    if (!node) {
+        if (message->h.type == OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE ||
+            message->h.type == OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE) {
+            ogs_assert(pfcp_status == OGS_PFCP_STATUS_SUCCESS);
+            node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list,
+                    &node_id, &from);
+            if (!node) {
+                ogs_error("No memory: ogs_pfcp_node_add() failed");
+                goto cleanup;
+            }
+            ogs_debug("Added PFCP-Node: addr_list %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
+
+            pfcp_node_fsm_init(node, false);
+
+        } else {
+            ogs_error("Cannot find PFCP-Node: type [%d] node_id %s from %s",
+                    message->h.type,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                        ogs_pfcp_node_id_to_string_static(&node_id) :
+                        "NULL",
+                    ogs_sockaddr_to_string_static(&from));
+            goto cleanup;
+        }
+    } else {
+        ogs_debug("Found PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+        ogs_expect(OGS_OK == ogs_pfcp_node_merge(
+                    node,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?  &node_id : NULL,
+                    &from));
+        ogs_debug("Merged PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+    }
+
     e->pfcp_node = node;
     e->pkbuf = pkbuf;
+    e->pfcp_message = message;
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
         ogs_error("ogs_queue_push() failed:%d", (int)rv);
-        ogs_pkbuf_free(e->pkbuf);
-        sgwu_event_free(e);
+        goto cleanup;
     }
+
+    return;
+
+cleanup:
+    ogs_pkbuf_free(pkbuf);
+    ogs_pfcp_message_free(message);
+    sgwu_event_free(e);
 }
 
 int sgwu_pfcp_open(void)

--- a/src/sgwu/sgwu-sm.c
+++ b/src/sgwu/sgwu-sm.c
@@ -58,21 +58,11 @@ void sgwu_state_operational(ogs_fsm_t *s, sgwu_event_t *e)
         ogs_assert(e);
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
+        pfcp_message = e->pfcp_message;
+        ogs_assert(pfcp_message);
         node = e->pfcp_node;
         ogs_assert(node);
-
-        /*
-         * Issue #1911
-         *
-         * Because ogs_pfcp_message_t is over 80kb in size,
-         * it can cause stack overflow.
-         * To avoid this, the pfcp_message structure uses heap memory.
-         */
-        if ((pfcp_message = ogs_pfcp_parse_msg(recvbuf)) == NULL) {
-            ogs_error("ogs_pfcp_parse_msg() failed");
-            ogs_pkbuf_free(recvbuf);
-            break;
-        }
+        ogs_assert(OGS_FSM_STATE(&node->sm));
 
         rv = ogs_pfcp_xact_receive(node, &pfcp_message->h, &xact);
         if (rv != OGS_OK) {
@@ -81,7 +71,6 @@ void sgwu_state_operational(ogs_fsm_t *s, sgwu_event_t *e)
             break;
         }
 
-        e->pfcp_message = pfcp_message;
         e->pfcp_xact_id = xact ? xact->id : OGS_INVALID_POOL_ID;
         ogs_fsm_dispatch(&node->sm, e);
         if (OGS_FSM_CHECK(&node->sm, sgwu_pfcp_state_exception)) {

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -206,15 +206,17 @@ void smf_bearer_binding(smf_sess_t *sess)
                         else
                             bearer->pgw_s5u_teid = ul_pdr->teid;
                     } else {
-                        if (sess->pfcp_node->addr.ogs_sa_family == AF_INET)
+                        ogs_assert(sess->pfcp_node->addr_list);
+                        if (sess->pfcp_node->addr_list->ogs_sa_family ==
+                                AF_INET)
                             ogs_assert(OGS_OK ==
                                 ogs_copyaddrinfo(&bearer->pgw_s5u_addr,
-                                    &sess->pfcp_node->addr));
-                        else if (sess->pfcp_node->addr.ogs_sa_family ==
+                                    sess->pfcp_node->addr_list));
+                        else if (sess->pfcp_node->addr_list->ogs_sa_family ==
                                 AF_INET6)
                             ogs_assert(OGS_OK ==
                                 ogs_copyaddrinfo(&bearer->pgw_s5u_addr6,
-                                    &sess->pfcp_node->addr));
+                                    sess->pfcp_node->addr_list));
                         else
                             ogs_assert_if_reached();
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1184,8 +1184,6 @@ static ogs_pfcp_node_t *selected_upf_node(
 
 void smf_sess_select_upf(smf_sess_t *sess)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_assert(sess);
 
     /*
@@ -1201,8 +1199,9 @@ void smf_sess_select_upf(smf_sess_t *sess)
         selected_upf_node(ogs_pfcp_self()->pfcp_node, sess);
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
-    ogs_debug("UE using UPF on IP[%s]",
-            OGS_ADDR(&ogs_pfcp_self()->pfcp_node->addr, buf));
+    ogs_debug("UE using UPF on IP %s",
+            ogs_sockaddr_to_string_static(
+                ogs_pfcp_self()->pfcp_node->addr_list));
 }
 
 smf_sess_t *smf_sess_add_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type)
@@ -2186,14 +2185,16 @@ void smf_sess_create_indirect_data_forwarding(smf_sess_t *sess)
                     else
                         sess->handover.upf_dl_teid = pdr->teid;
                 } else {
-                    if (sess->pfcp_node->addr.ogs_sa_family == AF_INET)
+                    ogs_assert(sess->pfcp_node->addr_list);
+                    if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET)
                         ogs_assert(OGS_OK == ogs_copyaddrinfo(
                             &sess->handover.upf_dl_addr,
-                            &sess->pfcp_node->addr));
-                    else if (sess->pfcp_node->addr.ogs_sa_family == AF_INET6)
+                            sess->pfcp_node->addr_list));
+                    else if (sess->pfcp_node->addr_list->ogs_sa_family ==
+                            AF_INET6)
                         ogs_assert(OGS_OK == ogs_copyaddrinfo(
                             &sess->handover.upf_dl_addr6,
-                            &sess->pfcp_node->addr));
+                            sess->pfcp_node->addr_list));
                     else
                         ogs_assert_if_reached();
 

--- a/src/smf/gx-handler.c
+++ b/src/smf/gx-handler.c
@@ -210,14 +210,15 @@ uint32_t smf_gx_handle_cca_initial_request(
             else
                 bearer->pgw_s5u_teid = ul_pdr->teid;
         } else {
-            if (sess->pfcp_node->addr.ogs_sa_family == AF_INET)
+            ogs_assert(sess->pfcp_node->addr_list);
+            if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &bearer->pgw_s5u_addr, &sess->pfcp_node->addr));
-            else if (sess->pfcp_node->addr.ogs_sa_family == AF_INET6)
+                        &bearer->pgw_s5u_addr, sess->pfcp_node->addr_list));
+            else if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET6)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &bearer->pgw_s5u_addr6, &sess->pfcp_node->addr));
+                        &bearer->pgw_s5u_addr6, sess->pfcp_node->addr_list));
             else
                 ogs_assert_if_reached();
 

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -645,14 +645,15 @@ bool smf_npcf_smpolicycontrol_handle_create(
             else
                 sess->upf_n3_teid = ul_pdr->teid;
         } else {
-            if (sess->pfcp_node->addr.ogs_sa_family == AF_INET)
+            ogs_assert(sess->pfcp_node->addr_list);
+            if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &sess->upf_n3_addr, &sess->pfcp_node->addr));
-            else if (sess->pfcp_node->addr.ogs_sa_family == AF_INET6)
+                        &sess->upf_n3_addr, sess->pfcp_node->addr_list));
+            else if (sess->pfcp_node->addr_list->ogs_sa_family == AF_INET6)
                 ogs_assert(OGS_OK ==
                     ogs_copyaddrinfo(
-                        &sess->upf_n3_addr6, &sess->pfcp_node->addr));
+                        &sess->upf_n3_addr6, sess->pfcp_node->addr_list));
             else
                 ogs_assert_if_reached();
 

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -101,7 +101,11 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     ogs_pkbuf_t *pkbuf = NULL;
     ogs_sockaddr_t from;
     ogs_pfcp_node_t *node = NULL;
+    ogs_pfcp_message_t *message = NULL;
     ogs_pfcp_header_t *h = NULL;
+
+    ogs_pfcp_status_e pfcp_status;;
+    ogs_pfcp_node_id_t node_id;
 
     ogs_assert(fd != INVALID_SOCKET);
 
@@ -142,28 +146,105 @@ static void pfcp_recv_cb(short when, ogs_socket_t fd, void *data)
     e = smf_event_new(SMF_EVT_N4_MESSAGE);
     ogs_assert(e);
 
-    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list, &from);
-    if (!node) {
-        node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list, &from);
-        if (!node) {
-            ogs_error("No memory: ogs_pfcp_node_add() failed");
-            ogs_pkbuf_free(e->pkbuf);
-            ogs_event_free(e);
-            return;
-        }
-
-        node->sock = data;
-        pfcp_node_fsm_init(node, false);
+    /*
+     * Issue #1911
+     *
+     * Because ogs_pfcp_message_t is over 80kb in size,
+     * it can cause stack overflow.
+     * To avoid this, the pfcp_message structure uses heap memory.
+     */
+    if ((message = ogs_pfcp_parse_msg(pkbuf)) == NULL) {
+        ogs_error("ogs_pfcp_parse_msg() failed");
+        ogs_pkbuf_free(pkbuf);
+        ogs_event_free(e);
+        return;
     }
+
+    pfcp_status = ogs_pfcp_extract_node_id(message, &node_id);
+    switch (pfcp_status) {
+    case OGS_PFCP_STATUS_SUCCESS:
+    case OGS_PFCP_STATUS_NODE_ID_NONE:
+    case OGS_PFCP_STATUS_NODE_ID_OPTIONAL_ABSENT:
+        ogs_debug("ogs_pfcp_extract_node_id() "
+                "type [%d] pfcp_status [%d] node_id [%s] from %s",
+                message->h.type, pfcp_status,
+                pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                    ogs_pfcp_node_id_to_string_static(&node_id) :
+                    "NULL",
+                ogs_sockaddr_to_string_static(&from));
+        break;
+
+    case OGS_PFCP_ERROR_SEMANTIC_INCORRECT_MESSAGE:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_PRESENT:
+    case OGS_PFCP_ERROR_NODE_ID_NOT_FOUND:
+    case OGS_PFCP_ERROR_UNKNOWN_MESSAGE:
+        ogs_error("ogs_pfcp_extract_node_id() failed "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+
+    default:
+        ogs_error("Unexpected pfcp_status "
+                "type [%d] pfcp_status [%d] from %s",
+                message->h.type, pfcp_status,
+                ogs_sockaddr_to_string_static(&from));
+        goto cleanup;
+    }
+
+    node = ogs_pfcp_node_find(&ogs_pfcp_self()->pfcp_peer_list,
+            pfcp_status == OGS_PFCP_STATUS_SUCCESS ? &node_id : NULL, &from);
+    if (!node) {
+        if (message->h.type == OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE ||
+            message->h.type == OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE) {
+            ogs_assert(pfcp_status == OGS_PFCP_STATUS_SUCCESS);
+            node = ogs_pfcp_node_add(&ogs_pfcp_self()->pfcp_peer_list,
+                    &node_id, &from);
+            if (!node) {
+                ogs_error("No memory: ogs_pfcp_node_add() failed");
+                goto cleanup;
+            }
+            ogs_debug("Added PFCP-Node: addr_list %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
+
+            pfcp_node_fsm_init(node, false);
+
+        } else {
+            ogs_error("Cannot find PFCP-Node: type [%d] node_id %s from %s",
+                    message->h.type,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?
+                        ogs_pfcp_node_id_to_string_static(&node_id) :
+                        "NULL",
+                    ogs_sockaddr_to_string_static(&from));
+            goto cleanup;
+        }
+    } else {
+        ogs_debug("Found PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+        ogs_expect(OGS_OK == ogs_pfcp_node_merge(
+                    node,
+                    pfcp_status == OGS_PFCP_STATUS_SUCCESS ?  &node_id : NULL,
+                    &from));
+        ogs_debug("Merged PFCP-Node: addr_list %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
+    }
+
     e->pfcp_node = node;
     e->pkbuf = pkbuf;
+    e->pfcp_message = message;
 
     rv = ogs_queue_push(ogs_app()->queue, e);
     if (rv != OGS_OK) {
         ogs_error("ogs_queue_push() failed:%d", (int)rv);
-        ogs_pkbuf_free(e->pkbuf);
-        ogs_event_free(e);
+        goto cleanup;
     }
+
+    return;
+
+cleanup:
+    ogs_pkbuf_free(pkbuf);
+    ogs_pfcp_message_free(message);
+    ogs_event_free(e);
 }
 
 int smf_pfcp_open(void)

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -405,22 +405,11 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         ogs_assert(e);
         recvbuf = e->pkbuf;
         ogs_assert(recvbuf);
+        pfcp_message = e->pfcp_message;
+        ogs_assert(pfcp_message);
         pfcp_node = e->pfcp_node;
         ogs_assert(pfcp_node);
         ogs_assert(OGS_FSM_STATE(&pfcp_node->sm));
-
-        /*
-         * Issue #1911
-         *
-         * Because ogs_pfcp_message_t is over 80kb in size,
-         * it can cause stack overflow.
-         * To avoid this, the pfcp_message structure uses heap memory.
-         */
-        if ((pfcp_message = ogs_pfcp_parse_msg(recvbuf)) == NULL) {
-            ogs_error("ogs_pfcp_parse_msg() failed");
-            ogs_pkbuf_free(recvbuf);
-            break;
-        }
 
         rv = ogs_pfcp_xact_receive(pfcp_node, &pfcp_message->h, &pfcp_xact);
         if (rv != OGS_OK) {
@@ -429,7 +418,6 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
             break;
         }
 
-        e->pfcp_message = pfcp_message;
         e->pfcp_xact_id = pfcp_xact ? pfcp_xact->id : OGS_INVALID_POOL_ID;
 
         e->gtp2_message = NULL;

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -30,7 +30,6 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data);
 
 void upf_pfcp_state_initial(ogs_fsm_t *s, upf_event_t *e)
 {
-    int rv;
     ogs_pfcp_node_t *node = NULL;
 
     ogs_assert(s);
@@ -40,10 +39,6 @@ void upf_pfcp_state_initial(ogs_fsm_t *s, upf_event_t *e)
 
     node = e->pfcp_node;
     ogs_assert(node);
-
-    rv = ogs_pfcp_connect(
-            ogs_pfcp_self()->pfcp_sock, ogs_pfcp_self()->pfcp_sock6, node);
-    ogs_assert(rv == OGS_OK);
 
     node->t_no_heartbeat = ogs_timer_add(ogs_app()->timer_mgr,
             upf_timer_no_heartbeat, node);
@@ -68,12 +63,9 @@ void upf_pfcp_state_final(ogs_fsm_t *s, upf_event_t *e)
 
 void upf_pfcp_state_will_associate(ogs_fsm_t *s, upf_event_t *e)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_pfcp_node_t *node = NULL;
     ogs_pfcp_xact_t *xact = NULL;
     ogs_pfcp_message_t *message = NULL;
-    ogs_sockaddr_t *addr = NULL;
     ogs_assert(s);
     ogs_assert(e);
 
@@ -101,11 +93,8 @@ void upf_pfcp_state_will_associate(ogs_fsm_t *s, upf_event_t *e)
     case UPF_EVT_N4_TIMER:
         switch(e->timer_id) {
         case UPF_TIMER_ASSOCIATION:
-            addr = node->sa_list;
-            ogs_assert(addr);
-
-            ogs_warn("Retry association with peer [%s]:%d failed",
-                        OGS_ADDR(addr, buf), OGS_PORT(addr));
+            ogs_warn("Retry association with peer failed %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
 
             ogs_assert(node->t_association);
             ogs_timer_start(node->t_association,
@@ -160,13 +149,10 @@ void upf_pfcp_state_will_associate(ogs_fsm_t *s, upf_event_t *e)
 
 void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
 {
-    char buf[OGS_ADDRSTRLEN];
-
     ogs_pfcp_node_t *node = NULL;
     ogs_pfcp_xact_t *xact = NULL;
     ogs_pfcp_message_t *message = NULL;
 
-    ogs_sockaddr_t *addr = NULL;
     upf_sess_t *sess = NULL;
 
     ogs_assert(s);
@@ -176,14 +162,11 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
 
     node = e->pfcp_node;
     ogs_assert(node);
-    addr = node->sa_list;
-    ogs_assert(addr);
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
-        ogs_info("PFCP associated [%s]:%d",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+        ogs_info("PFCP associated %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_local_conf()->time.message.pfcp.no_heartbeat_duration);
         ogs_assert(OGS_OK ==
@@ -196,9 +179,8 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
         }
         break;
     case OGS_FSM_EXIT_SIG:
-        ogs_info("PFCP de-associated [%s]:%d",
-            OGS_ADDR(&node->addr, buf),
-            OGS_PORT(&node->addr));
+        ogs_info("PFCP de-associated %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
         ogs_timer_stop(node->t_no_heartbeat);
         break;
     case UPF_EVT_N4_MESSAGE:
@@ -267,16 +249,14 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
             }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_REQUEST_TYPE:
-            ogs_warn("PFCP[REQ] has already been associated [%s]:%d",
-                OGS_ADDR(&node->addr, buf),
-                OGS_PORT(&node->addr));
+            ogs_warn("PFCP[REQ] has already been associated %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
             ogs_pfcp_up_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
-            ogs_warn("PFCP[RSP] has already been associated [%s]:%d",
-                OGS_ADDR(&node->addr, buf),
-                OGS_PORT(&node->addr));
+            ogs_warn("PFCP[RSP] has already been associated %s",
+                    ogs_sockaddr_to_string_static(node->addr_list));
             ogs_pfcp_up_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             break;
@@ -322,8 +302,8 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
         }
         break;
     case UPF_EVT_N4_NO_HEARTBEAT:
-        ogs_warn("No Heartbeat from SMF [%s]:%d",
-                    OGS_ADDR(addr, buf), OGS_PORT(addr));
+        ogs_warn("No Heartbeat from SMF %s",
+                ogs_sockaddr_to_string_static(node->addr_list));
         OGS_FSM_TRAN(s, upf_pfcp_state_will_associate);
         break;
     default:


### PR DESCRIPTION
This pull request introduces several improvements and refactoring efforts across PFCP and core modules to enhance address handling, logging consistency, and server binding capabilities. The key changes include:

### Improved PFCP Node Address Management:

- Updates PFCP node handling to use the addr_list field and related merge functions, moving away from obsolete sa_list references.
- Integrates ogs_pfcp_extract_node_id() and related APIs to safely extract PFCP Node IDs, providing robust error handling and reducing stack usage.

### Enhanced Server Binding via FQDN Resolution:

- Modifies PFCP/GTP context parsing to iterate over multiple resolved IP addresses from a Fully Qualified Domain Name (FQDN).
- Enables the server to bind to and listen on each IP address obtained from an FQDN resolution, supporting multi-interface and redundant IP configurations.

### Consistent Logging with Static Buffer:

- Replaces direct usage of OGS_ADDR/OGS_PORT macros with ogs_sockaddr_to_string_static() for uniform IPv4/IPv6 logging.
- Removes redundant stack buffer allocations for address printing by leveraging a static buffer.

These changes collectively improve code maintainability, reliability of PFCP message processing, and the server's ability to handle multiple network interfaces efficiently.