### PR TITLE
[MME/AMF]: Align reject cause for unknown UE/IMSI with 3GPP TS 29.272 Annex A (#3924)

### DIFF
--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -944,7 +944,7 @@ static ogs_nas_5gmm_cause_t gmm_cause_from_sbi(int status)
 
     switch(status) {
     case OGS_SBI_HTTP_STATUS_NOT_FOUND:
-        gmm_cause = OGS_5GMM_CAUSE_PLMN_NOT_ALLOWED;
+        gmm_cause = OGS_5GMM_CAUSE_5GS_SERVICES_NOT_ALLOWED;
         break;
     case OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT:
         gmm_cause = OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED;

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -403,7 +403,7 @@ static uint8_t emm_cause_from_diameter(
     if (dia_exp_err) {
         switch (*dia_exp_err) {
         case OGS_DIAM_S6A_ERROR_USER_UNKNOWN:                   /* 5001 */
-            return OGS_NAS_EMM_CAUSE_PLMN_NOT_ALLOWED;
+            return OGS_NAS_EMM_CAUSE_EPS_SERVICES_AND_NON_EPS_SERVICES_NOT_ALLOWED;
         case OGS_DIAM_S6A_ERROR_UNKNOWN_EPS_SUBSCRIPTION:       /* 5420 */
             /* FIXME: Error diagnostic? */
             return OGS_NAS_EMM_CAUSE_NO_SUITABLE_CELLS_IN_TRACKING_AREA;


### PR DESCRIPTION
According to 3GPP TS 29.272 Annex A, when the HSS/UDM responds with DIAMETER_ERROR_USER_UNKNOWN (5001), the MME/AMF should respond to the UE with NAS EMM cause #8 (EPS services and non-EPS services not allowed), rather than cause #11 (PLMN not allowed).

Previously, Open5GS returned cause #11 by default. However, this behavior is problematic for private LTE environments where multiple operators may use the same PLMN (e.g., 999/99 as per ITU-T E.212). In such cases, a UE rejected with cause #11 will add the PLMN to its Forbidden PLMN list (FPLMN), causing the device to avoid that PLMN for an extended period—even if another compatible private network using the same PLMN exists.

This patch restores compliance with TS 29.272 by changing the default mapping from cause #11 to cause #8 in both the 4G MME (emm_cause_from_diameter) and 5G AMF (gmm_cause_from_sbi) when handling unknown subscriber cases.

This ensures:
- Standard-conformant behavior across networks
- Better UE behavior in roaming or private LTE scenarios
- Avoids unnecessary FPLMN blacklisting in UE

Reference Issues:
- #263
- #1281
- #1332