### PR TITLE
Fix Prometheus v3 Content-Type Header Requirement

### DIFF
--- a/lib/metrics/prometheus/context.c
+++ b/lib/metrics/prometheus/context.c
@@ -209,6 +209,7 @@ static _MHD_Result mhd_server_access_handler(void *cls, struct MHD_Connection *c
     if (strcmp(url, "/metrics") == 0) {
         buf = prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
         rsp = MHD_create_response_from_buffer(strlen(buf), (void *)buf, MHD_RESPMEM_MUST_FREE);
+        MHD_add_response_header(rsp, "Content-Type", "text/plain; version=0.0.4; charset=utf-8");
         ret = MHD_queue_response(connection, MHD_HTTP_OK, rsp);
         MHD_destroy_response(rsp);
         return ret;


### PR DESCRIPTION

Prometheus v3 enforces stricter validation of the `Content-Type` header when scraping metrics. If the default configuration of Prometheus v3 is used, a `Content-Type` header is required. See the official documentation for more details:  
[Prometheus v3 Migration Guide - Scrape Protocols](https://prometheus.io/docs/prometheus/3.0/migration/#scrape-protocols).

When using the default Prometheus v3 configuration, the following error occurs:

```
Error scraping target: non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target.
```
![imagen](https://github.com/user-attachments/assets/2a1df329-b0a9-472a-8d7e-df8f9204a418)

This Pull Request fixes this issue by adding the required `Content-Type` header, ensuring compatibility with the default Prometheus v3 configuration.
