### PR TITLE
[PCF] split PCF_UE context into distinct AM and SM contexts (#3868)

### DIFF
--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -172,7 +172,8 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
                 }
 
                 if (!sess) {
-                    ogs_error("Not found [%s]", message.h.uri);
+                    ogs_error("Not found [%s:%s]",
+                            message.h.method, message.h.uri);
                     ogs_assert(true ==
                         ogs_sbi_server_send_error(stream,
                             OGS_SBI_HTTP_STATUS_NOT_FOUND,

--- a/src/pcf/am-sm.c
+++ b/src/pcf/am-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -37,7 +37,7 @@ void pcf_am_state_final(ogs_fsm_t *s, pcf_event_t *e)
 void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 {
     bool handled;
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_am_t *pcf_ue_am = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
     ogs_pool_id_t stream_id;
@@ -48,8 +48,8 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     pcf_sm_debug(e);
 
-    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_am = pcf_ue_am_find_by_id(e->pcf_ue_am_id);
+    ogs_assert(pcf_ue_am);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
@@ -75,9 +75,9 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
         SWITCH(message->h.method)
         CASE(OGS_SBI_HTTP_METHOD_POST)
             handled = pcf_npcf_am_policy_control_handle_create(
-                    pcf_ue, stream, message);
+                    pcf_ue_am, stream, message);
             if (!handled) {
-                ogs_error("[%s] Cannot handle SBI message", pcf_ue->supi);
+                ogs_error("[%s] Cannot handle SBI message", pcf_ue_am->supi);
                 OGS_FSM_TRAN(s, pcf_am_state_exception);
             }
             break;
@@ -89,7 +89,7 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
         DEFAULT
             ogs_error("[%s] Invalid HTTP method [%s]",
-                    pcf_ue->supi, message->h.method);
+                    pcf_ue_am->supi, message->h.method);
             ogs_assert(true ==
                 ogs_sbi_server_send_error(stream,
                     OGS_SBI_HTTP_STATUS_METHOD_NOT_ALLOWED, message,
@@ -122,39 +122,40 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         if (message->res_status ==
                                 OGS_SBI_HTTP_STATUS_NOT_FOUND) {
                             ogs_warn("[%s] Cannot find SUPI [%d]",
-                                pcf_ue->supi, message->res_status);
+                                pcf_ue_am->supi, message->res_status);
                         } else {
                             ogs_error("[%s] HTTP response error [%d]",
-                                pcf_ue->supi, message->res_status);
+                                pcf_ue_am->supi, message->res_status);
                         }
                         ogs_assert(true ==
                             ogs_sbi_server_send_error(
                                 stream, message->res_status,
-                                NULL, "HTTP response error", pcf_ue->supi,
+                                NULL, "HTTP response error", pcf_ue_am->supi,
                                 NULL));
                         break;
                     }
 
-                    pcf_nudr_dr_handle_query_am_data(pcf_ue, stream, message);
+                    pcf_nudr_dr_handle_query_am_data(
+                            pcf_ue_am, stream, message);
                     break;
 
                 DEFAULT
                     ogs_error("[%s] Invalid resource name [%s]",
-                            pcf_ue->supi, message->h.resource.component[1]);
+                            pcf_ue_am->supi, message->h.resource.component[1]);
                     ogs_assert_if_reached();
                 END
                 break;
 
             DEFAULT
                 ogs_error("[%s] Invalid resource name [%s]",
-                        pcf_ue->supi, message->h.resource.component[0]);
+                        pcf_ue_am->supi, message->h.resource.component[0]);
                 ogs_assert_if_reached();
             END
             break;
 
         DEFAULT
             ogs_error("[%s] Invalid API name [%s]",
-                    pcf_ue->supi, message->h.service.name);
+                    pcf_ue_am->supi, message->h.service.name);
             ogs_assert(true ==
                 ogs_sbi_server_send_error(stream,
                     OGS_SBI_HTTP_STATUS_BAD_REQUEST, message,
@@ -164,21 +165,22 @@ void pcf_am_state_operational(ogs_fsm_t *s, pcf_event_t *e)
         break;
 
     default:
-        ogs_error("[%s] Unknown event %s", pcf_ue->supi, pcf_event_get_name(e));
+        ogs_error("[%s] Unknown event %s",
+                pcf_ue_am->supi, pcf_event_get_name(e));
         break;
     }
 }
 
 void pcf_am_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_am_t *pcf_ue_am = NULL;
     ogs_assert(s);
     ogs_assert(e);
 
     pcf_sm_debug(e);
 
-    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_am = pcf_ue_am_find_by_id(e->pcf_ue_am_id);
+    ogs_assert(pcf_ue_am);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
@@ -188,21 +190,22 @@ void pcf_am_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
         break;
 
     default:
-        ogs_error("[%s] Unknown event %s", pcf_ue->supi, pcf_event_get_name(e));
+        ogs_error("[%s] Unknown event %s", pcf_ue_am->supi,
+                pcf_event_get_name(e));
         break;
     }
 }
 
 void pcf_am_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_am_t *pcf_ue_am = NULL;
     ogs_assert(s);
     ogs_assert(e);
 
     pcf_sm_debug(e);
 
-    pcf_ue = pcf_ue_find_by_id(e->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_am = pcf_ue_am_find_by_id(e->pcf_ue_am_id);
+    ogs_assert(pcf_ue_am);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
@@ -212,7 +215,8 @@ void pcf_am_state_exception(ogs_fsm_t *s, pcf_event_t *e)
         break;
 
     default:
-        ogs_error("[%s] Unknown event %s", pcf_ue->supi, pcf_event_get_name(e));
+        ogs_error("[%s] Unknown event %s", pcf_ue_am->supi,
+                pcf_event_get_name(e));
         break;
     }
 }

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -38,14 +38,18 @@ extern int __pcf_log_domain;
 #define OGS_LOG_DOMAIN __pcf_log_domain
 
 typedef struct pcf_context_s {
-    ogs_list_t      pcf_ue_list;
-    ogs_hash_t      *supi_hash;
+    ogs_list_t      pcf_ue_am_list;
+#define PCF_UE_SM_IS_LAST_SESSION(__pCF) \
+     ((__pCF) && (ogs_list_count(&(__pCF)->sess_list)) == 1)
+    ogs_list_t      pcf_ue_sm_list;
+    ogs_hash_t      *supi_am_hash;
+    ogs_hash_t      *supi_sm_hash;
 
     ogs_hash_t      *ipv4addr_hash;
     ogs_hash_t      *ipv6prefix_hash;
 } pcf_context_t;
 
-struct pcf_ue_s {
+struct pcf_ue_am_s {
     ogs_sbi_object_t sbi;
     ogs_pool_id_t id;
     ogs_fsm_t sm;
@@ -70,10 +74,29 @@ struct pcf_ue_s {
 
     OpenAPI_policy_association_request_t *policy_association_request;
     OpenAPI_ambr_t *subscribed_ue_ambr;
+};
+
+struct pcf_ue_sm_s {
+    ogs_lnode_t lnode;
+    ogs_pool_id_t id;
+
+    char *supi;
+    char *gpsi;
 
     ogs_list_t sess_list;
 };
 
+#define PCF_SESS_CLEAR(__sESS) \
+    do { \
+        pcf_ue_sm_t *pcf_ue_sm = NULL; \
+        ogs_assert(__sESS); \
+        pcf_ue_sm = pcf_ue_sm_find_by_id((__sESS)->pcf_ue_sm_id); \
+        ogs_assert(pcf_ue_sm); \
+        if (PCF_UE_SM_IS_LAST_SESSION(pcf_ue_sm)) \
+            pcf_ue_sm_remove(pcf_ue_sm); \
+        else \
+            pcf_sess_remove(__sESS); \
+    } while(0)
 struct pcf_sess_s {
     ogs_sbi_object_t sbi;
     ogs_pool_id_t id;
@@ -156,7 +179,7 @@ struct pcf_sess_s {
     ogs_list_t app_list;
 
     /* Related Context */
-    ogs_pool_id_t pcf_ue_id;
+    ogs_pool_id_t pcf_ue_sm_id;
 };
 
 typedef struct pcf_app_s {
@@ -181,30 +204,37 @@ pcf_context_t *pcf_self(void);
 
 int pcf_context_parse_config(void);
 
-pcf_ue_t *pcf_ue_add(char *supi);
-void pcf_ue_remove(pcf_ue_t *pcf_ue);
-void pcf_ue_remove_all(void);
-pcf_ue_t *pcf_ue_find_by_supi(char *supi);
-pcf_ue_t *pcf_ue_find_by_association_id(char *association_id);
+pcf_ue_am_t *pcf_ue_am_add(char *supi);
+void pcf_ue_am_remove(pcf_ue_am_t *pcf_ue_am);
+void pcf_ue_am_remove_all(void);
+pcf_ue_am_t *pcf_ue_am_find_by_supi(char *supi);
+pcf_ue_am_t *pcf_ue_am_find_by_association_id(char *association_id);
 
-pcf_sess_t *pcf_sess_add(pcf_ue_t *pcf_ue, uint8_t psi);
+pcf_ue_sm_t *pcf_ue_sm_add(char *supi);
+void pcf_ue_sm_remove(pcf_ue_sm_t *pcf_ue_sm);
+void pcf_ue_sm_remove_all(void);
+pcf_ue_sm_t *pcf_ue_sm_find_by_supi(char *supi);
+pcf_ue_sm_t *pcf_ue_sm_find_by_association_id(char *association_id);
+
+pcf_sess_t *pcf_sess_add(pcf_ue_sm_t *pcf_ue_sm, uint8_t psi);
 void pcf_sess_remove(pcf_sess_t *sess);
-void pcf_sess_remove_all(pcf_ue_t *pcf_ue);
+void pcf_sess_remove_all(pcf_ue_sm_t *pcf_ue_sm);
 
 bool pcf_sess_set_ipv4addr(pcf_sess_t *sess, char *ipv4addr);
 bool pcf_sess_set_ipv6prefix(pcf_sess_t *sess, char *ipv6prefix);
 
 pcf_sess_t *pcf_sess_find(uint32_t index);
 pcf_sess_t *pcf_sess_find_by_sm_policy_id(char *sm_policy_id);
-pcf_sess_t *pcf_sess_find_by_psi(pcf_ue_t *pcf_ue, uint8_t psi);
-pcf_sess_t *pcf_sess_find_by_dnn(pcf_ue_t *pcf_ue, char *dnn);
+pcf_sess_t *pcf_sess_find_by_psi(pcf_ue_sm_t *pcf_ue_sm, uint8_t psi);
+pcf_sess_t *pcf_sess_find_by_dnn(pcf_ue_sm_t *pcf_ue_sm, char *dnn);
 pcf_sess_t *pcf_sess_find_by_ipv4addr(char *ipv4addr_string);
 pcf_sess_t *pcf_sess_find_by_ipv6addr(char *ipv6addr_string);
 pcf_sess_t *pcf_sess_find_by_ipv6prefix(char *ipv6prefix_string);
 int pcf_sessions_number_by_snssai_and_dnn(
-        pcf_ue_t *pcf_ue, ogs_s_nssai_t *s_nssai, char *dnn);
+        pcf_ue_sm_t *pcf_ue_sm, ogs_s_nssai_t *s_nssai, char *dnn);
 
-pcf_ue_t *pcf_ue_find_by_id(ogs_pool_id_t id);
+pcf_ue_am_t *pcf_ue_am_find_by_id(ogs_pool_id_t id);
+pcf_ue_sm_t *pcf_ue_sm_find_by_id(ogs_pool_id_t id);
 pcf_sess_t *pcf_sess_find_by_id(ogs_pool_id_t id);
 
 pcf_app_t *pcf_app_add(pcf_sess_t *sess);

--- a/src/pcf/event.h
+++ b/src/pcf/event.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -26,14 +26,16 @@
 extern "C" {
 #endif
 
-typedef struct pcf_ue_s pcf_ue_t;
+typedef struct pcf_ue_am_s pcf_ue_am_t;
+typedef struct pcf_ue_sm_s pcf_ue_sm_t;
 typedef struct pcf_sess_s pcf_sess_t;
 typedef struct pcf_app_s pcf_app_t;
 
 typedef struct pcf_event_s {
     ogs_event_t h;
 
-    ogs_pool_id_t pcf_ue_id;
+    ogs_pool_id_t pcf_ue_am_id;
+    ogs_pool_id_t pcf_ue_sm_id;
     ogs_pool_id_t sess_id;
     pcf_app_t *app;
 } pcf_event_t;

--- a/src/pcf/namf-build.c
+++ b/src/pcf/namf-build.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,21 +20,21 @@
 #include "namf-build.h"
 
 ogs_sbi_request_t *pcf_namf_callback_build_am_policy_control(
-        pcf_ue_t *pcf_ue, void *data)
+        pcf_ue_am_t *pcf_ue_am, void *data)
 {
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
 
     OpenAPI_policy_update_t PolicyUpdate;
 
-    ogs_assert(pcf_ue);
-    ogs_assert(pcf_ue->notification_uri);
+    ogs_assert(pcf_ue_am);
+    ogs_assert(pcf_ue_am->notification_uri);
 
     memset(&PolicyUpdate, 0, sizeof(PolicyUpdate));
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
-    message.h.uri = pcf_ue->notification_uri;
+    message.h.uri = pcf_ue_am->notification_uri;
 
     message.PolicyUpdate = &PolicyUpdate;
 

--- a/src/pcf/namf-build.h
+++ b/src/pcf/namf-build.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 ogs_sbi_request_t *pcf_namf_callback_build_am_policy_control(
-        pcf_ue_t *pcf_ue, void *data);
+        pcf_ue_am_t *pcf_ue_am, void *data);
 
 #ifdef __cplusplus
 }

--- a/src/pcf/nbsf-build.c
+++ b/src/pcf/nbsf-build.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -22,7 +22,7 @@
 ogs_sbi_request_t *pcf_nbsf_management_build_register(
         pcf_sess_t *sess, void *data)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
 
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
@@ -40,8 +40,8 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     int i;
 
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
@@ -53,8 +53,8 @@ ogs_sbi_request_t *pcf_nbsf_management_build_register(
     memset(&PcfBinding, 0, sizeof(PcfBinding));
     memset(&sNssai, 0, sizeof(sNssai));
 
-    PcfBinding.supi = pcf_ue->supi;
-    PcfBinding.gpsi = pcf_ue->gpsi;
+    PcfBinding.supi = pcf_ue_sm->supi;
+    PcfBinding.gpsi = pcf_ue_sm->gpsi;
 
     PcfBinding.ipv4_addr = sess->ipv4addr_string;
     PcfBinding.ipv6_prefix = sess->ipv6prefix_string;
@@ -183,14 +183,14 @@ end:
 ogs_sbi_request_t *pcf_nbsf_management_build_de_register(
         pcf_sess_t *sess, void *data)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
 
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
     ogs_assert(sess->binding.resource_uri);
 
     memset(&message, 0, sizeof(message));

--- a/src/pcf/nnrf-handler.c
+++ b/src/pcf/nnrf-handler.c
@@ -29,7 +29,8 @@ void pcf_nnrf_handle_nf_discover(
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
 
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
+    pcf_ue_am_t *pcf_ue_am = NULL;
     pcf_sess_t *sess = NULL;
 
     OpenAPI_nf_type_e target_nf_type = OpenAPI_nf_type_NULL;
@@ -60,13 +61,13 @@ void pcf_nnrf_handle_nf_discover(
     }
 
     if (sbi_object->type == OGS_SBI_OBJ_UE_TYPE) {
-        pcf_ue = pcf_ue_find_by_id(sbi_object_id);
-        ogs_assert(pcf_ue);
+        pcf_ue_am = pcf_ue_am_find_by_id(sbi_object_id);
+        ogs_assert(pcf_ue_am);
     } else if (sbi_object->type == OGS_SBI_OBJ_SESS_TYPE) {
         sess = pcf_sess_find_by_id(sbi_object_id);
         ogs_assert(sess);
-        pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-        ogs_assert(pcf_ue);
+        pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+        ogs_assert(pcf_ue_sm);
     } else {
         ogs_fatal("(NF discover) Not implemented [%s:%d]",
             ogs_sbi_service_type_to_name(service_type), sbi_object->type);
@@ -78,8 +79,9 @@ void pcf_nnrf_handle_nf_discover(
     nf_instance = ogs_sbi_nf_instance_find_by_discovery_param(
                     target_nf_type, requester_nf_type, discovery_option);
     if (!nf_instance) {
-        ogs_error("[%s:%d] (NF discover) No [%s:%s]",
-                    pcf_ue ? pcf_ue->supi : "Unknown",
+        ogs_error("[%s:%s:%d] (NF discover) No [%s:%s]",
+                    pcf_ue_am ? pcf_ue_am->supi : "Unknown",
+                    pcf_ue_sm ? pcf_ue_sm->supi : "Unknown",
                     sess ? sess->psi : 0,
                     ogs_sbi_service_type_to_name(service_type),
                     OpenAPI_nf_type_ToString(requester_nf_type));

--- a/src/pcf/npcf-handler.h
+++ b/src/pcf/npcf-handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-bool pcf_npcf_am_policy_control_handle_create(pcf_ue_t *pcf_ue,
+bool pcf_npcf_am_policy_control_handle_create(pcf_ue_am_t *pcf_ue_am,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,

--- a/src/pcf/nudr-build.c
+++ b/src/pcf/nudr-build.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -20,12 +20,12 @@
 #include "nudr-build.h"
 
 ogs_sbi_request_t *pcf_nudr_dr_build_query_am_data(
-        pcf_ue_t *pcf_ue, void *data)
+        pcf_ue_am_t *pcf_ue_am, void *data)
 {
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
 
-    ogs_assert(pcf_ue);
+    ogs_assert(pcf_ue_am);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_GET;
@@ -33,7 +33,7 @@ ogs_sbi_request_t *pcf_nudr_dr_build_query_am_data(
     message.h.api.version = (char *)OGS_SBI_API_V1;
     message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_POLICY_DATA;
     message.h.resource.component[1] = (char *)OGS_SBI_RESOURCE_NAME_UES;
-    message.h.resource.component[2] = pcf_ue->supi;
+    message.h.resource.component[2] = pcf_ue_am->supi;
     message.h.resource.component[3] = (char *)OGS_SBI_RESOURCE_NAME_AM_DATA;
 
     request = ogs_sbi_build_request(&message);
@@ -45,14 +45,14 @@ ogs_sbi_request_t *pcf_nudr_dr_build_query_am_data(
 ogs_sbi_request_t *pcf_nudr_dr_build_query_sm_data(
         pcf_sess_t *sess, void *data)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
 
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
 
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_GET;
@@ -60,7 +60,7 @@ ogs_sbi_request_t *pcf_nudr_dr_build_query_sm_data(
     message.h.api.version = (char *)OGS_SBI_API_V1;
     message.h.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_POLICY_DATA;
     message.h.resource.component[1] = (char *)OGS_SBI_RESOURCE_NAME_UES;
-    message.h.resource.component[2] = pcf_ue->supi;
+    message.h.resource.component[2] = pcf_ue_sm->supi;
     message.h.resource.component[3] = (char *)OGS_SBI_RESOURCE_NAME_SM_DATA;
 
     message.param.snssai_presence = true;

--- a/src/pcf/nudr-build.h
+++ b/src/pcf/nudr-build.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 ogs_sbi_request_t *pcf_nudr_dr_build_query_am_data(
-        pcf_ue_t *pcf_ue, void *data);
+        pcf_ue_am_t *pcf_ue_am, void *data);
 
 ogs_sbi_request_t *pcf_nudr_dr_build_query_sm_data(
         pcf_sess_t *sess, void *data);

--- a/src/pcf/nudr-handler.c
+++ b/src/pcf/nudr-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -22,7 +22,8 @@
 #include "nudr-handler.h"
 
 bool pcf_nudr_dr_handle_query_am_data(
-    pcf_ue_t *pcf_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+    pcf_ue_am_t *pcf_ue_am,
+    ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
 {
     int rv, status = 0;
     char *strerror = NULL;
@@ -34,7 +35,7 @@ bool pcf_nudr_dr_handle_query_am_data(
 
     ogs_subscription_data_t subscription_data;
 
-    ogs_assert(pcf_ue);
+    ogs_assert(pcf_ue_am);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);
@@ -51,52 +52,52 @@ bool pcf_nudr_dr_handle_query_am_data(
         OpenAPI_lnode_t *node = NULL;
 
         if (!recvmsg->AmPolicyData) {
-            strerror = ogs_msprintf("[%s] No AmPolicyData", pcf_ue->supi);
+            strerror = ogs_msprintf("[%s] No AmPolicyData", pcf_ue_am->supi);
             status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
 
-        if (!pcf_ue->policy_association_request) {
+        if (!pcf_ue_am->policy_association_request) {
             strerror = ogs_msprintf("[%s] No PolicyAssociationRequest",
-                    pcf_ue->supi);
+                    pcf_ue_am->supi);
             status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
 
-        rv = ogs_dbi_subscription_data(pcf_ue->supi, &subscription_data);
+        rv = ogs_dbi_subscription_data(pcf_ue_am->supi, &subscription_data);
         if (rv != OGS_OK) {
             strerror = ogs_msprintf("[%s] Cannot find SUPI in DB",
-                    pcf_ue->supi);
+                    pcf_ue_am->supi);
             status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
             goto cleanup;
         }
 
         if (!subscription_data.ambr.uplink &&
                 !subscription_data.ambr.downlink) {
-            strerror = ogs_msprintf("[%s] No UE-AMBR", pcf_ue->supi);
+            strerror = ogs_msprintf("[%s] No UE-AMBR", pcf_ue_am->supi);
             status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
             goto cleanup;
         }
 
         memset(&PolicyAssociation, 0, sizeof(PolicyAssociation));
-        PolicyAssociation.request = pcf_ue->policy_association_request;
+        PolicyAssociation.request = pcf_ue_am->policy_association_request;
         PolicyAssociation.supp_feat =
-            ogs_uint64_to_string(pcf_ue->am_policy_control_features);
+            ogs_uint64_to_string(pcf_ue_am->am_policy_control_features);
         ogs_assert(PolicyAssociation.supp_feat);
 
         TriggerList = OpenAPI_list_create();
         ogs_assert(TriggerList);
 
         memset(&UeAmbr, 0, sizeof(UeAmbr));
-        if (OGS_SBI_FEATURES_IS_SET(pcf_ue->am_policy_control_features,
+        if (OGS_SBI_FEATURES_IS_SET(pcf_ue_am->am_policy_control_features,
                     OGS_SBI_NPCF_AM_POLICY_CONTROL_UE_AMBR_AUTHORIZATION)) {
-            if (pcf_ue->subscribed_ue_ambr) {
+            if (pcf_ue_am->subscribed_ue_ambr) {
                 ogs_bitrate_t subscribed_ue_ambr;
 
                 subscribed_ue_ambr.uplink = ogs_sbi_bitrate_from_string(
-                        pcf_ue->subscribed_ue_ambr->uplink);
+                        pcf_ue_am->subscribed_ue_ambr->uplink);
                 subscribed_ue_ambr.downlink = ogs_sbi_bitrate_from_string(
-                        pcf_ue->subscribed_ue_ambr->downlink);
+                        pcf_ue_am->subscribed_ue_ambr->downlink);
 
                 if (((subscribed_ue_ambr.uplink / 1000) !=
                      (subscription_data.ambr.uplink / 1000)) ||
@@ -124,7 +125,7 @@ bool pcf_nudr_dr_handle_query_am_data(
         header.api.version = (char *)OGS_SBI_API_V1;
         header.resource.component[0] =
             (char *)OGS_SBI_RESOURCE_NAME_POLICIES;
-        header.resource.component[1] = pcf_ue->association_id;
+        header.resource.component[1] = pcf_ue_am->association_id;
 
         memset(&sendmsg, 0, sizeof(sendmsg));
         sendmsg.PolicyAssociation = &PolicyAssociation;
@@ -148,17 +149,18 @@ bool pcf_nudr_dr_handle_query_am_data(
 
         ogs_subscription_data_free(&subscription_data);
 
-        OpenAPI_list_for_each(PolicyAssociation.request->allowed_snssais, node) {
+        OpenAPI_list_for_each(
+                PolicyAssociation.request->allowed_snssais, node) {
             struct OpenAPI_snssai_s *Snssai = node->data;
             if (Snssai) {
                 ogs_s_nssai_t s_nssai;
                 s_nssai.sst = Snssai->sst;
                 s_nssai.sd = ogs_s_nssai_sd_from_string(Snssai->sd);
 
-                pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+                pcf_metrics_inst_by_slice_add(&pcf_ue_am->guami.plmn_id,
                         &s_nssai, PCF_METR_CTR_PA_POLICYAMASSOSUCC, 1);
             } else {
-                ogs_error("[%s] No Snssai", pcf_ue->supi);
+                ogs_error("[%s] No Snssai", pcf_ue_am->supi);
             }
         }
 
@@ -166,7 +168,7 @@ bool pcf_nudr_dr_handle_query_am_data(
 
     DEFAULT
         strerror = ogs_msprintf("[%s] Invalid resource name [%s]", 
-                        pcf_ue->supi, recvmsg->h.resource.component[3]);
+                        pcf_ue_am->supi, recvmsg->h.resource.component[3]);
     END
 
 cleanup:
@@ -188,13 +190,13 @@ bool pcf_nudr_dr_handle_query_sm_data(
 {
     int status = 0;
     char *strerror = NULL;
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     ogs_sbi_server_t *server = NULL;
     int r;
 
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);
@@ -205,7 +207,7 @@ bool pcf_nudr_dr_handle_query_sm_data(
     CASE(OGS_SBI_RESOURCE_NAME_SM_DATA)
         if (!recvmsg->SmPolicyData) {
             strerror = ogs_msprintf("[%s:%d] No SmPolicyData",
-                    pcf_ue->supi, sess->psi);
+                    pcf_ue_sm->supi, sess->psi);
             status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
@@ -221,7 +223,8 @@ bool pcf_nudr_dr_handle_query_sm_data(
 
     DEFAULT
         strerror = ogs_msprintf("[%s:%d] Invalid resource name [%s]", 
-                    pcf_ue->supi, sess->psi, recvmsg->h.resource.component[3]);
+                    pcf_ue_sm->supi, sess->psi,
+                    recvmsg->h.resource.component[3]);
     END
 
 cleanup:

--- a/src/pcf/nudr-handler.h
+++ b/src/pcf/nudr-handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019,2020 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -27,7 +27,8 @@ extern "C" {
 #endif
 
 bool pcf_nudr_dr_handle_query_am_data(
-    pcf_ue_t *pcf_ue, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+    pcf_ue_am_t *pcf_ue_am,
+    ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 
 bool pcf_nudr_dr_handle_query_sm_data(
     pcf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);

--- a/src/pcf/pcf-sm.c
+++ b/src/pcf/pcf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -53,8 +53,9 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
 
-    pcf_ue_t *pcf_ue = NULL;
-    ogs_pool_id_t pcf_ue_id = OGS_INVALID_POOL_ID;
+    pcf_ue_am_t *pcf_ue_am = NULL;
+    ogs_pool_id_t pcf_ue_am_id = OGS_INVALID_POOL_ID;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     pcf_sess_t *sess = NULL;
     ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     pcf_app_t *app_session = NULL;
@@ -140,18 +141,18 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             CASE(OGS_SBI_HTTP_METHOD_POST)
                 if (message.PolicyAssociationRequest &&
                     message.PolicyAssociationRequest->supi) {
-                    pcf_ue = pcf_ue_find_by_supi(
+                    pcf_ue_am = pcf_ue_am_find_by_supi(
                                 message.PolicyAssociationRequest->supi);
-                    if (!pcf_ue) {
-                        pcf_ue = pcf_ue_add(
+                    if (!pcf_ue_am) {
+                        pcf_ue_am = pcf_ue_am_add(
                             message.PolicyAssociationRequest->supi);
-                        ogs_assert(pcf_ue);
+                        ogs_assert(pcf_ue_am);
                     }
                 }
                 break;
             CASE(OGS_SBI_HTTP_METHOD_DELETE)
                 if (message.h.resource.component[1]) {
-                    pcf_ue = pcf_ue_find_by_association_id(
+                    pcf_ue_am = pcf_ue_am_find_by_association_id(
                                 message.h.resource.component[1]);
                 } else {
                     ogs_error("No Policy Association Id");
@@ -160,7 +161,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             DEFAULT
             END
 
-            if (!pcf_ue) {
+            if (!pcf_ue_am) {
                 ogs_error("Not found [%s]", message.h.method);
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(stream,
@@ -169,17 +170,17 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 break;
             }
 
-            ogs_assert(OGS_FSM_STATE(&pcf_ue->sm));
+            ogs_assert(OGS_FSM_STATE(&pcf_ue_am->sm));
 
-            e->pcf_ue_id = pcf_ue->id;
+            e->pcf_ue_am_id = pcf_ue_am->id;
             e->h.sbi.message = &message;
-            ogs_fsm_dispatch(&pcf_ue->sm, e);
-            if (OGS_FSM_CHECK(&pcf_ue->sm, pcf_am_state_exception)) {
-                ogs_error("[%s] State machine exception", pcf_ue->supi);
-                pcf_ue_remove(pcf_ue);
-            } else if (OGS_FSM_CHECK(&pcf_ue->sm, pcf_am_state_deleted)) {
-                ogs_debug("[%s] PCF-AM removed", pcf_ue->supi);
-                pcf_ue_remove(pcf_ue);
+            ogs_fsm_dispatch(&pcf_ue_am->sm, e);
+            if (OGS_FSM_CHECK(&pcf_ue_am->sm, pcf_am_state_exception)) {
+                ogs_error("[%s] State machine exception", pcf_ue_am->supi);
+                pcf_ue_am_remove(pcf_ue_am);
+            } else if (OGS_FSM_CHECK(&pcf_ue_am->sm, pcf_am_state_deleted)) {
+                ogs_debug("[%s] PCF-AM removed", pcf_ue_am->supi);
+                pcf_ue_am_remove(pcf_ue_am);
             }
             break;
 
@@ -191,14 +192,14 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         message.SmPolicyContextData->supi &&
                         message.SmPolicyContextData->pdu_session_id) {
 
-                        pcf_ue = pcf_ue_find_by_supi(
+                        pcf_ue_sm = pcf_ue_sm_find_by_supi(
                                     message.SmPolicyContextData->supi);
-                        if (!pcf_ue) {
+                        if (!pcf_ue_sm) {
                             if (!strcmp(message.h.method,
                                         OGS_SBI_HTTP_METHOD_POST)) {
-                                pcf_ue = pcf_ue_add(
+                                pcf_ue_sm = pcf_ue_sm_add(
                                             message.SmPolicyContextData->supi);
-                                if (!pcf_ue) {
+                                if (!pcf_ue_sm) {
                                     ogs_error("[%s:%d] Invalid Request [%s]",
                                             message.SmPolicyContextData->supi,
                                             message.SmPolicyContextData->
@@ -218,13 +219,13 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                             }
                         }
 
-                        if (pcf_ue) {
-                            sess = pcf_sess_find_by_psi(pcf_ue, message.
+                        if (pcf_ue_sm) {
+                            sess = pcf_sess_find_by_psi(pcf_ue_sm, message.
                                     SmPolicyContextData->pdu_session_id);
                             if (!sess) {
                                 if (!strcmp(message.h.method,
                                             OGS_SBI_HTTP_METHOD_POST)) {
-                                    sess = pcf_sess_add(pcf_ue, message.
+                                    sess = pcf_sess_add(pcf_ue_sm, message.
                                         SmPolicyContextData->pdu_session_id);
                                     if (!sess) {
                                         ogs_error("[%s:%d] "
@@ -236,7 +237,7 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                                                 message.h.method);
                                     } else
                                         ogs_debug("[%s:%d] PCF session added",
-                                                    pcf_ue->supi, sess->psi);
+                                                    pcf_ue_sm->supi, sess->psi);
                                 } else {
                                     ogs_error("[%s:%d] "
                                             "Invalid HTTP method [%s]",
@@ -258,15 +259,15 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             END
             if (!sess) {
                 ogs_error("Not found [%s]", message.h.uri);
-                /*
-                 * TS29.512
-                 * 4.2.2.2 SM Policy Association establishment
-                 *
-                 * If the user information received within the "supi" attribute is
-                 * unknown, the PCF shall reject the request with an HTTP "400 Bad
-                 * Request" response message including the "cause" attribute
-                 * of the ProblemDetails data structure set to "USER_UNKNOWN".
-                 */
+            /*
+             * TS29.512
+             * 4.2.2.2 SM Policy Association establishment
+             *
+             * If the user information received within the "supi" attribute is
+             * unknown, the PCF shall reject the request with an HTTP "400 Bad
+             * Request" response message including the "cause" attribute
+             * of the ProblemDetails data structure set to "USER_UNKNOWN".
+             */
                 ogs_assert(true ==
                     ogs_sbi_server_send_error(stream,
                         OGS_SBI_HTTP_STATUS_BAD_REQUEST,
@@ -280,10 +281,11 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             e->h.sbi.message = &message;
             ogs_fsm_dispatch(&sess->sm, e);
             if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
-                /* Clang scan-build SA: NULL pointer dereference: pcf_ue=NULL, remove logging of pcf_ue->supi. */
+                /* Clang scan-build SA: NULL pointer dereference:
+                 * pcf_ue_sm=NULL, remove logging of pcf_ue_sm->supi. */
                 ogs_error("[%s:%d] State machine exception",
-                        pcf_ue ? pcf_ue->supi : "Unknown", sess->psi);
-                pcf_sess_remove(sess);
+                        pcf_ue_sm ? pcf_ue_sm->supi : "Unknown", sess->psi);
+                PCF_SESS_CLEAR(sess);
             }
             break;
 
@@ -332,10 +334,11 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
             e->h.sbi.message = &message;
             ogs_fsm_dispatch(&sess->sm, e);
             if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
-                /* Clang scan-build SA: NULL pointer dereference: pcf_ue=NULL, remove logging of pcf_ue->supi. */
+                /* Clang scan-build SA: NULL pointer dereference:
+                 * pcf_ue_sm=NULL, remove logging of pcf_ue_sm->supi. */
                 ogs_error("[%s:%d] State machine exception",
-                        pcf_ue ? pcf_ue->supi : "Unknown", sess->psi);
-                pcf_sess_remove(sess);
+                        pcf_ue_sm ? pcf_ue_sm->supi : "Unknown", sess->psi);
+                PCF_SESS_CLEAR(sess);
             }
             break;
 
@@ -496,9 +499,9 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     }
 
-                    pcf_ue_id = sbi_xact->sbi_object_id;
-                    ogs_assert(pcf_ue_id >= OGS_MIN_POOL_ID &&
-                            pcf_ue_id <= OGS_MAX_POOL_ID);
+                    pcf_ue_am_id = sbi_xact->sbi_object_id;
+                    ogs_assert(pcf_ue_am_id >= OGS_MIN_POOL_ID &&
+                            pcf_ue_am_id <= OGS_MAX_POOL_ID);
 
                     if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
                         sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
@@ -507,20 +510,21 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
                     ogs_sbi_xact_remove(sbi_xact);
 
-                    pcf_ue = pcf_ue_find_by_id(pcf_ue_id);
-                    if (!pcf_ue) {
-                        ogs_error("UE(pcf_ue) Context "
+                    pcf_ue_am = pcf_ue_am_find_by_id(pcf_ue_am_id);
+                    if (!pcf_ue_am) {
+                        ogs_error("UE(pcf_ue_am) Context "
                                     "has already been removed");
                         break;
                     }
 
-                    e->pcf_ue_id = pcf_ue->id;
+                    e->pcf_ue_am_id = pcf_ue_am->id;
                     e->h.sbi.message = &message;
 
-                    ogs_fsm_dispatch(&pcf_ue->sm, e);
-                    if (OGS_FSM_CHECK(&pcf_ue->sm, pcf_am_state_exception)) {
-                        ogs_error("[%s] State machine exception", pcf_ue->supi);
-                        pcf_ue_remove(pcf_ue);
+                    ogs_fsm_dispatch(&pcf_ue_am->sm, e);
+                    if (OGS_FSM_CHECK(&pcf_ue_am->sm, pcf_am_state_exception)) {
+                        ogs_error("[%s] State machine exception",
+                                pcf_ue_am->supi);
+                        pcf_ue_am_remove(pcf_ue_am);
                     }
                     break;
 
@@ -556,8 +560,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     }
 
-                    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-                    ogs_assert(pcf_ue);
+                    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+                    ogs_assert(pcf_ue_sm);
 
                     e->sess_id = sess->id;
                     e->h.sbi.message = &message;
@@ -565,8 +569,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     ogs_fsm_dispatch(&sess->sm, e);
                     if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
                         ogs_error("[%s:%d] State machine exception",
-                                    pcf_ue->supi, sess->psi);
-                        pcf_sess_remove(sess);
+                                    pcf_ue_sm->supi, sess->psi);
+                        PCF_SESS_CLEAR(sess);
                     }
                     break;
 
@@ -607,7 +611,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
                 if (sbi_xact->assoc_stream_id >= OGS_MIN_POOL_ID &&
                     sbi_xact->assoc_stream_id <= OGS_MAX_POOL_ID)
-                    e->h.sbi.data = OGS_UINT_TO_POINTER(sbi_xact->assoc_stream_id);
+                    e->h.sbi.data = OGS_UINT_TO_POINTER(
+                            sbi_xact->assoc_stream_id);
 
                 ogs_sbi_xact_remove(sbi_xact);
 
@@ -617,8 +622,8 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     break;
                 }
 
-                pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-                ogs_assert(pcf_ue);
+                pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+                ogs_assert(pcf_ue_sm);
 
                 e->sess_id = sess->id;
                 e->h.sbi.message = &message;
@@ -626,12 +631,12 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 ogs_fsm_dispatch(&sess->sm, e);
                 if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_exception)) {
                     ogs_error("[%s:%d] State machine exception",
-                                pcf_ue->supi, sess->psi);
-                    pcf_sess_remove(sess);
+                                pcf_ue_sm->supi, sess->psi);
+                    PCF_SESS_CLEAR(sess);
                 } else if (OGS_FSM_CHECK(&sess->sm, pcf_sm_state_deleted)) {
                     ogs_debug("[%s:%d] PCF session removed",
-                                pcf_ue->supi, sess->psi);
-                    pcf_sess_remove(sess);
+                                pcf_ue_sm->supi, sess->psi);
+                    PCF_SESS_CLEAR(sess);
                 }
                 break;
 
@@ -754,16 +759,16 @@ void pcf_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
             switch(sbi_object->type) {
             case OGS_SBI_OBJ_UE_TYPE:
-                pcf_ue_id = sbi_xact->sbi_object_id;
-                ogs_assert(pcf_ue_id >= OGS_MIN_POOL_ID &&
-                        pcf_ue_id <= OGS_MAX_POOL_ID);
+                pcf_ue_am_id = sbi_xact->sbi_object_id;
+                ogs_assert(pcf_ue_am_id >= OGS_MIN_POOL_ID &&
+                        pcf_ue_am_id <= OGS_MAX_POOL_ID);
 
-                pcf_ue = pcf_ue_find_by_id(pcf_ue_id);
-                if (!pcf_ue) {
-                    ogs_error("UE(pcf_ue) has already been removed");
+                pcf_ue_am = pcf_ue_am_find_by_id(pcf_ue_am_id);
+                if (!pcf_ue_am) {
+                    ogs_error("UE(pcf_ue_am) has already been removed");
                     break;
                 }
-                ogs_error("[%s] Cannot receive SBI message", pcf_ue->supi);
+                ogs_error("[%s] Cannot receive SBI message", pcf_ue_am->supi);
                 break;
 
             case OGS_SBI_OBJ_SESS_TYPE:

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -169,23 +169,23 @@ static int pcf_sbi_discover_and_send(
     return OGS_OK;
 }
 
-int pcf_ue_sbi_discover_and_send(
+int pcf_ue_am_sbi_discover_and_send(
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
-        ogs_sbi_request_t *(*build)(pcf_ue_t *pcf_ue, void *data),
-        pcf_ue_t *pcf_ue, ogs_sbi_stream_t *stream, void *data)
+        ogs_sbi_request_t *(*build)(pcf_ue_am_t *pcf_ue_am, void *data),
+        pcf_ue_am_t *pcf_ue_am, ogs_sbi_stream_t *stream, void *data)
 {
     int r;
 
     r = pcf_sbi_discover_and_send(
-            pcf_ue->id, &pcf_ue->sbi, service_type, discovery_option,
-            (ogs_sbi_build_f)build, pcf_ue, stream, data);
+            pcf_ue_am->id, &pcf_ue_am->sbi, service_type, discovery_option,
+            (ogs_sbi_build_f)build, pcf_ue_am, stream, data);
     if (r != OGS_OK) {
-        ogs_error("pcf_ue_sbi_discover_and_send() failed");
+        ogs_error("pcf_ue_am_sbi_discover_and_send() failed");
         ogs_assert(true ==
             ogs_sbi_server_send_error(stream,
                 OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT, NULL,
-                "Cannot discover", pcf_ue->supi, NULL));
+                "Cannot discover", pcf_ue_am->supi, NULL));
         return r;
     }
 
@@ -260,17 +260,17 @@ static int client_delete_notify_cb(
     return OGS_OK;
 }
 
-bool pcf_sbi_send_am_policy_control_notify(pcf_ue_t *pcf_ue)
+bool pcf_sbi_send_am_policy_control_notify(pcf_ue_am_t *pcf_ue_am)
 {
     bool rc;
     ogs_sbi_request_t *request = NULL;
     ogs_sbi_client_t *client = NULL;
 
-    ogs_assert(pcf_ue);
-    client = pcf_ue->namf.client;
+    ogs_assert(pcf_ue_am);
+    client = pcf_ue_am->namf.client;
     ogs_assert(client);
 
-    request = pcf_namf_callback_build_am_policy_control(pcf_ue, NULL);
+    request = pcf_namf_callback_build_am_policy_control(pcf_ue_am, NULL);
     if (!request) {
         ogs_error("pcf_namf_callback_build_am_policy_control() failed");
         return false;
@@ -290,7 +290,7 @@ bool pcf_sbi_send_smpolicycontrol_create_response(
 {
     int i, rv, status = 0;
     char *strerror = NULL;
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     ogs_sbi_server_t *server = NULL;
 
     ogs_sbi_message_t sendmsg;
@@ -323,24 +323,24 @@ bool pcf_sbi_send_smpolicycontrol_create_response(
     OpenAPI_list_t *PolicyCtrlReqTriggers = NULL;
 
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
     ogs_assert(stream);
     server = ogs_sbi_server_from_stream(stream);
     ogs_assert(server);
 
     memset(&session_data, 0, sizeof(ogs_session_data_t));
 
-    ogs_assert(pcf_ue->supi);
+    ogs_assert(pcf_ue_sm->supi);
     ogs_assert(sess->dnn);
 
     rv = pcf_db_qos_data(
-            pcf_ue->supi,
+            pcf_ue_sm->supi,
             sess->home.presence == true ? &sess->home.plmn_id : NULL,
             &sess->s_nssai, sess->dnn, &session_data);
     if (rv != OGS_OK) {
         strerror = ogs_msprintf("[%s:%d] Cannot find SUPI in DB",
-                pcf_ue->supi, sess->psi);
+                pcf_ue_sm->supi, sess->psi);
         status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
         goto cleanup;
     }
@@ -348,20 +348,20 @@ bool pcf_sbi_send_smpolicycontrol_create_response(
     session = &session_data.session;
 
     if (!session->qos.index) {
-        strerror = ogs_msprintf("[%s:%d] No 5QI", pcf_ue->supi, sess->psi);
+        strerror = ogs_msprintf("[%s:%d] No 5QI", pcf_ue_sm->supi, sess->psi);
         status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
     if (!session->qos.arp.priority_level) {
         strerror = ogs_msprintf("[%s:%d] No Priority Level",
-                pcf_ue->supi, sess->psi);
+                pcf_ue_sm->supi, sess->psi);
         status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
 
     if (!session->ambr.uplink && !session->ambr.downlink) {
         strerror = ogs_msprintf("[%s:%d] No Session-AMBR",
-                pcf_ue->supi, sess->psi);
+                pcf_ue_sm->supi, sess->psi);
         status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
         goto cleanup;
     }
@@ -599,7 +599,8 @@ bool pcf_sbi_send_smpolicycontrol_create_response(
     if (SmPolicyDecision.supp_feat)
         ogs_free(SmPolicyDecision.supp_feat);
 
-    pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+    pcf_metrics_inst_by_slice_add(
+            sess->home.presence == true ? &sess->home.plmn_id : NULL,
             &sess->s_nssai, PCF_METR_CTR_PA_POLICYSMASSOSUCC, 1);
 
     OGS_SESSION_DATA_FREE(&session_data);

--- a/src/pcf/sbi-path.h
+++ b/src/pcf/sbi-path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -35,18 +35,18 @@ void pcf_sbi_close(void);
 
 bool pcf_sbi_send_request(
         ogs_sbi_nf_instance_t *nf_instance, ogs_sbi_xact_t *xact);
-int pcf_ue_sbi_discover_and_send(
+int pcf_ue_am_sbi_discover_and_send(
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
-        ogs_sbi_request_t *(*build)(pcf_ue_t *pcf_ue, void *data),
-        pcf_ue_t *pcf_ue, ogs_sbi_stream_t *stream, void *data);
+        ogs_sbi_request_t *(*build)(pcf_ue_am_t *pcf_ue_am, void *data),
+        pcf_ue_am_t *pcf_ue_am, ogs_sbi_stream_t *stream, void *data);
 int pcf_sess_sbi_discover_and_send(
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
         ogs_sbi_request_t *(*build)(pcf_sess_t *sess, void *data),
         pcf_sess_t *sess, ogs_sbi_stream_t *stream, void *data);
 
-bool pcf_sbi_send_am_policy_control_notify(pcf_ue_t *pcf_ue);
+bool pcf_sbi_send_am_policy_control_notify(pcf_ue_am_t *pcf_ue_am);
 bool pcf_sbi_send_smpolicycontrol_create_response(
         pcf_sess_t *sess, ogs_sbi_stream_t *stream);
 bool pcf_sbi_send_smpolicycontrol_update_notify(

--- a/src/pcf/sm-sm.c
+++ b/src/pcf/sm-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -38,7 +38,7 @@ void pcf_sm_state_final(ogs_fsm_t *s, pcf_event_t *e)
 void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 {
     bool handled;
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     pcf_sess_t *sess = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
@@ -52,8 +52,8 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
     sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
@@ -84,7 +84,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                 if (!handled) {
                     ogs_error("[%s:%d] "
                             "pcf_npcf_smpolicycontrol_handle_create() failed",
-                            pcf_ue->supi, sess->psi);
+                            pcf_ue_sm->supi, sess->psi);
                     OGS_FSM_TRAN(s, pcf_sm_state_exception);
                 }
             } else {
@@ -95,14 +95,14 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     if (!handled) {
                         ogs_error("[%s:%d] "
                             "pcf_npcf_smpolicycontrol_handle_delete() failed",
-                            pcf_ue->supi, sess->psi);
+                            pcf_ue_sm->supi, sess->psi);
                         OGS_FSM_TRAN(s, pcf_sm_state_exception);
                     }
                     break;
 
                 DEFAULT
                     ogs_error("[%s:%d] Invalid HTTP URI [%s]",
-                            pcf_ue->supi, sess->psi, message->h.uri);
+                            pcf_ue_sm->supi, sess->psi, message->h.uri);
                     ogs_assert(true ==
                         ogs_sbi_server_send_error(stream,
                             OGS_SBI_HTTP_STATUS_METHOD_NOT_ALLOWED, message,
@@ -121,7 +121,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     DEFAULT
                         ogs_error("[%s:%d] Invalid resource name [%s]",
-                                pcf_ue->supi, sess->psi,
+                                pcf_ue_sm->supi, sess->psi,
                                 message->h.resource.component[2]);
                         ogs_assert(true ==
                             ogs_sbi_server_send_error(stream,
@@ -136,7 +136,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     DEFAULT
                         ogs_error("[%s:%d] Unknown method [%s]",
-                                pcf_ue->supi, sess->psi, message->h.method);
+                                pcf_ue_sm->supi, sess->psi, message->h.method);
                         ogs_assert(true ==
                             ogs_sbi_server_send_error(stream,
                                 OGS_SBI_HTTP_STATUS_METHOD_NOT_ALLOWED, message,
@@ -151,7 +151,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                     break;
                 DEFAULT
                     ogs_error("[%s:%d] Unknown method [%s]",
-                            pcf_ue->supi, sess->psi, message->h.method);
+                            pcf_ue_sm->supi, sess->psi, message->h.method);
                     ogs_assert(true ==
                         ogs_sbi_server_send_error(stream,
                             OGS_SBI_HTTP_STATUS_METHOD_NOT_ALLOWED, message,
@@ -162,7 +162,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
         DEFAULT
             ogs_error("[%s:%d] Invalid API name [%s]",
-                        pcf_ue->supi, sess->psi, message->h.service.name);
+                        pcf_ue_sm->supi, sess->psi, message->h.service.name);
             ogs_assert_if_reached();
         END
         break;
@@ -192,42 +192,44 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         if (message->res_status ==
                                 OGS_SBI_HTTP_STATUS_NOT_FOUND) {
                             ogs_warn("[%s:%d] Cannot find SUPI [%d]",
-                                pcf_ue->supi, sess->psi, message->res_status);
-                            /*
-                             * TS29.512
-                             * 4.2.2.2 SM Policy Association establishment
-                             *
-                             * If the user information received within the "supi"
-                             * attribute is unknown, the PCF shall reject the
-                             * request with an HTTP "400 Bad Request" response
-                             * message including the "cause" attribute of the
-                             * ProblemDetails data structure set to "USER_UNKNOWN".
-                             */
+                                pcf_ue_sm->supi,
+                                sess->psi, message->res_status);
+                        /*
+                         * TS29.512
+                         * 4.2.2.2 SM Policy Association establishment
+                         *
+                         * If the user information received within the "supi"
+                         * attribute is unknown, the PCF shall reject the
+                         * request with an HTTP "400 Bad Request" response
+                         * message including the "cause" attribute of the
+                         * ProblemDetails data structure set to "USER_UNKNOWN".
+                         */
                             ogs_assert(true ==
                                 ogs_sbi_server_send_error(
                                     stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
                                     NULL, "End user is unknown to the PCF",
-                                    pcf_ue->supi, "USER_UNKNOWN"));
+                                    pcf_ue_sm->supi, "USER_UNKNOWN"));
                         } else {
                             ogs_error("[%s:%d] HTTP response error [%d]",
-                                pcf_ue->supi, sess->psi, message->res_status);
-                            /*
-                             * TS29.512
-                             * 4.2.2.2 SM Policy Association establishment
-                             *
-                             * If the PCF, based on local configuration and/or
-                             * operator policies, denies the creation of the
-                             * Individual SM Policy resource, the PCF may reject
-                             * the request and include in an HTTP "403 Forbidden"
-                             * response message the "cause" attribute of the
-                             * ProblemDetails data structure set to
-                             * "POLICY_CONTEXT_DENIED".
-                             */
+                                pcf_ue_sm->supi,
+                                sess->psi, message->res_status);
+                        /*
+                         * TS29.512
+                         * 4.2.2.2 SM Policy Association establishment
+                         *
+                         * If the PCF, based on local configuration and/or
+                         * operator policies, denies the creation of the
+                         * Individual SM Policy resource, the PCF may reject
+                         * the request and include in an HTTP "403 Forbidden"
+                         * response message the "cause" attribute of the
+                         * ProblemDetails data structure set to
+                         * "POLICY_CONTEXT_DENIED".
+                         */
                             ogs_assert(true ==
                                 ogs_sbi_server_send_error(
                                     stream, OGS_SBI_HTTP_STATUS_FORBIDDEN,
                                     NULL, "HTTP response error",
-                                    pcf_ue->supi, "POLICY_CONTEXT_DENIED"));
+                                    pcf_ue_sm->supi, "POLICY_CONTEXT_DENIED"));
                         }
                         break;
                     }
@@ -237,7 +239,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
                 DEFAULT
                     ogs_error("[%s:%d] Invalid resource name [%s]",
-                            pcf_ue->supi, sess->psi,
+                            pcf_ue_sm->supi, sess->psi,
                             message->h.resource.component[1]);
                     ogs_assert_if_reached();
                 END
@@ -245,7 +247,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
             DEFAULT
                 ogs_error("[%s:%d] Invalid resource name [%s]",
-                        pcf_ue->supi, sess->psi,
+                        pcf_ue_sm->supi, sess->psi,
                         message->h.resource.component[0]);
                 ogs_assert_if_reached();
             END
@@ -260,7 +262,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         if (message->res_status !=
                                 OGS_SBI_HTTP_STATUS_NO_CONTENT) {
                             ogs_warn("[%s:%d] HTTP response error [%d]",
-                                pcf_ue->supi, sess->psi, message->res_status);
+                                pcf_ue_sm->supi, sess->psi, message->res_status);
 
 /*
  * The PCfBindings resource for that UE may not exist in the BSF
@@ -272,7 +274,8 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                             ogs_assert(true ==
                                 ogs_sbi_server_send_error(stream,
                                     message->res_status,
-                                    NULL, "HTTP response error", pcf_ue->supi));
+                                    NULL, "HTTP response error",
+                                    pcf_ue_sm->supi));
                             OGS_FSM_TRAN(s, pcf_sm_state_exception);
                             break;
 #endif
@@ -284,7 +287,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     DEFAULT
                         ogs_error("[%s:%d] Unknown method [%s]",
-                                pcf_ue->supi, sess->psi, message->h.method);
+                                pcf_ue_sm->supi, sess->psi, message->h.method);
                         ogs_assert_if_reached();
                     END
                     break;
@@ -297,7 +300,8 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                                     sess, stream, message);
                         } else {
                             ogs_error("[%s:%d] HTTP response error [%d]",
-                                pcf_ue->supi, sess->psi, message->res_status);
+                                pcf_ue_sm->supi,
+                                sess->psi, message->res_status);
 
                             /*
                              * Send Response
@@ -310,7 +314,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
                         break;
                     DEFAULT
                         ogs_error("[%s:%d] Unknown method [%s]",
-                                pcf_ue->supi, sess->psi, message->h.method);
+                                pcf_ue_sm->supi, sess->psi, message->h.method);
                         ogs_assert_if_reached();
                     END
                 }
@@ -318,7 +322,7 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
             DEFAULT
                 ogs_error("[%s:%d] Invalid resource name [%s]",
-                        pcf_ue->supi, sess->psi,
+                        pcf_ue_sm->supi, sess->psi,
                         message->h.resource.component[0]);
                 ogs_assert_if_reached();
             END
@@ -326,21 +330,21 @@ void pcf_sm_state_operational(ogs_fsm_t *s, pcf_event_t *e)
 
         DEFAULT
             ogs_error("[%s:%d] Invalid API name [%s]",
-                        pcf_ue->supi, sess->psi, message->h.service.name);
+                        pcf_ue_sm->supi, sess->psi, message->h.service.name);
             ogs_assert_if_reached();
         END
         break;
 
     default:
         ogs_error("[%s:%d] Unknown event %s",
-                pcf_ue->supi, sess->psi, pcf_event_get_name(e));
+                pcf_ue_sm->supi, sess->psi, pcf_event_get_name(e));
         break;
     }
 }
 
 void pcf_sm_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     pcf_sess_t *sess = NULL;
 
     ogs_assert(s);
@@ -350,12 +354,13 @@ void pcf_sm_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 
     sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+        pcf_metrics_inst_by_slice_add(
+                sess->home.presence == true ? &sess->home.plmn_id : NULL,
                 &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, -1);
         break;
 
@@ -364,14 +369,14 @@ void pcf_sm_state_deleted(ogs_fsm_t *s, pcf_event_t *e)
 
     default:
         ogs_error("[%s:%d] Unknown event %s",
-                pcf_ue->supi, sess->psi, pcf_event_get_name(e));
+                pcf_ue_sm->supi, sess->psi, pcf_event_get_name(e));
         break;
     }
 }
 
 void pcf_sm_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 {
-    pcf_ue_t *pcf_ue = NULL;
+    pcf_ue_sm_t *pcf_ue_sm = NULL;
     pcf_sess_t *sess = NULL;
 
     ogs_assert(s);
@@ -381,12 +386,13 @@ void pcf_sm_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 
     sess = pcf_sess_find_by_id(e->sess_id);
     ogs_assert(sess);
-    pcf_ue = pcf_ue_find_by_id(sess->pcf_ue_id);
-    ogs_assert(pcf_ue);
+    pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
+    ogs_assert(pcf_ue_sm);
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
-        pcf_metrics_inst_by_slice_add(&pcf_ue->guami.plmn_id,
+        pcf_metrics_inst_by_slice_add(
+                sess->home.presence == true ? &sess->home.plmn_id : NULL,
                 &sess->s_nssai, PCF_METR_GAUGE_PA_SESSIONNBR, -1);
         break;
 
@@ -395,7 +401,7 @@ void pcf_sm_state_exception(ogs_fsm_t *s, pcf_event_t *e)
 
     default:
         ogs_error("[%s:%d] Unknown event %s",
-                pcf_ue->supi, sess->psi, pcf_event_get_name(e));
+                pcf_ue_sm->supi, sess->psi, pcf_event_get_name(e));
         break;
     }
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1084,6 +1084,9 @@ void smf_ue_remove(smf_ue_t *smf_ue)
         ogs_free(smf_ue->supi);
     }
 
+    if (smf_ue->gpsi)
+        ogs_free(smf_ue->gpsi);
+
     if (smf_ue->imsi_len) {
         ogs_hash_set(self.imsi_hash, smf_ue->imsi, smf_ue->imsi_len, NULL);
     }

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -117,6 +117,9 @@ typedef struct smf_ue_s {
     /* SUPI */
     char *supi;
 
+    /* GPSI */
+    char *gpsi;
+
     /* IMSI */
     uint8_t imsi[OGS_MAX_IMSI_LEN];
     int imsi_len;

--- a/src/smf/npcf-build.c
+++ b/src/smf/npcf-build.c
@@ -75,6 +75,9 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
      */
     SmPolicyContextData.chargingcharacteristics = (char *)"00000800";
 
+    /* GPSI */
+    SmPolicyContextData.gpsi = smf_ue->gpsi;
+
     /*
      * Use ogs_sbi_supi_in_vplmn() instead of ogs_sbi_plmn_id_in_vplmn().
      * This is because some vendors might not use the full DNN in LBO and
@@ -287,8 +290,6 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
 end:
     if (SmPolicyContextData.notification_uri)
         ogs_free(SmPolicyContextData.notification_uri);
-    if (SmPolicyContextData.gpsi)
-        ogs_free(SmPolicyContextData.gpsi);
 
     if (SmPolicyContextData.dnn)
         ogs_free(SmPolicyContextData.dnn);

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -220,6 +220,10 @@ bool smf_nsmf_handle_create_sm_context(
             }
             ogs_free(type);
         }
+
+        if (smf_ue->gpsi)
+            ogs_free(smf_ue->gpsi);
+        smf_ue->gpsi = ogs_strdup(SmContextCreateData->gpsi);
     }
 
     /* Serving PLMN & Home PLMN */


### PR DESCRIPTION
Separate the monolithic PCF_UE structure into PCF_UE_AM and PCF_UE_SM to fully decouple AM‐ and SM‐policy lifecycles.