### PR TITLE
[SBI] Log error code description upon query failure

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -754,7 +754,7 @@ static void check_multi_info(ogs_sbi_client_t *client)
                 }
 
             } else
-                ogs_warn("[%d] %s", res, conn->error);
+                ogs_warn("%s (%d): %s", curl_easy_strerror(res), res, conn->error);
 
             ogs_assert(conn->client_cb);
             if (res == CURLE_OK)


### PR DESCRIPTION
Sometimes (eg res=16) the conn->error buffer is left empty by curl, so also logging the name of the error code provides some extra useful information.