### PR TITLE
[SMF] If GTPU conf has advert addr, use it in up2cp FAR

### DIFF
--- a/lib/gtp/context.c
+++ b/lib/gtp/context.c
@@ -481,6 +481,13 @@ int ogs_gtp_context_parse_config(const char *local, const char *remote)
                                 rv = ogs_filteraddrinfo(&adv_addr6, AF_INET6);
                                 ogs_assert(rv == OGS_OK);
 
+                                if (adv_addr || adv_addr6) {
+                                    rv = ogs_sockaddr_to_ip(
+                                            adv_addr, adv_addr6,
+                                            &self.gtpu_ip);
+                                    ogs_assert(rv == OGS_OK);
+                                }
+
                         /* Find first IPv4/IPv6 address in the list.
                          *
                          * In the following configuration,

--- a/lib/gtp/path.h
+++ b/lib/gtp/path.h
@@ -57,9 +57,10 @@ extern "C" {
         \
         ogs_assert(ogs_gtp_self()->gtpu_addr || ogs_gtp_self()->gtpu_addr6); \
         \
-        ogs_sockaddr_to_ip( \
-                ogs_gtp_self()->gtpu_addr, ogs_gtp_self()->gtpu_addr6, \
-                &ogs_gtp_self()->gtpu_ip); \
+        if (!ogs_gtp_self()->gtpu_ip.ipv4 && !ogs_gtp_self()->gtpu_ip.ipv6) \
+            ogs_sockaddr_to_ip( \
+                    ogs_gtp_self()->gtpu_addr, ogs_gtp_self()->gtpu_addr6, \
+                    &ogs_gtp_self()->gtpu_ip); \
     } while(0)
 
 ogs_sock_t *ogs_gtp_server(ogs_socknode_t *node);


### PR DESCRIPTION
SMF constructs up2cp FAR's outer_header_creation with `ogs_gtp_self()->gtpu_ip` as DST IP address. Therefore, set 
`ogs_gtp_self()->gtpu_ip` to GTPU advertise address. If advertise addr is not set, fall back to socket address as usual.