### PR TITLE
[SBI] Fix NF Instance Cleanup and Prevent RST on NF Restart (#3740)

### DIFF
--- a/lib/sbi/client.h
+++ b/lib/sbi/client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,15 +40,15 @@ extern "C" {
             client = ((__cTX)->client); \
             ogs_assert(client); \
             if (client->fqdn) { \
-                ogs_warn("NF EndPoint(fqdn) updated [%s:%d]", \
+                ogs_warn("UnRef NF EndPoint(fqdn) [%s:%d]", \
                         client->fqdn, client->fqdn_port); \
             } \
             if (client->addr) { \
-                ogs_warn("NF EndPoint(addr) updated [%s:%d]", \
+                ogs_warn("UnRef NF EndPoint(addr) [%s:%d]", \
                     OGS_ADDR(client->addr, buf), OGS_PORT(client->addr)); \
             } \
             if (client->addr6) { \
-                ogs_warn("NF EndPoint(addr6) updated [%s:%d]", \
+                ogs_warn("UnRef NF EndPoint(addr6) [%s:%d]", \
                     OGS_ADDR(client->addr6, buf), OGS_PORT(client->addr6)); \
             } \
             ogs_sbi_client_remove(client); \
@@ -58,15 +58,15 @@ extern "C" {
         ((__cTX)->client) = (__pClient); \
         ogs_debug("CLIENT Ref [%d]", (__pClient)->reference_count); \
         if ((__pClient)->fqdn) { \
-            ogs_info("NF EndPoint(fqdn) setup [%s:%d]", \
+            ogs_info("Setup NF EndPoint(fqdn) [%s:%d]", \
                     (__pClient)->fqdn, (__pClient)->fqdn_port); \
         } \
         if ((__pClient)->addr) { \
-            ogs_info("NF EndPoint(addr) setup [%s:%d]", \
+            ogs_info("Setup NF EndPoint(addr) [%s:%d]", \
                 OGS_ADDR((__pClient)->addr, buf), OGS_PORT((__pClient)->addr)); \
         } \
         if ((__pClient)->addr6) { \
-            ogs_info("NF EndPoint(addr6) setup [%s:%d]", \
+            ogs_info("Setup NF EndPoint(addr6) [%s:%d]", \
                 OGS_ADDR((__pClient)->addr6, buf), \
                 OGS_PORT((__pClient)->addr6)); \
         } \

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -202,8 +202,9 @@ typedef struct ogs_sbi_object_s {
     ogs_sbi_obj_type_e type;
 
     struct {
-        ogs_sbi_nf_instance_t *nf_instance;
+        char *nf_instance_id;
 
+#if ENABLE_VALIDITY_TIMEOUT
         /*
          * Search.Result stored in nf_instance->time.validity_duration;
          *
@@ -213,6 +214,7 @@ typedef struct ogs_sbi_object_s {
          * if no validityPeriod in SearchResult, validity_timeout is 0.
          */
         ogs_time_t validity_timeout;
+#endif
     } nf_type_array[OGS_SBI_MAX_NUM_OF_NF_TYPE],
       service_type_array[OGS_SBI_MAX_NUM_OF_SERVICE_TYPE];
 
@@ -478,49 +480,77 @@ void ogs_sbi_client_associate(ogs_sbi_nf_instance_t *nf_instance);
 
 int ogs_sbi_default_client_port(OpenAPI_uri_scheme_e scheme);
 
+#if ENABLE_VALIDITY_TIMEOUT
 #define OGS_SBI_SETUP_NF_INSTANCE(__cTX, __nFInstance) \
     do { \
         ogs_assert(__nFInstance); \
         ogs_assert((__nFInstance)->id); \
+        ogs_assert((__nFInstance)->nf_type); \
         ogs_assert((__nFInstance)->t_validity); \
         \
-        if ((__cTX).nf_instance) { \
-            ogs_warn("[%s] NF Instance updated [type:%s validity:%ds]", \
-                    ((__cTX).nf_instance)->id, \
-                    OpenAPI_nf_type_ToString(((__cTX).nf_instance)->nf_type), \
-                    ((__cTX).nf_instance)->time.validity_duration); \
+        if ((__cTX).nf_instance_id) { \
+            ogs_warn("[%s] Unlink NF Instance " \
+                    "[type:%s validity:%d timeout:%lds]", \
+                    ((__cTX).nf_instance_id), \
+                    OpenAPI_nf_type_ToString((__nFInstance)->nf_type), \
+                    (__nFInstance)->time.validity_duration, \
+                    (long)((__cTX).validity_timeout)); \
+            ogs_free((__cTX).nf_instance_id); \
         } \
         \
-        ((__cTX).nf_instance) = __nFInstance; \
+        ((__cTX).nf_instance_id) = ogs_strdup((__nFInstance)->id); \
         if ((__nFInstance)->time.validity_duration) { \
             ((__cTX).validity_timeout) = (__nFInstance)->t_validity->timeout; \
         } else { \
             ((__cTX).validity_timeout) = 0; \
         } \
-        ogs_info("[%s] NF Instance setup [type:%s validity:%ds]", \
-                (__nFInstance)->id, \
+        ogs_info("[%s] Setup NF Instance [type:%s validity:%d timeout:%lds]", \
+                ((__cTX).nf_instance_id), \
                 OpenAPI_nf_type_ToString((__nFInstance)->nf_type), \
-                (__nFInstance)->time.validity_duration); \
+                (__nFInstance)->time.validity_duration, \
+                (long)((__cTX).validity_timeout)); \
     } while(0)
+#else
+#define OGS_SBI_SETUP_NF_INSTANCE(__cTX, __nFInstance) \
+    do { \
+        ogs_assert(__nFInstance); \
+        ogs_assert((__nFInstance)->id); \
+        ogs_assert((__nFInstance)->nf_type); \
+        \
+        if ((__cTX).nf_instance_id) { \
+            ogs_warn("[%s] Unlink NF Instance [type:%s]", \
+                    ((__cTX).nf_instance_id), \
+                    OpenAPI_nf_type_ToString((__nFInstance)->nf_type)); \
+            ogs_free((__cTX).nf_instance_id); \
+        } \
+        \
+        ((__cTX).nf_instance_id) = ogs_strdup((__nFInstance)->id); \
+        ogs_info("[%s] Setup NF Instance [type:%s]", \
+                ((__cTX).nf_instance_id), \
+                OpenAPI_nf_type_ToString((__nFInstance)->nf_type)); \
+    } while(0)
+#endif
 
 /*
- * Search.Result stored in nf_instance->time.validity_duration;
+ * Issue #3470
  *
- * validity_timeout = nf_instance->validity->timeout =
- *     ogs_get_monotonic_time() + nf_instance->time.validity_duration;
+ * Previously, nf_instance pointers were stored in nf_type_array and
+ * service_type_array. This led to a dangling pointer problem when an
+ * nf_instance was removed via ogs_sbi_nf_instance_remove().
  *
- * if no validityPeriod in SearchResult, validity_timeout is 0.
+ * To resolve this, we now store nf_instance_id instead, and use
+ * ogs_sbi_nf_instance_find(nf_instance_id) to verify the validity of an
+ * nf_instance.
  */
+#if ENABLE_VALIDITY_TIMEOUT
 #define OGS_SBI_GET_NF_INSTANCE(__cTX) \
     ((__cTX).validity_timeout == 0 || \
      (__cTX).validity_timeout > ogs_get_monotonic_time() ? \
-        ((__cTX).nf_instance) : NULL)
-
-#define OGS_SBI_NF_INSTANCE_VALID(__nFInstance) \
-    (((__nFInstance) && ((__nFInstance)->t_validity) && \
-     ((__nFInstance)->time.validity_duration == 0 || \
-      (__nFInstance)->t_validity->timeout > ogs_get_monotonic_time())) ? \
-         true : false)
+        (ogs_sbi_nf_instance_find((__cTX).nf_instance_id)) : NULL)
+#else
+#define OGS_SBI_GET_NF_INSTANCE(__cTX) \
+        ogs_sbi_nf_instance_find((__cTX).nf_instance_id)
+#endif
 
 bool ogs_sbi_discovery_param_is_matched(
         ogs_sbi_nf_instance_t *nf_instance,

--- a/lib/sbi/mhd-server.c
+++ b/lib/sbi/mhd-server.c
@@ -32,6 +32,7 @@ static void server_final(void);
 
 static int server_start(ogs_sbi_server_t *server,
         int (*cb)(ogs_sbi_request_t *request, void *data));
+static void server_graceful_shutdown(ogs_sbi_server_t *server);
 static void server_stop(ogs_sbi_server_t *server);
 
 static bool server_send_rspmem_persistent(
@@ -49,6 +50,7 @@ const ogs_sbi_server_actions_t ogs_mhd_server_actions = {
     server_final,
 
     server_start,
+    server_graceful_shutdown,
     server_stop,
 
     server_send_rspmem_persistent,
@@ -285,6 +287,13 @@ static int server_start(ogs_sbi_server_t *server,
         ogs_info("mhd_server() [%s]:%d", OGS_ADDR(addr, buf), OGS_PORT(addr));
 
     return OGS_OK;
+}
+
+static void server_graceful_shutdown(ogs_sbi_server_t *server)
+{
+    ogs_assert(server);
+
+    /* No need to shutdown gracefully */
 }
 
 static void server_stop(ogs_sbi_server_t *server)

--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -282,7 +282,17 @@ int ogs_sbi_discover_and_send(ogs_sbi_xact_t *xact)
         ogs_assert(scp_client);
     }
 
-    /* Target NF-Instance */
+/*
+ * Issue #3470
+ *
+ * Previously, nf_instance pointers were stored in nf_type_array and
+ * service_type_array. This led to a dangling pointer problem when an
+ * nf_instance was removed via ogs_sbi_nf_instance_remove().
+ *
+ * To resolve this, we now store nf_instance_id instead, and use
+ * ogs_sbi_nf_instance_find(nf_instance_id) to verify the validity of an
+ * nf_instance.
+ */
     nf_instance = OGS_SBI_GET_NF_INSTANCE(
             sbi_object->service_type_array[service_type]);
     ogs_debug("OGS_SBI_GET_NF_INSTANCE [nf_instance:%p,service_name:%s]",

--- a/lib/sbi/server.c
+++ b/lib/sbi/server.c
@@ -156,6 +156,14 @@ int ogs_sbi_server_start_all(
     return OGS_OK;
 }
 
+void ogs_sbi_server_graceful_shutdown_all(void)
+{
+    ogs_sbi_server_t *server = NULL, *next_server = NULL;
+
+    ogs_list_for_each_safe(&ogs_sbi_self()->server_list, next_server, server)
+        ogs_sbi_server_actions.graceful_shutdown(server);
+}
+
 void ogs_sbi_server_stop_all(void)
 {
     ogs_sbi_server_t *server = NULL, *next_server = NULL;

--- a/lib/sbi/server.h
+++ b/lib/sbi/server.h
@@ -59,6 +59,7 @@ typedef struct ogs_sbi_server_actions_s {
 
     int (*start)(ogs_sbi_server_t *server,
             int (*cb)(ogs_sbi_request_t *request, void *data));
+    void (*graceful_shutdown)(ogs_sbi_server_t *server);
     void (*stop)(ogs_sbi_server_t *server);
 
     bool (*send_rspmem_persistent)(
@@ -87,6 +88,7 @@ void ogs_sbi_server_set_advertise(
 
 int ogs_sbi_server_start_all(
         int (*cb)(ogs_sbi_request_t *request, void *data));
+void ogs_sbi_server_graceful_shutdown_all(void);
 void ogs_sbi_server_stop_all(void);
 
 bool ogs_sbi_server_send_rspmem_persistent(

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *

--- a/src/amf/init.c
+++ b/src/amf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -79,6 +79,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/amf/namf-build.c
+++ b/src/amf/namf-build.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *

--- a/src/ausf/init.c
+++ b/src/ausf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -64,6 +64,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/bsf/init.c
+++ b/src/bsf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -66,6 +66,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/nrf/init.c
+++ b/src/nrf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -59,9 +59,8 @@ static ogs_timer_t *t_termination_holding = NULL;
 
 static void event_termination(void)
 {
-    /*
-     * Add business-login during Daemon termination
-     */
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Start holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/nssf/init.c
+++ b/src/nssf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -64,6 +64,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/pcf/init.c
+++ b/src/pcf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -77,6 +77,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/scp/context.c
+++ b/src/scp/context.c
@@ -339,8 +339,6 @@ void scp_assoc_remove(scp_assoc_t *assoc)
 
     if (assoc->client)
         ogs_sbi_client_remove(assoc->client);
-    if (assoc->nrf_client)
-        ogs_sbi_client_remove(assoc->nrf_client);
 
     if (assoc->target_apiroot)
         ogs_free(assoc->target_apiroot);

--- a/src/scp/context.h
+++ b/src/scp/context.h
@@ -46,7 +46,6 @@ typedef struct scp_assoc_s {
     ogs_pool_id_t stream_id;
 
     ogs_sbi_client_t *client;
-    ogs_sbi_client_t *nrf_client;
 
     ogs_sbi_request_t *request;
 

--- a/src/scp/init.c
+++ b/src/scp/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -66,6 +66,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/sepp/context.c
+++ b/src/sepp/context.c
@@ -567,8 +567,6 @@ void sepp_assoc_remove(sepp_assoc_t *assoc)
 
     if (assoc->client)
         ogs_sbi_client_remove(assoc->client);
-    if (assoc->nrf_client)
-        ogs_sbi_client_remove(assoc->nrf_client);
 
     ogs_pool_free(&sepp_assoc_pool, assoc);
 }

--- a/src/sepp/context.h
+++ b/src/sepp/context.h
@@ -85,7 +85,6 @@ typedef struct sepp_assoc_s {
     ogs_pool_id_t stream_id;
 
     ogs_sbi_client_t *client;
-    ogs_sbi_client_t *nrf_client;
 
     ogs_sbi_request_t *request;
     ogs_sbi_service_type_e service_type;

--- a/src/sepp/init.c
+++ b/src/sepp/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2023-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -71,6 +71,9 @@ static void event_termination(void)
     /* Sending N32 Termination to Peer SMF */
     ogs_list_for_each(&sepp_self()->peer_list, sepp_node)
         sepp_handshake_fsm_fini(sepp_node);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -104,6 +104,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/udm/init.c
+++ b/src/udm/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -64,6 +64,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);

--- a/src/udr/init.c
+++ b/src/udr/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -67,6 +67,9 @@ static void event_termination(void)
     /* Sending NF Instance De-registeration to NRF */
     ogs_list_for_each(&ogs_sbi_self()->nf_instance_list, nf_instance)
         ogs_sbi_nf_fsm_fini(nf_instance);
+
+    /* Gracefully shutdown the server by sending GOAWAY to each session. */
+    ogs_sbi_server_graceful_shutdown_all();
 
     /* Starting holding timer */
     t_termination_holding = ogs_timer_add(ogs_app()->timer_mgr, NULL, NULL);


### PR DESCRIPTION
This pull request addresses Issue #3740, where an incomplete NF instance cleanup due 
to a reference counting error causes the system to fall back to the default port 80 
after a UDR restart. The stale nf_instance pointer retained in service_type_array results 
in an invalid client being used, leading to connection failures when the UE re-registers.

In curl 8.9.1, the issue is compounded by curl reusing existing connections when another 
NF restarts, which causes the nghttp2 server to send an RST. To resolve this, we now 
send a GOAWAY frame to every active session on server shutdown, ensuring graceful 
termination and preventing RST errors. This behavior was not observed in previous versions 
(e.g. curl 7.81.0).

This PR consists of two commits:

1. [SBI] Send GOAWAY on shutdown for all sessions to prevent RST (#3470)
   - When another NF restarts, curl reuses the connection. In curl 8.9.1, this causes 
     the nghttp2 server to send an RST.
   - The change sends a GOAWAY frame to every active session during server shutdown, 
     ensuring a graceful termination and avoiding RST errors.

2. [SBI] Fix NF recovery failure on NF restart (#3740)
   - The nf_instance pointers in nf_type_array and service_type_array were not fully 
     cleaned up because the reference count was decremented only once despite being 
     incremented twice during association.
   - This resulted in the fallback to nf_instance->client (which used the default port 80) 
     during subsequent NF operations.
   - The fix involves storing nf_instance_id instead of a direct pointer and verifying the 
     instance validity using ogs_sbi_nf_instance_find(), ensuring proper cleanup and 
     recovery.

These changes ensure that:
- All active sessions receive a GOAWAY frame on shutdown to prevent unexpected RST errors.
- NF instance cleanup is correctly performed, preventing connection failures due to the 
  fallback to an invalid client.