### PR TITLE
[SBI] explicitly set NF Instance ID to NULL when removing NF Instance

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1357,6 +1357,7 @@ void ogs_sbi_nf_instance_remove(ogs_sbi_nf_instance_t *nf_instance)
     if (nf_instance->id) {
         ogs_sbi_subscription_data_remove_all_by_nf_instance_id(nf_instance->id);
         ogs_free(nf_instance->id);
+        nf_instance->id = NULL;
     }
 
     if (nf_instance->client)


### PR DESCRIPTION
This prevents garbage or exposure of sensitive data when NF instance is used-after-free. This is especially visible when UE deregisters, AMF discovers UDM to send Amf3GppAccessRegistration and re-setups the NF Instance.

02/03 11:30:33.249: [sbi] WARNING: [internet] NF Instance updated [type:UDM validity:30s] (../lib/sbi/path.c:297)
02/03 11:30:33.249: [sbi] INFO: [fd0c4d42-4574-4b9c-8623-d595f355f219] NF Instance setup [type:UDM validity:30s] (../lib/sbi/path.c:297)



-- Appropriate fix will be sent later.