### PR TITLE
[HSS,S6A] Add two Supported-Features AVPs to ULA for 5G-NSA roaming (#3832)

### DIFF
--- a/lib/diameter/s6a/message.c
+++ b/lib/diameter/s6a/message.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -92,6 +92,10 @@ struct dict_object *ogs_diam_s6a_software_version = NULL;
 struct dict_object *ogs_diam_s6a_msisdn = NULL;
 struct dict_object *ogs_diam_s6a_a_msisdn = NULL;
 
+struct dict_object *ogs_diam_s6a_supported_features = NULL;
+struct dict_object *ogs_diam_s6a_feature_list_id = NULL;
+struct dict_object *ogs_diam_s6a_feature_list = NULL;
+
 extern int ogs_dict_s6a_entry(char *conffile);
 
 int ogs_diam_s6a_init(void)
@@ -175,6 +179,10 @@ int ogs_diam_s6a_init(void)
 
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "MSISDN", &ogs_diam_s6a_msisdn);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "A-MSISDN", &ogs_diam_s6a_a_msisdn);
+
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Supported-Features", &ogs_diam_s6a_supported_features);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List-ID", &ogs_diam_s6a_feature_list_id);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List", &ogs_diam_s6a_feature_list);
 
     return 0;
 }

--- a/lib/diameter/s6a/message.h
+++ b/lib/diameter/s6a/message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -158,6 +158,10 @@ extern struct dict_object *ogs_diam_s6a_software_version;
 
 extern struct dict_object *ogs_diam_s6a_msisdn;
 extern struct dict_object *ogs_diam_s6a_a_msisdn;
+
+extern struct dict_object *ogs_diam_s6a_supported_features;
+extern struct dict_object *ogs_diam_s6a_feature_list_id;
+extern struct dict_object *ogs_diam_s6a_feature_list;
 
 typedef struct ogs_diam_e_utran_vector_s {
     uint8_t                 xres[OGS_MAX_RES_LEN];

--- a/src/hss/hss-s6a-path.c
+++ b/src/hss/hss-s6a-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -972,6 +972,76 @@ static int hss_ogs_diam_s6a_ulr_cb( struct msg **msg, struct avp *avp,
     /* Set Vendor-Specific-Application-Id AVP */
     ret = ogs_diam_message_vendor_specific_appid_set(
             ans, OGS_DIAM_S6A_APPLICATION_ID);
+    ogs_assert(ret == 0);
+
+    /*
+     * AVP 628 Supported-Features
+     *     AVP 629 Feature-List-ID: 1
+     *         AVP 630 Feature-List: (misc subscriber restrictions)
+     */
+    ret = fd_msg_avp_new(ogs_diam_s6a_supported_features, 0, &avp);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_vendor_id, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.i32 = OGS_3GPP_VENDOR_ID;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_s6a_feature_list_id, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.i32 = 1;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_s6a_feature_list, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.u32 = 0x0000000b;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_add(ans, MSG_BRW_LAST_CHILD, avp);
+    ogs_assert(ret == 0);
+
+    /*
+     * AVP 628 Supported-Features
+     *     AVP 629 Feature-List-ID: 2
+     *         AVP 630 Feature-List: (“NR as Secondary RAT: Supported”)
+     */
+    ret = fd_msg_avp_new(ogs_diam_s6a_supported_features, 0, &avp);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_vendor_id, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.i32 = OGS_3GPP_VENDOR_ID;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_s6a_feature_list_id, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.i32 = 2;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_new(ogs_diam_s6a_feature_list, 0, &avpch1);
+    ogs_assert(ret == 0);
+    val.u32 = 0x08000001;
+    ret = fd_msg_avp_setvalue (avpch1, &val);
+    ogs_assert(ret == 0);
+    ret = fd_msg_avp_add (avp, MSG_BRW_LAST_CHILD, avpch1);
+    ogs_assert(ret == 0);
+
+    ret = fd_msg_avp_add(ans, MSG_BRW_LAST_CHILD, avp);
     ogs_assert(ret == 0);
 
     /* Send the answer */


### PR DESCRIPTION
This commit adds support for two Supported-Features AVPs in the UpdateLocationAnswer (ULA) to enable 5G-NSA roaming. The first AVP includes subscriber restrictions, while the second AVP signals that NR as Secondary RAT is supported. Updates include modifications to lib/diameter/s6a/message.c, lib/diameter/s6a/message.h, and src/hss/hss-s6a-path.c.