### PR TITLE
[SMF] Prevent SMF crash on closed or invalid HTTP/2 stream

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -2442,11 +2442,15 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                                     NGAP_CauseNas_normal_release);
                         ogs_assert(n2smbuf);
 
-                        ogs_assert(stream);
-                        smf_sbi_send_sm_context_updated_data_n1_n2_message(
-                                sess, stream, n1smbuf,
-                                OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,
-                                n2smbuf);
+                        if (stream) {
+                            smf_sbi_send_sm_context_updated_data_n1_n2_message(
+                                    sess, stream, n1smbuf,
+                                    OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,
+                                    n2smbuf);
+                        } else {
+                            ogs_error("Stream has already been removed");
+                            break;
+                        }
                     }
 
                     OGS_FSM_TRAN(s, smf_gsm_state_wait_5gc_n1_n2_release);


### PR DESCRIPTION
Bug:

During PDU Session release, if the HTTP/2 stream is already closed, the SMF may still attempt to process the event.
This leads to an assertion failure in `smf_gsm_state_wait_pfcp_deletion`, causing the SMF process to crash:
```
07/16 06:45:43.112: [smf] FATAL: smf_gsm_state_wait_pfcp_deletion: Assertion `stream' failed. (../src/smf/gsm-sm.c:1622)
07/16 06:45:43.113: [core] FATAL: backtrace() returned 10 addresses (../lib/core/ogs-abort.c:37)
```

Fix:

A null check for the stream is added before sending the PDU_RES_REL_CMD. If the stream has already been removed, SMF now logs an error instead of asserting.