### PR TITLE
[DBI] Improve YAML policy config by adding SUPI range filtering

### DIFF
--- a/configs/examples/5gc-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-sepp1-999-70.yaml.in
@@ -350,9 +350,9 @@ pcf:
       - address: 127.0.1.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 001
-        mnc: 01
+    - supi_range:
+        - 001010000000001-001019999999999
+        - 315010000000001-315010999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -428,85 +428,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 315
-        mnc: 010
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/examples/5gc-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-sepp2-001-01.yaml.in
@@ -351,9 +351,9 @@ pcf:
       - address: 127.0.2.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 999
-        mnc: 70
+    - supi_range:
+        - 999700000000001-999709999999999
+        - 315010000000001-315010999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -429,85 +429,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 315
-        mnc: 010
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/examples/5gc-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-sepp3-315-010.yaml.in
@@ -351,9 +351,9 @@ pcf:
       - address: 127.0.3.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 999
-        mnc: 70
+    - supi_range:
+        - 999700000000001-999709999999999
+        - 001010000000001-001019999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -429,85 +429,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 001
-        mnc: 01
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/examples/5gc-tls-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-tls-sepp1-999-70.yaml.in
@@ -355,9 +355,9 @@ pcf:
       - address: 127.0.1.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 001
-        mnc: 01
+    - supi_range:
+        - 001010000000001-001019999999999
+        - 315010000000001-315010999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -433,85 +433,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 315
-        mnc: 010
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/examples/5gc-tls-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-tls-sepp2-001-01.yaml.in
@@ -356,9 +356,9 @@ pcf:
       - address: 127.0.2.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 999
-        mnc: 70
+    - supi_range:
+        - 999700000000001-999709999999999
+        - 315010000000001-315010999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -434,85 +434,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 315
-        mnc: 010
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/examples/5gc-tls-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-tls-sepp3-315-010.yaml.in
@@ -356,9 +356,9 @@ pcf:
       - address: 127.0.3.13
         port: 9090
   policy:
-    - plmn_id:
-        mcc: 999
-        mnc: 70
+    - supi_range:
+        - 999700000000001-999709999999999
+        - 001010000000001-001010999999999
       slice:
         - sst: 1  # 1,2,3,4
           default_indicator: true
@@ -434,85 +434,6 @@ pcf:
                       uplink:
                         value: 802
                         unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-    - plmn_id:
-        mcc: 001
-        mnc: 01
-      slice:
-        - sst: 1  # 1,2,3,4
-          default_indicator: true
-          session:
-            - name: internet
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3
-              qos:
-                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-            - name: ims
-              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-              ambr:
-                downlink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                uplink:
-                  value: 1
-                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-              qos:
-                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                arp:
-                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-              pcc_rule:
-                - qos:
-                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 82
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                - qos:
-                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-                    arp:
-                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-                    mbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                    gbr:
-                      downlink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-                      uplink:
-                        value: 802
-                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-
 nssf:
   sbi:
     server:

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -25,73 +25,85 @@ pcf:
         port: 9090
 
 ################################################################################
-# Locally configured policy
-# - The PCF in the VPLMN uses locally configured policies
-#   according to the roaming agreement with the HPLMN operator
-#   as input for PCC Rule generation.
+# PCF Policy Configuration: UE Home PLMN and SUPI Range Based Policies
 ################################################################################
 #
-#  o You don't have to use MongoDB if you use the policy configuration as below.
+# This configuration applies policies based on the UE's home PLMN ID and
+# SUPI range. When both supi_range and plmn_id are specified in a policy,
+# the policy is applied only if both conditions are met.
+#
+# supi_range: Specifies one or more ranges of SUPIs. A maximum of 16 ranges
+#             can be defined.
+# plmn_id  : Specifies the UE's home PLMN using MCC and MNC.
+#
+# Example:
 #
 #  policy:
-#    - plmn_id:
+#    - supi_range:          # Filter policies by SUPI
+#        - 999700000000001-999709999999999
+#        - 315010000000001-315010999999999
+#      plmn_id:             # Filter policies by home PLMN-ID
 #        mcc: 999
 #        mnc: 70
-#      slice:
-#        - sst: 1  # 1,2,3,4
+#      slice:               # Specify slice configuration
+#        - sst: 1          # Allowed values: 1, 2, 3, 4
 #          default_indicator: true
-#          session:
+#          session:          # Define session based on DNN
 #            - name: internet
-#              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
+#              type: 3       # 1: IPv4, 2: IPv6, 3: IPv4v6
 #              ambr:
 #                downlink:
 #                  value: 1
-#                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                  unit: 3   # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
 #                uplink:
 #                  value: 1
 #                  unit: 3
 #              qos:
-#                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
+#                index: 9      # Allowed values: 1,2,3,4,65,66,67,75,71,72,
+#                              # 73,74,76,5,6,7,8,9,69,70,79,80,82,83,
+#                              # 84,85,86
 #                arp:
-#                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-#                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
+#                  priority_level: 8   # Allowed values: 1 to 15
+#                  pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#                  pre_emption_capability: 1     # 1: Disabled, 2: Enabled
 #            - name: ims
-#              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
+#              type: 3       # 1: IPv4, 2: IPv6, 3: IPv4v6
 #              ambr:
 #                downlink:
 #                  value: 1
-#                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                  unit: 3   # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
 #                uplink:
 #                  value: 1
-#                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                  unit: 3
 #              qos:
-#                index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
+#                index: 5      # Allowed values: 1,2,3,4,65,66,67,75,71,72,
+#                              # 73,74,76,5,6,7,8,9,69,70,79,80,82,83,
+#                              # 84,85,86
 #                arp:
-#                  priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-#                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
+#                  priority_level: 1   # Allowed values: 1 to 15
+#                  pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#                  pre_emption_capability: 1     # 1: Disabled, 2: Enabled
 #              pcc_rule:
 #                - qos:
-#                    index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
+#                    index: 1   # Allowed values as above
 #                    arp:
-#                      priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#                      pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-#                      pre_emption_capability: 1   # 1: Disabled, 2:Enabled
+#                      priority_level: 1   # Allowed values: 1 to 15
+#                      pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#                      pre_emption_capability: 1     # 1: Disabled, 2: Enabled
 #                    mbr:
 #                      downlink:
 #                        value: 82
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1   # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
 #                      uplink:
 #                        value: 82
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                    gbr:
 #                      downlink:
 #                        value: 82
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                      uplink:
 #                        value: 82
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                  flow:
 #                    - direction: 2
 #                      description: "permit out icmp from any to assigned"
@@ -102,48 +114,48 @@ pcf:
 #                    - direction: 1
 #                      description: "permit out udp from 10.200.136.98/32 1-65535 to assigned 50021"
 #                - qos:
-#                    index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
+#                    index: 2   # Allowed values as above
 #                    arp:
-#                      priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#                      pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-#                      pre_emption_capability: 2   # 1: Disabled, 2:Enabled
+#                      priority_level: 4   # Allowed values: 1 to 15
+#                      pre_emption_vulnerability: 2  # 1: Disabled, 2: Enabled
+#                      pre_emption_capability: 2     # 1: Disabled, 2: Enabled
 #                    mbr:
 #                      downlink:
 #                        value: 802
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                      uplink:
 #                        value: 802
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                    gbr:
 #                      downlink:
 #                        value: 802
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                        unit: 1
 #                      uplink:
 #                        value: 802
-#                        unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#    - plmn_id:
-#        mcc: 001
-#        mnc: 01
-#      slice:
-#        - sst: 1  # 1,2,3,4
+#                        unit: 1
+#
+#    - supi_range:         # Filter policies by SUPI only
+#        - 001010000000001-001019999999999
+#      slice:               # Specify slice configuration
+#        - sst: 1          # Allowed values: 1, 2, 3, 4
 #          sd: 000001
 #          default_indicator: true
-#          session:
+#          session:          # Define session based on DNN
 #            - name: internet
-#              type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
+#              type: 3       # 1: IPv4, 2: IPv6, 3: IPv4v6
 #              ambr:
 #                downlink:
 #                  value: 1
-#                  unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+#                  unit: 3   # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
 #                uplink:
 #                  value: 1
 #                  unit: 3
 #              qos:
-#                index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
+#                index: 9      # Allowed values as above
 #                arp:
-#                  priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#                  pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-#                  pre_emption_capability: 1  # 1: Disabled, 2:Enabled
+#                  priority_level: 8   # Allowed values: 1 to 15
+#                  pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#                  pre_emption_capability: 1     # 1: Disabled, 2: Enabled
 #
 ################################################################################
 # SBI Server

--- a/configs/open5gs/pcrf.yaml.in
+++ b/configs/open5gs/pcrf.yaml.in
@@ -16,90 +16,119 @@ pcrf:
         port: 9090
 
 ################################################################################
-# Locally configured policy
+# PCRF Policy Configuration: SUPI Range Based Policies
 ################################################################################
 #
-#  o You don't have to use MongoDB if you use the policy configuration as below.
+# This configuration applies policies based solely on the UE's SUPI range.
 #
-#  session:
-#    - name: internet
-#      type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-#      ambr:
-#        downlink:
-#          value: 1
-#          unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#        uplink:
-#          value: 1
-#          unit: 3
-#      qos:
-#        index: 9  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-#        arp:
-#          priority_level: 8  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#          pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-#          pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-#    - name: ims
-#      type: 3  # 1:IPv4, 2:IPv6, 3:IPv4v6
-#      ambr:
-#        downlink:
-#          value: 1
-#          unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#        uplink:
-#          value: 1
-#          unit: 3  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#      qos:
-#        index: 5  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-#        arp:
-#          priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#          pre_emption_vulnerability: 1  # 1: Disabled, 2:Enabled
-#          pre_emption_capability: 1  # 1: Disabled, 2:Enabled
-#      pcc_rule:
-#        - qos:
-#            index: 1  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-#            arp:
-#              priority_level: 1  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#              pre_emption_vulnerability: 1   # 1: Disabled, 2:Enabled
-#              pre_emption_capability: 1   # 1: Disabled, 2:Enabled
-#            mbr:
-#              downlink:
-#                value: 82
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#              uplink:
-#                value: 82
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#            gbr:
-#              downlink:
-#                value: 82
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#              uplink:
-#                value: 82
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#          flow:
-#            - direction: 2
-#              description: "permit out icmp from any to assigned"
-#            - direction: 1
-#              description: "permit out icmp from any to assigned"
-#            - direction: 2
-#              description: "permit out udp from 10.200.136.98/32 23455 to assigned 1-65535"
-#            - direction: 1
-#              description: "permit out udp from 10.200.136.98/32 1-65535 to assigned 50021"
-#        - qos:
-#            index: 2  # 1, 2, 3, 4, 65, 66, 67, 75, 71, 72, 73, 74, 76, 5, 6, 7, 8, 9, 69, 70, 79, 80, 82, 83, 84, 85, 86
-#            arp:
-#              priority_level: 4  # 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-#              pre_emption_vulnerability: 2   # 1: Disabled, 2:Enabled
-#              pre_emption_capability: 2   # 1: Disabled, 2:Enabled
-#            mbr:
-#              downlink:
-#                value: 802
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#              uplink:
-#                value: 802
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#            gbr:
-#              downlink:
-#                value: 802
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
-#              uplink:
-#                value: 802
-#                unit: 1  # 0:bps, 1:Kbps, 2:Mbps, 3:Gbps, 4:Tbps
+# supi_range: Specifies one or more ranges of SUPIs.
+# session:   Defines the session configuration for each DNN.
 #
+# Example:
+#
+#  policy:
+#    - supi_range:          # Filter policies by SUPI
+#        - 999700000000001-999709999999999
+#        - 315010000000001-315010999999999
+#      session:              # Define session based on DNN
+#        - name: internet
+#          type: 3         # 1: IPv4, 2: IPv6, 3: IPv4v6
+#          ambr:
+#            downlink:
+#              value: 1
+#              unit: 3     # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
+#            uplink:
+#              value: 1
+#              unit: 3
+#          qos:
+#            index: 9        # Allowed values: 1,2,3,4,65,66,67,75,71,72,
+#                             # 73,74,76,5,6,7,8,9,69,70,79,80,82,83,
+#                             # 84,85,86
+#            arp:
+#              priority_level: 8   # Allowed values: 1 to 15
+#              pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#              pre_emption_capability: 1     # 1: Disabled, 2: Enabled
+#        - name: ims
+#          type: 3         # 1: IPv4, 2: IPv6, 3: IPv4v6
+#          ambr:
+#            downlink:
+#              value: 1
+#              unit: 3
+#            uplink:
+#              value: 1
+#              unit: 3
+#          qos:
+#            index: 5        # Allowed values as above
+#            arp:
+#              priority_level: 1   # Allowed values: 1 to 15
+#              pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#              pre_emption_capability: 1     # 1: Disabled, 2: Enabled
+#          pcc_rule:
+#            - qos:
+#                index: 1    # Allowed values as above
+#                arp:
+#                  priority_level: 1
+#                  pre_emption_vulnerability: 1
+#                  pre_emption_capability: 1
+#                mbr:
+#                  downlink:
+#                    value: 82
+#                    unit: 1   # 0: bps, 1: Kbps, 2: Mbps, 3: Gbps, 4: Tbps
+#                  uplink:
+#                    value: 82
+#                    unit: 1
+#                gbr:
+#                  downlink:
+#                    value: 82
+#                    unit: 1
+#                  uplink:
+#                    value: 82
+#                    unit: 1
+#              flow:
+#                - direction: 2
+#                  description: "permit out icmp from any to assigned"
+#                - direction: 1
+#                  description: "permit out icmp from any to assigned"
+#                - direction: 2
+#                  description: "permit out udp from 10.200.136.98/32 23455 to assigned 1-65535"
+#                - direction: 1
+#                  description: "permit out udp from 10.200.136.98/32 1-65535 to assigned 50021"
+#            - qos:
+#                index: 2    # Allowed values as above
+#                arp:
+#                  priority_level: 4   # Allowed values: 1 to 15
+#                  pre_emption_vulnerability: 2  # 1: Disabled, 2: Enabled
+#                  pre_emption_capability: 2     # 1: Disabled, 2: Enabled
+#                mbr:
+#                  downlink:
+#                    value: 802
+#                    unit: 1
+#                  uplink:
+#                    value: 802
+#                    unit: 1
+#                gbr:
+#                  downlink:
+#                    value: 802
+#                    unit: 1
+#                  uplink:
+#                    value: 802
+#                    unit: 1
+#
+#    - supi_range:         # Filter policies by SUPI only
+#        - 001010000000001-001019999999999
+#      session:              # Define session based on DNN
+#        - name: internet
+#          type: 3         # 1: IPv4, 2: IPv6, 3: IPv4v6
+#          ambr:
+#            downlink:
+#              value: 1
+#              unit: 3
+#            uplink:
+#              value: 1
+#              unit: 3
+#          qos:
+#            index: 9        # Allowed values as above
+#            arp:
+#              priority_level: 8   # Allowed values: 1 to 15
+#              pre_emption_vulnerability: 1  # 1: Disabled, 2: Enabled
+#              pre_emption_capability: 1     # 1: Disabled, 2: Enabled

--- a/docs/_docs/guide/02-building-open5gs-from-sources.md
+++ b/docs/_docs/guide/02-building-open5gs-from-sources.md
@@ -64,9 +64,9 @@ Install the common dependencies for building the source code.
 $ sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git cmake libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
 ```
 
-Install libidn-dev or libidn11-dev Depending on Your System
+Install libidn-dev or libidn11-dev depending on your system
 ```bash
-if apt-cache show libidn-dev > /dev/null 2>&1; then
+$ if apt-cache show libidn-dev > /dev/null 2>&1; then
     sudo apt-get install -y --no-install-recommends libidn-dev
 else
     sudo apt-get install -y --no-install-recommends libidn11-dev

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -144,9 +144,24 @@ typedef struct ogs_local_conf_s {
 
 } ogs_app_local_conf_t;
 
+/* Structure for SUPI-range */
+typedef struct {
+    int num;
+#define OGS_MAX_NUM_OF_SUPI_RANGE 16
+    uint64_t start[OGS_MAX_NUM_OF_SUPI_RANGE];
+    uint64_t end[OGS_MAX_NUM_OF_SUPI_RANGE];
+} ogs_supi_range_t;
+
+
+/* Policy configuration structure.  In a real system, additional fields
+ * (e.g., for plmn_id, slice list, etc.) would be added.
+ */
 typedef struct ogs_app_policy_conf_s {
     ogs_lnode_t lnode;
 
+    ogs_supi_range_t supi_range;
+
+    bool plmn_id_valid;
     ogs_plmn_id_t plmn_id;
 
     ogs_list_t slice_list;
@@ -183,13 +198,17 @@ int ogs_app_parse_local_conf(const char *local);
 int ogs_app_parse_sockopt_config(
         ogs_yaml_iter_t *parent, ogs_sockopt_t *option);
 
+int ogs_app_parse_supi_range_conf(
+        ogs_yaml_iter_t *parent, ogs_supi_range_t *supi_range);
+
 int ogs_app_check_policy_conf(void);
 int ogs_app_parse_session_conf(
         ogs_yaml_iter_t *parent, ogs_app_slice_conf_t *slice_conf);
 
-ogs_app_policy_conf_t *ogs_app_policy_conf_add(ogs_plmn_id_t *plmn_id);
-ogs_app_policy_conf_t *ogs_app_policy_conf_find_by_plmn_id(
-        ogs_plmn_id_t *plmn_id);
+ogs_app_policy_conf_t *ogs_app_policy_conf_add(
+        ogs_supi_range_t *supi_range, ogs_plmn_id_t *plmn_id);
+ogs_app_policy_conf_t *ogs_app_policy_conf_find(
+        char *supi, ogs_plmn_id_t *plmn_id);
 void ogs_app_policy_conf_remove(ogs_app_policy_conf_t *policy_conf);
 void ogs_app_policy_conf_remove_all(void);
 
@@ -209,7 +228,7 @@ void ogs_app_session_conf_remove_all(
         ogs_app_slice_conf_t *slice_conf);
 
 int ogs_app_config_session_data(
-        ogs_plmn_id_t *plmn_id, ogs_s_nssai_t *s_nssai, char *dnn,
+        char *supi, ogs_plmn_id_t *plmn_id, ogs_s_nssai_t *s_nssai, char *dnn,
         ogs_session_data_t *session_data);
 
 #ifdef __cplusplus

--- a/lib/core/ogs-conv.c
+++ b/lib/core/ogs-conv.c
@@ -214,17 +214,17 @@ char *ogs_uint64_to_string(uint64_t x)
     return dup;
 }
 
-ogs_uint24_t ogs_uint24_from_string(char *str)
+ogs_uint24_t ogs_uint24_from_string(char *str, int base)
 {
     ogs_uint24_t x;
 
     ogs_assert(str);
 
-    x.v = ogs_uint64_from_string(str);
+    x.v = ogs_uint64_from_string(str, base);
     return x;
 }
 
-uint64_t ogs_uint64_from_string(char *str)
+uint64_t ogs_uint64_from_string(char *str, int base)
 {
     uint64_t x;
 
@@ -234,7 +234,7 @@ uint64_t ogs_uint64_from_string(char *str)
         return 0;
 
     errno = 0;
-    x = strtoll(str, NULL, 16);
+    x = strtoll(str, NULL, base);
 
     if ((errno == ERANGE && (x == LONG_MAX || x == LONG_MIN)) ||
             (errno != 0 && x == 0)) {

--- a/lib/core/ogs-conv.h
+++ b/lib/core/ogs-conv.h
@@ -53,8 +53,17 @@ char *ogs_uint36_to_0string(uint64_t x);
 char *ogs_uint64_to_0string(uint64_t x);
 char *ogs_uint64_to_string(uint64_t x);
 
-ogs_uint24_t ogs_uint24_from_string(char *str);
-uint64_t ogs_uint64_from_string(char *str);
+#define ogs_uint24_from_string_decimal(str) \
+    ogs_uint24_from_string((str), 10)
+#define ogs_uint24_from_string_hexadecimal(str) \
+    ogs_uint24_from_string((str), 16)
+ogs_uint24_t ogs_uint24_from_string(char *str, int base);
+
+#define ogs_uint64_from_string_decimal(str) \
+    ogs_uint64_from_string((str), 10)
+#define ogs_uint64_from_string_hexadecimal(str) \
+    ogs_uint64_from_string((str), 16)
+uint64_t ogs_uint64_from_string(char *str, int base);
 
 double *ogs_alloc_double(double value);
 

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -650,7 +650,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                                     if (v) {
                                                         e_cell_id[
                                                             num_of_e_cell_id] =
-                                                        ogs_uint64_from_string(
+                                                        ogs_uint64_from_string_hexadecimal(
                                                                 (char*)v);
                                                         num_of_e_cell_id++;
                                                     }
@@ -686,7 +686,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                                     if (v) {
                                                         nr_cell_id[
                                                             num_of_nr_cell_id] =
-                                                        ogs_uint64_from_string(
+                                                        ogs_uint64_from_string_hexadecimal(
                                                                 (char*)v);
                                                         num_of_nr_cell_id++;
                                                     }

--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -398,7 +398,7 @@ ogs_uint24_t ogs_s_nssai_sd_from_string(const char *hex)
     if (hex == NULL)
         return sd;
 
-    return ogs_uint24_from_string((char *)hex);
+    return ogs_uint24_from_string_hexadecimal((char *)hex);
 }
 
 int ogs_fqdn_build(char *dst, const char *src, int length)

--- a/lib/sbi/conv.c
+++ b/lib/sbi/conv.c
@@ -1070,7 +1070,7 @@ bool ogs_sbi_s_nssai_from_string(ogs_s_nssai_t *s_nssai, char *str)
             ogs_error("ogs_strdup[%s:%s] failed", str, token);
             goto cleanup;
         }
-        s_nssai->sd = ogs_uint24_from_string(sd);
+        s_nssai->sd = ogs_uint24_from_string_hexadecimal(sd);
     }
 
     rc = true;
@@ -1414,7 +1414,7 @@ bool ogs_sbi_parse_nr_location(ogs_5gs_tai_t *tai, ogs_nr_cgi_t *nr_cgi,
         if (Tai->plmn_id)
             ogs_sbi_parse_plmn_id(&tai->plmn_id, Tai->plmn_id);
         if (Tai->tac)
-            tai->tac = ogs_uint24_from_string(Tai->tac);
+            tai->tac = ogs_uint24_from_string_hexadecimal(Tai->tac);
     }
 
     Ncgi = NrLocation->ncgi;
@@ -1422,7 +1422,8 @@ bool ogs_sbi_parse_nr_location(ogs_5gs_tai_t *tai, ogs_nr_cgi_t *nr_cgi,
         if (Ncgi->plmn_id)
             ogs_sbi_parse_plmn_id(&nr_cgi->plmn_id, Ncgi->plmn_id);
         if (Ncgi->nr_cell_id)
-            nr_cgi->cell_id = ogs_uint64_from_string(Ncgi->nr_cell_id);
+            nr_cgi->cell_id = ogs_uint64_from_string_hexadecimal(
+                    Ncgi->nr_cell_id);
 
     }
 

--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -875,7 +875,7 @@ int ogs_sbi_parse_request(
             char *v = ogs_hash_this_val(hi);
             if (v) {
                 discovery_option->requester_features =
-                    ogs_uint64_from_string(v);
+                    ogs_uint64_from_string_hexadecimal(v);
                 discovery_option_presence = true;
             }
         }
@@ -3369,7 +3369,7 @@ void ogs_sbi_discovery_option_parse_tai(
             if (Tai->plmn_id)
                 ogs_sbi_parse_plmn_id(&tai.plmn_id, Tai->plmn_id);
             if (Tai->tac)
-                tai.tac = ogs_uint24_from_string(Tai->tac);
+                tai.tac = ogs_uint24_from_string_hexadecimal(Tai->tac);
 
             ogs_sbi_discovery_option_set_tai(discovery_option, &tai);
 

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -472,7 +472,7 @@ static void handle_smf_info(
             nr_tai = &nf_info->smf.nr_tai[nf_info->smf.num_of_nr_tai];
             ogs_assert(nr_tai);
             ogs_sbi_parse_plmn_id(&nr_tai->plmn_id, TaiItem->plmn_id);
-            nr_tai->tac = ogs_uint24_from_string(TaiItem->tac);
+            nr_tai->tac = ogs_uint24_from_string_hexadecimal(TaiItem->tac);
 
             nf_info->smf.num_of_nr_tai++;
         }
@@ -507,11 +507,13 @@ static void handle_smf_info(
                     nf_info->smf.nr_tai_range
                         [nf_info->smf.num_of_nr_tai_range].
                             start[tac_index] =
-                                ogs_uint24_from_string(TacRangeItem->start);
+                                ogs_uint24_from_string_hexadecimal(
+                                        TacRangeItem->start);
                     nf_info->smf.nr_tai_range
                         [nf_info->smf.num_of_nr_tai_range].
                             end[tac_index] =
-                                ogs_uint24_from_string(TacRangeItem->end);
+                                ogs_uint24_from_string_hexadecimal(
+                                        TacRangeItem->end);
 
                     nf_info->smf.nr_tai_range
                         [nf_info->smf.num_of_nr_tai_range].
@@ -703,8 +705,10 @@ static void handle_amf_info(
             &nf_instance->nf_info_list, OpenAPI_nf_type_AMF);
     ogs_assert(nf_info);
 
-    nf_info->amf.amf_set_id = ogs_uint64_from_string(AmfInfo->amf_set_id);
-    nf_info->amf.amf_region_id = ogs_uint64_from_string(AmfInfo->amf_region_id);
+    nf_info->amf.amf_set_id = ogs_uint64_from_string_hexadecimal(
+            AmfInfo->amf_set_id);
+    nf_info->amf.amf_region_id = ogs_uint64_from_string_hexadecimal(
+            AmfInfo->amf_region_id);
     GuamiList = AmfInfo->guami_list;
 
     OpenAPI_list_for_each(GuamiList, node) {
@@ -739,7 +743,7 @@ static void handle_amf_info(
             nr_tai = &nf_info->amf.nr_tai[nf_info->amf.num_of_nr_tai];
             ogs_assert(nr_tai);
             ogs_sbi_parse_plmn_id(&nr_tai->plmn_id, TaiItem->plmn_id);
-            nr_tai->tac = ogs_uint24_from_string(TaiItem->tac);
+            nr_tai->tac = ogs_uint24_from_string_hexadecimal(TaiItem->tac);
             nf_info->amf.num_of_nr_tai++;
         }
     }
@@ -774,10 +778,12 @@ static void handle_amf_info(
 
                     nf_info->amf.nr_tai_range
                         [nf_info->amf.num_of_nr_tai_range].start[tac_index] =
-                                ogs_uint24_from_string(TacRangeItem->start);
+                                ogs_uint24_from_string_hexadecimal(
+                                        TacRangeItem->start);
                     nf_info->amf.nr_tai_range
                         [nf_info->amf.num_of_nr_tai_range].end[tac_index] =
-                                ogs_uint24_from_string(TacRangeItem->end);
+                                ogs_uint24_from_string_hexadecimal(
+                                        TacRangeItem->end);
 
                     nf_info->amf.nr_tai_range
                         [nf_info->amf.num_of_nr_tai_range].num_of_tac_range++;
@@ -962,7 +968,8 @@ void ogs_nnrf_nfm_handle_nf_status_subscribe(
     /* SBI Features */
     if (SubscriptionData->nrf_supported_features) {
         subscription_data->nrf_supported_features =
-            ogs_uint64_from_string(SubscriptionData->nrf_supported_features);
+            ogs_uint64_from_string_hexadecimal(
+                    SubscriptionData->nrf_supported_features);
     } else {
         subscription_data->nrf_supported_features = 0;
     }

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -759,7 +759,7 @@ int amf_context_parse_config(void)
                                         s_nssai->sst = atoi(sst);
                                         if (sd)
                                             s_nssai->sd =
-                                                ogs_uint24_from_string(
+                                                ogs_uint24_from_string_hexadecimal(
                                                         (char*)sd);
                                         else
                                             s_nssai->sd.v =

--- a/src/amf/npcf-handler.c
+++ b/src/amf/npcf-handler.c
@@ -149,7 +149,8 @@ int amf_npcf_am_policy_control_handle_create(
     PCF_AM_POLICY_STORE(amf_ue, header.uri, message.h.resource.component[1]);
 
     /* SBI Features */
-    supported_features = ogs_uint64_from_string(PolicyAssociation->supp_feat);
+    supported_features = ogs_uint64_from_string_hexadecimal(
+            PolicyAssociation->supp_feat);
     amf_ue->am_policy_control_features &= supported_features;
 
     OpenAPI_list_for_each(PolicyAssociation->triggers, node) {

--- a/src/bsf/nbsf-handler.c
+++ b/src/bsf/nbsf-handler.c
@@ -195,7 +195,8 @@ bool bsf_nbsf_management_handle_pcf_binding(
 
             if (RecvPcfBinding->supp_feat) {
                 uint64_t supported_features =
-                    ogs_uint64_from_string(RecvPcfBinding->supp_feat);
+                    ogs_uint64_from_string_hexadecimal(
+                            RecvPcfBinding->supp_feat);
                 sess->management_features &= supported_features;
 
                 if (sess->management_features != supported_features) {

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -889,7 +889,7 @@ int mme_context_parse_config(void)
                                                     if (v) {
                                                         e_cell_id[
                                                             num_of_e_cell_id] =
-                                                        ogs_uint64_from_string(
+                                                        ogs_uint64_from_string_hexadecimal(
                                                                 (char*)v);
                                                         num_of_e_cell_id++;
                                                     }
@@ -1118,7 +1118,7 @@ int mme_context_parse_config(void)
                                                     if (v) {
                                                         e_cell_id[
                                                             num_of_e_cell_id] =
-                                                        ogs_uint64_from_string(
+                                                        ogs_uint64_from_string_hexadecimal(
                                                                 (char*)v);
                                                         num_of_e_cell_id++;
                                                     }

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -499,7 +499,8 @@ bool nrf_nnrf_handle_nf_status_subscribe(
 
     if (SubscriptionData->requester_features) {
         subscription_data->requester_features =
-            ogs_uint64_from_string(SubscriptionData->requester_features);
+            ogs_uint64_from_string_hexadecimal(
+                    SubscriptionData->requester_features);
 
         /* No need to send SubscriptionData->requester_features to the NF */
         ogs_free(SubscriptionData->requester_features);

--- a/src/pcf/nbsf-handler.c
+++ b/src/pcf/nbsf-handler.c
@@ -70,7 +70,7 @@ bool pcf_nbsf_management_handle_register(
     PcfBinding = recvmsg->PcfBinding;
     if (PcfBinding->supp_feat) {
         uint64_t supported_features =
-            ogs_uint64_from_string(PcfBinding->supp_feat);
+            ogs_uint64_from_string_hexadecimal(PcfBinding->supp_feat);
         sess->management_features &= supported_features;
     }
 

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -118,7 +118,8 @@ bool pcf_npcf_am_policy_control_handle_create(pcf_ue_t *pcf_ue,
     ogs_freeaddrinfo(addr6);
 
     supported_features =
-        ogs_uint64_from_string(PolicyAssociationRequest->supp_feat);
+        ogs_uint64_from_string_hexadecimal(
+                PolicyAssociationRequest->supp_feat);
     pcf_ue->am_policy_control_features &= supported_features;
 
     if (PolicyAssociationRequest->gpsi) {
@@ -328,7 +329,8 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
 
     if (SmPolicyContextData->supp_feat) {
         uint64_t supported_features =
-            ogs_uint64_from_string(SmPolicyContextData->supp_feat);
+            ogs_uint64_from_string_hexadecimal(
+                    SmPolicyContextData->supp_feat);
         sess->smpolicycontrol_features &= supported_features;
     } else {
         sess->smpolicycontrol_features = 0;
@@ -703,7 +705,8 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
         goto cleanup;
     }
 
-    supported_features = ogs_uint64_from_string(AscReqData->supp_feat);
+    supported_features = ogs_uint64_from_string_hexadecimal(
+            AscReqData->supp_feat);
     sess->policyauthorization_features &= supported_features;
 
     if (sess->policyauthorization_features != supported_features) {

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -293,7 +293,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
                     OGS_SBI_CUSTOM_DISCOVERY_REQUESTER_FEATURES)) {
             if (val)
                 discovery_option->requester_features =
-                    ogs_uint64_from_string(val);
+                    ogs_uint64_from_string_hexadecimal(val);
         } else {
             /* ':scheme' and ':authority' will be automatically filled in later */
         }

--- a/src/sepp/n32c-handler.c
+++ b/src/sepp/n32c-handler.c
@@ -140,7 +140,8 @@ bool sepp_n32c_handshake_handle_security_capability_request(
 
     if (SecNegotiateReqData->supported_features) {
         uint64_t supported_features =
-            ogs_uint64_from_string(SecNegotiateReqData->supported_features);
+            ogs_uint64_from_string_hexadecimal(
+                    SecNegotiateReqData->supported_features);
         sepp_node->supported_features &= supported_features;
     } else {
         sepp_node->supported_features = 0;
@@ -209,7 +210,8 @@ bool sepp_n32c_handshake_handle_security_capability_response(
 
     if (SecNegotiateRspData->supported_features) {
         uint64_t supported_features =
-            ogs_uint64_from_string(SecNegotiateRspData->supported_features);
+            ogs_uint64_from_string_hexadecimal(
+                    SecNegotiateRspData->supported_features);
         sepp_node->supported_features &= supported_features;
     } else {
         sepp_node->supported_features = 0;

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -706,7 +706,7 @@ int smf_context_parse_config(void)
                                         s_nssai->sst = atoi(sst);
                                         if (sd)
                                             s_nssai->sd =
-                                                ogs_uint24_from_string(
+                                                ogs_uint24_from_string_hexadecimal(
                                                         (char*)sd);
                                         else
                                             s_nssai->sd.v =

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -377,7 +377,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
     /* SBI Features */
     if (SmPolicyDecision->supp_feat) {
         uint64_t supported_features =
-            ogs_uint64_from_string(SmPolicyDecision->supp_feat);
+            ogs_uint64_from_string_hexadecimal(SmPolicyDecision->supp_feat);
         sess->smpolicycontrol_features &= supported_features;
     } else {
         sess->smpolicycontrol_features = 0;

--- a/tests/af/npcf-handler.c
+++ b/tests/af/npcf-handler.c
@@ -116,7 +116,8 @@ void af_npcf_policyauthorization_handle_create(
 
     PCF_APP_SESSION_STORE(sess, header.uri, message.h.resource.component[1]);
 
-    supported_features = ogs_uint64_from_string(AscReqData->supp_feat);
+    supported_features = ogs_uint64_from_string_hexadecimal(
+            AscReqData->supp_feat);
     sess->policyauthorization_features &= supported_features;
 
 cleanup:

--- a/tests/common/context.c
+++ b/tests/common/context.c
@@ -626,7 +626,7 @@ int test_context_parse_config(void)
                                         s_nssai->sst = atoi(sst);
                                         if (sd)
                                             s_nssai->sd =
-                                                ogs_uint24_from_string(
+                                                ogs_uint24_from_string_hexadecimal(
                                                         (char*)sd);
                                         else
                                             s_nssai->sd.v =

--- a/tests/core/conv-test.c
+++ b/tests/core/conv-test.c
@@ -168,104 +168,104 @@ static void conv_test8(abts_case *tc, void *data)
     x = 0;
     str = ogs_uint64_to_string(0);
     ABTS_STR_EQUAL(tc, "", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string("0"));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal("0"));
     ogs_free(str);
 
     x = 1;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "1", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x12;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "12", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x1234;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "1234", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x12345;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "12345", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x1234567;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "1234567", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x12345678;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "12345678", str);
-    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string(str));
+    ABTS_INT_EQUAL(tc, x, ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789a;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789a", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789ab;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789ab", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789abc;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789abc", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789abcd;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789abcd", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789abcde;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789abcde", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x123456789abcdef;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "123456789abcdef", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 
     x = 0x120456789abcdef0;
     str = ogs_uint64_to_string(x);
     ABTS_STR_EQUAL(tc, "120456789abcdef0", str);
-    ABTS_TRUE(tc, x == ogs_uint64_from_string(str));
+    ABTS_TRUE(tc, x == ogs_uint64_from_string_hexadecimal(str));
     ogs_free(str);
 }
 


### PR DESCRIPTION
Previously, policies were configured via YAML files without MongoDB. This update enhances the YAML approach by adding the 'supi_range' key to filter policies based on UE SUPI ranges. When both 'supi_range' and 'plmn_id' are provided, both conditions must be met.

Note that PLMN-ID filtering will be deprecated in a future release.