### PR TITLE
[UDM] Update UE state machine to handle authentication retrieval errors (#3864)

### DIFF
--- a/src/udm/ue-sm.c
+++ b/src/udm/ue-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -302,8 +302,12 @@ void udm_ue_state_operational(ogs_fsm_t *s, udm_event_t *e)
             CASE(OGS_SBI_RESOURCE_NAME_SUBSCRIPTION_DATA)
                 SWITCH(message->h.resource.component[2])
                 CASE(OGS_SBI_RESOURCE_NAME_AUTHENTICATION_DATA)
-                    udm_nudr_dr_handle_subscription_authentication(
-                            udm_ue, stream, message);
+                    if (udm_nudr_dr_handle_subscription_authentication(
+                            udm_ue, stream, message) == false) {
+                        ogs_error("udm_nudr_dr_handle_subscription_"
+                                "authentication() failed");
+                        OGS_FSM_TRAN(s, udm_ue_state_exception);
+                    }
                     break;
 
                 CASE(OGS_SBI_RESOURCE_NAME_CONTEXT_DATA)


### PR DESCRIPTION
- In `udm_ue_state_operational()`:
  - Wrap the call to `udm_nudr_dr_handle_subscription_authentication()` in an `if` check.
  - On failure (`false`), log an error via `ogs_error("udm_nudr_dr_handle_subscription_authentication() failed")`.
  - Transition the FSM to `udm_ue_state_exception` using `OGS_FSM_TRAN()`.

This change ensures that failures during subscription authentication REST calls are not silently ignored, and that the UE state machine moves into an exception state for proper error handling and recovery.