### PR TITLE
[AMF] Fix AMF crash during UE handover by handling unexpected SBI responses (#3707)

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1977,6 +1977,29 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             END
             break;
 
+        CASE(OGS_SBI_SERVICE_NAME_NUDM_SDM)
+            if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
+                (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) &&
+                (sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)) {
+                ogs_error("[%s] HTTP response error [%d]",
+                          amf_ue->supi, sbi_message->res_status);
+            }
+
+            SWITCH(sbi_message->h.resource.component[1])
+            CASE(OGS_SBI_RESOURCE_NAME_AM_DATA)
+            CASE(OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA)
+            CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXT_IN_SMF_DATA)
+            CASE(OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS)
+                ogs_warn("[%s] Ignore SBI message", amf_ue->supi);
+                break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[1]);
+                ogs_assert_if_reached();
+            END
+            break;
+
         CASE(OGS_SBI_SERVICE_NAME_NPCF_AM_POLICY_CONTROL)
             SWITCH(sbi_message->h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_POLICIES)


### PR DESCRIPTION
During handover between two gNBs, the AMF enters an invalid state when it receives an unexpected SBI response from the UDM in the process of sending a smf-select-data request. This bug could lead to an AMF crash as the state machine in gmm_state_registration encountered an unknown state.

The fix adds explicit handling for SBI messages with resource names such as AM_DATA, SMF_SELECT_DATA, UE_CONTEXT_IN_SMF_DATA, and SDM_SUBSCRIPTIONS. If the HTTP response status is not OK, CREATED, or NO_CONTENT, a warning is logged and the message is ignored. This prevents the AMF from transitioning into an abnormal state and improves overall stability during frequent handovers.