### PR TITLE
[SBI] Guard against missing poll.write in session_write_callback to prevent shutdown assertion (#3893, #3807, #2411, #2312)

### DIFF
--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -1762,9 +1762,12 @@ static void session_write_callback(short when, ogs_socket_t fd, void *data)
     ogs_assert(sbi_sess);
 
     if (ogs_list_empty(&sbi_sess->write_queue) == true) {
-        ogs_assert(sbi_sess->poll.write);
-        ogs_pollset_remove(sbi_sess->poll.write);
-        sbi_sess->poll.write = NULL;
+        if (sbi_sess->poll.write) {
+            ogs_pollset_remove(sbi_sess->poll.write);
+            sbi_sess->poll.write = NULL;
+        } else
+            ogs_warn("poll.write has already been removed");
+
         return;
     }
 


### PR DESCRIPTION
Prior to this change, `session_write_callback()` unconditionally asserted that `sbi_sess->poll.write` was non-NULL when the write queue drained, then removed it from the poll set. In edge cases—particularly when using curl 8.x with external epoll and `SIGPIPE` disabled—a late `EPOLLOUT` or errant write-ready notification could arrive after `poll.write` had already been cleared. This triggered the assertion in `nghttp2-server.c:1765`, aborting the process on shutdown or session teardown.

This commit replaces the hard assertion with a runtime guard. If `poll.write` is present, it is removed and reset to NULL as before. If it is already NULL, we emit an warning log (`ogs_warn`) instead of aborting. This ensures any stray write events after cleanup are safely ignored, allowing a clean exit without crashing.

- Wrap `ogs_pollset_remove()` and pointer clear in `if (sbi_sess->poll.write)`
- Log an warning when `poll.write` is unexpectedly absent
- Preserve original behavior when `poll.write` is valid

This change resolves the fatal assertion observed on process exit after the EPOLLERR/SIGPIPE fix and improves overall shutdown robustness.