### PR TITLE
more verbose DNN reject message

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1358,8 +1358,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
             }
 
             if (!selected_slice || !sess->dnn) {
-                ogs_warn("[%s] DNN Not Supported OR "
-                            "Not Subscribed in the Slice", amf_ue->supi);
+                ogs_warn("[%s] Ue requested DNN \"%s\" Not Supported OR "
+                            "Not Subscribed in the Slice", amf_ue->supi, dnn->value);
                 r = nas_5gs_send_gmm_status(amf_ue,
                         OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE);
                 ogs_expect(r == OGS_OK);


### PR DESCRIPTION
When a UE asks for a DNN that the core does not support, it would be helpful to expand the error message in the AMF to print the name of the DNN for easier debugging.