### PR TITLE
[AMF/MME] Fix security context restoration and state transition cleanup (#3756)

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -2651,6 +2651,62 @@ uint8_t amf_selected_enc_algorithm(amf_ue_t *amf_ue)
     }
 
     return 0;
+}
+
+/* Backup the sensitive security context fields from the UE context */
+void amf_backup_security_context(amf_ue_t *amf_ue,
+                                 amf_security_context_t *backup)
+{
+    ogs_assert(amf_ue);
+    ogs_assert(backup);
+
+    memcpy(&backup->ue_security_capability, &amf_ue->ue_security_capability,
+           sizeof(backup->ue_security_capability));
+    memcpy(&backup->ue_network_capability, &amf_ue->ue_network_capability,
+           sizeof(backup->ue_network_capability));
+    memcpy(backup->rand, amf_ue->rand, OGS_RAND_LEN);
+    memcpy(backup->autn, amf_ue->autn, OGS_AUTN_LEN);
+    memcpy(backup->xres_star, amf_ue->xres_star, OGS_MAX_RES_LEN);
+    memcpy(backup->abba, amf_ue->abba, OGS_NAS_MAX_ABBA_LEN);
+    backup->abba_len = amf_ue->abba_len;
+    memcpy(backup->hxres_star, amf_ue->hxres_star, OGS_MAX_RES_LEN);
+    memcpy(backup->kamf, amf_ue->kamf, OGS_SHA256_DIGEST_SIZE);
+    memcpy(backup->knas_int, amf_ue->knas_int, OGS_SHA256_DIGEST_SIZE/2);
+    memcpy(backup->knas_enc, amf_ue->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
+    backup->dl_count = amf_ue->dl_count;
+    backup->ul_count = amf_ue->ul_count.i32;
+    memcpy(backup->kgnb, amf_ue->kgnb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(backup->nh, amf_ue->nh, OGS_SHA256_DIGEST_SIZE);
+    backup->selected_enc_algorithm = amf_ue->selected_enc_algorithm;
+    backup->selected_int_algorithm = amf_ue->selected_int_algorithm;
+}
+
+/* Restore the sensitive security context fields into the UE context */
+void amf_restore_security_context(amf_ue_t *amf_ue,
+                                  const amf_security_context_t *backup)
+{
+    ogs_assert(amf_ue);
+    ogs_assert(backup);
+
+    memcpy(&amf_ue->ue_security_capability, &backup->ue_security_capability,
+           sizeof(amf_ue->ue_security_capability));
+    memcpy(&amf_ue->ue_network_capability, &backup->ue_network_capability,
+           sizeof(amf_ue->ue_network_capability));
+    memcpy(amf_ue->rand, backup->rand, OGS_RAND_LEN);
+    memcpy(amf_ue->autn, backup->autn, OGS_AUTN_LEN);
+    memcpy(amf_ue->xres_star, backup->xres_star, OGS_MAX_RES_LEN);
+    memcpy(amf_ue->abba, backup->abba, OGS_NAS_MAX_ABBA_LEN);
+    amf_ue->abba_len = backup->abba_len;
+    memcpy(amf_ue->hxres_star, backup->hxres_star, OGS_MAX_RES_LEN);
+    memcpy(amf_ue->kamf, backup->kamf, OGS_SHA256_DIGEST_SIZE);
+    memcpy(amf_ue->knas_int, backup->knas_int, OGS_SHA256_DIGEST_SIZE/2);
+    memcpy(amf_ue->knas_enc, backup->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
+    amf_ue->dl_count = backup->dl_count;
+    amf_ue->ul_count.i32 = backup->ul_count;
+    memcpy(amf_ue->kgnb, backup->kgnb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(amf_ue->nh, backup->nh, OGS_SHA256_DIGEST_SIZE);
+    amf_ue->selected_enc_algorithm = backup->selected_enc_algorithm;
+    amf_ue->selected_int_algorithm = backup->selected_int_algorithm;
 }
 
 void amf_clear_subscribed_info(amf_ue_t *amf_ue)

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -237,6 +237,67 @@ struct ran_ue_s {
     ogs_pool_id_t   amf_ue_id;
 }; 
 
+typedef struct amf_security_context_s {
+    /* UE security capability info: supported security features. */
+    ogs_nas_ue_security_capability_t ue_security_capability;
+    /* UE network capability info: supported network features. */
+    ogs_nas_ue_network_capability_t ue_network_capability;
+
+    /* Random challenge value */
+    uint8_t rand[OGS_RAND_LEN];
+    /* Authentication token */
+    uint8_t autn[OGS_AUTN_LEN];
+    /* Expected auth response. */
+    uint8_t xres_star[OGS_MAX_RES_LEN];
+
+    /* NAS backoff parameter value. */
+    uint8_t abba[OGS_NAS_MAX_ABBA_LEN];
+    uint8_t abba_len;
+
+    /* Hash of XRES*. */
+    uint8_t hxres_star[OGS_MAX_RES_LEN];
+    /* Key for AMF derived from NAS key. */
+    uint8_t kamf[OGS_SHA256_DIGEST_SIZE];
+
+    /* Integrity and ciphering keys */
+    uint8_t knas_int[OGS_SHA256_DIGEST_SIZE/2];
+    uint8_t knas_enc[OGS_SHA256_DIGEST_SIZE/2];
+    /* Downlink counter */
+    uint32_t dl_count;
+    /* Uplink counter (24-bit stored in uint32_t) */
+    uint32_t ul_count;
+    /* gNB key derived from kasme */
+    uint8_t kgnb[OGS_SHA256_DIGEST_SIZE];
+
+    /*
+     * Next Hop Channing Counter
+     *
+     * Note that the "nhcc" field is not included in the backup
+     * because it is a transient counter used only during next-hop key
+     * derivation. In our design, only the persistent keying material
+     * and related values that are required to recreate the security context
+     * are backed up. The nhcc value is recalculated or updated dynamically
+     * when the next hop key is derived (e.g. via ogs_kdf_nh_enb()),
+     * so it is not necessary to store it in the backup.
+     *
+     * If there is a requirement to preserve the exact nhcc value across state
+     * transitions, you could add it to the backup structure, but typically
+     * it is treated as a computed, temporary value that can be reinitialized
+     * safely without compromising the security context.
+     * struct {
+     *   ED2(uint8_t nhcc_spare:5;,
+     *   uint8_t nhcc:3;)
+     * };
+     */
+
+    /* Next hop key */
+    uint8_t         nh[OGS_SHA256_DIGEST_SIZE];
+
+    /* Selected algorithms (set by UDM/subscription) */
+    uint8_t         selected_enc_algorithm;
+    uint8_t         selected_int_algorithm;
+} amf_security_context_t;
+
 struct amf_ue_s {
     ogs_sbi_object_t sbi;
     ogs_pool_id_t id;
@@ -367,6 +428,12 @@ struct amf_ue_s {
     int             security_context_available;
     int             mac_failed;
 
+    /* flag: 1 = allow restoration of security context, 0 = disallow */
+    bool            can_restore_security_context;
+
+    /* Backup of security context fields */
+    amf_security_context_t sec_backup;
+
     /* Security Context */
     ogs_nas_ue_security_capability_t ue_security_capability;
     ogs_nas_ue_network_capability_t ue_network_capability;
@@ -391,20 +458,29 @@ struct amf_ue_s {
         char *resource_uri;
         ogs_sbi_client_t *client;
     } confirmation_for_5g_aka;
+    /* Random challenge value */
     uint8_t         rand[OGS_RAND_LEN];
+    /* Authentication token */
     uint8_t         autn[OGS_AUTN_LEN];
+    /* Expected auth response. */
     uint8_t         xres_star[OGS_MAX_RES_LEN];
 
+    /* NAS backoff parameter value. */
     uint8_t         abba[OGS_NAS_MAX_ABBA_LEN];
     uint8_t         abba_len;
 
+    /* Hash of XRES*. */
     uint8_t         hxres_star[OGS_MAX_RES_LEN];
+    /* Key for AMF derived from NAS key. */
     uint8_t         kamf[OGS_SHA256_DIGEST_SIZE];
     OpenAPI_auth_result_e auth_result;
 
+    /* Integrity and ciphering keys */
     uint8_t         knas_int[OGS_SHA256_DIGEST_SIZE/2];
     uint8_t         knas_enc[OGS_SHA256_DIGEST_SIZE/2];
+    /* Downlink counter */
     uint32_t        dl_count;
+    /* Uplink counter (24-bit stored in uint32_t) */
     union {
         struct {
         ED3(uint8_t spare;,
@@ -413,14 +489,17 @@ struct amf_ue_s {
         } __attribute__ ((packed));
         uint32_t i32;
     } ul_count;
+    /* gNB key derived from kasme */
     uint8_t         kgnb[OGS_SHA256_DIGEST_SIZE];
 
     struct {
     ED2(uint8_t nhcc_spare:5;,
         uint8_t nhcc:3;) /* Next Hop Channing Counter */
     };
+    /* Next hop key */
     uint8_t         nh[OGS_SHA256_DIGEST_SIZE]; /* NH Security Key */
 
+    /* Selected algorithms (set by UDM/subscription) */
     /* defined in 'lib/nas/common/types.h'
      * #define OGS_NAS_SECURITY_ALGORITHMS_NEA0        0
      * #define OGS_NAS_SECURITY_ALGORITHMS_128_NEA1    1
@@ -1005,6 +1084,11 @@ int amf_m_tmsi_free(amf_m_tmsi_t *tmsi);
 
 uint8_t amf_selected_int_algorithm(amf_ue_t *amf_ue);
 uint8_t amf_selected_enc_algorithm(amf_ue_t *amf_ue);
+
+void amf_backup_security_context(
+        amf_ue_t *amf_ue, amf_security_context_t *backup);
+void amf_restore_security_context(
+        amf_ue_t *amf_ue, const amf_security_context_t *backup);
 
 void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 

--- a/src/mme/emm-handler.h
+++ b/src/mme/emm-handler.h
@@ -33,6 +33,10 @@ int emm_handle_attach_complete(
         enb_ue_t *enb_ue, mme_ue_t *mme_ue,
         ogs_nas_eps_attach_complete_t *attach_complete);
 
+int emm_handle_authentication_response(
+        enb_ue_t *enb_ue, mme_ue_t *mme_ue,
+        ogs_nas_eps_authentication_response_t *authentication_response);
+
 int emm_handle_identity_response(
         enb_ue_t *enb_ue, mme_ue_t *mme_ue,
         ogs_nas_eps_identity_response_t *identity_response);

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -5028,6 +5028,82 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     }
 
     return 0;
+}
+
+/* Backup the sensitive security context fields from the UE context */
+void mme_backup_security_context(
+        mme_ue_t *mme_ue, mme_security_context_t *backup)
+{
+    ogs_assert(mme_ue);
+    ogs_assert(backup);
+
+    memcpy(&backup->ue_network_capability,
+            &mme_ue->ue_network_capability,
+            sizeof(backup->ue_network_capability));
+    memcpy(&backup->ms_network_capability,
+            &mme_ue->ms_network_capability,
+            sizeof(backup->ms_network_capability));
+    memcpy(&backup->ue_additional_security_capability,
+            &mme_ue->ue_additional_security_capability,
+            sizeof(backup->ue_additional_security_capability));
+    memcpy(backup->xres, mme_ue->xres, OGS_MAX_RES_LEN);
+    backup->xres_len = mme_ue->xres_len;
+    memcpy(backup->kasme, mme_ue->kasme, OGS_SHA256_DIGEST_SIZE);
+    memcpy(backup->rand, mme_ue->rand, OGS_RAND_LEN);
+    memcpy(backup->autn, mme_ue->autn, OGS_AUTN_LEN);
+    memcpy(backup->knas_int, mme_ue->knas_int,
+           OGS_SHA256_DIGEST_SIZE / 2);
+    memcpy(backup->knas_enc, mme_ue->knas_enc,
+           OGS_SHA256_DIGEST_SIZE / 2);
+    backup->dl_count = mme_ue->dl_count;
+    backup->ul_count = mme_ue->ul_count.i32;
+    memcpy(backup->kenb, mme_ue->kenb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(backup->hash_mme, mme_ue->hash_mme, OGS_HASH_MME_LEN);
+    backup->nonceue = mme_ue->nonceue;
+    backup->noncemme = mme_ue->noncemme;
+    backup->gprs_ciphering_key_sequence_number =
+        mme_ue->gprs_ciphering_key_sequence_number;
+    memcpy(backup->nh, mme_ue->nh, OGS_SHA256_DIGEST_SIZE);
+    backup->selected_enc_algorithm = mme_ue->selected_enc_algorithm;
+    backup->selected_int_algorithm = mme_ue->selected_int_algorithm;
+}
+
+/* Restore the sensitive security context fields into the UE context */
+void mme_restore_security_context(
+        mme_ue_t *mme_ue, const mme_security_context_t *backup)
+{
+    ogs_assert(mme_ue);
+    ogs_assert(backup);
+
+    memcpy(&mme_ue->ue_network_capability,
+            &backup->ue_network_capability,
+            sizeof(mme_ue->ue_network_capability));
+    memcpy(&mme_ue->ms_network_capability,
+            &backup->ms_network_capability,
+            sizeof(mme_ue->ms_network_capability));
+    memcpy(&mme_ue->ue_additional_security_capability,
+            &backup->ue_additional_security_capability,
+            sizeof(mme_ue->ue_additional_security_capability));
+    memcpy(mme_ue->xres, backup->xres, OGS_MAX_RES_LEN);
+    mme_ue->xres_len = backup->xres_len;
+    memcpy(mme_ue->kasme, backup->kasme, OGS_SHA256_DIGEST_SIZE);
+    memcpy(mme_ue->rand, backup->rand, OGS_RAND_LEN);
+    memcpy(mme_ue->autn, backup->autn, OGS_AUTN_LEN);
+    memcpy(mme_ue->knas_int, backup->knas_int,
+           OGS_SHA256_DIGEST_SIZE / 2);
+    memcpy(mme_ue->knas_enc, backup->knas_enc,
+           OGS_SHA256_DIGEST_SIZE / 2);
+    mme_ue->dl_count = backup->dl_count;
+    mme_ue->ul_count.i32 = backup->ul_count;
+    memcpy(mme_ue->kenb, backup->kenb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(mme_ue->hash_mme, backup->hash_mme, OGS_HASH_MME_LEN);
+    mme_ue->nonceue = backup->nonceue;
+    mme_ue->noncemme = backup->noncemme;
+    mme_ue->gprs_ciphering_key_sequence_number =
+        backup->gprs_ciphering_key_sequence_number;
+    memcpy(mme_ue->nh, backup->nh, OGS_SHA256_DIGEST_SIZE);
+    mme_ue->selected_enc_algorithm = backup->selected_enc_algorithm;
+    mme_ue->selected_int_algorithm = backup->selected_int_algorithm;
 }
 
 static void stats_add_enb_ue(void)

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -342,6 +342,69 @@ struct sgw_ue_s {
     ogs_pool_id_t mme_ue_id;
 };
 
+typedef struct mme_security_context_s {
+    /* UE network capability info: supported network features. */
+    ogs_nas_ue_network_capability_t ue_network_capability;
+    /* MS network capability info: supported network features. */
+    ogs_nas_ms_network_capability_t ms_network_capability;
+    /* UE additional security capability: extra security features. */
+    ogs_nas_ue_additional_security_capability_t
+        ue_additional_security_capability;
+
+    /* Expected response and its length */
+    uint8_t xres[OGS_MAX_RES_LEN];
+    uint8_t xres_len;
+    /* Derived key from HSS */
+    uint8_t kasme[OGS_SHA256_DIGEST_SIZE];
+    /* Random challenge value */
+    uint8_t rand[OGS_RAND_LEN];
+    /* Authentication token */
+    uint8_t autn[OGS_AUTN_LEN];
+    /* Integrity and ciphering keys */
+    uint8_t knas_int[OGS_SHA256_DIGEST_SIZE/2];
+    uint8_t knas_enc[OGS_SHA256_DIGEST_SIZE/2];
+    /* Downlink counter */
+    uint32_t dl_count;
+    /* Uplink counter (24-bit stored in uint32_t) */
+    uint32_t ul_count;
+    /* eNB key derived from kasme */
+    uint8_t kenb[OGS_SHA256_DIGEST_SIZE];
+    /* Hash used for NAS message integrity */
+    uint8_t hash_mme[OGS_HASH_MME_LEN];
+    /* Nonces for resynchronization */
+    uint32_t nonceue;
+    uint32_t noncemme;
+    /* GPRS ciphering key sequence number */
+    uint8_t gprs_ciphering_key_sequence_number;
+
+    /*
+     * Next Hop Channing Counter
+     *
+     * Note that the "nhcc" field is not included in the backup
+     * because it is a transient counter used only during next-hop key
+     * derivation. In our design, only the persistent keying material
+     * and related values that are required to recreate the security context
+     * are backed up. The nhcc value is recalculated or updated dynamically
+     * when the next hop key is derived (e.g. via ogs_kdf_nh_enb()),
+     * so it is not necessary to store it in the backup.
+     *
+     * If there is a requirement to preserve the exact nhcc value across state
+     * transitions, you could add it to the backup structure, but typically
+     * it is treated as a computed, temporary value that can be reinitialized
+     * safely without compromising the security context.
+     * struct {
+     *   ED2(uint8_t nhcc_spare:5;,
+     *       uint8_t nhcc:3;)
+     * };
+     */
+
+    /* Next hop key */
+    uint8_t nh[OGS_SHA256_DIGEST_SIZE];
+    /* Selected algorithms (set by HSS/subscription) */
+    uint8_t selected_enc_algorithm;
+    uint8_t selected_int_algorithm;
+} mme_security_context_t;
+
 struct mme_ue_s {
     ogs_lnode_t     lnode;
     ogs_pool_id_t   id;
@@ -462,19 +525,32 @@ struct mme_ue_s {
     int             security_context_available;
     int             mac_failed;
 
+    /* flag: 1 = allow restoration of security context, 0 = disallow */
+    bool            can_restore_security_context;
+
+    /* Backup of security context fields */
+    mme_security_context_t sec_backup;
+
     /* Security Context */
     ogs_nas_ue_network_capability_t ue_network_capability;
     ogs_nas_ms_network_capability_t ms_network_capability;
     ogs_nas_ue_additional_security_capability_t
         ue_additional_security_capability;
+    /* Expected response and its length */
     uint8_t         xres[OGS_MAX_RES_LEN];
     uint8_t         xres_len;
+    /* Derived key from HSS */
     uint8_t         kasme[OGS_SHA256_DIGEST_SIZE];
+    /* Random challenge value */
     uint8_t         rand[OGS_RAND_LEN];
+    /* Authentication token */
     uint8_t         autn[OGS_AUTN_LEN];
+    /* Integrity and ciphering keys */
     uint8_t         knas_int[OGS_SHA256_DIGEST_SIZE/2];
     uint8_t         knas_enc[OGS_SHA256_DIGEST_SIZE/2];
+    /* Downlink counter */
     uint32_t        dl_count;
+    /* Uplink counter (24-bit stored in i32) */
     union {
         struct {
         ED3(uint8_t spare;,
@@ -483,17 +559,23 @@ struct mme_ue_s {
         } __attribute__ ((packed));
         uint32_t i32;
     } ul_count;
+    /* eNB key derived from kasme */
     uint8_t         kenb[OGS_SHA256_DIGEST_SIZE];
+    /* Hash used for NAS message integrity */
     uint8_t         hash_mme[OGS_HASH_MME_LEN];
+    /* Nonces for resynchronization */
     uint32_t        nonceue, noncemme;
+    /* GPRS ciphering key sequence number */
     uint8_t         gprs_ciphering_key_sequence_number;
 
     struct {
     ED2(uint8_t nhcc_spare:5;,
         uint8_t nhcc:3;) /* Next Hop Channing Counter */
     };
-    uint8_t         nh[OGS_SHA256_DIGEST_SIZE]; /* NH Security Key */
+    /* Next hop key */
+    uint8_t         nh[OGS_SHA256_DIGEST_SIZE];
 
+    /* Selected algorithms (set by HSS/subscription) */
     /* defined in 'nas_ies.h'
      * #define NAS_SECURITY_ALGORITHMS_EIA0        0
      * #define NAS_SECURITY_ALGORITHMS_128_EEA1    1
@@ -1132,6 +1214,11 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
+
+void mme_backup_security_context(
+        mme_ue_t *mme_ue, mme_security_context_t *backup);
+void mme_restore_security_context(
+        mme_ue_t *mme_ue, const mme_security_context_t *backup);
 
 #ifdef __cplusplus
 }

--- a/tests/attach/auth-test.c
+++ b/tests/attach/auth-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -345,11 +345,6 @@ static void test1_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, recvbuf);
     tests1ap_recv(test_ue, recvbuf);
 
-    /* Receive UE Context Release Command */
-    recvbuf = testenb_s1ap_read(s1ap);
-    ABTS_PTR_NOTNULL(tc, recvbuf);
-    tests1ap_recv(test_ue, recvbuf);
-
     /* Send Attach Request - No Integrity */
     sess->pdn_connectivity_param.eit = 1;
     sess->pdn_connectivity_param.pco = 1;
@@ -406,17 +401,6 @@ static void test1_func(abts_case *tc, void *data)
     recvbuf = testenb_s1ap_read(s1ap);
     ABTS_PTR_NOTNULL(tc, recvbuf);
     tests1ap_recv(test_ue, recvbuf);
-
-    /* Receive UE Context Release Command */
-    recvbuf = testenb_s1ap_read(s1ap);
-    ABTS_PTR_NOTNULL(tc, recvbuf);
-    tests1ap_recv(test_ue, recvbuf);
-
-    /* Send UE Context Release Complete */
-    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
-    ABTS_PTR_NOTNULL(tc, sendbuf);
-    rv = testenb_s1ap_send(s1ap, sendbuf);
-    ABTS_INT_EQUAL(tc, OGS_OK, rv);
 
     /*
      * --- Immediately Re-attach Test ---
@@ -488,6 +472,30 @@ static void test1_func(abts_case *tc, void *data)
     recvbuf = testenb_s1ap_read(s1ap);
     ABTS_PTR_NOTNULL(tc, recvbuf);
     tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Detach Request */
+    emmbuf = testemm_build_detach_request(test_ue, 1, true, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive OLD UE Context Release Command */
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send OLD UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
 
     /* Receive UE Context Release Command */
     recvbuf = testenb_s1ap_read(s1ap);

--- a/tests/registration/reset-test.c
+++ b/tests/registration/reset-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -650,14 +650,158 @@ static void test3_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, recvbuf);
     testngap_recv(test_ue, recvbuf);
 
-#if 0 /* To reject UE registration */
     /********** Insert Subscriber in Database */
     doc = test_db_new_simple(test_ue);
     ABTS_PTR_NOTNULL(tc, doc);
     ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
-#endif
 
     /* Send Registration request */
+    gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    test_ue->registration_request_param.gmm_capability = 1;
+    test_ue->registration_request_param.s1_ue_network_capability = 1;
+    test_ue->registration_request_param.requested_nssai = 1;
+    test_ue->registration_request_param.last_visited_registered_tai = 1;
+    test_ue->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    gmmbuf = testgmm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    gmmbuf = testgmm_build_security_mode_complete(test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send UERadioCapabilityInfoIndication */
+    sendbuf = testngap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send PDU session establishment request */
+    sess = test_sess_add_by_dnn_and_psi(test_ue, "internet", 5);
+    ogs_assert(sess);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 1;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive PDUSessionResourceSetupRequest +
+     * DL NAS transport +
+     * PDU session establishment accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send PDUSessionResourceSetupResponse */
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send De-registration request */
+    gmmbuf = testgmm_build_de_registration_request(test_ue, 1, true, true);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* Wait for removing subscriber */
+    ogs_msleep(100);
+
+    /* Send Registration request */
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
     gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
     ABTS_PTR_NOTNULL(tc, gmmbuf);
 
@@ -708,11 +852,6 @@ static void test3_func(abts_case *tc, void *data)
     ogs_pkbuf_free(recvbuf);
 
     ogs_msleep(300);
-
-#if 0 /* To reject UE registration */
-    /********** Remove Subscriber in Database */
-    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
-#endif
 
     /* gNB disonncect from UPF */
     testgnb_gtpu_close(gtpu);


### PR DESCRIPTION
- Backup sensitive security context fields (e.g. xres, kasme, rand, autn, keys, counters) when transitioning from REGISTERED state.
- Set the can_restore_security_context flag in common_register_state() based on whether the transition originates from a REGISTERED or de-registered state.
- In emm_state_authentication(), restore the security context and revert to the REGISTERED state on authentication failure only if restoration is allowed; otherwise, transition to an exception state.
- Remove the redundant unconditional state transition in the cleanup block to prevent overriding a valid restoration.