### PR TITLE
[AUSF] Cleanup ausf_ue when it is not found in UDM

### DIFF
--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -173,6 +173,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                 if (message->res_status == OGS_SBI_HTTP_STATUS_NOT_FOUND) {
                     ogs_warn("[%s] Cannot find SUPI [%d]",
                         ausf_ue->suci, message->res_status);
+                    OGS_FSM_TRAN(s, ausf_ue_state_exception);
                 } else {
                     ogs_error("[%s] HTTP response error [%d]",
                         ausf_ue->suci, message->res_status);

--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -173,7 +173,6 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                 if (message->res_status == OGS_SBI_HTTP_STATUS_NOT_FOUND) {
                     ogs_warn("[%s] Cannot find SUPI [%d]",
                         ausf_ue->suci, message->res_status);
-                    OGS_FSM_TRAN(s, ausf_ue_state_exception);
                 } else {
                     ogs_error("[%s] HTTP response error [%d]",
                         ausf_ue->suci, message->res_status);
@@ -183,6 +182,7 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                         stream, message->res_status,
                         NULL, "HTTP response error", ausf_ue->suci,
                         message->ProblemDetails->cause));
+                OGS_FSM_TRAN(s, ausf_ue_state_exception);
                 break;
             }
 


### PR DESCRIPTION
Hi @acetcom,

I have noticed that while running open5gs's AUSF with a commercial AMF, that certain scenarios would cause the AUSF to stop functioning over time.  I would observe this error in the logs:

```
ERROR: ogs_pool_id_calloc() failed (../src/ausf/context.c:138)
ERROR: Not found [POST] (../src/ausf/ausf-sm.c:158)
```

We do not have many devices on this network.  From further checking of the logs, a single UE would generate multiple different SUCIs over many failed authentication attempts causing the memory pool to be full at around 1024 `ausf_ue`'s.  I am suggesting this change to remove an `ausf_ue` if the user is not found in the UDM.