### PR TITLE
[AMF] prevent crash on npcf-am-policy-control SBI response handling (#3671)

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1977,6 +1977,31 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             END
             break;
 
+        CASE(OGS_SBI_SERVICE_NAME_NPCF_AM_POLICY_CONTROL)
+            SWITCH(sbi_message->h.resource.component[0])
+            CASE(OGS_SBI_RESOURCE_NAME_POLICIES)
+                SWITCH(sbi_message->h.method)
+                CASE(OGS_SBI_HTTP_METHOD_POST)
+                    if (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) {
+                        ogs_error("[%s] HTTP response error [%d]",
+                                amf_ue->supi, sbi_message->res_status);
+                    }
+                    ogs_error("[%s] Ignore SBI message", amf_ue->supi);
+                    break;
+
+                DEFAULT
+                    ogs_error("Unknown method [%s]", sbi_message->h.method);
+                    ogs_assert_if_reached();
+                END
+                break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[0]);
+                ogs_assert_if_reached();
+            END
+            break;
+
         DEFAULT
             ogs_error("Invalid service name [%s]", sbi_message->h.service.name);
             ogs_assert_if_reached();


### PR DESCRIPTION
This commit addresses an Open5GS bug where the AMF process crashes when receiving npcf-am-policy-control service responses during UE handovers. The crash was occurring in the gmm_state_authentication() function when the AMF encountered an unexpected SBI (Service Based Interface) message from the PCF related to AM Policy Control requests.

Added a new case block in gmm_state_authentication() to explicitly handle messages with the service name OGS_SBI_SERVICE_NAME_NPCF_AM_POLICY_CONTROL.