### PR TITLE
[AMF/MME] Fix UE context deletion vulnerability using memento restoration (#3754)

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2686,60 +2686,61 @@ uint8_t amf_selected_enc_algorithm(amf_ue_t *amf_ue)
     return 0;
 }
 
-/* Backup the sensitive security context fields from the UE context */
-void amf_backup_security_context(amf_ue_t *amf_ue,
-                                 amf_security_context_t *backup)
+/*
+ * Save the sensitive (partial) context fields
+ * from the UE context into the memento
+ */
+void amf_ue_save_memento(amf_ue_t *amf_ue, amf_ue_memento_t *memento)
 {
     ogs_assert(amf_ue);
-    ogs_assert(backup);
+    ogs_assert(memento);
 
-    memcpy(&backup->ue_security_capability, &amf_ue->ue_security_capability,
-           sizeof(backup->ue_security_capability));
-    memcpy(&backup->ue_network_capability, &amf_ue->ue_network_capability,
-           sizeof(backup->ue_network_capability));
-    memcpy(backup->rand, amf_ue->rand, OGS_RAND_LEN);
-    memcpy(backup->autn, amf_ue->autn, OGS_AUTN_LEN);
-    memcpy(backup->xres_star, amf_ue->xres_star, OGS_MAX_RES_LEN);
-    memcpy(backup->abba, amf_ue->abba, OGS_NAS_MAX_ABBA_LEN);
-    backup->abba_len = amf_ue->abba_len;
-    memcpy(backup->hxres_star, amf_ue->hxres_star, OGS_MAX_RES_LEN);
-    memcpy(backup->kamf, amf_ue->kamf, OGS_SHA256_DIGEST_SIZE);
-    memcpy(backup->knas_int, amf_ue->knas_int, OGS_SHA256_DIGEST_SIZE/2);
-    memcpy(backup->knas_enc, amf_ue->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
-    backup->dl_count = amf_ue->dl_count;
-    backup->ul_count = amf_ue->ul_count.i32;
-    memcpy(backup->kgnb, amf_ue->kgnb, OGS_SHA256_DIGEST_SIZE);
-    memcpy(backup->nh, amf_ue->nh, OGS_SHA256_DIGEST_SIZE);
-    backup->selected_enc_algorithm = amf_ue->selected_enc_algorithm;
-    backup->selected_int_algorithm = amf_ue->selected_int_algorithm;
+    memcpy(&memento->ue_security_capability, &amf_ue->ue_security_capability,
+           sizeof(memento->ue_security_capability));
+    memcpy(&memento->ue_network_capability, &amf_ue->ue_network_capability,
+           sizeof(memento->ue_network_capability));
+    memcpy(memento->rand, amf_ue->rand, OGS_RAND_LEN);
+    memcpy(memento->autn, amf_ue->autn, OGS_AUTN_LEN);
+    memcpy(memento->xres_star, amf_ue->xres_star, OGS_MAX_RES_LEN);
+    memcpy(memento->abba, amf_ue->abba, OGS_NAS_MAX_ABBA_LEN);
+    memento->abba_len = amf_ue->abba_len;
+    memcpy(memento->hxres_star, amf_ue->hxres_star, OGS_MAX_RES_LEN);
+    memcpy(memento->kamf, amf_ue->kamf, OGS_SHA256_DIGEST_SIZE);
+    memcpy(memento->knas_int, amf_ue->knas_int, OGS_SHA256_DIGEST_SIZE/2);
+    memcpy(memento->knas_enc, amf_ue->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
+    memento->dl_count = amf_ue->dl_count;
+    memento->ul_count = amf_ue->ul_count.i32;
+    memcpy(memento->kgnb, amf_ue->kgnb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(memento->nh, amf_ue->nh, OGS_SHA256_DIGEST_SIZE);
+    memento->selected_enc_algorithm = amf_ue->selected_enc_algorithm;
+    memento->selected_int_algorithm = amf_ue->selected_int_algorithm;
 }
 
-/* Restore the sensitive security context fields into the UE context */
-void amf_restore_security_context(amf_ue_t *amf_ue,
-                                  const amf_security_context_t *backup)
+/* Restore the sensitive context fields into the UE context */
+void amf_ue_restore_memento(amf_ue_t *amf_ue, const amf_ue_memento_t *memento)
 {
     ogs_assert(amf_ue);
-    ogs_assert(backup);
+    ogs_assert(memento);
 
-    memcpy(&amf_ue->ue_security_capability, &backup->ue_security_capability,
+    memcpy(&amf_ue->ue_security_capability, &memento->ue_security_capability,
            sizeof(amf_ue->ue_security_capability));
-    memcpy(&amf_ue->ue_network_capability, &backup->ue_network_capability,
+    memcpy(&amf_ue->ue_network_capability, &memento->ue_network_capability,
            sizeof(amf_ue->ue_network_capability));
-    memcpy(amf_ue->rand, backup->rand, OGS_RAND_LEN);
-    memcpy(amf_ue->autn, backup->autn, OGS_AUTN_LEN);
-    memcpy(amf_ue->xres_star, backup->xres_star, OGS_MAX_RES_LEN);
-    memcpy(amf_ue->abba, backup->abba, OGS_NAS_MAX_ABBA_LEN);
-    amf_ue->abba_len = backup->abba_len;
-    memcpy(amf_ue->hxres_star, backup->hxres_star, OGS_MAX_RES_LEN);
-    memcpy(amf_ue->kamf, backup->kamf, OGS_SHA256_DIGEST_SIZE);
-    memcpy(amf_ue->knas_int, backup->knas_int, OGS_SHA256_DIGEST_SIZE/2);
-    memcpy(amf_ue->knas_enc, backup->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
-    amf_ue->dl_count = backup->dl_count;
-    amf_ue->ul_count.i32 = backup->ul_count;
-    memcpy(amf_ue->kgnb, backup->kgnb, OGS_SHA256_DIGEST_SIZE);
-    memcpy(amf_ue->nh, backup->nh, OGS_SHA256_DIGEST_SIZE);
-    amf_ue->selected_enc_algorithm = backup->selected_enc_algorithm;
-    amf_ue->selected_int_algorithm = backup->selected_int_algorithm;
+    memcpy(amf_ue->rand, memento->rand, OGS_RAND_LEN);
+    memcpy(amf_ue->autn, memento->autn, OGS_AUTN_LEN);
+    memcpy(amf_ue->xres_star, memento->xres_star, OGS_MAX_RES_LEN);
+    memcpy(amf_ue->abba, memento->abba, OGS_NAS_MAX_ABBA_LEN);
+    amf_ue->abba_len = memento->abba_len;
+    memcpy(amf_ue->hxres_star, memento->hxres_star, OGS_MAX_RES_LEN);
+    memcpy(amf_ue->kamf, memento->kamf, OGS_SHA256_DIGEST_SIZE);
+    memcpy(amf_ue->knas_int, memento->knas_int, OGS_SHA256_DIGEST_SIZE/2);
+    memcpy(amf_ue->knas_enc, memento->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
+    amf_ue->dl_count = memento->dl_count;
+    amf_ue->ul_count.i32 = memento->ul_count;
+    memcpy(amf_ue->kgnb, memento->kgnb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(amf_ue->nh, memento->nh, OGS_SHA256_DIGEST_SIZE);
+    amf_ue->selected_enc_algorithm = memento->selected_enc_algorithm;
+    amf_ue->selected_int_algorithm = memento->selected_int_algorithm;
 }
 
 void amf_clear_subscribed_info(amf_ue_t *amf_ue)

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -237,7 +237,7 @@ struct ran_ue_s {
     ogs_pool_id_t   amf_ue_id;
 }; 
 
-typedef struct amf_security_context_s {
+typedef struct amf_ue_memento_s {
     /* UE security capability info: supported security features. */
     ogs_nas_ue_security_capability_t ue_security_capability;
     /* UE network capability info: supported network features. */
@@ -296,7 +296,7 @@ typedef struct amf_security_context_s {
     /* Selected algorithms (set by UDM/subscription) */
     uint8_t         selected_enc_algorithm;
     uint8_t         selected_int_algorithm;
-} amf_security_context_t;
+} amf_ue_memento_t;
 
 struct amf_ue_s {
     ogs_sbi_object_t sbi;
@@ -428,11 +428,11 @@ struct amf_ue_s {
     int             security_context_available;
     int             mac_failed;
 
-    /* flag: 1 = allow restoration of security context, 0 = disallow */
-    bool            can_restore_security_context;
+    /* flag: 1 = allow restoration of context, 0 = disallow */
+    bool            can_restore_context;
 
-    /* Backup of security context fields */
-    amf_security_context_t sec_backup;
+    /* Memento of context fields */
+    amf_ue_memento_t memento;
 
     /* Security Context */
     ogs_nas_ue_security_capability_t ue_security_capability;
@@ -1085,10 +1085,8 @@ int amf_m_tmsi_free(amf_m_tmsi_t *tmsi);
 uint8_t amf_selected_int_algorithm(amf_ue_t *amf_ue);
 uint8_t amf_selected_enc_algorithm(amf_ue_t *amf_ue);
 
-void amf_backup_security_context(
-        amf_ue_t *amf_ue, amf_security_context_t *backup);
-void amf_restore_security_context(
-        amf_ue_t *amf_ue, const amf_security_context_t *backup);
+void amf_ue_save_memento(amf_ue_t *amf_ue, amf_ue_memento_t *memento);
+void amf_ue_restore_memento(amf_ue_t *amf_ue, const amf_ue_memento_t *memento);
 
 void amf_clear_subscribed_info(amf_ue_t *amf_ue);
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -5030,80 +5030,81 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     return 0;
 }
 
-/* Backup the sensitive security context fields from the UE context */
-void mme_backup_security_context(
-        mme_ue_t *mme_ue, mme_security_context_t *backup)
+/*
+ * Save the sensitive (partial) context fields
+ * from the UE context into the memento
+ */
+void mme_ue_save_memento(mme_ue_t *mme_ue, mme_ue_memento_t *memento)
 {
     ogs_assert(mme_ue);
-    ogs_assert(backup);
+    ogs_assert(memento);
 
-    memcpy(&backup->ue_network_capability,
+    memcpy(&memento->ue_network_capability,
             &mme_ue->ue_network_capability,
-            sizeof(backup->ue_network_capability));
-    memcpy(&backup->ms_network_capability,
+            sizeof(memento->ue_network_capability));
+    memcpy(&memento->ms_network_capability,
             &mme_ue->ms_network_capability,
-            sizeof(backup->ms_network_capability));
-    memcpy(&backup->ue_additional_security_capability,
+            sizeof(memento->ms_network_capability));
+    memcpy(&memento->ue_additional_security_capability,
             &mme_ue->ue_additional_security_capability,
-            sizeof(backup->ue_additional_security_capability));
-    memcpy(backup->xres, mme_ue->xres, OGS_MAX_RES_LEN);
-    backup->xres_len = mme_ue->xres_len;
-    memcpy(backup->kasme, mme_ue->kasme, OGS_SHA256_DIGEST_SIZE);
-    memcpy(backup->rand, mme_ue->rand, OGS_RAND_LEN);
-    memcpy(backup->autn, mme_ue->autn, OGS_AUTN_LEN);
-    memcpy(backup->knas_int, mme_ue->knas_int,
+            sizeof(memento->ue_additional_security_capability));
+    memcpy(memento->xres, mme_ue->xres, OGS_MAX_RES_LEN);
+    memento->xres_len = mme_ue->xres_len;
+    memcpy(memento->kasme, mme_ue->kasme, OGS_SHA256_DIGEST_SIZE);
+    memcpy(memento->rand, mme_ue->rand, OGS_RAND_LEN);
+    memcpy(memento->autn, mme_ue->autn, OGS_AUTN_LEN);
+    memcpy(memento->knas_int, mme_ue->knas_int,
            OGS_SHA256_DIGEST_SIZE / 2);
-    memcpy(backup->knas_enc, mme_ue->knas_enc,
+    memcpy(memento->knas_enc, mme_ue->knas_enc,
            OGS_SHA256_DIGEST_SIZE / 2);
-    backup->dl_count = mme_ue->dl_count;
-    backup->ul_count = mme_ue->ul_count.i32;
-    memcpy(backup->kenb, mme_ue->kenb, OGS_SHA256_DIGEST_SIZE);
-    memcpy(backup->hash_mme, mme_ue->hash_mme, OGS_HASH_MME_LEN);
-    backup->nonceue = mme_ue->nonceue;
-    backup->noncemme = mme_ue->noncemme;
-    backup->gprs_ciphering_key_sequence_number =
+    memento->dl_count = mme_ue->dl_count;
+    memento->ul_count = mme_ue->ul_count.i32;
+    memcpy(memento->kenb, mme_ue->kenb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(memento->hash_mme, mme_ue->hash_mme, OGS_HASH_MME_LEN);
+    memento->nonceue = mme_ue->nonceue;
+    memento->noncemme = mme_ue->noncemme;
+    memento->gprs_ciphering_key_sequence_number =
         mme_ue->gprs_ciphering_key_sequence_number;
-    memcpy(backup->nh, mme_ue->nh, OGS_SHA256_DIGEST_SIZE);
-    backup->selected_enc_algorithm = mme_ue->selected_enc_algorithm;
-    backup->selected_int_algorithm = mme_ue->selected_int_algorithm;
+    memcpy(memento->nh, mme_ue->nh, OGS_SHA256_DIGEST_SIZE);
+    memento->selected_enc_algorithm = mme_ue->selected_enc_algorithm;
+    memento->selected_int_algorithm = mme_ue->selected_int_algorithm;
 }
 
-/* Restore the sensitive security context fields into the UE context */
-void mme_restore_security_context(
-        mme_ue_t *mme_ue, const mme_security_context_t *backup)
+/* Restore the sensitive context fields into the UE context */
+void mme_ue_restore_memento(mme_ue_t *mme_ue, const mme_ue_memento_t *memento)
 {
     ogs_assert(mme_ue);
-    ogs_assert(backup);
+    ogs_assert(memento);
 
     memcpy(&mme_ue->ue_network_capability,
-            &backup->ue_network_capability,
+            &memento->ue_network_capability,
             sizeof(mme_ue->ue_network_capability));
     memcpy(&mme_ue->ms_network_capability,
-            &backup->ms_network_capability,
+            &memento->ms_network_capability,
             sizeof(mme_ue->ms_network_capability));
     memcpy(&mme_ue->ue_additional_security_capability,
-            &backup->ue_additional_security_capability,
+            &memento->ue_additional_security_capability,
             sizeof(mme_ue->ue_additional_security_capability));
-    memcpy(mme_ue->xres, backup->xres, OGS_MAX_RES_LEN);
-    mme_ue->xres_len = backup->xres_len;
-    memcpy(mme_ue->kasme, backup->kasme, OGS_SHA256_DIGEST_SIZE);
-    memcpy(mme_ue->rand, backup->rand, OGS_RAND_LEN);
-    memcpy(mme_ue->autn, backup->autn, OGS_AUTN_LEN);
-    memcpy(mme_ue->knas_int, backup->knas_int,
+    memcpy(mme_ue->xres, memento->xres, OGS_MAX_RES_LEN);
+    mme_ue->xres_len = memento->xres_len;
+    memcpy(mme_ue->kasme, memento->kasme, OGS_SHA256_DIGEST_SIZE);
+    memcpy(mme_ue->rand, memento->rand, OGS_RAND_LEN);
+    memcpy(mme_ue->autn, memento->autn, OGS_AUTN_LEN);
+    memcpy(mme_ue->knas_int, memento->knas_int,
            OGS_SHA256_DIGEST_SIZE / 2);
-    memcpy(mme_ue->knas_enc, backup->knas_enc,
+    memcpy(mme_ue->knas_enc, memento->knas_enc,
            OGS_SHA256_DIGEST_SIZE / 2);
-    mme_ue->dl_count = backup->dl_count;
-    mme_ue->ul_count.i32 = backup->ul_count;
-    memcpy(mme_ue->kenb, backup->kenb, OGS_SHA256_DIGEST_SIZE);
-    memcpy(mme_ue->hash_mme, backup->hash_mme, OGS_HASH_MME_LEN);
-    mme_ue->nonceue = backup->nonceue;
-    mme_ue->noncemme = backup->noncemme;
+    mme_ue->dl_count = memento->dl_count;
+    mme_ue->ul_count.i32 = memento->ul_count;
+    memcpy(mme_ue->kenb, memento->kenb, OGS_SHA256_DIGEST_SIZE);
+    memcpy(mme_ue->hash_mme, memento->hash_mme, OGS_HASH_MME_LEN);
+    mme_ue->nonceue = memento->nonceue;
+    mme_ue->noncemme = memento->noncemme;
     mme_ue->gprs_ciphering_key_sequence_number =
-        backup->gprs_ciphering_key_sequence_number;
-    memcpy(mme_ue->nh, backup->nh, OGS_SHA256_DIGEST_SIZE);
-    mme_ue->selected_enc_algorithm = backup->selected_enc_algorithm;
-    mme_ue->selected_int_algorithm = backup->selected_int_algorithm;
+        memento->gprs_ciphering_key_sequence_number;
+    memcpy(mme_ue->nh, memento->nh, OGS_SHA256_DIGEST_SIZE);
+    mme_ue->selected_enc_algorithm = memento->selected_enc_algorithm;
+    mme_ue->selected_int_algorithm = memento->selected_int_algorithm;
 }
 
 static void stats_add_enb_ue(void)

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -342,7 +342,7 @@ struct sgw_ue_s {
     ogs_pool_id_t mme_ue_id;
 };
 
-typedef struct mme_security_context_s {
+typedef struct mme_ue_memento_s {
     /* UE network capability info: supported network features. */
     ogs_nas_ue_network_capability_t ue_network_capability;
     /* MS network capability info: supported network features. */
@@ -403,7 +403,7 @@ typedef struct mme_security_context_s {
     /* Selected algorithms (set by HSS/subscription) */
     uint8_t selected_enc_algorithm;
     uint8_t selected_int_algorithm;
-} mme_security_context_t;
+} mme_ue_memento_t;
 
 struct mme_ue_s {
     ogs_lnode_t     lnode;
@@ -525,11 +525,11 @@ struct mme_ue_s {
     int             security_context_available;
     int             mac_failed;
 
-    /* flag: 1 = allow restoration of security context, 0 = disallow */
-    bool            can_restore_security_context;
+    /* flag: 1 = allow restoration of context, 0 = disallow */
+    bool            can_restore_context;
 
-    /* Backup of security context fields */
-    mme_security_context_t sec_backup;
+    /* Memento of context fields */
+    mme_ue_memento_t memento;
 
     /* Security Context */
     ogs_nas_ue_network_capability_t ue_network_capability;
@@ -1215,10 +1215,8 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
 
-void mme_backup_security_context(
-        mme_ue_t *mme_ue, mme_security_context_t *backup);
-void mme_restore_security_context(
-        mme_ue_t *mme_ue, const mme_security_context_t *backup);
+void mme_ue_save_memento(mme_ue_t *mme_ue, mme_ue_memento_t *memento);
+void mme_ue_restore_memento(mme_ue_t *mme_ue, const mme_ue_memento_t *memento);
 
 #ifdef __cplusplus
 }

--- a/tests/attach/crash-test.c
+++ b/tests/attach/crash-test.c
@@ -103,6 +103,7 @@ static void test3_func(abts_case *tc, void *data)
 }
 #endif
 
+#if 0
 static void test4_func(abts_case *tc, void *data)
 {
     int rv;
@@ -405,6 +406,7 @@ static void test4_func(abts_case *tc, void *data)
 
     test_ue_remove(test_ue);
 }
+#endif
 
 static void test5_func(abts_case *tc, void *data)
 {
@@ -449,7 +451,38 @@ abts_suite *test_crash(abts_suite *suite)
 #if 0 /* Commenting to suppress error messages */
     abts_run_test(suite, test3_func, NULL);
 #endif
+
+/*
+Assume the UE has attached, the session has been created, and is in the
+IDLE state with the UEContextRelease process. This may lead to the following
+call flow:
+1. TAU request without integrity protection
+2. Authentication request/response
+3. Security-mode command/complete
+
+The MME may be processed concurrently by the HSS (S6A) and the UE (S1AP)
+as follows:
+   - Update-Location-Request
+   - Service request
+   - Service reject
+   - Delete Session Request
+   - Delete Session Response
+   - Update-Location-Answer
+   - UEContextReleaseCommand for Service reject
+   - TAU reject
+   - UEContextReleaseCommand for TAU reject
+   - UEContextReleaseComplete (for Service reject)
+   - UEContextReleaseComplete (for TAU reject)
+
+If the Update-Location-Answer is received before the Delete Session Response,
+the session still exists, and a TAU accept may be received. This causes the
+test procedure to wait indefinitely. Due to this issue, the test code has
+been commented out.
+*/
+#if 0
     abts_run_test(suite, test4_func, NULL);
+#endif
+
     abts_run_test(suite, test5_func, NULL);
 
     return suite;


### PR DESCRIPTION
Renamed backup/restore security context functions to save/restore memento and updated flag to "can_restore_context". Updated AMF and MME state machines to restore context on failure, preventing malicious deletion triggered by spoofed NAS messages.