### PR TITLE
[HSS,DBI] Fetch IFC Data from DB and Insert into CX User Data AVP

### DIFF
--- a/lib/dbi/ims.c
+++ b/lib/dbi/ims.c
@@ -120,7 +120,8 @@ int ogs_dbi_ims_data(char *supi, ogs_ims_data_t *ims_data)
     bson_error_t error;
     const bson_t *document;
     bson_iter_t iter;
-    bson_iter_t child1_iter;
+    bson_iter_t child1_iter, child2_iter, child3_iter, child4_iter, child5_iter;
+    bson_iter_t child6_iter, child7_iter, child8_iter, child9_iter;
     const char *utf8 = NULL;
     uint32_t length = 0;
 
@@ -190,6 +191,218 @@ int ogs_dbi_ims_data(char *supi, ogs_ims_data_t *ims_data)
                 }
             }
             ims_data->num_of_msisdn = msisdn_index;
+        } else if (!strcmp(key, "ifc") && 
+            BSON_ITER_HOLDS_ARRAY(&iter)) {
+            int ifc_index = 0;
+            bson_iter_recurse(&iter, &child2_iter);
+            while (bson_iter_next(&child2_iter)) {
+                ogs_assert(ifc_index < OGS_MAX_NUM_OF_IFC);
+                bson_iter_recurse(&child2_iter, &child3_iter);
+                while (bson_iter_next(&child3_iter)) {
+                    const char *child3_key = bson_iter_key(&child3_iter);
+                    if (!strcmp(child3_key, "priority") &&
+                        BSON_ITER_HOLDS_INT32(&child3_iter)) {
+                        ims_data->ifc[ifc_index].priority =
+                            bson_iter_int32(&child3_iter);
+                    } else if (!strcmp(child3_key, "application_server") &&
+                        BSON_ITER_HOLDS_DOCUMENT(&child3_iter)) {
+                        bson_iter_recurse(&child3_iter, &child4_iter);
+                        while (bson_iter_next(&child4_iter)) {
+                            const char *child4_key =
+                                bson_iter_key(&child4_iter);
+                            if (!strcmp(child4_key, "server_name") &&
+                                BSON_ITER_HOLDS_UTF8(&child4_iter)) {
+                                utf8 = bson_iter_utf8(&child4_iter, &length);
+                                ims_data->ifc[ifc_index]
+                                    .application_server.server_name =
+                                    ogs_strndup(utf8, length);
+                            } else if (!strcmp(child4_key, "default_handling") &&
+                                       BSON_ITER_HOLDS_INT32(&child4_iter)) {
+                                ims_data->ifc[ifc_index]
+                                    .application_server.default_handling =
+                                    bson_iter_int32(&child4_iter);
+                            }
+                        }
+                    } else if (!strcmp(child3_key, "trigger_point") &&
+                               BSON_ITER_HOLDS_DOCUMENT(&child3_iter)) {
+                        bson_iter_recurse(&child3_iter, &child5_iter);
+                        while (bson_iter_next(&child5_iter)) {
+                            const char *child5_key =
+                                bson_iter_key(&child5_iter);
+                            if (!strcmp(child5_key, "condition_type_cnf") &&
+                                BSON_ITER_HOLDS_INT32(&child5_iter)) {
+                                ims_data->ifc[ifc_index]
+                                    .trigger_point.condition_type_cnf =
+                                    bson_iter_int32(&child5_iter);
+                            } else if (!strcmp(child5_key, "spt") &&
+                                       BSON_ITER_HOLDS_ARRAY(&child5_iter)) {
+                                int spt_index = 0;
+                                bson_iter_recurse(&child5_iter, &child6_iter);
+                                while (bson_iter_next(&child6_iter)) {
+                                    ogs_assert(spt_index < OGS_MAX_NUM_OF_SPT);
+                                    bson_iter_recurse(&child6_iter,
+                                                      &child7_iter);
+                                    while (bson_iter_next(&child7_iter)) {
+                                        const char *child7_key =
+                                            bson_iter_key(&child7_iter);
+                                        if (!strcmp(child7_key,
+                                                    "condition_negated") &&
+                                            BSON_ITER_HOLDS_INT32(&child7_iter)) {
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .condition_negated =
+                                                bson_iter_int32(
+                                                    &child7_iter);
+                                        } else if (!strcmp(child7_key, "group") &&
+                                                   BSON_ITER_HOLDS_INT32(
+                                                       &child7_iter)) {
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .group = bson_iter_int32(
+                                                &child7_iter);
+                                        } else if (!strcmp(child7_key,
+                                                           "method") &&
+                                                   BSON_ITER_HOLDS_UTF8(
+                                                       &child7_iter)) {
+                                            utf8 = bson_iter_utf8(&child7_iter,
+                                                                  &length);
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .method =
+                                                ogs_strndup(utf8, length);
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .type = HAS_METHOD;
+                                        } else if (!strcmp(child7_key,
+                                                           "session_case") &&
+                                                   BSON_ITER_HOLDS_INT32(
+                                                       &child7_iter)) {
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .session_case =
+                                                bson_iter_int32(
+                                                    &child7_iter);
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .type = HAS_SESSION_CASE;
+                                        } else if (!strcmp(child7_key,
+                                                           "sip_header") &&
+                                                   BSON_ITER_HOLDS_DOCUMENT(
+                                                       &child7_iter)) {
+                                            bson_iter_recurse(&child7_iter,
+                                                              &child8_iter);
+                                            while (bson_iter_next(&child8_iter)) {
+                                                const char *child8_key =
+                                                    bson_iter_key(
+                                                        &child8_iter);
+                                                if (!strcmp(child8_key,
+                                                            "header") &&
+                                                    BSON_ITER_HOLDS_UTF8(
+                                                        &child8_iter)) {
+                                                    utf8 = bson_iter_utf8(
+                                                        &child8_iter,
+                                                        &length);
+                                                    ims_data->ifc[ifc_index]
+                                                        .trigger_point
+                                                        .spt[spt_index]
+                                                        .header =
+                                                        ogs_strndup(utf8,
+                                                                    length);
+                                                } else if (!strcmp(child8_key,
+                                                                   "content") &&
+                                                           BSON_ITER_HOLDS_UTF8(
+                                                               &child8_iter)) {
+                                                    utf8 = bson_iter_utf8(
+                                                        &child8_iter,
+                                                        &length);
+                                                    ims_data->ifc[ifc_index]
+                                                        .trigger_point
+                                                        .spt[spt_index]
+                                                        .header_content =
+                                                        ogs_strndup(utf8,
+                                                                    length);
+                                                }
+                                            }
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .type = HAS_SIP_HEADER;
+                                        } else if (!strcmp(child7_key,
+                                                           "sdp_line") &&
+                                                   BSON_ITER_HOLDS_DOCUMENT(
+                                                       &child7_iter)) {
+                                            bson_iter_recurse(&child7_iter,
+                                                              &child9_iter);
+                                            while (bson_iter_next(&child9_iter)) {
+                                                const char *child9_key =
+                                                    bson_iter_key(
+                                                        &child9_iter);
+                                                if (!strcmp(child9_key,
+                                                            "line") &&
+                                                    BSON_ITER_HOLDS_UTF8(
+                                                        &child9_iter)) {
+                                                    utf8 = bson_iter_utf8(
+                                                        &child9_iter,
+                                                        &length);
+                                                    ims_data->ifc[ifc_index]
+                                                        .trigger_point
+                                                        .spt[spt_index]
+                                                        .sdp_line =
+                                                        ogs_strndup(utf8,
+                                                                    length);
+                                                } else if (!strcmp(child9_key,
+                                                                   "content") &&
+                                                           BSON_ITER_HOLDS_UTF8(
+                                                               &child9_iter)) {
+                                                    utf8 = bson_iter_utf8(
+                                                        &child9_iter,
+                                                        &length);
+                                                    ims_data->ifc[ifc_index]
+                                                        .trigger_point
+                                                        .spt[spt_index]
+                                                        .sdp_line_content =
+                                                        ogs_strndup(utf8,
+                                                                    length);
+                                                }
+                                            }
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .type = HAS_SDP_LINE;
+                                        } else if (!strcmp(child7_key,
+                                                           "request_uri") &&
+                                                   BSON_ITER_HOLDS_UTF8(
+                                                       &child7_iter)) {
+                                            utf8 = bson_iter_utf8(&child7_iter,
+                                                                  &length);
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .request_uri =
+                                                ogs_strndup(utf8, length);
+                                            ims_data->ifc[ifc_index]
+                                                .trigger_point
+                                                .spt[spt_index]
+                                                .type = HAS_REQUEST_URI;
+                                        }
+                                    }
+                                    spt_index++;
+                                }
+                                ims_data->ifc->trigger_point.num_of_spt =
+                                    spt_index;
+                            }
+                        }
+                    }
+                }
+                ifc_index++;
+            }
+            ims_data->num_of_ifc = ifc_index;
         }
     }
 

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -955,6 +955,76 @@ typedef struct ogs_media_component_s {
     int                 num_of_sub;
 } ogs_media_component_t;
 
+#define OGS_MAX_NUM_OF_SPT 20
+#define OGS_MAX_NUM_OF_IFC 20
+
+/*
+ * Defines matching mechanism type of SPT
+ */
+typedef enum {
+    INVALID_TYPE,
+    HAS_METHOD,
+    HAS_SESSION_CASE,
+    HAS_SIP_HEADER,
+    HAS_SDP_LINE,
+    HAS_REQUEST_URI,
+} spt_type_e;
+
+/**************************************************
+ * Service Point Trigger Structure (SPT)         */
+typedef struct _spt_t {
+    spt_type_e type; /* Matching mechanism type of SPT */
+    int        condition_negated; /* Indicates if the Service Point Trigger instance is negated */
+    int        group; /* The SPT group or list of SPT groups assigned to the SPT */
+    const char *method; /* The method of the SIP request */
+    int        session_case; /* The direction of the SIP request as evaluated by the S-CSCF */
+    const char *header; /* A header in the SIP request*/
+	const char *header_content; /* Optionally the value of the header in the SIP request */
+    const char *sdp_line; /* A SDP line within the body (if any) of a SIP request */
+	const char *sdp_line_content; /* Optionally the value in the SDP line of a SIP request */
+    const char *request_uri; /* The request-URI of the SIP request */
+} spt_t;
+
+/*
+ * Defines what logical operators should be used between SPTs belonging to
+ * different groups
+ */
+typedef enum {
+    DISJUNCTIVE_NORMAL_FORMAT,  /* an ORed set of ANDed subsets */
+    CONJUNCTIVE_NORMAL_FORMAT /* an ANDed set of ORed subsets */
+} condition_type_cnf_e;
+
+/**************************************************
+ * Trigger Point Structure
+ * Each TriggerPoint is made up of Service Point Trigger (SPTs) which are 
+ * individual rules that are matched or not matched, that are either combined
+ * as logical AND or logical OR statements when evaluated.
+ */
+typedef struct _trigger_point_t {
+    int                  num_of_spt;
+    condition_type_cnf_e condition_type_cnf; 
+    spt_t                spt[OGS_MAX_NUM_OF_SPT];
+} trigger_point_t;
+
+/**************************************************
+ * Application Server Structure                  */
+typedef struct _application_server_t {
+    const char *server_name;
+    int        default_handling;
+} application_server_t;
+
+/**************************************************
+ * IFC Structure 
+ * 3GPP TS 29.562
+ */
+typedef struct _ifc_t {
+    int priority; /* The priority of the IFC. The higher the Priority Number the lower the priority of the Filter
+    Criteria is*/
+    trigger_point_t trigger_point; /* The conditions that should be checked to find out if the indicated Application
+    Server should be contacted or not */
+    application_server_t application_server; /* the Application Server which shall be triggered if the conditions are met */
+} ifc_t;
+
 typedef struct ogs_ims_data_s {
     int num_of_msisdn;
     struct {
@@ -966,6 +1036,9 @@ typedef struct ogs_ims_data_s {
 #define OGS_MAX_NUM_OF_MEDIA_COMPONENT 16
     ogs_media_component_t media_component[OGS_MAX_NUM_OF_MEDIA_COMPONENT];
     int num_of_media_component;
+
+    int num_of_ifc;
+    ifc_t ifc[OGS_MAX_NUM_OF_IFC];
 } ogs_ims_data_t;
 
 void ogs_ims_data_free(ogs_ims_data_t *ims_data);

--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -1011,6 +1011,146 @@ char *hss_cx_download_user_data(
             ogs_assert(user_data);
         }
 
+        // IFC data
+        for (int n = 0; n < ims_data->num_of_ifc; n++) {
+            user_data = ogs_mstrcatf(user_data, "%s",
+                        ogs_diam_cx_xml_ifc_s);
+            ogs_assert(user_data); 
+            
+              // priority
+              user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                          ogs_diam_cx_xml_priority_s,
+                          ims_data->ifc[n].priority,
+                          ogs_diam_cx_xml_priority_e);
+              ogs_assert(user_data);
+              
+              // trigger point
+              user_data = ogs_mstrcatf(user_data, "%s",
+                          ogs_diam_cx_xml_tp_s);
+              ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                            ogs_diam_cx_xml_cnf_s,
+                            ims_data->ifc[n].trigger_point.condition_type_cnf,
+                            ogs_diam_cx_xml_cnf_e);
+                ogs_assert(user_data);
+
+                // SPTs
+                for (int m = 0; m < ims_data->ifc[n].trigger_point.num_of_spt; m++) {
+                    user_data = ogs_mstrcatf(user_data, "%s",
+                                ogs_diam_cx_xml_spt_s);
+                    ogs_assert(user_data);
+                      
+                      // condition negated
+                      user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                                  ogs_diam_cx_xml_condition_negated_s,
+                                  ims_data->ifc[n].trigger_point.spt[m].condition_negated,
+                                  ogs_diam_cx_xml_condition_negated_e);
+                      ogs_assert(user_data);
+                      
+                      // group
+                      user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                                  ogs_diam_cx_xml_group_s,
+                                  ims_data->ifc[n].trigger_point.spt[m].group,
+                                  ogs_diam_cx_xml_group_e);
+                      ogs_assert(user_data);
+                      
+                      // method
+                      if (ims_data->ifc[n].trigger_point.spt[m].type == HAS_METHOD) {
+                          user_data = ogs_mstrcatf(user_data, "%s%s%s",
+                                      ogs_diam_cx_xml_method_s,
+                                      ims_data->ifc[n].trigger_point.spt[m].method,
+                                      ogs_diam_cx_xml_method_e);
+                          ogs_assert(user_data);
+                      }
+
+                      // session case
+                      if (ims_data->ifc[n].trigger_point.spt[m].type == HAS_SESSION_CASE) {
+                          user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                                      ogs_diam_cx_xml_session_case_s,
+                                      ims_data->ifc[n].trigger_point.spt[m].session_case,
+                                      ogs_diam_cx_xml_session_case_e);
+                          ogs_assert(user_data);
+                      }
+
+                      // sip header
+                      if (ims_data->ifc[n].trigger_point.spt[m].type == HAS_SIP_HEADER) {
+                          user_data = ogs_mstrcatf(user_data, "%s",
+                                      ogs_diam_cx_xml_sip_hdr_s);
+                          ogs_assert(user_data);
+
+                            user_data = ogs_mstrcatf(user_data, "%s%s%s",
+                                        ogs_diam_cx_xml_header_s,
+                                        ims_data->ifc[n].trigger_point.spt[m].header,
+                                        ogs_diam_cx_xml_header_e);
+                            ogs_assert(user_data);
+
+                            if  (ims_data->ifc[n].trigger_point.spt[m].header_content) {
+                                user_data = ogs_mstrcatf(user_data, "%s%s%s",
+                                            ogs_diam_cx_xml_content_s,
+                                            ims_data->ifc[n].trigger_point.spt[m].header_content,
+                                            ogs_diam_cx_xml_content_e);
+                                ogs_assert(user_data);
+                            }
+
+                          user_data = ogs_mstrcatf(user_data, "%s",
+                                      ogs_diam_cx_xml_sip_hdr_e);
+                          ogs_assert(user_data);
+                      }
+                      
+                      // request uri
+                      if (ims_data->ifc[n].trigger_point.spt[m].type == HAS_REQUEST_URI) {
+                          user_data = ogs_mstrcatf(user_data, "%s%s%s",
+                                    ogs_diam_cx_xml_req_uri_s,
+                                    ims_data->ifc[n].trigger_point.spt[m].request_uri,
+                                    ogs_diam_cx_xml_req_uri_e);
+                          ogs_assert(user_data);
+                      }
+
+                      // extension
+                      user_data = ogs_mstrcatf(user_data, "%s",
+                                  ogs_diam_cx_xml_extension_s);
+                      ogs_assert(user_data);
+
+                      user_data = ogs_mstrcatf(user_data, "%s",
+                                  ogs_diam_cx_xml_extension_e);
+                      ogs_assert(user_data);
+
+                    user_data = ogs_mstrcatf(user_data, "%s",
+                                ogs_diam_cx_xml_spt_e);
+                    ogs_assert(user_data);
+                }
+            
+              user_data = ogs_mstrcatf(user_data, "%s",
+                          ogs_diam_cx_xml_tp_e);
+              ogs_assert(user_data);
+
+              // application server
+              user_data = ogs_mstrcatf(user_data, "%s",
+                          ogs_diam_cx_xml_app_server_s);
+              ogs_assert(user_data);
+
+                user_data = ogs_mstrcatf(user_data, "%s%s%s",
+                            ogs_diam_cx_xml_server_name_s,
+                            ims_data->ifc[n].application_server.server_name,
+                            ogs_diam_cx_xml_server_name_e);
+                ogs_assert(user_data);
+                
+                user_data = ogs_mstrcatf(user_data, "%s%d%s",
+                            ogs_diam_cx_xml_default_handling_s,
+                            ims_data->ifc[n].application_server.default_handling, 
+                            ogs_diam_cx_xml_default_handling_e);
+                ogs_assert(user_data);
+
+              user_data = ogs_mstrcatf(user_data, "%s",
+                          ogs_diam_cx_xml_app_server_e);
+              ogs_assert(user_data);
+
+            user_data = ogs_mstrcatf(user_data, "%s",
+                        ogs_diam_cx_xml_ifc_e);
+            ogs_assert(user_data);
+        }
+        
         if(self.sms_over_ims) {
             user_data = ogs_mstrcatf(user_data, "%s",
                         ogs_diam_cx_xml_ifc_s);


### PR DESCRIPTION
This PR enhances the SAA message generation by fetching Initial Filter Criteria (IFC) data from the database and embedding it into the cx-user-data XML tag. The change ensures SAA responses dynamically include subscriber-specific IFC configurations, improving compliance with 3GPP Cx interface requirements. Integration tests validate data consistency, and existing APIs remain unaffected. This enables richer service triggering for VoLTE/IMS use cases.