### PR TITLE
[HR] V-UPF: preserve PSC on N2 indirect (Access->Access) without QER (#2194)

### DIFF
--- a/docs/_posts/2025-07-19-release-v2.7.6.md
+++ b/docs/_posts/2025-07-19-release-v2.7.6.md
@@ -1,6 +1,6 @@
 ---
 title: "v2.7.6 - Bug fixed"
-date: 2025-03-30 22:05:00 +0900
+date: 2025-07-19 22:05:00 +0900
 categories:
   - Release
 tags:

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -199,6 +199,14 @@ void sgwu_sxa_handle_session_modification_request(
         goto cleanup;
 
     for (i = 0; i < OGS_MAX_NUM_OF_PDR; i++) {
+        if (ogs_pfcp_handle_update_pdr(&sess->pfcp, &req->update_pdr[i],
+                    &cause_value, &offending_ie_value) == NULL)
+            break;
+    }
+    if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
+        goto cleanup;
+
+    for (i = 0; i < OGS_MAX_NUM_OF_PDR; i++) {
         if (ogs_pfcp_handle_remove_pdr(&sess->pfcp, &req->remove_pdr[i],
                 &cause_value, &offending_ie_value) == false)
             break;


### PR DESCRIPTION
Home-Routed roaming: during Xn/N2 handover the source gNB may forward remaining DL data to the core using UL PDU Session Information (PSC). On the V-UPF the PSC was lost on the indirect path because OHR+OHC removed the incoming GTP-U header (and its extensions) and we did not recreate PSC when no QER/QFI was provisioned by the V-SMF.

This change makes the V-UPF rebuild a DL PSC for the target gNB even when QER is absent, limited to the Access->Access indirect path (source gNB -> V-UPF -> target gNB).

Why this is needed in HR:
- In HR deployments the V-SMF typically does not provision QER/QFI for the temporary indirect path. Without recreating PSC from recvhdr, the extension header disappears after OHR+OHC and the target gNB cannot see the QFI during handover buffering/forwarding.