### PR TITLE
[UPF] Fixes: Crash in upf_sess_set_ue_ip when PDN type is invalid (#3727)

### DIFF
--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -400,7 +400,6 @@ uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
     uint8_t cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 
     ogs_assert(sess);
-    ogs_assert(session_type);
     ogs_assert(pdr);
     ogs_assert(pdr->ue_ip_addr_len);
     ue_ip = &pdr->ue_ip_addr;
@@ -487,9 +486,10 @@ uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
                 pdr->dnn ? pdr->dnn : "");
         }
     } else {
-        ogs_warn("Cannot support PDN-Type[%d], [IPv4:%d IPv6:%d DNN:%s]",
+        ogs_error("Invalid PDN-Type[%d], [IPv4:%d IPv6:%d DNN:%s]",
                 session_type, ue_ip->ipv4, ue_ip->ipv6,
                 pdr->dnn ? pdr->dnn : "");
+        return OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED;
     }
 
     ogs_info("UE F-SEID[UP:0x%lx CP:0x%lx] "


### PR DESCRIPTION
When receiving a PFCP Session Establishment Request with an invalid PDN type(0), the UPF would crash due to a failed assertion.

This commit improves error handling by:

- Removing the session_type assertion check that caused the crash
- Changing warning log to error log for better visibility
- Returning CAUSE_SERVICE_NOT_SUPPORTED instead of proceeding with invalid type

This prevents potential DoS attacks through malformed PFCP messages.