### PR TITLE
[AMF] Fix slice->session overflow

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -814,7 +814,7 @@ typedef struct ogs_slice_data_s {
     uint32_t all_apn_config_inc;
 
     int num_of_session;
-    ogs_session_t session[OGS_MAX_NUM_OF_SESS];
+    ogs_session_t session[OGS_MAX_NUM_OF_DNN];
 } ogs_slice_data_t;
 
 ogs_slice_data_t *ogs_slice_find_by_s_nssai(

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2752,7 +2752,7 @@ void amf_clear_subscribed_info(amf_ue_t *amf_ue)
 
     ogs_assert(amf_ue->num_of_slice <= OGS_MAX_NUM_OF_SLICE);
     for (i = 0; i < amf_ue->num_of_slice; i++) {
-        ogs_assert(amf_ue->slice[i].num_of_session <= OGS_MAX_NUM_OF_SESS);
+        ogs_assert(amf_ue->slice[i].num_of_session <= OGS_MAX_NUM_OF_DNN);
         for (j = 0; j < amf_ue->slice[i].num_of_session; j++) {
             ogs_assert(amf_ue->slice[i].session[j].name);
             ogs_free(amf_ue->slice[i].session[j].name);

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -214,6 +214,12 @@ int amf_nudm_sdm_handle_provisioned(
                             DnnInfoList = SubscribedSnssaiInfo->dnn_infos;
                             if (DnnInfoList) {
                                 OpenAPI_list_for_each(DnnInfoList, node2) {
+                                    if (slice->num_of_session>=OGS_MAX_NUM_OF_DNN) {
+                                        ogs_error("DNN overflow at S-NSSAI"
+                                                "[SST:%d SD:0x%x]",
+                                                s_nssai.sst, s_nssai.sd.v);
+                                        break;
+                                    }
                                     DnnInfo = node2->data;
                                     if (DnnInfo) {
                                         ogs_session_t *session =


### PR DESCRIPTION
`amf_nudm_sdm_handle_provisioned()` saves all subscribed DNNs of a slice into slice->session.

So slice->num_of_session corresponds to the number of subscribed DNNs, not the number of sessions.

But the number of DNNs (`OGS_MAX_NUM_OF_DNN`) can be greater than the number of sessions per UE (`OGS_MAX_NUM_OF_SESS`).

Strange enough `gmm_handle_ul_nas_transport()` tolerates (ignores) max session count overflow.

Bug:

The slice->num_of_session overflows `OGS_MAX_NUM_OF_SESS` in case of number of dnn > `OGS_MAX_NUM_OF_SESS`.
The overflow causes undefined behavior, at least memoryleak of overflowed session names:
```
amf  | 07/29 14:10:43.901: [sctp] INFO: AMF terminate...done (../src/amf/app.c:42)
amf  | full talloc report on 'core' (total      5 bytes in   2 blocks)
amf  |     ims          contains      4 bytes in   1 blocks (ref 0) 0x7f3044066330
```

AMF crashes during the next registration procedure or on AMF restart in `amf_clear_subscribed_info()` due to num_of_session > OGS_MAX_NUM_OF_SESS:
```
[amf] FATAL: amf_clear_subscribed_info: Assertion `amf_ue->slice[i].num_of_session <= OGS_MAX_NUM_OF_SESS' failed. (../src/amf/context.c:3022)
```

Fix:

The size of the array of sessions in `ogs_slice_data_t` is enlarged to `OGS_MAX_NUM_OF_DNN`.

Additionally an error is reported when number of subscribed DNNs exceeds the array length and assertion before clearing is changed to assert when `OGS_MAX_NUM_OF_DNN` is exceeded only.