### PR TITLE
[all] fix possible null dereference when using ProblemDetails

### DIFF
--- a/src/ausf/ue-sm.c
+++ b/src/ausf/ue-sm.c
@@ -181,7 +181,8 @@ void ausf_ue_state_operational(ogs_fsm_t *s, ausf_event_t *e)
                     ogs_sbi_server_send_error(
                         stream, message->res_status,
                         NULL, "HTTP response error", ausf_ue->suci,
-                        message->ProblemDetails->cause));
+                        (message->ProblemDetails) ?
+                                message->ProblemDetails->cause : NULL));
                 OGS_FSM_TRAN(s, ausf_ue_state_exception);
                 break;
             }

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -532,7 +532,8 @@ void smf_gsm_state_wait_5gc_sm_policy_association(ogs_fsm_t *s, smf_event_t *e)
                         ogs_sbi_server_send_error(
                             stream, sbi_message->res_status,
                             sbi_message, strerror, NULL,
-                            sbi_message->ProblemDetails->cause));
+                            (sbi_message->ProblemDetails) ?
+                                    sbi_message->ProblemDetails->cause : NULL));
                     ogs_free(strerror);
 
                     OGS_FSM_TRAN(s, smf_gsm_state_exception);
@@ -1018,7 +1019,8 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                         ogs_sbi_server_send_error(
                             stream, sbi_message->res_status,
                             sbi_message, strerror, NULL,
-                            sbi_message->ProblemDetails->cause));
+                            (sbi_message->ProblemDetails) ?
+                                    sbi_message->ProblemDetails->cause : NULL));
                     ogs_free(strerror);
 
                     OGS_FSM_TRAN(s, smf_gsm_state_exception);

--- a/src/udm/nudr-handler.c
+++ b/src/udm/nudr-handler.c
@@ -90,7 +90,8 @@ bool udm_nudr_dr_handle_subscription_authentication(
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(
                         stream, recvmsg->res_status, recvmsg, strerror, NULL,
-                        recvmsg->ProblemDetails->cause));
+                        (recvmsg->ProblemDetails) ?
+                                recvmsg->ProblemDetails->cause : NULL));
                 ogs_free(strerror);
                 return false;
             }
@@ -195,7 +196,8 @@ bool udm_nudr_dr_handle_subscription_authentication(
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(
                         stream, recvmsg->res_status, recvmsg, strerror, NULL,
-                        recvmsg->ProblemDetails->cause));
+                        (recvmsg->ProblemDetails) ?
+                                recvmsg->ProblemDetails->cause : NULL));
                 ogs_free(strerror);
                 return false;
             }
@@ -284,7 +286,8 @@ bool udm_nudr_dr_handle_subscription_authentication(
             ogs_assert(true ==
                 ogs_sbi_server_send_error(
                     stream, recvmsg->res_status, recvmsg, strerror, NULL,
-                    recvmsg->ProblemDetails->cause));
+                    (recvmsg->ProblemDetails) ?
+                            recvmsg->ProblemDetails->cause : NULL));
             ogs_free(strerror);
             return false;
         }
@@ -416,7 +419,8 @@ bool udm_nudr_dr_handle_subscription_context(
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream, recvmsg->res_status,
                 NULL, "HTTP response error", udm_ue->supi,
-                recvmsg->ProblemDetails->cause));
+                (recvmsg->ProblemDetails) ?
+                        recvmsg->ProblemDetails->cause : NULL));
         return false;
     }
 
@@ -793,7 +797,8 @@ bool udm_nudr_dr_handle_smf_registration(
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream, recvmsg->res_status,
                 NULL, "HTTP response error", udm_ue->supi,
-                recvmsg->ProblemDetails->cause));
+                (recvmsg->ProblemDetails) ?
+                        recvmsg->ProblemDetails->cause : NULL));
         return false;
     }
 


### PR DESCRIPTION
In case that NF do not send ProblemDetails in the response. Do not assume that ProblemDetails is always present, to prevent null pointer dereferencing.