### PR TITLE
[AMF/SEC] pass AMF UE context to downlink NAS transport to prevent fatal crash (#3950)

### DIFF
--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -47,15 +47,17 @@ int nas_5gs_send_to_gnb(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
 }
 
 int nas_5gs_send_to_downlink_nas_transport(
-        ran_ue_t *ran_ue, ogs_pkbuf_t *pkbuf)
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf)
 {
     int rv;
     ogs_pkbuf_t *ngapbuf = NULL;
 
     ogs_assert(ran_ue);
+    ogs_assert(amf_ue);
     ogs_assert(pkbuf);
 
-    ngapbuf = ngap_build_downlink_nas_transport(ran_ue, pkbuf, false, false);
+    ngapbuf = ngap_build_downlink_nas_transport(
+            ran_ue, amf_ue, pkbuf, false, false);
     if (!ngapbuf) {
         ogs_error("ngap_build_downlink_nas_transport() failed");
         return OGS_ERROR;
@@ -163,7 +165,7 @@ int nas_5gs_send_registration_accept(amf_ue_t *amf_ue)
             ogs_expect(rv == OGS_OK);
         } else {
             ngapbuf = ngap_build_downlink_nas_transport(
-                    ran_ue, gmmbuf, true, true);
+                    ran_ue, amf_ue, gmmbuf, true, true);
             if (!ngapbuf) {
                 ogs_error("ngap_build_downlink_nas_transport() failed");
                 return OGS_ERROR;
@@ -216,7 +218,7 @@ int nas_5gs_send_registration_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -295,7 +297,7 @@ int nas_5gs_send_service_accept(amf_ue_t *amf_ue)
             rv = nas_5gs_send_to_gnb(amf_ue, ngapbuf);
             ogs_expect(rv == OGS_OK);
         } else {
-            rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+            rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
             ogs_expect(rv == OGS_OK);
         }
     }
@@ -320,7 +322,7 @@ int nas_5gs_send_service_reject(
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -355,7 +357,7 @@ int nas_5gs_send_de_registration_accept(amf_ue_t *amf_ue)
             return OGS_ERROR;
         }
 
-        rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+        rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
         if (rv != OGS_OK) {
             ogs_error("nas_5gs_send_to_downlink_nas_transport() failed");
             return rv;
@@ -413,7 +415,7 @@ int nas_5gs_send_de_registration_request(
     ogs_timer_start(amf_ue->t3522.timer,
             amf_timer_cfg(AMF_TIMER_T3522)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -457,7 +459,7 @@ int nas_5gs_send_identity_request(amf_ue_t *amf_ue)
     ogs_timer_start(amf_ue->t3570.timer,
             amf_timer_cfg(AMF_TIMER_T3570)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -503,7 +505,7 @@ int nas_5gs_send_authentication_request(amf_ue_t *amf_ue)
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_AMF_AUTH_REQ);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -536,7 +538,7 @@ int nas_5gs_send_authentication_reject(amf_ue_t *amf_ue)
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_AMF_AUTH_REJECT);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -580,7 +582,7 @@ int nas_5gs_send_security_mode_command(amf_ue_t *amf_ue)
     ogs_timer_start(amf_ue->t3560.timer,
             amf_timer_cfg(AMF_TIMER_T3560)->duration);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -643,7 +645,7 @@ int nas_5gs_send_configuration_update_command(
 
     amf_metrics_inst_global_inc(AMF_METR_GLOB_CTR_MM_CONF_UPDATE);
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -842,7 +844,7 @@ int nas_send_pdu_session_release_command(amf_sess_t *sess,
     } else if (gmmbuf) {
         ogs_pkbuf_free(n2smbuf);
         ngapbuf = ngap_build_downlink_nas_transport(
-                ran_ue, gmmbuf, false, false);
+                ran_ue, amf_ue, gmmbuf, false, false);
         if (!ngapbuf) {
             ogs_error("ngap_build_downlink_nas_transport() failed");
             return OGS_ERROR;
@@ -900,7 +902,7 @@ int nas_5gs_send_gmm_status(amf_ue_t *amf_ue, ogs_nas_5gmm_cause_t cause)
         return OGS_ERROR;
     }
 
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;
@@ -1018,7 +1020,7 @@ int nas_5gs_send_dl_nas_transport(ran_ue_t *ran_ue, amf_sess_t *sess,
         ogs_error("gmm_build_dl_nas_transport() failed");
         return OGS_ERROR;
     }
-    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, gmmbuf);
+    rv = nas_5gs_send_to_downlink_nas_transport(ran_ue, amf_ue, gmmbuf);
     ogs_expect(rv == OGS_OK);
 
     return rv;

--- a/src/amf/nas-path.h
+++ b/src/amf/nas-path.h
@@ -30,7 +30,7 @@ extern "C" {
 
 int nas_5gs_send_to_gnb(amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf);
 int nas_5gs_send_to_downlink_nas_transport(
-        ran_ue_t *ran_ue, ogs_pkbuf_t *pkbuf);
+        ran_ue_t *ran_ue, amf_ue_t *amf_ue, ogs_pkbuf_t *pkbuf);
 
 int nas_5gs_send_registration_accept(amf_ue_t *amf_ue);
 int nas_5gs_send_registration_reject(

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -293,10 +293,9 @@ ogs_pkbuf_t *ngap_build_ran_configuration_update_failure(
 }
 
 ogs_pkbuf_t *ngap_build_downlink_nas_transport(
-    ran_ue_t *ran_ue, ogs_pkbuf_t *gmmbuf, bool ue_ambr, bool allowed_nssai)
+    ran_ue_t *ran_ue, amf_ue_t *amf_ue,
+    ogs_pkbuf_t *gmmbuf, bool ue_ambr, bool allowed_nssai)
 {
-    amf_ue_t *amf_ue = NULL;
-
     NGAP_NGAP_PDU_t pdu;
     NGAP_InitiatingMessage_t *initiatingMessage = NULL;
     NGAP_DownlinkNASTransport_t *DownlinkNASTransport = NULL;
@@ -310,14 +309,7 @@ ogs_pkbuf_t *ngap_build_downlink_nas_transport(
 
     ogs_assert(gmmbuf);
     ogs_assert(ran_ue);
-    amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
-    if (!amf_ue) {
-        ogs_fatal("    AMF-UE-ID[%d] RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
-                ran_ue->amf_ue_id,
-                (long long)ran_ue->ran_ue_ngap_id,
-                (long long)ran_ue->amf_ue_ngap_id);
-        ogs_assert_if_reached();
-    }
+    ogs_assert(amf_ue);
 
     ogs_debug("DownlinkNASTransport");
 

--- a/src/amf/ngap-build.h
+++ b/src/amf/ngap-build.h
@@ -35,7 +35,8 @@ ogs_pkbuf_t *ngap_build_ran_configuration_update_failure(
         NGAP_Cause_PR group, long cause, long time_to_wait);
 
 ogs_pkbuf_t *ngap_build_downlink_nas_transport(
-    ran_ue_t *ran_ue, ogs_pkbuf_t *gmmbuf, bool ue_ambr, bool allowed_nssai);
+    ran_ue_t *ran_ue, amf_ue_t *amf_ue,
+    ogs_pkbuf_t *gmmbuf, bool ue_ambr, bool allowed_nssai);
 
 ogs_pkbuf_t *ngap_ue_build_initial_context_setup_request(
     amf_ue_t *amf_ue, ogs_pkbuf_t *gmmbuf);


### PR DESCRIPTION
When SM Context creation fails (e.g. 504 from SMF) the AMF continued to build and send a NAS downlink message by dynamically looking up the AMF UE context from ran_ue->amf_ue_id inside ngap_build_downlink_nas_transport(). If ran_ue_deassociate() had already removed that mapping, the lookup would return NULL, triggering a fatal assertion and crashing the AMF.

This patch changes:
  1. nas_5gs_send_to_downlink_nas_transport() and ngap_build_downlink_nas_transport() signatures to accept an explicit amf_ue_t * parameter alongside ran_ue_t *.
  2. All calls to nas_5gs_send_to_downlink_nas_transport() to pass the correct amf_ue pointer (from sess->amf_ue_id).
  3. Removal of the dynamic lookup and fatal assertion in ngap_build_downlink_nas_transport(), replacing it with ogs_assert(amf_ue) on the passed-in context.

By carrying the valid AMF UE context through the call chain, we ensure that downlink NAS transport always has a correct pointer, even when the ran_ue-to-amf_ue mapping has been cleared. This prevents invalid internal state transitions and eliminates the ngap_build_downlink_nas_transport() crash when handling SMF failures.