### PR TITLE
Add support for TAI ranges in AmfInfo

### DIFF
--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -363,7 +363,7 @@ typedef struct ogs_sbi_sepp_info_s {
 } ogs_sbi_sepp_info_t;
 
 typedef struct ogs_sbi_amf_info_s {
-    uint8_t amf_set_id;
+    uint16_t amf_set_id;
     uint16_t amf_region_id;
 
     int num_of_guami;

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -26,10 +26,6 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info);
 static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info);
 static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info);
 static OpenAPI_sepp_info_t *build_sepp_info(ogs_sbi_nf_info_t *nf_info);
-static void free_smf_info(OpenAPI_smf_info_t *SmfInfo);
-static void free_amf_info(OpenAPI_amf_info_t *AmfInfo);
-static void free_scp_info(OpenAPI_scp_info_t *ScpInfo);
-static void free_sepp_info(OpenAPI_sepp_info_t *SeppInfo);
 
 ogs_sbi_request_t *ogs_nnrf_nfm_build_register(void)
 {
@@ -464,7 +460,7 @@ void ogs_nnrf_nfm_free_nf_profile(OpenAPI_nf_profile_t *NFProfile)
         if (SmfInfoMap) {
             SmfInfo = SmfInfoMap->value;
             if (SmfInfo)
-                free_smf_info(SmfInfo);
+                OpenAPI_smf_info_free(SmfInfo);
             if (SmfInfoMap->key)
                 ogs_free(SmfInfoMap->key);
             ogs_free(SmfInfoMap);
@@ -473,14 +469,14 @@ void ogs_nnrf_nfm_free_nf_profile(OpenAPI_nf_profile_t *NFProfile)
     OpenAPI_list_free(NFProfile->smf_info_list);
 
     if (NFProfile->smf_info)
-        free_smf_info(NFProfile->smf_info);
+        OpenAPI_smf_info_free(NFProfile->smf_info);
 
     OpenAPI_list_for_each(NFProfile->amf_info_list, node) {
         AmfInfoMap = node->data;
         if (AmfInfoMap) {
             AmfInfo = AmfInfoMap->value;
             if (AmfInfo)
-                free_amf_info(AmfInfo);
+                OpenAPI_amf_info_free(AmfInfo);
             if (AmfInfoMap->key)
                 ogs_free(AmfInfoMap->key);
             ogs_free(AmfInfoMap);
@@ -489,13 +485,13 @@ void ogs_nnrf_nfm_free_nf_profile(OpenAPI_nf_profile_t *NFProfile)
     OpenAPI_list_free(NFProfile->amf_info_list);
 
     if (NFProfile->amf_info)
-        free_amf_info(NFProfile->amf_info);
+        OpenAPI_amf_info_free(NFProfile->amf_info);
 
     if (NFProfile->scp_info)
-        free_scp_info(NFProfile->scp_info);
+        OpenAPI_scp_info_free(NFProfile->scp_info);
 
     if (NFProfile->sepp_info)
-        free_sepp_info(NFProfile->sepp_info);
+        OpenAPI_sepp_info_free(NFProfile->sepp_info);
 
     ogs_free(NFProfile);
 }
@@ -760,7 +756,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
     sNssaiSmfInfoList = OpenAPI_list_create();
     if (!sNssaiSmfInfoList) {
         ogs_error("No sNssaiSmfInfoList");
-        free_smf_info(SmfInfo);
+        OpenAPI_smf_info_free(SmfInfo);
         return NULL;
     }
 
@@ -768,7 +764,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
         DnnSmfInfoList = OpenAPI_list_create();
         if (!DnnSmfInfoList) {
             ogs_error("No DnnSmfInfoList");
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(sNssaiSmfInfoList);
             return NULL;
         }
@@ -785,7 +781,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("CHECK CONFIGURATION: No DNN");
 
             OpenAPI_list_free(DnnSmfInfoList);
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(sNssaiSmfInfoList);
 
             return NULL;
@@ -813,7 +809,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
     TaiList = OpenAPI_list_create();
     if (!TaiList) {
         ogs_error("No TaiList");
-        free_smf_info(SmfInfo);
+        OpenAPI_smf_info_free(SmfInfo);
         return NULL;
     }
 
@@ -821,7 +817,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
         TaiItem = ogs_calloc(1, sizeof(*TaiItem));
         if (!TaiItem) {
             ogs_error("No TaiItem");
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -831,7 +827,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("No TaiItem->plmn_id");
             if (TaiItem)
                 ogs_free(TaiItem);
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -844,7 +840,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
                     ogs_sbi_free_plmn_id(TaiItem->plmn_id);
                 ogs_free(TaiItem);
             }
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -860,7 +856,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
     TaiRangeList = OpenAPI_list_create();
     if (!TaiRangeList) {
         ogs_error("No TaiRangeList");
-        free_smf_info(SmfInfo);
+        OpenAPI_smf_info_free(SmfInfo);
         return NULL;
     }
 
@@ -868,7 +864,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
         TacRangeList = OpenAPI_list_create();
         if (!TacRangeList) {
             ogs_error("No TacRangeList");
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiRangeList);
             return NULL;
         }
@@ -894,7 +890,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("CHECK CONFIGURATION: No Start/End in TacRange");
 
             OpenAPI_list_free(TacRangeList);
-            free_smf_info(SmfInfo);
+            OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiRangeList);
 
             return NULL;
@@ -946,20 +942,20 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
     AmfInfo->amf_set_id = ogs_msprintf("%03x", nf_info->amf.amf_set_id);
     if (!AmfInfo->amf_set_id) {
         ogs_error("No amf_set_id");
-        free_amf_info(AmfInfo);
+        OpenAPI_amf_info_free(AmfInfo);
         return NULL;
     }
     AmfInfo->amf_region_id = ogs_msprintf("%02x", nf_info->amf.amf_region_id);
     if (!AmfInfo->amf_region_id) {
         ogs_error("No amf_region_id");
-        free_amf_info(AmfInfo);
+        OpenAPI_amf_info_free(AmfInfo);
         return NULL;
     }
 
     guamiAmfInfoList = OpenAPI_list_create();
     if (!guamiAmfInfoList) {
         ogs_error("No guamiAmfInfoList");
-        free_amf_info(AmfInfo);
+        OpenAPI_amf_info_free(AmfInfo);
         return NULL;
     }
 
@@ -968,7 +964,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         guamiAmfInfoItem = ogs_calloc(1, sizeof(*guamiAmfInfoItem));
         if (!guamiAmfInfoItem) {
             ogs_error("guamiAmfInfoItem");
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
         }
@@ -979,7 +975,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("guamiAmfInfoItem->plmn_id");
             if (guamiAmfInfoItem)
                 ogs_free(guamiAmfInfoItem);
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
         }
@@ -992,7 +988,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
                     ogs_free(guamiAmfInfoItem->plmn_id);
                 ogs_free(guamiAmfInfoItem);
             }
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
         }
@@ -1008,7 +1004,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
     TaiList = OpenAPI_list_create();
     if (!TaiList) {
         ogs_error("No TaiList");
-        free_amf_info(AmfInfo);
+        OpenAPI_amf_info_free(AmfInfo);
         return NULL;
     }
 
@@ -1016,7 +1012,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         TaiItem = ogs_calloc(1, sizeof(*TaiItem));
         if (!TaiList) {
             ogs_error("No TaiItem");
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -1026,7 +1022,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("No TaiItem->plmn_id");
             if (TaiItem)
                 ogs_free(TaiItem);
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -1039,7 +1035,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
                     ogs_sbi_free_plmn_id(TaiItem->plmn_id);
                 ogs_free(TaiItem);
             }
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
@@ -1055,7 +1051,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
     TaiRangeList = OpenAPI_list_create();
     if (!TaiRangeList) {
         ogs_error("No TaiRangeList");
-        free_amf_info(AmfInfo);
+        OpenAPI_amf_info_free(AmfInfo);
         return NULL;
     }
 
@@ -1063,7 +1059,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         TacRangeList = OpenAPI_list_create();
         if (!TacRangeList) {
             ogs_error("No TacRangeList");
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiRangeList);
             return NULL;
         }
@@ -1089,7 +1085,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_error("CHECK CONFIGURATION: No Start/End in TacRange");
 
             OpenAPI_list_free(TacRangeList);
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiRangeList);
 
             return NULL;
@@ -1098,7 +1094,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         TaiRangeItem = ogs_calloc(1, sizeof(*TaiRangeItem));
         if (!TaiRangeItem) {
             ogs_error("No TaiRangeItem");
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiRangeList);
             return NULL;
         }
@@ -1108,7 +1104,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         if (!TaiRangeItem->plmn_id) {
             ogs_error("No TaiRangeItem->plmn_id");
             ogs_free(TaiRangeItem);
-            free_amf_info(AmfInfo);
+            OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiRangeList);
             return NULL;
         }
@@ -1148,26 +1144,26 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
     PortList = OpenAPI_list_create();
     if (!PortList) {
         ogs_error("No PortList");
-        free_scp_info(ScpInfo);
+        OpenAPI_scp_info_free(ScpInfo);
         return NULL;
     }
 
     if (nf_info->scp.http.presence) {
         PortMap = OpenAPI_map_create(
-                    (char *)"http", ogs_alloc_double(nf_info->scp.http.port));
+                ogs_strdup("http"), ogs_alloc_double(nf_info->scp.http.port));
         if (!PortMap) {
             ogs_error("No PortMap");
-            free_scp_info(ScpInfo);
+            OpenAPI_scp_info_free(ScpInfo);
             return NULL;
         }
         OpenAPI_list_add(PortList, PortMap);
     }
     if (nf_info->scp.https.presence) {
         PortMap = OpenAPI_map_create(
-                    (char *)"https", ogs_alloc_double(nf_info->scp.https.port));
+                ogs_strdup("https"), ogs_alloc_double(nf_info->scp.https.port));
         if (!PortMap) {
             ogs_error("No PortMap");
-            free_scp_info(ScpInfo);
+            OpenAPI_scp_info_free(ScpInfo);
             return NULL;
         }
         OpenAPI_list_add(PortList, PortMap);
@@ -1181,7 +1177,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
     DomainInfoList = OpenAPI_list_create();
     if (!DomainInfoList) {
         ogs_error("No DomainInfoList");
-        free_scp_info(ScpInfo);
+        OpenAPI_scp_info_free(ScpInfo);
         return NULL;
     }
     for (i = 0; i < nf_info->scp.num_of_domain; i++) {
@@ -1190,7 +1186,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
         DomainInfo = ogs_calloc(1, sizeof(*DomainInfo));
         if (!DomainInfo) {
             ogs_error("No DomainInfo");
-            free_scp_info(ScpInfo);
+            OpenAPI_scp_info_free(ScpInfo);
             return NULL;
         }
 
@@ -1199,7 +1195,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
         PortList = OpenAPI_list_create();
         if (!PortList) {
             ogs_error("No PortList");
-            free_scp_info(ScpInfo);
+            OpenAPI_scp_info_free(ScpInfo);
             return NULL;
         }
 
@@ -1209,7 +1205,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
                         ogs_alloc_double(nf_info->scp.domain[i].http.port));
             if (!PortMap) {
                 ogs_error("No PortMap");
-                free_scp_info(ScpInfo);
+                OpenAPI_scp_info_free(ScpInfo);
                 return NULL;
             }
             OpenAPI_list_add(PortList, PortMap);
@@ -1220,7 +1216,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
                         ogs_alloc_double(nf_info->scp.domain[i].https.port));
             if (!PortMap) {
                 ogs_error("No PortMap");
-                free_scp_info(ScpInfo);
+                OpenAPI_scp_info_free(ScpInfo);
                 return NULL;
             }
             OpenAPI_list_add(PortList, PortMap);
@@ -1235,7 +1231,7 @@ static OpenAPI_scp_info_t *build_scp_info(ogs_sbi_nf_info_t *nf_info)
                     nf_info->scp.domain[i].name, DomainInfo);
         if (!DomainInfoMap) {
             ogs_error("No PortMap");
-            free_scp_info(ScpInfo);
+            OpenAPI_scp_info_free(ScpInfo);
             return NULL;
         }
 
@@ -1267,7 +1263,7 @@ static OpenAPI_sepp_info_t *build_sepp_info(ogs_sbi_nf_info_t *nf_info)
     PortList = OpenAPI_list_create();
     if (!PortList) {
         ogs_error("No PortList");
-        free_sepp_info(SeppInfo);
+        OpenAPI_sepp_info_free(SeppInfo);
         return NULL;
     }
 
@@ -1276,7 +1272,7 @@ static OpenAPI_sepp_info_t *build_sepp_info(ogs_sbi_nf_info_t *nf_info)
                     (char *)"http", ogs_alloc_double(nf_info->sepp.http.port));
         if (!PortMap) {
             ogs_error("No PortMap");
-            free_sepp_info(SeppInfo);
+            OpenAPI_sepp_info_free(SeppInfo);
             return NULL;
         }
         OpenAPI_list_add(PortList, PortMap);
@@ -1286,7 +1282,7 @@ static OpenAPI_sepp_info_t *build_sepp_info(ogs_sbi_nf_info_t *nf_info)
                     (char *)"https", ogs_alloc_double(nf_info->sepp.https.port));
         if (!PortMap) {
             ogs_error("No PortMap");
-            free_sepp_info(SeppInfo);
+            OpenAPI_sepp_info_free(SeppInfo);
             return NULL;
         }
         OpenAPI_list_add(PortList, PortMap);
@@ -1298,230 +1294,6 @@ static OpenAPI_sepp_info_t *build_sepp_info(ogs_sbi_nf_info_t *nf_info)
         OpenAPI_list_free(PortList);
 
     return SeppInfo;
-}
-
-static void free_smf_info(OpenAPI_smf_info_t *SmfInfo)
-{
-    OpenAPI_list_t *sNssaiSmfInfoList = NULL;
-    OpenAPI_snssai_smf_info_item_t *sNssaiSmfInfoItem = NULL;
-    OpenAPI_ext_snssai_t *sNssai = NULL;
-    OpenAPI_list_t *DnnSmfInfoList = NULL;
-    OpenAPI_dnn_smf_info_item_t *DnnSmfInfoItem = NULL;
-
-    OpenAPI_list_t *TaiList = NULL;
-    OpenAPI_tai_t *TaiItem = NULL;
-    OpenAPI_list_t *TaiRangeList = NULL;
-    OpenAPI_tai_range_t *TaiRangeItem = NULL;
-    OpenAPI_list_t *TacRangeList = NULL;
-    OpenAPI_tac_range_t *TacRangeItem = NULL;
-
-    OpenAPI_lnode_t *node = NULL, *node2 = NULL;
-
-    ogs_assert(SmfInfo);
-
-    sNssaiSmfInfoList = SmfInfo->s_nssai_smf_info_list;
-    OpenAPI_list_for_each(sNssaiSmfInfoList, node) {
-        sNssaiSmfInfoItem = node->data;
-        ogs_assert(sNssaiSmfInfoItem);
-
-        DnnSmfInfoList = sNssaiSmfInfoItem->dnn_smf_info_list;
-        OpenAPI_list_for_each(DnnSmfInfoList, node2) {
-            DnnSmfInfoItem = node2->data;
-            ogs_assert(DnnSmfInfoItem);
-            ogs_free(DnnSmfInfoItem);
-        }
-        OpenAPI_list_free(DnnSmfInfoList);
-
-        sNssai = sNssaiSmfInfoItem->s_nssai;
-        if (sNssai) {
-            if (sNssai->sd)
-                ogs_free(sNssai->sd);
-            ogs_free(sNssai);
-        }
-
-        ogs_free(sNssaiSmfInfoItem);
-    }
-    OpenAPI_list_free(sNssaiSmfInfoList);
-
-    TaiList = SmfInfo->tai_list;
-    OpenAPI_list_for_each(TaiList, node) {
-        TaiItem = node->data;
-        ogs_assert(TaiItem);
-        if (TaiItem->plmn_id)
-            ogs_sbi_free_plmn_id(TaiItem->plmn_id);
-        if (TaiItem->tac)
-            ogs_free(TaiItem->tac);
-        ogs_free(TaiItem);
-    }
-    OpenAPI_list_free(TaiList);
-
-    TaiRangeList = SmfInfo->tai_range_list;
-    OpenAPI_list_for_each(TaiRangeList, node) {
-        TaiRangeItem = node->data;
-        ogs_assert(TaiRangeItem);
-
-        if (TaiRangeItem->plmn_id)
-            ogs_sbi_free_plmn_id(TaiRangeItem->plmn_id);
-
-        TacRangeList = TaiRangeItem->tac_range_list;
-        OpenAPI_list_for_each(TacRangeList, node2) {
-            TacRangeItem = node2->data;
-            ogs_assert(TacRangeItem);
-            if (TacRangeItem->start)
-                ogs_free(TacRangeItem->start);
-            if (TacRangeItem->end)
-                ogs_free(TacRangeItem->end);
-
-            ogs_free(TacRangeItem);
-        }
-        OpenAPI_list_free(TacRangeList);
-
-        ogs_free(TaiRangeItem);
-    }
-    OpenAPI_list_free(TaiRangeList);
-
-    ogs_free(SmfInfo);
-}
-
-static void free_amf_info(OpenAPI_amf_info_t *AmfInfo)
-{
-    OpenAPI_list_t *guamiAmfInfoList = NULL;
-    OpenAPI_guami_t *guamiAmfInfoItem = NULL;
-
-    OpenAPI_list_t *TaiList = NULL;
-    OpenAPI_tai_t *TaiItem = NULL;
-    OpenAPI_list_t *TaiRangeList = NULL;
-    OpenAPI_tai_range_t *TaiRangeItem = NULL;
-    OpenAPI_list_t *TacRangeList = NULL;
-    OpenAPI_tac_range_t *TacRangeItem = NULL;
-
-    OpenAPI_lnode_t *node = NULL, *node2 = NULL;
-
-    ogs_assert(AmfInfo);
-
-    if (AmfInfo->amf_set_id)
-        ogs_free(AmfInfo->amf_set_id);
-    if (AmfInfo->amf_region_id)
-        ogs_free(AmfInfo->amf_region_id);
-
-    guamiAmfInfoList = AmfInfo->guami_list;
-    OpenAPI_list_for_each(guamiAmfInfoList, node) {
-        guamiAmfInfoItem = node->data;
-        if (guamiAmfInfoItem) {
-            if (guamiAmfInfoItem->plmn_id) {
-                if (guamiAmfInfoItem->plmn_id->mcc)
-                    ogs_free(guamiAmfInfoItem->plmn_id->mcc);
-                if (guamiAmfInfoItem->plmn_id->mnc)
-                    ogs_free(guamiAmfInfoItem->plmn_id->mnc);
-                ogs_free(guamiAmfInfoItem->plmn_id);
-            }
-            if (guamiAmfInfoItem->amf_id)
-                ogs_free(guamiAmfInfoItem->amf_id);
-        }
-        ogs_free(guamiAmfInfoItem);
-    }
-
-    OpenAPI_list_free(guamiAmfInfoList);
-
-    TaiList = AmfInfo->tai_list;
-    OpenAPI_list_for_each(TaiList, node) {
-        TaiItem = node->data;
-        ogs_assert(TaiItem);
-        if (TaiItem->plmn_id)
-            ogs_sbi_free_plmn_id(TaiItem->plmn_id);
-        if (TaiItem->tac)
-            ogs_free(TaiItem->tac);
-        ogs_free(TaiItem);
-    }
-    OpenAPI_list_free(TaiList);
-
-    TaiRangeList = AmfInfo->tai_range_list;
-    OpenAPI_list_for_each(TaiRangeList, node) {
-        TaiRangeItem = node->data;
-        ogs_assert(TaiRangeItem);
-
-        if (TaiRangeItem->plmn_id)
-            ogs_sbi_free_plmn_id(TaiRangeItem->plmn_id);
-
-        TacRangeList = TaiRangeItem->tac_range_list;
-        OpenAPI_list_for_each(TacRangeList, node2) {
-            TacRangeItem = node2->data;
-            ogs_assert(TacRangeItem);
-            if (TacRangeItem->start)
-                ogs_free(TacRangeItem->start);
-            if (TacRangeItem->end)
-                ogs_free(TacRangeItem->end);
-
-            ogs_free(TacRangeItem);
-        }
-        OpenAPI_list_free(TacRangeList);
-
-        ogs_free(TaiRangeItem);
-    }
-    OpenAPI_list_free(TaiRangeList);
-
-    ogs_free(AmfInfo);
-}
-
-static void free_scp_info(OpenAPI_scp_info_t *ScpInfo)
-{
-    OpenAPI_map_t *PortMap = NULL;
-    OpenAPI_lnode_t *node = NULL, *node2 = NULL;
-
-    OpenAPI_map_t *DomainInfoMap = NULL;
-    OpenAPI_scp_domain_info_t *DomainInfo = NULL;
-
-    ogs_assert(ScpInfo);
-
-    OpenAPI_list_for_each(ScpInfo->scp_ports, node) {
-        PortMap = node->data;
-        if (PortMap) {
-            ogs_free(PortMap->value);
-            OpenAPI_map_free(PortMap);
-        }
-    }
-    OpenAPI_list_free(ScpInfo->scp_ports);
-
-    OpenAPI_list_for_each(ScpInfo->scp_domain_info_list, node) {
-        DomainInfoMap = node->data;
-        if (DomainInfoMap) {
-            DomainInfo = DomainInfoMap->value;
-            if (DomainInfo) {
-                OpenAPI_list_for_each(DomainInfo->scp_ports, node2) {
-                    PortMap = node2->data;
-                    if (PortMap) {
-                        ogs_free(PortMap->value);
-                        OpenAPI_map_free(PortMap);
-                    }
-                }
-                OpenAPI_list_free(DomainInfo->scp_ports);
-                ogs_free(DomainInfo);
-            }
-            OpenAPI_map_free(DomainInfoMap);
-        }
-    }
-    OpenAPI_list_free(ScpInfo->scp_domain_info_list);
-
-    ogs_free(ScpInfo);
-}
-
-static void free_sepp_info(OpenAPI_sepp_info_t *SeppInfo)
-{
-    OpenAPI_map_t *PortMap = NULL;
-    OpenAPI_lnode_t *node = NULL;
-
-    ogs_assert(SeppInfo);
-
-    OpenAPI_list_for_each(SeppInfo->sepp_ports, node) {
-        PortMap = node->data;
-        if (PortMap) {
-            ogs_free(PortMap->value);
-            OpenAPI_map_free(PortMap);
-        }
-    }
-    OpenAPI_list_free(SeppInfo->sepp_ports);
-
-    ogs_free(SeppInfo);
 }
 
 ogs_sbi_request_t *ogs_nnrf_nfm_build_update(void)

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -835,11 +835,7 @@ static OpenAPI_smf_info_t *build_smf_info(ogs_sbi_nf_info_t *nf_info)
             ogs_uint24_to_0string(nf_info->smf.nr_tai[i].tac);
         if (!TaiItem->tac) {
             ogs_error("No TaiItem->tac");
-            if (TaiItem) {
-                if (TaiItem->plmn_id)
-                    ogs_sbi_free_plmn_id(TaiItem->plmn_id);
-                ogs_free(TaiItem);
-            }
+            OpenAPI_tai_free(TaiItem);
             OpenAPI_smf_info_free(SmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
@@ -963,7 +959,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
 
         guamiAmfInfoItem = ogs_calloc(1, sizeof(*guamiAmfInfoItem));
         if (!guamiAmfInfoItem) {
-            ogs_error("guamiAmfInfoItem");
+            ogs_error("No guamiAmfInfoItem");
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
@@ -972,9 +968,8 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         guamiAmfInfoItem->plmn_id =
                 ogs_sbi_build_plmn_id_nid(&nf_info->amf.guami[i].plmn_id);
         if (!guamiAmfInfoItem->plmn_id) {
-            ogs_error("guamiAmfInfoItem->plmn_id");
-            if (guamiAmfInfoItem)
-                ogs_free(guamiAmfInfoItem);
+            ogs_error("No guamiAmfInfoItem->plmn_id");
+            OpenAPI_guami_free(guamiAmfInfoItem);
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
@@ -982,12 +977,8 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         guamiAmfInfoItem->amf_id =
                 ogs_amf_id_to_string(&nf_info->amf.guami[i].amf_id);
         if (!guamiAmfInfoItem->amf_id) {
-            ogs_error("guamiAmfInfoItem->amf_id");
-            if (guamiAmfInfoItem) {
-                if (guamiAmfInfoItem->plmn_id)
-                    ogs_free(guamiAmfInfoItem->plmn_id);
-                ogs_free(guamiAmfInfoItem);
-            }
+            ogs_error("No guamiAmfInfoItem->amf_id");
+            OpenAPI_guami_free(guamiAmfInfoItem);
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(guamiAmfInfoList);
             return NULL;
@@ -1020,21 +1011,15 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
                 &nf_info->amf.nr_tai[i].plmn_id);
         if (!TaiItem->plmn_id) {
             ogs_error("No TaiItem->plmn_id");
-            if (TaiItem)
-                ogs_free(TaiItem);
+            OpenAPI_tai_free(TaiItem);
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;
         }
-        TaiItem->tac =
-            ogs_uint24_to_0string(nf_info->amf.nr_tai[i].tac);
+        TaiItem->tac = ogs_uint24_to_0string(nf_info->amf.nr_tai[i].tac);
         if (!TaiItem->tac) {
             ogs_error("No TaiItem->tac");
-            if (TaiItem) {
-                if (TaiItem->plmn_id)
-                    ogs_sbi_free_plmn_id(TaiItem->plmn_id);
-                ogs_free(TaiItem);
-            }
+            OpenAPI_tai_free(TaiItem);
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
             return NULL;

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -948,6 +948,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
         return NULL;
     }
 
+    /* Guami list */
     guamiAmfInfoList = OpenAPI_list_create();
     if (!guamiAmfInfoList) {
         ogs_error("No guamiAmfInfoList");
@@ -992,6 +993,8 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
     else
         OpenAPI_list_free(guamiAmfInfoList);
 
+
+    /* TAI list */
     TaiList = OpenAPI_list_create();
     if (!TaiList) {
         ogs_error("No TaiList");
@@ -1001,7 +1004,7 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
 
     for (i = 0; i < nf_info->amf.num_of_nr_tai; i++) {
         TaiItem = ogs_calloc(1, sizeof(*TaiItem));
-        if (!TaiList) {
+        if (!TaiItem) {
             ogs_error("No TaiItem");
             OpenAPI_amf_info_free(AmfInfo);
             OpenAPI_list_free(TaiList);
@@ -1033,6 +1036,8 @@ static OpenAPI_amf_info_t *build_amf_info(ogs_sbi_nf_info_t *nf_info)
     else
         OpenAPI_list_free(TaiList);
 
+
+    /* TAI range list */
     TaiRangeList = OpenAPI_list_create();
     if (!TaiRangeList) {
         ogs_error("No TaiRangeList");

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -709,8 +709,8 @@ static void handle_amf_info(
             AmfInfo->amf_set_id);
     nf_info->amf.amf_region_id = ogs_uint64_from_string_hexadecimal(
             AmfInfo->amf_region_id);
-    GuamiList = AmfInfo->guami_list;
 
+    GuamiList = AmfInfo->guami_list;
     OpenAPI_list_for_each(GuamiList, node) {
         GuamiAmfInfoItem = node->data;
         if (GuamiAmfInfoItem) {
@@ -741,7 +741,7 @@ static void handle_amf_info(
             }
 
             nr_tai = &nf_info->amf.nr_tai[nf_info->amf.num_of_nr_tai];
-            ogs_assert(nr_tai);
+
             ogs_sbi_parse_plmn_id(&nr_tai->plmn_id, TaiItem->plmn_id);
             nr_tai->tac = ogs_uint24_from_string_hexadecimal(TaiItem->tac);
             nf_info->amf.num_of_nr_tai++;

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1105,14 +1105,16 @@ int amf_context_nf_info(void)
                 &nf_instance->nf_info_list, OpenAPI_nf_type_AMF);
         ogs_assert(nf_info);
 
-        nf_info->amf.amf_set_id = self.served_guami[next_new_i].amf_id.set2;
-        nf_info->amf.amf_region_id = self.served_guami[next_new_i].amf_id.region;
+        nf_info->amf.amf_set_id =
+                ogs_amf_set_id(&self.served_guami[next_new_i].amf_id);
+        nf_info->amf.amf_region_id =
+                self.served_guami[next_new_i].amf_id.region;
 
         next_found = false;
         info_i = 0;
         for (served_i = next_new_i; served_i <
                 self.num_of_served_guami; served_i++) {
-            if ((self.served_guami[served_i].amf_id.set2 ==
+            if ((ogs_amf_set_id(&self.served_guami[served_i].amf_id) ==
                     nf_info->amf.amf_set_id) &&
                 (self.served_guami[served_i].amf_id.region ==
                     nf_info->amf.amf_region_id)) {
@@ -1123,8 +1125,8 @@ int amf_context_nf_info(void)
                 if (!next_found) {
                     int handled_i;
                     for (handled_i = 0; handled_i < served_i; handled_i++) {
-                        if ((self.served_guami[handled_i].amf_id.set2 ==
-                                self.served_guami[served_i].amf_id.set2) &&
+                        if ((ogs_amf_set_id(&self.served_guami[handled_i].amf_id) ==
+                                ogs_amf_set_id(&self.served_guami[served_i].amf_id)) &&
                             (self.served_guami[handled_i].amf_id.region ==
                                 self.served_guami[served_i].amf_id.region)) {
                             break;


### PR DESCRIPTION
- [SBI] replace calls to `free_<nf>_info()` with `OpenAPI_<nf>_info_free()`   - this commit can be removed in case we prefer manual free()-ing of OpenAPI structs or if we do something differently than the auto-generated code
- fix AMF crash in case it's configuration contains multiple TAC ranges which causes an out-of-array-bounds write
- add support for TAI ranges in the AmfInfo instead of manually adding multiple TAI items