### PR TITLE
[SEC] Fix crash in eNBDirectInformationTransfer due to missing Inter_SystemInformationTransferType

### DIFF
--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -2268,7 +2268,7 @@ void s1ap_handle_enb_direct_information_transfer(
     ogs_plmn_id_t plmn_id;
     ogs_nas_rai_t rai;
     uint16_t cell_id;
-    unsigned int i;
+    int i, r;
     mme_sgsn_t *sgsn = NULL;
 
     ogs_assert(enb);
@@ -2293,7 +2293,15 @@ void s1ap_handle_enb_direct_information_transfer(
 
     /* Clang scan-build SA: NULL pointer dereference: Inter_SystemInformationTransferType=NULL if above
      * protocolIEs.list.count=0 in loop. */
-    ogs_assert(Inter_SystemInformationTransferType);
+    if (!Inter_SystemInformationTransferType) {
+        ogs_warn("No Inter_SystemInformationTransferType");
+        r = s1ap_send_error_indication(enb, NULL, NULL,
+                S1AP_Cause_PR_protocol, S1AP_CauseProtocol_semantic_error);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
+
 
     RIMTransfer = Inter_SystemInformationTransferType->choice.rIMTransfer;
 

--- a/tests/attach/crash-test.c
+++ b/tests/attach/crash-test.c
@@ -406,6 +406,40 @@ static void test4_func(abts_case *tc, void *data)
     test_ue_remove(test_ue);
 }
 
+static void test5_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    sendbuf = test_s1ap_build_malformed_enb_direct_information_transfer(0);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    testenb_s1ap_close(s1ap);
+}
+
 abts_suite *test_crash(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -416,6 +450,7 @@ abts_suite *test_crash(abts_suite *suite)
     abts_run_test(suite, test3_func, NULL);
 #endif
     abts_run_test(suite, test4_func, NULL);
+    abts_run_test(suite, test5_func, NULL);
 
     return suite;
 }

--- a/tests/common/s1ap-build.c
+++ b/tests/common/s1ap-build.c
@@ -2196,3 +2196,28 @@ ogs_pkbuf_t *test_s1ap_build_oversized_message(int i)
 
     return pkbuf;
 }
+
+ogs_pkbuf_t *test_s1ap_build_malformed_enb_direct_information_transfer(int i)
+{
+    ogs_pkbuf_t *pkbuf = NULL;
+    const char *payload[TEST_S1AP_MAX_MESSAGE] = {
+        "0025"
+        "0110000001000000 1000008200000000 1000010000001000 0082000000001000"
+        "00",
+        "",
+    };
+
+    uint16_t len[TEST_S1AP_MAX_MESSAGE] = {
+        35,
+        0,
+    };
+
+    char hexbuf[OGS_HUGE_LEN];
+
+    pkbuf = ogs_pkbuf_alloc(NULL, OGS_MAX_SDU_LEN);
+    ogs_assert(pkbuf);
+    ogs_pkbuf_put_data(pkbuf,
+        ogs_hex_from_string(payload[i], hexbuf, sizeof(hexbuf)), len[i]);
+
+    return pkbuf;
+}

--- a/tests/common/s1ap-build.h
+++ b/tests/common/s1ap-build.h
@@ -73,6 +73,7 @@ ogs_pkbuf_t *test_s1ap_build_malformed_s1_setup_request(int i);
 ogs_pkbuf_t *test_s1ap_build_malformed_enb_status_transfer(int i);
 ogs_pkbuf_t *test_s1ap_build_malformed_e_rab_modification_indication(int i);
 ogs_pkbuf_t *test_s1ap_build_oversized_message(int i);
+ogs_pkbuf_t *test_s1ap_build_malformed_enb_direct_information_transfer(int i);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request resolves an issue where the system would crash when Inter_SystemInformationTransferType was not present.