### PR TITLE
[AMF/MME] Prevent AMF/MME crash when UE context is deleted (#3910)

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -1312,8 +1312,6 @@ static void common_register_state(ogs_fsm_t *s, amf_event_t *e,
         ogs_assert(nas_message);
 
         ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
-        ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
         if (!ran_ue) {
             ogs_error("No NG Context SUPI[%s] NAS-Type[%d] "
                     "RAN-UE-ID[%d:%p]",
@@ -1753,7 +1751,15 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(nas_message);
 
         ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
+        if (!ran_ue) {
+            ogs_error("No NG Context SUPI[%s] NAS-Type[%d] "
+                    "RAN-UE-ID[%d:%p]",
+                    amf_ue->supi, nas_message->gmm.h.message_type,
+                    amf_ue->ran_ue_id, ran_ue_find_by_id(amf_ue->ran_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         h.type = e->nas.type;
 
@@ -2112,7 +2118,15 @@ void gmm_state_security_mode(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(nas_message);
 
         ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
+        if (!ran_ue) {
+            ogs_error("No NG Context SUPI[%s] NAS-Type[%d] "
+                    "RAN-UE-ID[%d:%p]",
+                    amf_ue->supi, nas_message->gmm.h.message_type,
+                    amf_ue->ran_ue_id, ran_ue_find_by_id(amf_ue->ran_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         h.type = e->nas.type;
 
@@ -2657,7 +2671,15 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(nas_message);
 
         ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
+        if (!ran_ue) {
+            ogs_error("No NG Context SUPI[%s] NAS-Type[%d] "
+                    "RAN-UE-ID[%d:%p]",
+                    amf_ue->supi, nas_message->gmm.h.message_type,
+                    amf_ue->ran_ue_id, ran_ue_find_by_id(amf_ue->ran_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         h.type = e->nas.type;
 
@@ -2951,7 +2973,15 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(nas_message);
 
         ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
+        if (!ran_ue) {
+            ogs_error("No NG Context SUPI[%s] NAS-Type[%d] "
+                    "RAN-UE-ID[%d:%p]",
+                    amf_ue->supi, nas_message->gmm.h.message_type,
+                    amf_ue->ran_ue_id, ran_ue_find_by_id(amf_ue->ran_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         h.type = e->nas.type;
 
@@ -3069,7 +3099,27 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
         ogs_assert(sbi_message);
 
         ran_ue_t *ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
-        ogs_assert(ran_ue);
+        if (!ran_ue) {
+            int i;
+            ogs_error("No NG Context SUPI[%s] Status[%d] RAN-UE-ID[%d:%p]",
+                    amf_ue->supi, sbi_message->res_status,
+                    amf_ue->ran_ue_id, ran_ue_find_by_id(amf_ue->ran_ue_id));
+
+            if (sbi_message->h.method)
+                ogs_error("    h.method[%s]", sbi_message->h.method);
+            if (sbi_message->h.uri)
+                ogs_error("    h.uri[%s]", sbi_message->h.uri);
+            if (sbi_message->h.service.name)
+                ogs_error("    h.service.name[%s]",
+                        sbi_message->h.service.name);
+            if (sbi_message->h.api.version)
+                ogs_error("    h.api.version[%s]", sbi_message->h.api.version);
+            for (i = 0; i < OGS_SBI_MAX_NUM_OF_RESOURCE_COMPONENT &&
+                        sbi_message->h.resource.component[i]; i++)
+                ogs_error("    h.resource.component[%s:%d]",
+                        sbi_message->h.resource.component[i], i);
+            break;
+        }
 
         SWITCH(sbi_message->h.service.name)
         CASE(OGS_SBI_SERVICE_NAME_NAUSF_AUTH)

--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -1106,7 +1106,17 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue) {
+            ogs_error("No S1 Context IMSI[%s] NAS-Type[%d] "
+                    "ENB-UE-ID[%d:%d][%p:%p]",
+                    mme_ue->imsi_bcd, message->emm.h.message_type,
+                    e->enb_ue_id, mme_ue->enb_ue_id,
+                    enb_ue_find_by_id(e->enb_ue_id),
+                    enb_ue_find_by_id(mme_ue->enb_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         switch (message->emm.h.message_type) {
         case OGS_NAS_EPS_AUTHENTICATION_RESPONSE:
@@ -1288,7 +1298,17 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue) {
+            ogs_error("No S1 Context IMSI[%s] NAS-Type[%d] "
+                    "ENB-UE-ID[%d:%d][%p:%p]",
+                    mme_ue->imsi_bcd, message->emm.h.message_type,
+                    e->enb_ue_id, mme_ue->enb_ue_id,
+                    enb_ue_find_by_id(e->enb_ue_id),
+                    enb_ue_find_by_id(mme_ue->enb_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         if (message->emm.h.security_header_type
                 == OGS_NAS_SECURITY_HEADER_FOR_SERVICE_REQUEST_MESSAGE) {
@@ -1528,7 +1548,17 @@ void emm_state_initial_context_setup(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue) {
+            ogs_error("No S1 Context IMSI[%s] NAS-Type[%d] "
+                    "ENB-UE-ID[%d:%d][%p:%p]",
+                    mme_ue->imsi_bcd, message->emm.h.message_type,
+                    e->enb_ue_id, mme_ue->enb_ue_id,
+                    enb_ue_find_by_id(e->enb_ue_id),
+                    enb_ue_find_by_id(mme_ue->enb_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         xact_count = mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR);
 
@@ -1820,7 +1850,17 @@ void emm_state_exception(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue) {
+            ogs_error("No S1 Context IMSI[%s] NAS-Type[%d] "
+                    "ENB-UE-ID[%d:%d][%p:%p]",
+                    mme_ue->imsi_bcd, message->emm.h.message_type,
+                    e->enb_ue_id, mme_ue->enb_ue_id,
+                    enb_ue_find_by_id(e->enb_ue_id),
+                    enb_ue_find_by_id(mme_ue->enb_ue_id));
+            ogs_assert(e->pkbuf);
+            ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
+            break;
+        }
 
         h.type = e->nas_type;
 


### PR DESCRIPTION
Prevent crashes when UE context is missing in AMF and MME by replacing direct assertions with conditional checks and error logging.

Removed unconditional ogs_assert(ran_ue) in AMF's GMM handlers and ogs_assert(enb_ue) in MME's EMM handlers.

Now, if the UE context lookup returns NULL, log an error (including SUPI/IMSI, NAS message type, and IDs), dump the NAS packet in hex for debugging, and exit the handler gracefully instead of aborting.