### PR TITLE
[SBI] use CURL_AT_LEAST_VERSION for MAX_CONCURRENT_STREAMS check

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -161,7 +161,7 @@ ogs_sbi_client_t *ogs_sbi_client_add(
     curl_multi_setopt(multi, CURLMOPT_SOCKETDATA, client);
     curl_multi_setopt(multi, CURLMOPT_TIMERFUNCTION, multi_timer_cb);
     curl_multi_setopt(multi, CURLMOPT_TIMERDATA, client);
-#ifdef CURLMOPT_MAX_CONCURRENT_STREAMS
+#if CURL_AT_LEAST_VERSION(7,67,0)
     curl_multi_setopt(multi, CURLMOPT_MAX_CONCURRENT_STREAMS,
                         ogs_app()->pool.stream);
 #endif


### PR DESCRIPTION
In lib/sbi/client.c, the conditional compilation for CURLMOPT_MAX_CONCURRENT_STREAMS was using #ifdef, which does not ensure the option is set when the symbol is undefined.

Replace the check with #if CURL_AT_LEAST_VERSION(7,67,0) so that the client applies the max concurrent streams setting on supported libcurl versions. This fixes pool.event always showing the default value and enables dynamic adjustment according to pool.stream.