### PR TITLE
[sbi] add option to support binding local interface/ip for sbi calls

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -133,6 +133,9 @@ ogs_sbi_client_t *ogs_sbi_client_add(
         client->sslkeylog =
             ogs_strdup(ogs_sbi_self()->tls.client.sslkeylog);
 
+    if (ogs_sbi_self()->local_if)
+       client->local_if = ogs_strdup(ogs_sbi_self()->local_if);
+
     ogs_debug("ogs_sbi_client_add [%s]", OpenAPI_uri_scheme_ToString(scheme));
     OGS_OBJECT_REF(client);
 

--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -217,6 +217,8 @@ void ogs_sbi_client_remove(ogs_sbi_client_t *client)
         ogs_free(client->cert);
     if (client->sslkeylog)
         ogs_free(client->sslkeylog);
+    if (client->local_if)
+        ogs_free(client->local_if);
 
     if (client->fqdn)
         ogs_free(client->fqdn);
@@ -556,6 +558,10 @@ static connection_t *connection_add(
     if (client->resolve) {
         conn->resolve_list = curl_slist_append(NULL, client->resolve);
         curl_easy_setopt(conn->easy, CURLOPT_RESOLVE, conn->resolve_list);
+    }
+
+    if (client->local_if) {
+        curl_easy_setopt(conn->easy, CURLOPT_INTERFACE, client->local_if);
     }
 
     curl_easy_setopt(conn->easy, CURLOPT_PRIVATE, conn);

--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -81,6 +81,7 @@ typedef struct ogs_sbi_client_s {
     OpenAPI_uri_scheme_e scheme;
     bool insecure_skip_verify;
     char *cacert, *private_key, *cert, *sslkeylog;
+    char *local_if;
 
     char *fqdn;
     uint16_t fqdn_port;

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -256,7 +256,9 @@ int ogs_sbi_context_parse_config(
                         const char *default_key =
                             ogs_yaml_iter_key(&default_iter);
                         ogs_assert(default_key);
-                        if (!strcmp(default_key, "tls")) {
+                        if (!strcmp(default_key, "interface")) {
+                           self.local_if = ogs_yaml_iter_value(&default_iter);
+                        } else if (!strcmp(default_key, "tls")) {
                             ogs_yaml_iter_t tls_iter;
                             ogs_yaml_iter_recurse(&default_iter, &tls_iter);
                             while (ogs_yaml_iter_next(&tls_iter)) {

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1073,6 +1073,7 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
     const char *client_private_key = NULL;
     const char *client_cert = NULL;
     const char *client_sslkeylog = NULL;
+    const char *local_if = NULL;
 
     bool rc;
 
@@ -1116,6 +1117,8 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
             client_cert = ogs_yaml_iter_value(iter);
         } else if (!strcmp(key, "client_sslkeylogfile")) {
             client_sslkeylog = ogs_yaml_iter_value(iter);
+        } else if (!strcmp(key, "interface")) {
+            local_if = ogs_yaml_iter_value(iter);
         }
     }
 
@@ -1190,6 +1193,13 @@ ogs_sbi_client_t *ogs_sbi_context_parse_client_config(ogs_yaml_iter_t *iter)
             ogs_free(client->sslkeylog);
         client->sslkeylog = ogs_strdup(client_sslkeylog);
         ogs_assert(client->sslkeylog);
+    }
+
+    if (local_if) {
+        if (client->local_if)
+            ogs_free(client->local_if);
+        client->local_if = ogs_strdup(local_if);
+        ogs_assert(client->local_if);
     }
 
     if ((!client_private_key && client_cert) ||

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -88,6 +88,8 @@ typedef struct ogs_sbi_context_s {
         } client;
     } tls;
 
+    const char *local_if;
+
     ogs_list_t server_list;
     ogs_list_t client_list;
 


### PR DESCRIPTION
Currently with the SBI interface, libcurl sets up all outgoing HTTP sessions by not binding a local port/interface/IP at all and just letting the OS routing system decide what makes sense. This is fine in certain contexts but is less than ideal in others.  Problem examples include (1) a system with multiple public IPs, (2) machines that bridge public/private networks, or (3) most important to me, the loopback interface, where the logs can get confusing because a service like the AMF can *bind* the interface 127.0.0.5 but all outgoing comms still come from 127.0.0.1.

This PR adds the optional "interface" config parameter to an SBI clienet that allows an operator to restrict the local interface to a specific interface or IP address by passing a string to libcurl. Allowable syntax includes an interface name, an IP address, or a hostname. See https://curl.se/libcurl/c/CURLOPT_INTERFACE.html for more details. If this parameter is not included, default behavior is unchanged as described above.

