### PR TITLE
[SMF] Add userLocationInfo and timeZone to PCF SM Policy request (#3755)

### DIFF
--- a/src/hss/hss-context.c
+++ b/src/hss/hss-context.c
@@ -923,7 +923,7 @@ char *hss_cx_download_user_data(
     hss_impu_t *impu = NULL;
 
     bool barring_indication_presence = true;
-    int i;
+    int i, n, m;
 
     ogs_assert(user_name);
     ogs_assert(visited_network_identifier);
@@ -1012,7 +1012,7 @@ char *hss_cx_download_user_data(
         }
 
         /* IFC data */
-        for (int n = 0; n < ims_data->num_of_ifc; n++) {
+        for (n = 0; n < ims_data->num_of_ifc; n++) {
             user_data = ogs_mstrcatf(user_data, "%s",
                         ogs_diam_cx_xml_ifc_s);
             ogs_assert(user_data);
@@ -1036,7 +1036,7 @@ char *hss_cx_download_user_data(
                 ogs_assert(user_data);
 
                 /* SPTs */
-                for (int m = 0; m < ims_data->ifc[n].trigger_point.num_of_spt;
+                for (m = 0; m < ims_data->ifc[n].trigger_point.num_of_spt;
                         m++) {
                     user_data = ogs_mstrcatf(user_data, "%s",
                                 ogs_diam_cx_xml_spt_s);


### PR DESCRIPTION
This commit enhances the SM Policy request sent to the PCF by incorporating user location information and time zone data.

The SMF now builds a userLocationInfo structure using the session's NR TAI and NR CGI details, along with a timestamp generated from the current GMT time.

Additionally, the UE's time zone is included in the request context, and the ratType is explicitly set to NR.