### PR TITLE
[AMF] fix possible assertion

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2079,7 +2079,7 @@ amf_ue_t *amf_ue_find_by_ue_context_id(char *ue_context_id)
     return amf_ue;
 }
 
-void amf_ue_set_suci(amf_ue_t *amf_ue,
+int amf_ue_set_suci(amf_ue_t *amf_ue,
         ogs_nas_5gs_mobile_identity_t *mobile_identity)
 {
     amf_ue_t *old_amf_ue = NULL;
@@ -2090,7 +2090,12 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
     ogs_assert(mobile_identity);
 
     suci = ogs_nas_5gs_suci_from_mobile_identity(mobile_identity);
-    ogs_assert(suci);
+    if (!suci) {
+        ogs_error("Cannot get the SUCI from Mobile Identity");
+        ogs_log_hexdump(OGS_LOG_ERROR,
+                mobile_identity->buffer, mobile_identity->length);
+        return OGS_ERROR;
+    }
 
     /* Check if OLD amf_ue_t is existed */
     old_amf_ue = amf_ue_find_by_suci(suci);
@@ -2150,6 +2155,8 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
     }
     amf_ue->suci = suci;
     ogs_hash_set(self.suci_hash, amf_ue->suci, strlen(amf_ue->suci), amf_ue);
+
+    return OGS_OK;
 }
 
 void amf_ue_set_supi(amf_ue_t *amf_ue, char *supi)

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -880,7 +880,7 @@ amf_ue_t *amf_ue_find_by_supi(char *supi);
 amf_ue_t *amf_ue_find_by_ue_context_id(char *ue_context_id);
 
 amf_ue_t *amf_ue_find_by_message(ogs_nas_5gs_message_t *message);
-void amf_ue_set_suci(amf_ue_t *amf_ue,
+int amf_ue_set_suci(amf_ue_t *amf_ue,
         ogs_nas_5gs_mobile_identity_t *mobile_identity);
 void amf_ue_set_supi(amf_ue_t *amf_ue, char *supi);
 

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -170,7 +170,8 @@ ogs_nas_5gmm_cause_t gmm_handle_registration_request(amf_ue_t *amf_ue,
             return gmm_cause;
         }
 
-        amf_ue_set_suci(amf_ue, mobile_identity);
+        if (amf_ue_set_suci(amf_ue, mobile_identity) != OGS_OK)
+            return OGS_5GMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE;
         ogs_info("[%s]    SUCI", amf_ue->suci);
         break;
     case OGS_NAS_5GS_MOBILE_IDENTITY_GUTI:
@@ -1023,7 +1024,8 @@ ogs_nas_5gmm_cause_t gmm_handle_identity_response(amf_ue_t *amf_ue,
             return gmm_cause;
         }
 
-        amf_ue_set_suci(amf_ue, mobile_identity);
+        if (amf_ue_set_suci(amf_ue, mobile_identity) != OGS_OK)
+            return OGS_5GMM_CAUSE_SEMANTICALLY_INCORRECT_MESSAGE;
         ogs_info("[%s]    SUCI", amf_ue->suci);
     } else {
         ogs_error("Not supported Identity type[%d]",


### PR DESCRIPTION
In case of UE sending a malformed mobile identity, AMF would not be able to decode SUCI from it, causing an assertion and a Denial-Of-Service.