### PR TITLE
[SBI] Fix parsing and serialization of _links "item" array (#3897)

### DIFF
--- a/lib/sbi/custom/links.c
+++ b/lib/sbi/custom/links.c
@@ -45,7 +45,7 @@ cJSON *ogs_sbi_links_convertToJSON(ogs_sbi_links_t *links)
     linksJSON = cJSON_CreateObject();
     ogs_assert(linksJSON);
 
-    cJSON_AddItemToObject(linksJSON, "items", itemsJSON);
+    cJSON_AddItemToObject(linksJSON, "item", itemsJSON);
     cJSON_AddItemToObject(linksJSON, "self", selfJSON);
     cJSON_AddNumberToObject(linksJSON, "totalItemCount", cJSON_GetArraySize(itemsJSON));
 
@@ -73,9 +73,9 @@ ogs_sbi_links_t *ogs_sbi_links_parseFromJSON(cJSON *json)
         return NULL;
     }
 
-    _items = cJSON_GetObjectItemCaseSensitive(_links, "items");
+    _items = cJSON_GetObjectItemCaseSensitive(_links, "item");
     if (!_items) {
-        ogs_error("No items");
+        ogs_error("No item");
         return NULL;
     }
 


### PR DESCRIPTION
Previously, Open5GS assumed the _links map contained an array under the key "items". However, the 3GPP specification (TS29.510 section 4.9.4 and TS29.501 Table 6.1.6.2.25-1) defines this member name as "item".

As a result, when interacting with vendor NRF implementations that use "item", Open5GS could not find the array and logged "No items", causing JSON errors.

This change updates both serialization and parsing in lib/sbi/custom/links.c:

- In ogs_sbi_links_convertToJSON(), replace the property name "items" with "item" when building JSON.
- In ogs_sbi_links_parseFromJSON(), retrieve the array under "item" and adjust the error message to "No item" if the member is missing.

With these corrections, Open5GS will correctly handle NRF responses using "item" and remain compliant with the indirect communication model defined by 3GPP.