### PR TITLE
[AMF] Handle ng Setup Request with already existing gNBID

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -3040,3 +3040,4 @@ void amf_ue_save_to_release_session_list(amf_ue_t *amf_ue)
         }
     }
 }
+


### PR DESCRIPTION
**Summary**

This MR improves the handling of **_NG Setup Requests_** when a gNB with an existing gNB ID attempts to register. It sends **_NG Setup Failure_**.

**Changes**
-    Added validation to check for existing gNB IDs before processing NG Setup Requests.
-    Implemented appropriate handling logic to reject or update existing registrations safely.
-    Updated logging to provide better insights into gNB setup conflicts.

**Testing**
-    Verified successful registration of new gNBs.
-    Tested rejection and proper handling of duplicate gNB ID scenarios.