### PR TITLE
[SMF] Handle missing UPF gracefully in SMF session selection (#3907)

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1197,14 +1197,19 @@ void smf_sess_select_upf(smf_sess_t *sess)
         ogs_pfcp_self()->pfcp_node =
             ogs_list_last(&ogs_pfcp_self()->pfcp_peer_list);
 
-    /* setup GTP session with selected UPF */
-    ogs_pfcp_self()->pfcp_node =
-        selected_upf_node(ogs_pfcp_self()->pfcp_node, sess);
-    ogs_assert(ogs_pfcp_self()->pfcp_node);
-    OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
-    ogs_debug("UE using UPF on IP %s",
-            ogs_sockaddr_to_string_static(
-                ogs_pfcp_self()->pfcp_node->addr_list));
+    if (ogs_pfcp_self()->pfcp_node) {
+        /* setup GTP session with selected UPF */
+        ogs_pfcp_self()->pfcp_node =
+            selected_upf_node(ogs_pfcp_self()->pfcp_node, sess);
+        ogs_assert(ogs_pfcp_self()->pfcp_node);
+        OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
+        ogs_debug("UE using UPF on IP %s",
+                ogs_sockaddr_to_string_static(
+                    ogs_pfcp_self()->pfcp_node->addr_list));
+    } else {
+        ogs_error("No suitable UPF found for session");
+        ogs_assert(sess->pfcp_node == NULL);
+    }
 }
 
 smf_sess_t *smf_sess_add_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type)

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -475,8 +475,14 @@ bool smf_npcf_smpolicycontrol_handle_create(
     /* Select UPF based on UE Location Information */
     smf_sess_select_upf(sess);
 
+    /* Check if UPF selection was successful */
+    if (!sess->pfcp_node) {
+        ogs_error("[%s:%d] No UPF available for session",
+                  smf_ue->supi, sess->psi);
+        return false;
+    }
+
     /* Check if selected UPF is associated with SMF */
-    ogs_assert(sess->pfcp_node);
     if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
         ogs_error("[%s:%d] No associated UPF", smf_ue->supi, sess->psi);
         return false;

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -261,10 +261,18 @@ uint8_t smf_s5c_handle_create_session_request(
     /* Select PGW based on UE Location Information */
     smf_sess_select_upf(sess);
 
+    if (!sess->pfcp_node) {
+        ogs_error("[%s:%s] No UPF available for session",
+                  smf_ue->imsi_bcd, sess->session.name);
+        return OGS_GTP2_CAUSE_SYSTEM_FAILURE;
+    }
+
     /* Check if selected PGW is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
+    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
+        ogs_error("[%s:%s] selected UPF is not assocated with SMF",
+                  smf_ue->imsi_bcd, sess->session.name);
         return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+    }
 
     /* UE IP Address */
     paa = req->pdn_address_allocation.data;


### PR DESCRIPTION
In src/smf/context.c:

 - Wrap UPF selection logic in a conditional that checks if pfcp_node is non-NULL.

 - If no UPF is available (pfcp_node == NULL), log an error and assert that sess->pfcp_node remains NULL, instead of crashing.

 - Only call selected_upf_node() and set up the GTP session when a prior UPF entry exists.

In src/smf/gn-handler.c:

 - After invoking smf_sess_select_upf(), verify sess->pfcp_node.

 - If no UPF was selected, log an error ("No UPF available for session") and return OGS_GTP1_CAUSE_SYSTEM_FAILURE instead of asserting.

In src/smf/s5c-handler.c:

 - Mirror the same check for sess->pfcp_node after smf_sess_select_upf().

 - If no UPF is available, log an error and return OGS_GTP2_CAUSE_SYSTEM_FAILURE.

 - If the selected UPF is not yet PFCP-associated, log a specific error message and return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING.

These changes ensure that SMF does not abort when no UPF is configured or associated; instead, it fails the session request with an appropriate GTP cause.