### PR TITLE
[SMF] Improve robustness of PCO parsing and building by replacing fatal assertions with error handling (#3969)

### DIFF
--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -480,7 +480,7 @@ int ogs_pco_parse(ogs_pco_t *pco, unsigned char *data, int data_len)
         i++;
     }
     pco->num_of_id = i;
-    ogs_assert(size == data_len);
+    ogs_expect(size == data_len);
 
     return size;
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2931,7 +2931,11 @@ int smf_pco_build(uint8_t *pco_buf, uint8_t *buffer, int length)
     memset(&pco_ipcp, 0, sizeof(pco_ipcp));
 
     size = ogs_pco_parse(&ue, buffer, length);
-    ogs_assert(size);
+    if (size != length) {
+        ogs_error("ogs_pco_parse() failed [size:%d != length:%d]",
+                size, length);
+        return 0;
+    }
 
     memset(&smf, 0, sizeof(ogs_pco_t));
     smf.ext = ue.ext;
@@ -3143,6 +3147,7 @@ int smf_pco_build(uint8_t *pco_buf, uint8_t *buffer, int length)
     }
 
     size = ogs_pco_build(pco_buf, OGS_MAX_PCO_LEN, &smf);
+    ogs_expect(size > 0);
     return size;
 }
 

--- a/src/smf/gn-build.c
+++ b/src/smf/gn-build.c
@@ -214,7 +214,12 @@ ogs_pkbuf_t *smf_gn_build_create_pdp_context_response(
             sess->gtp.ue_pco.len && sess->gtp.ue_pco.data) {
         pco_len = smf_pco_build(
                 pco_buf, sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
-        ogs_assert(pco_len > 0);
+        if (pco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
+            return NULL;
+        }
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;
@@ -382,7 +387,12 @@ ogs_pkbuf_t *smf_gn_build_delete_pdp_context_response(
             sess->gtp.ue_pco.len && sess->gtp.ue_pco.data) {
         pco_len = smf_pco_build(
                 pco_buf, sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
-        ogs_assert(pco_len > 0);
+        if (pco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
+            return NULL;
+        }
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;
@@ -445,7 +455,12 @@ ogs_pkbuf_t *smf_gn_build_update_pdp_context_response(
         sess->gtp.ue_pco.len && sess->gtp.ue_pco.data) {
         pco_len = smf_pco_build(
                 pco_buf, sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
-        ogs_assert(pco_len > 0);
+        if (pco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
+            return NULL;
+        }
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;

--- a/src/smf/gsm-build.c
+++ b/src/smf/gsm-build.c
@@ -225,7 +225,12 @@ ogs_pkbuf_t *gsm_build_pdu_session_establishment_accept(smf_sess_t *sess)
         ogs_assert(epco_buf);
         epco_len = smf_pco_build(epco_buf,
                 sess->nas.ue_epco.buffer, sess->nas.ue_epco.length);
-        ogs_assert(epco_len > 0);
+        if (epco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->nas.ue_epco.buffer, sess->nas.ue_epco.length);
+            goto cleanup;
+        }
         pdu_session_establishment_accept->presencemask |=
             OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_ACCEPT_EXTENDED_PROTOCOL_CONFIGURATION_OPTIONS_PRESENT;
         extended_protocol_configuration_options->buffer = epco_buf;

--- a/src/smf/s5c-build.c
+++ b/src/smf/s5c-build.c
@@ -141,7 +141,12 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
             sess->gtp.ue_pco.len && sess->gtp.ue_pco.data) {
         pco_len = smf_pco_build(
                 pco_buf, sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
-        ogs_assert(pco_len > 0);
+        if (pco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
+            goto cleanup;
+        }
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;
@@ -152,7 +157,12 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
             sess->gtp.ue_apco.len && sess->gtp.ue_apco.data) {
         apco_len = smf_pco_build(
                 apco_buf, sess->gtp.ue_apco.data, sess->gtp.ue_apco.len);
-        ogs_assert(apco_len > 0);
+        if (apco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_apco.data, sess->gtp.ue_apco.len);
+            goto cleanup;
+        }
         rsp->additional_protocol_configuration_options.presence = 1;
         rsp->additional_protocol_configuration_options.data = apco_buf;
         rsp->additional_protocol_configuration_options.len = apco_len;
@@ -165,7 +175,12 @@ ogs_pkbuf_t *smf_s5c_build_create_session_response(
         ogs_assert(epco_buf);
         epco_len = smf_pco_build(
                 epco_buf, sess->gtp.ue_epco.data, sess->gtp.ue_epco.len);
-        ogs_assert(epco_len > 0);
+        if (epco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_epco.data, sess->gtp.ue_epco.len);
+            goto cleanup;
+        }
         rsp->extended_protocol_configuration_options.presence = 1;
         rsp->extended_protocol_configuration_options.data = epco_buf;
         rsp->extended_protocol_configuration_options.len = epco_len;
@@ -291,7 +306,12 @@ ogs_pkbuf_t *smf_s5c_build_delete_session_response(
             sess->gtp.ue_pco.len && sess->gtp.ue_pco.data) {
         pco_len = smf_pco_build(
                 pco_buf, sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
-        ogs_assert(pco_len > 0);
+        if (pco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_pco.data, sess->gtp.ue_pco.len);
+            goto cleanup;
+        }
         rsp->protocol_configuration_options.presence = 1;
         rsp->protocol_configuration_options.data = pco_buf;
         rsp->protocol_configuration_options.len = pco_len;
@@ -304,7 +324,12 @@ ogs_pkbuf_t *smf_s5c_build_delete_session_response(
         ogs_assert(epco_buf);
         epco_len = smf_pco_build(
                 epco_buf, sess->gtp.ue_epco.data, sess->gtp.ue_epco.len);
-        ogs_assert(epco_len > 0);
+        if (epco_len <= 0) {
+            ogs_error("smf_pco_build() failed");
+            ogs_log_hexdump(OGS_LOG_ERROR,
+                    sess->gtp.ue_epco.data, sess->gtp.ue_epco.len);
+            goto cleanup;
+        }
         rsp->extended_protocol_configuration_options.presence = 1;
         rsp->extended_protocol_configuration_options.data = epco_buf;
         rsp->extended_protocol_configuration_options.len = epco_len;
@@ -316,6 +341,7 @@ ogs_pkbuf_t *smf_s5c_build_delete_session_response(
     gtp_message.h.type = type;
     pkbuf = ogs_gtp2_build_msg(&gtp_message);
 
+cleanup:
     if (epco_buf)
         ogs_free(epco_buf);
 


### PR DESCRIPTION
Previously, malformed Protocol Configuration Options (PCO) data would trigger ogs_assert failures in both the generic parser and SMF build routines, causing the SMF process to abort unconditionally.

This commit replaces those fatal assertions with conditional checks:

In ogs_pco_parse(), switch from ogs_assert(size == data_len) to ogs_expect(size == data_len), allowing the function to return gracefully.

In SMF's PCO build (smf_pco_build) and all downstream build paths (including GN, GSM, S5C modules), replace ogs_assert(pco_len > 0) with explicit if (pco_len <= 0) checks that:

Ensure that malformed or incomplete PCOs no longer crash the process, but instead are handled cleanly so the network function can continue operating.