### PR TITLE
[CORE] Fix busy loop and blocking in curl with EPOLLERR handling in Open5GS 2.7.x (#3807, #2411, #2312)

### DIFF
--- a/lib/core/ogs-epoll.c
+++ b/lib/core/ogs-epoll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -232,22 +232,7 @@ static int epoll_process(ogs_pollset_t *pollset, ogs_time_t timeout)
 
         received = context->event_list[i].events;
         if (received & EPOLLERR) {
-        /*
-         * The libevent library has OGS_POLLOUT turned on in EPOLLERR.
-         *
-         * However, SIGPIPE can occur if write() is called
-         * when the peer connection is closed.
-         *
-         * Therefore, Open5GS turns off OGS_POLLOUT
-         * so that write() cannot be called in case of EPOLLERR.
-         *
-         * See also #2411 and #2312
-         */
-#if 0
             when = OGS_POLLIN|OGS_POLLOUT;
-#else
-            when = OGS_POLLIN;
-#endif
         } else if ((received & EPOLLHUP) && !(received & EPOLLRDHUP)) {
             when = OGS_POLLIN|OGS_POLLOUT;
         } else {

--- a/lib/core/ogs-signal.c
+++ b/lib/core/ogs-signal.c
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -277,9 +277,20 @@ static void remove_sync_sigs(sigset_t *sig_mask)
 #ifdef SIGIOT
     sigdelset(sig_mask, SIGIOT);
 #endif
+
+/*
+ * SIGPIPE can occur if write() is called when the peer connection is closed.
+ *
+ * Therefore, Open5GS ignore SIGPIE signal
+ *
+ * See also #2411 and #2312
+ */
+#if 0
 #ifdef SIGPIPE
     sigdelset(sig_mask, SIGPIPE);
 #endif
+#endif
+
 #ifdef SIGSEGV
     sigdelset(sig_mask, SIGSEGV);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -59,10 +59,6 @@ static int check_signal(int signum)
         ogs_info("SIGHUP received");
         ogs_log_cycle();
 
-        break;
-    case SIGWINCH:
-        ogs_info("Signal-NUM[%d] received (%s)",
-                signum, ogs_signal_description_get(signum));
         break;
     case SIGUSR1:
         fprintf(stderr,


### PR DESCRIPTION
In Open5GS 2.7.x, when using curl 8.x with external epoll, an issue occurred where the peer connection was closed, triggering EPOLLERR. At this point, POLL_OUT should have been set to trigger the write event handler, invoking `event_cb()` and calling `curl_multi_socket_action`. This would allow `curl_multi_info_read` to execute without blocking.

However, when `event_cb()` wasn't invoked, `curl_multi_socket_action` was not called, causing `curl_multi_info_read` to block. This resulted in a busy loop in epoll, continuously checking for the closed peer connection.

This issue specifically affects Open5GS 2.7.x with curl 8.x, and is observed on Ubuntu versions starting from **noble** and later. It does not occur on Ubuntu Jammy.

The solution involves globally ignoring SIGPIPE and fixing the epoll logic to ensure POLL_OUT is triggered when EPOLLERR occurs, allowing `curl_multi_socket_action` to be invoked and `curl_multi_info_read` to run non-blocking. This resolves the busy loop and connection issues caused by peer disconnects when using curl 8.x and external epoll.

This fix improves the stability and performance of Open5GS when used with curl 8.x and Ubuntu versions **noble** and above.