### PR TITLE
[KSI] Update EPC KSI issuance to match 5G Core behavior

### DIFF
--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -297,9 +297,10 @@ ogs_pkbuf_t *emm_build_authentication_request(mme_ue_t *mme_ue)
     message.emm.h.protocol_discriminator = OGS_NAS_PROTOCOL_DISCRIMINATOR_EMM;
     message.emm.h.message_type = OGS_NAS_EPS_AUTHENTICATION_REQUEST;
 
-    authentication_request->nas_key_set_identifierasme.tsc = 0;
+    authentication_request->nas_key_set_identifierasme.tsc =
+        mme_ue->nas_eps.mme.tsc;
     authentication_request->nas_key_set_identifierasme.value =
-        mme_ue->nas_eps.ksi;
+        mme_ue->nas_eps.mme.ksi;
     memcpy(authentication_request->authentication_parameter_rand.rand,
             mme_ue->rand, OGS_RAND_LEN);
     memcpy(authentication_request->authentication_parameter_autn.autn,
@@ -355,8 +356,8 @@ ogs_pkbuf_t *emm_build_security_mode_command(mme_ue_t *mme_ue)
     selected_nas_security_algorithms->type_of_ciphering_algorithm =
         mme_ue->selected_enc_algorithm;
 
-    nas_key_set_identifier->tsc = 0;
-    nas_key_set_identifier->value = 0;
+    nas_key_set_identifier->tsc = mme_ue->nas_eps.mme.tsc;
+    nas_key_set_identifier->value = mme_ue->nas_eps.mme.ksi;
 
     replayed_ue_security_capabilities->eea = mme_ue->ue_network_capability.eea;
     replayed_ue_security_capabilities->eia = mme_ue->ue_network_capability.eia;

--- a/src/mme/emm-handler.c
+++ b/src/mme/emm-handler.c
@@ -78,13 +78,26 @@ int emm_handle_attach_request(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
     memcpy(&mme_ue->nas_eps.attach, eps_attach_type,
             sizeof(ogs_nas_eps_attach_type_t));
     mme_ue->nas_eps.type = MME_EPS_TYPE_ATTACH_REQUEST;
-    mme_ue->nas_eps.ksi = eps_attach_type->nas_key_set_identifier;
-    ogs_debug("    OGS_NAS_EPS TYPE[%d] KSI[%d]",
-            mme_ue->nas_eps.type, mme_ue->nas_eps.ksi);
-    ogs_debug("    ATTACH TSC[%d] KSI[%d] VALUE[%d]",
+
+    ogs_debug("    ATTACH TYPE[%d] TSC[%d] KSI[%d] VALUE[%d]",
+            mme_ue->nas_eps.type,
             mme_ue->nas_eps.attach.tsc,
             mme_ue->nas_eps.attach.nas_key_set_identifier,
             mme_ue->nas_eps.attach.value);
+
+    mme_ue->nas_eps.ue.tsc = eps_attach_type->tsc;
+    mme_ue->nas_eps.ue.ksi = eps_attach_type->nas_key_set_identifier;
+    ogs_debug("    OLD TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+    if (mme_ue->nas_eps.ue.ksi < OGS_NAS_KSI_NO_KEY_IS_AVAILABLE) {
+        mme_ue->nas_eps.mme.tsc = mme_ue->nas_eps.ue.tsc;
+        mme_ue->nas_eps.mme.ksi = mme_ue->nas_eps.ue.ksi;
+    }
+    ogs_debug("    NEW TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+
     switch(mme_ue->nas_eps.attach.value){
         case OGS_NAS_ATTACH_TYPE_EPS_ATTACH:
             ogs_debug("    Requested EPS_ATTACH_TYPE[1, EPS_ATTACH]");
@@ -99,6 +112,7 @@ int emm_handle_attach_request(enb_ue_t *enb_ue, mme_ue_t *mme_ue,
             ogs_error("    Invalid Requested EPS_ATTACH_TYPE[%d]",
                 mme_ue->nas_eps.attach.value);
     }
+
     /*
      * ATTACH_REQUEST
      * TAU_REQUEST
@@ -457,14 +471,25 @@ int emm_handle_detach_request(
     mme_ue->nas_eps.type = MME_EPS_TYPE_DETACH_REQUEST_FROM_UE;
     mme_ue->detach_type = MME_DETACH_TYPE_REQUEST_FROM_UE;
 
-    mme_ue->nas_eps.ksi = detach_type->nas_key_set_identifier;
-    ogs_debug("    OGS_NAS_EPS TYPE[%d] KSI[%d]",
-            mme_ue->nas_eps.type, mme_ue->nas_eps.ksi);
-    ogs_debug("    DETACH TSC[%d] KSI[%d] SWITCH_OFF[%d] VALUE[%d]",
-            mme_ue->nas_eps.attach.tsc,
+    ogs_debug("    DETACH TYPE[%d] TSC[%d] KSI[%d] SWITCH_OFF[%d] VALUE[%d]",
+            mme_ue->nas_eps.type,
+            mme_ue->nas_eps.detach.tsc,
             mme_ue->nas_eps.detach.nas_key_set_identifier,
             mme_ue->nas_eps.detach.switch_off,
             mme_ue->nas_eps.attach.value);
+
+    mme_ue->nas_eps.ue.tsc = detach_type->tsc;
+    mme_ue->nas_eps.ue.ksi = detach_type->nas_key_set_identifier;
+    ogs_debug("    OLD TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+    if (mme_ue->nas_eps.ue.ksi < OGS_NAS_KSI_NO_KEY_IS_AVAILABLE) {
+        mme_ue->nas_eps.mme.tsc = mme_ue->nas_eps.ue.tsc;
+        mme_ue->nas_eps.mme.ksi = mme_ue->nas_eps.ue.ksi;
+    }
+    ogs_debug("    NEW TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
 
     switch (detach_request->detach_type.value) {
     /* 0 0 1 : EPS detach */
@@ -517,13 +542,23 @@ int emm_handle_service_request(
 
     /* Set EPS Service */
     mme_ue->nas_eps.type = MME_EPS_TYPE_SERVICE_REQUEST;
-    mme_ue->nas_eps.ksi = ksi_and_sequence_number->ksi;
-    ogs_debug("    OGS_NAS_EPS TYPE[%d] KSI[%d]",
-            mme_ue->nas_eps.type, mme_ue->nas_eps.ksi);
-    ogs_debug("    SERVICE TSC[%d] KSI[%d] VALUE[%d]",
+    ogs_debug("    SERVICE TYPE[%d] TSC[%d] KSI[%d] VALUE[%d]",
+            mme_ue->nas_eps.type,
             mme_ue->nas_eps.service.tsc,
             mme_ue->nas_eps.service.nas_key_set_identifier,
             mme_ue->nas_eps.service.value);
+
+    mme_ue->nas_eps.ue.ksi = ksi_and_sequence_number->ksi;
+    ogs_debug("    OLD TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+    if (mme_ue->nas_eps.ue.ksi < OGS_NAS_KSI_NO_KEY_IS_AVAILABLE) {
+        mme_ue->nas_eps.mme.tsc = mme_ue->nas_eps.ue.tsc;
+        mme_ue->nas_eps.mme.ksi = mme_ue->nas_eps.ue.ksi;
+    }
+    ogs_debug("    NEW TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
 
     /*
      * ATTACH_REQUEST
@@ -609,14 +644,25 @@ int emm_handle_tau_request(
     memcpy(&mme_ue->nas_eps.update, eps_update_type,
             sizeof(ogs_nas_eps_update_type_t));
     mme_ue->nas_eps.type = MME_EPS_TYPE_TAU_REQUEST;
-    mme_ue->nas_eps.ksi = eps_update_type->nas_key_set_identifier;
-    ogs_debug("    OGS_NAS_EPS TYPE[%d] KSI[%d]",
-            mme_ue->nas_eps.type, mme_ue->nas_eps.ksi);
-    ogs_debug("    UPDATE TSC[%d] KSI[%d] Active-flag[%d] VALUE[%d]",
+    ogs_debug("    UPDATE TYPE[%d] TSC[%d] KSI[%d] Active-flag[%d] VALUE[%d]",
+            mme_ue->nas_eps.type,
             mme_ue->nas_eps.update.tsc,
             mme_ue->nas_eps.update.nas_key_set_identifier,
             mme_ue->nas_eps.update.active_flag,
             mme_ue->nas_eps.update.value);
+
+    mme_ue->nas_eps.ue.tsc = eps_update_type->tsc;
+    mme_ue->nas_eps.ue.ksi = eps_update_type->nas_key_set_identifier;
+    ogs_debug("    OLD TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+    if (mme_ue->nas_eps.ue.ksi < OGS_NAS_KSI_NO_KEY_IS_AVAILABLE) {
+        mme_ue->nas_eps.mme.tsc = mme_ue->nas_eps.ue.tsc;
+        mme_ue->nas_eps.mme.ksi = mme_ue->nas_eps.ue.ksi;
+    }
+    ogs_debug("    NEW TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
 
     /*
      * ATTACH_REQUEST
@@ -756,9 +802,24 @@ int emm_handle_extended_service_request(
     memcpy(&mme_ue->nas_eps.service, service_type,
             sizeof(ogs_nas_service_type_t));
     mme_ue->nas_eps.type = MME_EPS_TYPE_EXTENDED_SERVICE_REQUEST;
-    mme_ue->nas_eps.ksi = service_type->nas_key_set_identifier;
-    ogs_debug("    OGS_NAS_EPS TYPE[%d] KSI[%d]",
-            mme_ue->nas_eps.type, mme_ue->nas_eps.ksi);
+    ogs_debug("    Extended SERVICE TYPE[%d] TSC[%d] KSI[%d] VALUE[%d]",
+            mme_ue->nas_eps.type,
+            mme_ue->nas_eps.service.tsc,
+            mme_ue->nas_eps.service.nas_key_set_identifier,
+            mme_ue->nas_eps.service.value);
+
+    mme_ue->nas_eps.ue.tsc = service_type->tsc;
+    mme_ue->nas_eps.ue.ksi = service_type->nas_key_set_identifier;
+    ogs_debug("    OLD TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
+    if (mme_ue->nas_eps.ue.ksi < OGS_NAS_KSI_NO_KEY_IS_AVAILABLE) {
+        mme_ue->nas_eps.mme.tsc = mme_ue->nas_eps.ue.tsc;
+        mme_ue->nas_eps.mme.ksi = mme_ue->nas_eps.ue.ksi;
+    }
+    ogs_debug("    NEW TSC[UE:%d,MME:%d] KSI[UE:%d,MME:%d]",
+            mme_ue->nas_eps.ue.tsc, mme_ue->nas_eps.mme.tsc,
+            mme_ue->nas_eps.ue.ksi, mme_ue->nas_eps.mme.ksi);
 
     /*
      * ATTACH_REQUEST

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3617,6 +3617,9 @@ mme_ue_t *mme_ue_add(enb_ue_t *enb_ue)
     mme_ue->csmap = NULL;
     mme_ue->vlr_ostream_id = 0;
 
+    /* Initialization */
+    mme_ue->nas_eps.mme.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+
     mme_ue_fsm_init(mme_ue);
 
     ogs_list_add(&self.mme_ue_list, mme_ue);

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -355,7 +355,13 @@ struct mme_ue_s {
 #define MME_EPS_TYPE_DETACH_REQUEST_FROM_UE         5
 #define MME_EPS_TYPE_DETACH_REQUEST_TO_UE           6
         uint8_t     type;
-        uint8_t     ksi;
+
+        struct {
+        ED3(uint8_t tsc:1;,
+            uint8_t ksi:3;,
+            uint8_t spare:4;)
+        } mme, ue;
+
         ogs_nas_eps_attach_type_t attach;
         ogs_nas_eps_update_type_t update;
         ogs_nas_service_type_t service;
@@ -446,13 +452,12 @@ struct mme_ue_s {
     ((__mME) && \
     ((__mME)->security_context_available == 1) && \
      ((__mME)->mac_failed == 0) && \
-     ((__mME)->nas_eps.ksi != OGS_NAS_KSI_NO_KEY_IS_AVAILABLE))
+     ((__mME)->nas_eps.ue.ksi != OGS_NAS_KSI_NO_KEY_IS_AVAILABLE))
 #define CLEAR_SECURITY_CONTEXT(__mME) \
     do { \
         ogs_assert((__mME)); \
         (__mME)->security_context_available = 0; \
         (__mME)->mac_failed = 0; \
-        (__mME)->nas_eps.ksi = 0; \
     } while(0)
     int             security_context_available;
     int             mac_failed;

--- a/src/mme/mme-gn-build.c
+++ b/src/mme/mme-gn-build.c
@@ -32,7 +32,7 @@ static int sess_fill_mm_context_decoded(mme_sess_t *sess, ogs_gtp1_mm_context_de
     *mmctx_dec = (ogs_gtp1_mm_context_decoded_t) {
         .gupii = 1, /* Integrity Protection not required */
         .ugipai = 1, /* Ignore "Used GPRS integrity protection algorithm" field" */
-        .ksi = mme_ue->nas_eps.ksi,
+        .ksi = mme_ue->nas_eps.mme.ksi,
         .sec_mode = OGS_GTP1_SEC_MODE_UMTS_KEY_AND_QUINTUPLETS,
         .num_vectors = 0, /* TODO: figure out how to fill the quintuplets */
         .drx_param = {

--- a/src/mme/mme-gn-handler.c
+++ b/src/mme/mme-gn-handler.c
@@ -407,7 +407,7 @@ int mme_gn_handle_sgsn_context_response(
              ogs_min(gtp1_mm_ctx.ms_network_capability_len, sizeof(mme_ue->ms_network_capability) - 1));
     /* TODO: how to fill first byte of mme_ue->ms_network_capability ? */
 
-    mme_ue->nas_eps.ksi = gtp1_mm_ctx.ksi;
+    mme_ue->nas_eps.mme.ksi = gtp1_mm_ctx.ksi;
     /* 3GPP TS 33.401 A.10, A.11: */
     mme_ue->noncemme = ogs_random32();
     /* 3GPP TS 33.401 7.2.6.2 Establishment of keys for cryptographically protected radio bearers: */

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -63,8 +63,12 @@ uint8_t mme_s6a_handle_aia(
 
     CLEAR_MME_UE_TIMER(mme_ue->t3460);
 
-    if (mme_ue->nas_eps.ksi == OGS_NAS_KSI_NO_KEY_IS_AVAILABLE)
-        mme_ue->nas_eps.ksi = 0;
+    if (mme_ue->nas_eps.mme.ksi < (OGS_NAS_KSI_NO_KEY_IS_AVAILABLE - 1))
+        mme_ue->nas_eps.mme.ksi++;
+    else
+        mme_ue->nas_eps.mme.ksi = 0;
+
+    mme_ue->nas_eps.ue.ksi = mme_ue->nas_eps.mme.ksi;
 
     return OGS_NAS_EMM_CAUSE_REQUEST_ACCEPTED;
 }

--- a/tests/attach/crash-test.c
+++ b/tests/attach/crash-test.c
@@ -140,7 +140,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf0;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/attach/guti-test.c
+++ b/tests/attach/guti-test.c
@@ -56,7 +56,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf0;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -1275,7 +1275,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x64010;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/attach/issues-test.c
+++ b/tests/attach/issues-test.c
@@ -1911,7 +1911,7 @@ static void pull_3122_v270_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf0;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/attach/simple-test.c
+++ b/tests/attach/simple-test.c
@@ -56,7 +56,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf0;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/attach/ue-context-test.c
+++ b/tests/attach/ue-context-test.c
@@ -217,7 +217,7 @@ static void test2_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x64010;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -518,7 +518,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x64010;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/non3gpp/epdg-test.c
+++ b/tests/non3gpp/epdg-test.c
@@ -63,7 +63,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -204,7 +204,7 @@ static void test2_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -350,7 +350,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/volte/bearer-test.c
+++ b/tests/volte/bearer-test.c
@@ -53,7 +53,7 @@ static void uni_directional_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -297,7 +297,7 @@ static void bi_directional_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/volte/rx-test.c
+++ b/tests/volte/rx-test.c
@@ -59,7 +59,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -571,7 +571,7 @@ static void test2_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -922,7 +922,7 @@ static void test3_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -1270,7 +1270,7 @@ static void test4_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -1798,7 +1798,7 @@ static void test5_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -2301,7 +2301,7 @@ static void test6_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -2723,7 +2723,7 @@ static void test7_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -3125,7 +3125,7 @@ static void test_issues3109_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
@@ -3449,7 +3449,7 @@ static void test_issues3240_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/volte/session-test.c
+++ b/tests/volte/session-test.c
@@ -53,7 +53,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/volte/simple-test.c
+++ b/tests/volte/simple-test.c
@@ -59,7 +59,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";

--- a/tests/volte/video-test.c
+++ b/tests/volte/video-test.c
@@ -57,7 +57,7 @@ static void test1_func(abts_case *tc, void *data)
     ogs_assert(test_ue);
 
     test_ue->e_cgi.cell_id = 0x1079baf;
-    test_ue->nas.ksi = 0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
     test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
 
     test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";


### PR DESCRIPTION
Previously, the EPC used the UE-provided KSI directly in the Authentication Request (except for the special case where the UE sent OGS_NAS_KSI_NO_KEY_IS_AVAILABLE, which was reset to 0).

This commit changes the EPC to follow the 5G Core approach for issuing KSI in Attach-Request.

Now, when a Attach Request is received and a new Authentication Vector is generated, the EPC performs the following steps:

- Extract the KSI value from the UE's request.
- Increment the extracted KSI by 1.
- Use the incremented KSI in the Authentication Request sent to the UE.

This detailed process ensures that the EPC issues the KSI consistently with 5G Core standards, improving key management and interoperability.