### PR TITLE
[PFCP] fix crash for when PFCP NodeId is FQDN

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1081,6 +1081,7 @@ int ogs_pfcp_node_merge(ogs_pfcp_node_t *node,
                 ogs_freeaddrinfo(node->addr_list);
                 node->addr_list = tmp_list;
                 node->last_dns_refresh = now;
+                node->current_addr = NULL;
                 tmp_list = NULL;
             }
         }


### PR DESCRIPTION
Test scenario:
- start 5G core
- wait for 5 minutes after SMF establishes PFCP association to UPF (DNS query refresh interval)
- register UE and establish PDU session
- crash

[upf] DEBUG: upf_state_operational(): UPF_EVT_N4_MESSAGE (../src/upf/upf-sm.c:51) [upf] DEBUG: upf_pfcp_state_associated(): UPF_EVT_N4_MESSAGE (../src/upf/pfcp-sm.c:185) [upf] INFO: [Added] Number of UPF-Sessions is now 1 (../src/upf/context.c:217) [upf] DEBUG: Session Establishment Request (../src/upf/n4-handler.c:66) [gtp] INFO: gtp_connect() [127.0.0.8]:2152 (../lib/gtp/path.c:60) [upf] INFO: UE F-SEID[UP:0x1230 CP:0x5817] APN[local] PDN-Type[1] IPv4[10.46.0.2] IPv6[] (../src/upf/context.c:532) [upf] INFO: UE F-SEID[UP:0x1230 CP:0x5817] APN[local] PDN-Type[1] IPv4[10.46.0.2] IPv6[] (../src/upf/context.c:532) [upf] DEBUG: Session Establishment Response (../src/upf/n4-build.c:36) [pfcp] FATAL: ogs_pfcp_sendto: should not be reached. (../lib/pfcp/path.c:158) [core] FATAL: backtrace() returned 12 addresses (../lib/core/ogs-abort.c:37) /open5gs/build/src/upf/../../lib/pfcp/libogspfcp.so.2(ogs_pfcp_sendto+0x1c8) [0x7f73c5ac0888] /open5gs/build/src/upf/../../lib/pfcp/libogspfcp.so.2(ogs_pfcp_xact_commit+0x170) [0x7f73c5ac3510] /open5gs/./build/src/upf/open5gs-upfd(+0x109eb) [0x55d7f20f99eb] /open5gs/./build/src/upf/open5gs-upfd(+0x12351) [0x55d7f20fb351] /open5gs/build/src/upf/../../lib/core/libogscore.so.2(ogs_fsm_dispatch+0x24) [0x7f73c5b57574] /open5gs/./build/src/upf/open5gs-upfd(+0xc445) [0x55d7f20f5445] /open5gs/build/src/upf/../../lib/core/libogscore.so.2(ogs_fsm_dispatch+0x24) [0x7f73c5b57574] /open5gs/./build/src/upf/open5gs-upfd(+0x77fb) [0x55d7f20f07fb] /open5gs/build/src/upf/../../lib/core/libogscore.so.2(+0xfb05) [0x7f73c5b4cb05] /lib/x86_64-linux-gnu/libc.so.6(+0x9ca94) [0x7f73c551ea94] /lib/x86_64-linux-gnu/libc.so.6(__clone+0x44) [0x7f73c55aba34]