### PR TITLE
[SBI] Fix improper inclusion of callback headers in non-callback requests (#3798)

### DIFF
--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -411,6 +411,8 @@ extern "C" {
     "N5g-ddnmf_Discovery_MonitorUpdateResult"
 #define OGS_SBI_CALLBACK_N5G_DDNMF_DISCOVERY_MATCH_INFORMATION \
     "N5g-ddnmf_Discovery_MatchInformation"
+#define OGS_SBI_CALLBACK_NAMF_COMMUNICATION_ONN1N2TRANSFERFAILURE \
+    "Namf_Communication_onN1N2TransferFailure"
 
 typedef struct ogs_sbi_header_s {
     char *method;

--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -1458,9 +1458,6 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_subscribe(
 
     message.SubscriptionData = SubscriptionData;
 
-    message.http.custom.callback =
-        (char *)OGS_SBI_CALLBACK_NNRF_NFMANAGEMENT_NF_STATUS_NOTIFY;
-
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
 
@@ -1548,9 +1545,6 @@ ogs_sbi_request_t *ogs_nnrf_nfm_build_status_unsubscribe(
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_DELETE;
     message.h.uri = subscription_data->resource_uri;
-
-    message.http.custom.callback =
-        (char *)OGS_SBI_CALLBACK_NNRF_NFMANAGEMENT_NF_STATUS_NOTIFY;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -224,6 +224,15 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
     message.http.accept = (char *)(OGS_SBI_CONTENT_JSON_TYPE ","
         OGS_SBI_CONTENT_NGAP_TYPE "," OGS_SBI_CONTENT_PROBLEM_TYPE);
 
+/*
+ * Callback Header Configuration
+ *
+ * The 3gpp-Sbi-Callback HTTP header (per 3GPP TS 29.500 v17.9.0) indicates that
+ * a message is an asynchronous notification or callback. This header should be
+ * included only in HTTP POST requests that are callbacks (e.g., event or
+ * notification messages) and must not be added to regular service requests,
+ * such as registration (HTTP PUT) or subscription requests.
+ */
     message.http.custom.callback =
         (char *)OGS_SBI_CALLBACK_NSMF_PDUSESSION_STATUS_NOTIFY;
 
@@ -528,6 +537,18 @@ ogs_sbi_request_t *amf_nsmf_callback_build_n1_n2_failure_notify(
     }
 
     message.N1N2MsgTxfrFailureNotification = &N1N2MsgTxfrFailureNotification;
+
+/*
+ * Callback Header Configuration
+ *
+ * The 3gpp-Sbi-Callback HTTP header (per 3GPP TS 29.500 v17.9.0) indicates that
+ * a message is an asynchronous notification or callback. This header should be
+ * included only in HTTP POST requests that are callbacks (e.g., event or
+ * notification messages) and must not be added to regular service requests,
+ * such as registration (HTTP PUT) or subscription requests.
+ */
+    message.http.custom.callback =
+        (char *)OGS_SBI_CALLBACK_NAMF_COMMUNICATION_ONN1N2TRANSFERFAILURE;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/amf/nudm-build.c
+++ b/src/amf/nudm-build.c
@@ -85,9 +85,6 @@ ogs_sbi_request_t *amf_nudm_uecm_build_registration(
 
     message.Amf3GppAccessRegistration = &Amf3GppAccessRegistration;
 
-    message.http.custom.callback =
-        (char *)OGS_SBI_CALLBACK_NUDM_UECM_DEREGISTRATION_NOTIFICATION;
-
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
 
@@ -242,9 +239,6 @@ ogs_sbi_request_t *amf_nudm_sdm_build_subscription(amf_ue_t *amf_ue, void *data)
     SDMSubscription.unique_subscription = 1;
 
     message.SDMSubscription = &SDMSubscription;
-
-    message.http.custom.callback =
-        (char *)OGS_SBI_CALLBACK_NUDM_SDM_NOTIFICATION;
 
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);

--- a/src/nrf/nnrf-build.c
+++ b/src/nrf/nnrf-build.c
@@ -81,6 +81,17 @@ ogs_sbi_request_t *nrf_nnrf_nfm_build_nf_status_notify(
             goto end;
         }
     }
+/*
+ * Callback Header Configuration
+ *
+ * The 3gpp-Sbi-Callback HTTP header (per 3GPP TS 29.500 v17.9.0) indicates that
+ * a message is an asynchronous notification or callback. This header should be
+ * included only in HTTP POST requests that are callbacks (e.g., event or
+ * notification messages) and must not be added to regular service requests,
+ * such as registration (HTTP PUT) or subscription requests.
+ */
+    message.http.custom.callback =
+        (char *)OGS_SBI_CALLBACK_NNRF_NFMANAGEMENT_NF_STATUS_NOTIFY;
 
     message.NotificationData = NotificationData;
 

--- a/src/smf/nudm-build.c
+++ b/src/smf/nudm-build.c
@@ -236,9 +236,6 @@ ogs_sbi_request_t *smf_nudm_sdm_build_subscription(
 
     message.SDMSubscription = &SDMSubscription;
 
-    message.http.custom.callback =
-        (char *)OGS_SBI_CALLBACK_NUDM_SDM_NOTIFICATION;
-
     request = ogs_sbi_build_request(&message);
     ogs_expect(request);
 


### PR DESCRIPTION
This commit fixes an issue where the callback header (3gpp-Sbi-Callback) was incorrectly added in non-callback requests. Specifically, for registration (PUT) and subscription requests in the AMF and SMF modules, the callback header was included even though these are not asynchronous notifications.

Changes include:
- Removing the callback header assignment in src/amf/nudm-build.c and src/smf/nudm-build.c for registration and subscription requests.
- Removing the callback header in NRF subscription-related builds in lib/sbi/nnrf-build.c where it was not required.
- Adding the callback header only for actual notification or callback operations (e.g. in src/amf/nsmf-build.c for N1/N2 transfer failure and in src/nrf/nnrf-build.c for NF status notifications).
- Introducing a new callback macro in lib/sbi/message.h for Namf_Communication_onN1N2TransferFailure.

This aligns the implementation with the standard, ensuring that callback headers are only included in genuine callback/notification messages.