### PR TITLE
[SBI] retrieve all currently registered NF's on app startup

### DIFF
--- a/lib/sbi/custom/links.c
+++ b/lib/sbi/custom/links.c
@@ -46,7 +46,8 @@ cJSON *ogs_sbi_links_convertToJSON(ogs_sbi_links_t *links)
     ogs_assert(linksJSON);
 
     cJSON_AddItemToObject(linksJSON, "items", itemsJSON);
-    cJSON_AddItemToObject(linksJSON, "self", selfJSON); 
+    cJSON_AddItemToObject(linksJSON, "self", selfJSON);
+    cJSON_AddNumberToObject(linksJSON, "totalItemCount", cJSON_GetArraySize(itemsJSON));
 
     /* root */
     root = cJSON_CreateObject();
@@ -55,4 +56,58 @@ cJSON *ogs_sbi_links_convertToJSON(ogs_sbi_links_t *links)
     cJSON_AddItemToObject(root, "_links", linksJSON);
 
     return root;
+}
+
+ogs_sbi_links_t *ogs_sbi_links_parseFromJSON(cJSON *json)
+{
+    ogs_sbi_links_t *links;
+    cJSON *_links = NULL;
+    cJSON *_items = NULL, *_item = NULL;
+    cJSON *_self = NULL;
+
+    ogs_assert(json);
+
+    _links = cJSON_GetObjectItemCaseSensitive(json, "_links");
+    if (!_links) {
+        ogs_error("No _links");
+        return NULL;
+    }
+
+    _items = cJSON_GetObjectItemCaseSensitive(_links, "items");
+    if (!_items) {
+        ogs_error("No items");
+        return NULL;
+    }
+
+
+    links = ogs_malloc(sizeof(ogs_sbi_links_t));
+    ogs_assert(links);
+
+    memset(links, 0, sizeof(*links));
+    links->items = OpenAPI_list_create();
+    ogs_assert(links->items);
+
+
+    cJSON_ArrayForEach(_item, _items) {
+        cJSON *href;
+        char *link;
+
+        href = cJSON_GetObjectItemCaseSensitive(_item, "href");
+        if (href) {
+            link = cJSON_GetStringValue(href);
+            OpenAPI_list_add(links->items, ogs_strdup(link));
+        }
+    }
+
+
+    _self = cJSON_GetObjectItemCaseSensitive(_links, "self");
+    if (_self) {
+        cJSON *self_href;
+
+        self_href = cJSON_GetObjectItemCaseSensitive(_self, "href");
+        if (self_href)
+            links->self = ogs_strdup(cJSON_GetStringValue(self_href));
+    }
+
+    return links;
 }

--- a/lib/sbi/custom/links.h
+++ b/lib/sbi/custom/links.h
@@ -23,6 +23,7 @@ typedef struct ogs_sbi_links_s {
 } ogs_sbi_links_t;
 
 cJSON *ogs_sbi_links_convertToJSON(ogs_sbi_links_t *links);
+ogs_sbi_links_t *ogs_sbi_links_parseFromJSON(cJSON *json);
 
 #ifdef __cplusplus
 }

--- a/lib/sbi/nf-sm.c
+++ b/lib/sbi/nf-sm.c
@@ -19,6 +19,93 @@
 
 #include "ogs-sbi.h"
 
+static void handle_nf_profile_retrieval(
+        char *nf_instance_id,
+        OpenAPI_nf_profile_t *NFProfile)
+{
+    ogs_sbi_nf_instance_t *nf_instance;
+    ogs_sbi_subscription_spec_t *subscription_spec = NULL;
+    bool save = false;
+
+    ogs_assert(nf_instance_id);
+    ogs_assert(NFProfile);
+
+    nf_instance = ogs_sbi_nf_instance_find(nf_instance_id);
+    if (nf_instance) {
+        /* already have this nf_instance; done */
+        return;
+    }
+
+    if (NF_INSTANCE_ID_IS_SELF(nf_instance_id)) {
+        /* don't save ourselves */
+        return;
+    }
+
+    nf_instance = ogs_sbi_nf_instance_add();
+    ogs_assert(nf_instance);
+
+    ogs_sbi_nf_instance_set_id(nf_instance, nf_instance_id);
+
+    ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
+
+    /* verify against our subscription list that we want to save this
+     * nf instance to our context */
+    ogs_list_for_each(&ogs_sbi_self()->subscription_spec_list, subscription_spec) {
+        ogs_sbi_nf_service_t *nf_service = NULL;
+
+        if (subscription_spec->subscr_cond.nf_type == nf_instance->nf_type) {
+            /* ok; save the nf_instance */
+            save = true;
+            break;
+        }
+
+        ogs_list_for_each(&nf_instance->nf_service_list, nf_service) {
+            if (subscription_spec->subscr_cond.service_name &&
+                nf_service->name &&
+                !strcmp(subscription_spec->subscr_cond.service_name, nf_service->name))
+            {
+                /* ok; save the nf_instance */
+                save = true;
+                break;
+            }
+        }
+
+        if (save)
+            break;
+    }
+
+    if (!save) {
+        ogs_sbi_nf_instance_remove(nf_instance);
+    } else {
+        ogs_sbi_nf_fsm_init(nf_instance);
+        ogs_info("[%s] (NRF-profile-get) NF registered", nf_instance->id);
+        ogs_sbi_client_associate(nf_instance);
+    }
+}
+
+static void handle_nf_list_retrieval(ogs_sbi_links_t *links)
+{
+    ogs_sbi_header_t header;
+    ogs_sbi_message_t msg;
+    OpenAPI_lnode_t *node = NULL;
+
+    OpenAPI_list_for_each(links->items, node) {
+
+        memset(&header, 0, sizeof(header));
+        header.uri = node->data;
+
+        if (ogs_sbi_parse_header(&msg, &header) != OGS_OK) {
+            ogs_error("Cannot parse href: %s", header.uri);
+            continue;
+        }
+
+        if (msg.h.resource.component[1])
+            ogs_nnrf_nfm_send_nf_profile_get(msg.h.resource.component[1]);
+
+        ogs_sbi_header_free(&header);
+    }
+}
+
 void ogs_sbi_nf_fsm_init(ogs_sbi_nf_instance_t *nf_instance)
 {
     ogs_event_t e;
@@ -227,6 +314,8 @@ void ogs_sbi_nf_state_registered(ogs_fsm_t *s, ogs_event_t *e)
                         subscription_spec->subscr_cond.nf_type,
                         subscription_spec->subscr_cond.service_name);
             }
+
+            ogs_nnrf_nfm_send_nf_list_retrieve();
         }
         break;
 
@@ -252,19 +341,64 @@ void ogs_sbi_nf_state_registered(ogs_fsm_t *s, ogs_event_t *e)
             SWITCH(message->h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_NF_INSTANCES)
 
-                if (message->res_status == OGS_SBI_HTTP_STATUS_NO_CONTENT ||
-                    message->res_status == OGS_SBI_HTTP_STATUS_OK) {
-                    if (nf_instance->time.heartbeat_interval)
-                        ogs_timer_start(nf_instance->t_no_heartbeat,
-                            ogs_time_from_sec(
-                                nf_instance->time.heartbeat_interval +
-                                ogs_local_conf()->time.nf_instance.
-                                    no_heartbeat_margin));
+                if (message->h.resource.component[1]) {
+                    SWITCH(message->h.method)
+                    CASE(OGS_SBI_HTTP_METHOD_PATCH)
+                        if (message->res_status == OGS_SBI_HTTP_STATUS_NO_CONTENT ||
+                            message->res_status == OGS_SBI_HTTP_STATUS_OK) {
+
+                            if (nf_instance->time.heartbeat_interval)
+                                ogs_timer_start(nf_instance->t_no_heartbeat,
+                                    ogs_time_from_sec(
+                                        nf_instance->time.heartbeat_interval +
+                                        ogs_local_conf()->time.nf_instance.
+                                            no_heartbeat_margin));
+
+                        } else {
+                            ogs_warn("[%s] HTTP response error [%d]",
+                                NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
+                                message->res_status);
+                            OGS_FSM_TRAN(s, &ogs_sbi_nf_state_exception);
+                        }
+                        break;
+
+                    CASE(OGS_SBI_HTTP_METHOD_GET)
+                        if (message->res_status == OGS_SBI_HTTP_STATUS_OK) {
+                            if (!message->h.resource.component[1]) {
+                                ogs_error("No NFInstanceId");
+                                break;
+                            }
+                            if (!message->NFProfile) {
+                                ogs_error("No NFProfile");
+                                break;
+                            }
+                            handle_nf_profile_retrieval(
+                                message->h.resource.component[1],
+                                message->NFProfile);
+                        } else {
+                            ogs_warn("[%s] HTTP response error [%d]",
+                                NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
+                                message->res_status);
+                            OGS_FSM_TRAN(s, &ogs_sbi_nf_state_exception);
+                        }
+                        break;
+                    DEFAULT
+                        ogs_error("Unknown method [%s]", message->h.method);
+                        break;
+                    END
                 } else {
-                    ogs_warn("[%s] HTTP response error [%d]",
-                            NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
-                            message->res_status);
-                    OGS_FSM_TRAN(s, &ogs_sbi_nf_state_exception);
+                    if (!message->links) {
+                        ogs_warn("No links");
+                        break;
+                    }
+                    if (message->res_status != OGS_SBI_HTTP_STATUS_OK) {
+                        ogs_warn("[%s] HTTP response error [%d]",
+                                NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
+                                message->res_status);
+                        break;
+                    }
+
+                    handle_nf_list_retrieval(message->links);
                 }
 
                 break;

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -1817,6 +1817,24 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_profile_retrieve(char *nf_instance_id)
     return request;
 }
 
+ogs_sbi_request_t *ogs_nnrf_nfm_build_nflist_retrieve(void)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_GET;
+    message.h.service.name = (char *)OGS_SBI_SERVICE_NAME_NNRF_NFM;
+    message.h.api.version = (char *)OGS_SBI_API_V1;
+    message.h.resource.component[0] =
+        (char *)OGS_SBI_RESOURCE_NAME_NF_INSTANCES;
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+    return request;
+}
+
 ogs_sbi_request_t *ogs_nnrf_disc_build_discover(
         OpenAPI_nf_type_e target_nf_type,
         OpenAPI_nf_type_e requester_nf_type,

--- a/lib/sbi/nnrf-build.h
+++ b/lib/sbi/nnrf-build.h
@@ -42,6 +42,7 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_update(
 ogs_sbi_request_t *ogs_nnrf_nfm_build_status_unsubscribe(
         ogs_sbi_subscription_data_t *subscription_data);
 ogs_sbi_request_t *ogs_nnrf_nfm_build_profile_retrieve(char *nf_instance_id);
+ogs_sbi_request_t *ogs_nnrf_nfm_build_nflist_retrieve(void);
 
 ogs_sbi_request_t *ogs_nnrf_disc_build_discover(
         OpenAPI_nf_type_e target_nf_type,

--- a/lib/sbi/nnrf-path.c
+++ b/lib/sbi/nnrf-path.c
@@ -180,3 +180,45 @@ bool ogs_nnrf_nfm_send_nf_status_unsubscribe(
 
     return rc;
 }
+
+bool ogs_nnrf_nfm_send_nf_list_retrieve(void)
+{
+    bool rc;
+    ogs_sbi_request_t *request = NULL;
+
+    request = ogs_nnrf_nfm_build_nflist_retrieve();
+    if (!request) {
+        ogs_error("No Request");
+        return false;
+    }
+
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, ogs_sbi_self()->nf_instance);
+    ogs_expect(rc == true);
+
+    ogs_sbi_request_free(request);
+
+    return rc;
+}
+
+bool ogs_nnrf_nfm_send_nf_profile_get(char *nf_instance_id)
+{
+    bool rc;
+    ogs_sbi_request_t *request = NULL;
+
+    request = ogs_nnrf_nfm_build_profile_retrieve(nf_instance_id);
+    if (!request) {
+        ogs_error("No Request");
+        return false;
+    }
+
+    rc = ogs_sbi_send_request_to_nrf(
+            OGS_SBI_SERVICE_TYPE_NNRF_NFM, NULL,
+            ogs_sbi_client_handler, request, ogs_sbi_self()->nf_instance);
+    ogs_expect(rc == true);
+
+    ogs_sbi_request_free(request);
+
+    return rc;
+}

--- a/lib/sbi/nnrf-path.h
+++ b/lib/sbi/nnrf-path.h
@@ -37,6 +37,8 @@ bool ogs_nnrf_nfm_send_nf_status_update(
         ogs_sbi_subscription_data_t *subscription_data);
 bool ogs_nnrf_nfm_send_nf_status_unsubscribe(
         ogs_sbi_subscription_data_t *subscription_data);
+bool ogs_nnrf_nfm_send_nf_list_retrieve(void);
+bool ogs_nnrf_nfm_send_nf_profile_get(char *nf_instance_id);
 
 bool ogs_nnrf_nfm_send_to_nrf(
         ogs_sbi_client_t *client, ogs_sbi_client_cb_f client_cb,


### PR DESCRIPTION
Before this, there were 2 different ways to search for neighbouring NF's:

a) in the case AMF was started _before_ UDM, AMF would create subscription to NRF to notify it when a UDM would (un)register. In this case, NF instance would remain in AMF's context indefinitely.

b) in the case AMF was started _after_ UDM, AMF would have to use NF discovery mechanism to search for NF's. In this case, NF instance would remain in AMF's context for the duration of Search's validity (defaults to 30 seconds). After validity expires, NF would expire. This means that for heavy traffic situations, AMF would constantly issue discovery requests.

[SBI] save only wanted NF instances on NF List Retrieval

When retrieving a list of NF Instances from NRF, save only the NF's that we want. Check the NF instance against our subscription list for either the NF type or NF Service.
This can still cause a DoS on NRF when NF starts in case there are 100's of NF's in the network, but prevents using too much memory on NF.