### PR TITLE
Add healthchecks for MongoDB and WebUI services in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   mongodb:
     image: mongo
@@ -10,6 +8,12 @@ services:
     volumes:
       - mongodb:/data/db
       - ../docs/assets/webui/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    # Healthcheck for MongoDB
+    healthcheck:
+      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   webui:
     build:
@@ -24,6 +28,12 @@ services:
     environment:
       - DB_URI=mongodb://mongodb/open5gs
       - WAIT_HOSTS=mongodb:27017
+    # Healthcheck for WebUI
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9999" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   base:
     build:
@@ -33,7 +43,6 @@ services:
         tag: ${TAG-latest}
     image: ${USER}/${DIST-ubuntu}-${TAG-latest}-open5gs-base
     command: /bin/bash -c "echo 'base' services"
-
   build:
     build:
       context: ../


### PR DESCRIPTION
This pull request updates the `docker/docker-compose.yml` file to improve service monitoring by adding healthchecks to key containers. 

* Added a healthcheck to the `mongodb` service that periodically runs a ping command to verify MongoDB is up and responsive.
* Added a healthcheck to the `webui` service that uses `curl` to check if the web interface is accessible.

**General cleanup:**

* Removed the explicit version declaration (`version: '3'`) from the top of the compose file, which is obsolete in newer Docker Compose versions.
* Minor formatting adjustments in the `base` service section for consistency.