### PR TITLE
[SEC] Handle maximum SDM subscription limit gracefully (#3688)

### DIFF
--- a/src/udm/nudm-handler.c
+++ b/src/udm/nudm-handler.c
@@ -701,7 +701,14 @@ bool udm_nudm_sdm_handle_subscription_create(
     }
 
     sdm_subscription = udm_sdm_subscription_add(udm_ue);
-    ogs_assert(sdm_subscription);
+    if (!sdm_subscription) {
+        ogs_error("[%s] udm_sdm_subscription_add() failed", udm_ue->supi);
+        ogs_assert(true ==
+            ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                recvmsg, "udm_sdm_subscription_add() failed",
+                udm_ue->supi, NULL));
+        return false;
+    }
 
     sdm_subscription->data_change_callback_uri =
         ogs_strdup(SDMSubscription->callback_reference);


### PR DESCRIPTION
Previously, the function `udm_nudm_sdm_handle_subscription_create()` would trigger a fatal assertion failure if the maximum number of SDM subscriptions was reached.

This commit adds error handling to check if the subscription pool allocation fails.

If `udm_sdm_subscription_add()` returns NULL, an appropriate error message is logged, and a 400 Bad Request response is sent back to the client instead of causing a crash.