### PR TITLE
[AUSF] Check length of SUCI_or_SUPI before trying to process

### DIFF
--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -135,6 +135,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             SWITCH(message.h.method)
             CASE(OGS_SBI_HTTP_METHOD_POST)
                 if (message.AuthenticationInfo &&
+                    message.AuthenticationInfo->supi_or_suci &&
                     strlen(message.AuthenticationInfo->supi_or_suci)) {
                     ausf_ue = ausf_ue_find_by_suci_or_supi(
                             message.AuthenticationInfo->supi_or_suci);

--- a/src/ausf/ausf-sm.c
+++ b/src/ausf/ausf-sm.c
@@ -135,7 +135,7 @@ void ausf_state_operational(ogs_fsm_t *s, ausf_event_t *e)
             SWITCH(message.h.method)
             CASE(OGS_SBI_HTTP_METHOD_POST)
                 if (message.AuthenticationInfo &&
-                    message.AuthenticationInfo->supi_or_suci) {
+                    strlen(message.AuthenticationInfo->supi_or_suci)) {
                     ausf_ue = ausf_ue_find_by_suci_or_supi(
                             message.AuthenticationInfo->supi_or_suci);
                     if (!ausf_ue) {


### PR DESCRIPTION
Hi @acetcom,

During testing, I found that sending a blank `supiOrSuci` to the AUSF would result in a crash.  I used this command to cause the crash:

```
curl -v -X POST --http2-prior-knowledge "http://127.0.0.11:7777/nausf-auth/v1/ue-authentications" -d '{"supiOrSuci":"","servingNetworkName":"5G:mnc533.mcc302.3gppnetwork.org"}'
```

This was the observed failure:
```
02/26 23:19:15.805: [core] FATAL: ogs_hash_get_debug: Assertion `klen' failed. (../lib/core/ogs-hash.c:316)
02/26 23:19:15.805: [core] FATAL: backtrace() returned 10 addresses (../lib/core/ogs-abort.c:37)
/usr/local/lib/x86_64-linux-gnu/libogscore.so.2(ogs_hash_get_debug+0x13a) [0x7f82918be92e]
/usr/local/bin/open5gs-ausfd(+0x668c) [0x556fdd9d168c]
/usr/local/bin/open5gs-ausfd(+0x673a) [0x556fdd9d173a]
/usr/local/bin/open5gs-ausfd(+0x92d0) [0x556fdd9d42d0]
/usr/local/lib/x86_64-linux-gnu/libogscore.so.2(ogs_fsm_dispatch+0x113) [0x7f82918bdba1]
/usr/local/bin/open5gs-ausfd(+0x4f60) [0x556fdd9cff60]
/usr/local/lib/x86_64-linux-gnu/libogscore.so.2(+0x117ba) [0x7f82918ae7ba]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x8609) [0x7f8290eb8609]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x43) [0x7f8290ff2353]
Aborted
```

This change will check to ensure that there is a positive length to the incoming `message.AuthenticationInfo->supi_or_suci` to avoid the crash.