### PR TITLE
need to NULL out poll/sock pointers to prevent mme crash on vlr detach

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -2838,10 +2838,14 @@ void mme_vlr_close(mme_vlr_t *vlr)
 {
     ogs_assert(vlr);
 
-    if (vlr->poll)
+    if (vlr->poll) {
         ogs_pollset_remove(vlr->poll);
-    if (vlr->sock)
+        vlr->poll = NULL;
+    }
+    if (vlr->sock) {
         ogs_sctp_destroy(vlr->sock);
+        vlr->sock = NULL;
+    }
 }
 
 mme_vlr_t *mme_vlr_find_by_sock(const ogs_sock_t *sock)


### PR DESCRIPTION
As currently written, if the MME connects to an MSC over SGsAP interface and then the MSC detaches, the MME will crash shortly afterwards. This is because it calls mme_vlr_close() on detach but does not NULL out the pointers, and then calls mme_vlr_close() again after the SGsAP timer fires. NULLing out these pointers allows graceful shutdown and also allows the MSC to reattach later.