### PR TITLE
[AMF] Rej. sess with cause 65 if max. no. of PDU sess. is reached 

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1308,6 +1308,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                 OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_REQUEST) {
 
             int i, j, k;
+            uint8_t cause =
+                OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE;
 
             nas_s_nssai = &ul_nas_transport->s_nssai;
             ogs_assert(nas_s_nssai);
@@ -1362,6 +1364,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                                         "count overflow [%d>=%d]",
                                         amf_ue->slice[i].num_of_session,
                                         OGS_MAX_NUM_OF_SESS);
+                                    cause =
+                                        OGS_5GMM_CAUSE_MAXIMUM_NUMBER_OF_PDU_SESSIONS_REACHED;
                                     break;
                                 }
                                 if (!ogs_strcasecmp(dnn->value,
@@ -1405,8 +1409,8 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
             if (!selected_slice || !sess->dnn) {
                 ogs_warn("[%s] Ue requested DNN \"%s\" Not Supported OR "
                             "Not Subscribed in the Slice", amf_ue->supi, dnn->value);
-                r = nas_5gs_send_gmm_status(amf_ue,
-                        OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE);
+                r = nas_5gs_send_back_gsm_message(
+                        ran_ue, sess, cause, AMF_NAS_BACKOFF_TIME);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 return OGS_ERROR;

--- a/tests/common/nas-path.c
+++ b/tests/common/nas-path.c
@@ -94,6 +94,8 @@ void testgsm_recv(test_sess_t *sess, ogs_pkbuf_t *pkbuf)
         testgsm_handle_pdu_session_establishment_accept(sess,
                 &message.gsm.pdu_session_establishment_accept);
         break;
+    case OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_REQUEST:
+        break;
     case OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_REJECT:
         break;
     case OGS_NAS_5GS_PDU_SESSION_MODIFICATION_COMMAND:

--- a/tests/vonr/session-test.c
+++ b/tests/vonr/session-test.c
@@ -1951,7 +1951,7 @@ static void test5_func(abts_case *tc, void *data)
             NGAP_ProcedureCode_id_DownlinkNASTransport,
             test_ue->ngap_procedure_code);
     ABTS_INT_EQUAL(tc,
-            OGS_NAS_5GS_5GMM_STATUS,
+            OGS_NAS_5GS_DL_NAS_TRANSPORT,
             test_ue->gmm_message_type);
 
     /* Waiting for deleting PDU session */
@@ -2227,7 +2227,7 @@ static void test6_func(abts_case *tc, void *data)
             NGAP_ProcedureCode_id_DownlinkNASTransport,
             test_ue->ngap_procedure_code);
     ABTS_INT_EQUAL(tc,
-            OGS_NAS_5GS_5GMM_STATUS,
+            OGS_NAS_5GS_DL_NAS_TRANSPORT,
             test_ue->gmm_message_type);
 
     /* Remove All Test Session */


### PR DESCRIPTION
If PDU_SESSION_ESTABLISHMENT_REQUEST is rejected, the AMF returns the
5GSM message which was not forwarded instead of 5GSM Status.

In case the maximum number of PDU sessions has already been reached for
the UE, the AMF shall send back to the UE 5GSM message with cause 65.

TS 24.501:

5.4.5.3 Network-initiated NAS transport procedure

5.4.5.3.1 General
The purpose of the network-initiated NAS transport procedure is to provide
a transport of:

h) a single uplink 5GSM message which was not forwarded, because the PLMN's
maximum number of PDU sessions has been reached;

5.4.5.3.2 Network-initiated NAS transport procedure initiation
In case h) in subclause 5.4.5.3.1, i.e. upon sending a single uplink 5GSM message
which was not forwarded, because the PLMN's maximum number of PDU sessions
has been reached, the AMF shall:

a) include the PDU session ID in the PDU session ID IE;
b) set the Payload container type IE to "N1 SM information";
c) set the Payload container IE to the 5GSM message which was not forwarded; and
d) set the 5GMM cause IE to the 5GMM cause https://github.com/open5gs/open5gs/issues/65 "maximum number of PDU sessions
 reached".

Trace: 
[Max_number_of_PDU_sess_1_reached_Cause65.zip](https://github.com/user-attachments/files/21530631/Max_number_of_PDU_sess_1_reached_Cause65.zip)
