### PR TITLE
[AMF][SBI] Fix AMF crashes and prevent timer callbacks from accessing freed objects (#4074)

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -781,8 +781,10 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                     break;
                 }
 
-                ogs_error("[%s:%s] Cannot receive SBI message",
-                        amf_ue->supi, amf_ue->suci);
+                ogs_error("[%s:%s] Cannot receive SBI message "
+                        "[type:%d,value:%d]", amf_ue->supi, amf_ue->suci,
+                        amf_ue->nas.message_type,
+                        amf_ue->nas.registration.value);
 
                 /*
                 * TS 23.502
@@ -808,6 +810,10 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
                         break;
                     }
+                } else if (amf_ue->nas.message_type ==
+                        OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE) {
+                    ogs_error("T3522 expired");
+                    break;
                 }
 
                 r = nas_5gs_send_gmm_reject_from_sbi(amf_ue,

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2115,7 +2115,9 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                     }
                     ogs_error("[%s] Ignore SBI message", amf_ue->supi);
                     break;
-
+                CASE(OGS_SBI_HTTP_METHOD_DELETE)
+                    ogs_error("[%s] Ignore SBI message", amf_ue->supi);
+                    break;
                 DEFAULT
                     ogs_error("Unknown method [%s]", sbi_message->h.method);
                     ogs_assert_if_reached();

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2059,6 +2059,14 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                      */
                     ogs_error("[%s] Ignore SBI message", amf_ue->supi);
                     break;
+                CASE(OGS_SBI_HTTP_METHOD_PATCH)
+                    /*
+                     * Issue #4074
+                     *
+                     * We need to ignore this message in this state.
+                     */
+                    ogs_error("[%s] Ignore SBI message", amf_ue->supi);
+                    break;
                 DEFAULT
                     ogs_error("[%s] Invalid HTTP method [%s]",
                             amf_ue->suci, sbi_message->h.method);


### PR DESCRIPTION
## Summary

This pull request addresses several crash and stability issues in the AMF and SBI layers, primarily related to unhandled HTTP methods and unsafe timer callbacks. These changes aim to improve the robustness of AMF when handling unexpected SBI messages and prevent use-after-free (UAF) or double-free scenarios under heavy load.

---

## Changes

### 🛠 AMF: Handle unexpected HTTP methods in `gmm_state_authentication`

**Commits:**  
- [`81fe41c`](https://github.com/open5gs/open5gs/commit/81fe41c8188bd3f5e9676a9f5f62dea24c246ae6)  
- [`4303bb4`](https://github.com/open5gs/open5gs/commit/4303bb4b64540a64235a4c76dfec58fd83fe0f36)

**Details:**
- Previously, if the AMF received a `PATCH` or `DELETE` request for the Registration API while in `gmm_state_authentication`, it would crash because these HTTP methods were not handled.
- These scenarios appear to be caused by race conditions.
- **Fix:** Explicitly handle `OGS_SBI_HTTP_METHOD_PATCH` and `OGS_SBI_HTTP_METHOD_DELETE` by logging an error and safely ignoring the message, similar to how other unexpected SBI messages are handled.

---

### ⚡ AMF: Fix crash when sending GMM reject after T3522 expiry

**Commit:**  
- [`62ecf74`](https://github.com/open5gs/open5gs/commit/62ecf74654bb87c3c96050f0f62d362beb98d1c7)

**Details:**
- Fixed a crash that occurred when the AMF attempted to send a GMM reject message after T3522 expiry.
- **Fixes:**
  - Added handling for `DEREGISTRATION_REQUEST_FROM_UE` events when T3522 expires.
  - Improved error logging with NAS message type and value for better traceability.

---

### 🧩 SBI: Prevent UAF/double-free in timer callbacks

**Commit:**  
- [`8b10ab5`](https://github.com/open5gs/open5gs/commit/8b10ab5db84067eba40bb5f243a6ed853761de05)

**Details:**
- Prevented use-after-free or double-free crashes caused by timer callbacks referencing already freed objects.
- **Fixes:**
  - Replaced `ogs_pool_alloc()` / `ogs_pool_free()` with `ogs_pool_id_calloc()` / `ogs_pool_id_free()` to assign stable pool IDs.
  - Passed pool IDs (instead of raw pointers) to `ogs_timer_add()`.
  - In `connection_timer_expired()` and `session_timer_expired()`, objects are now resolved via `ogs_pool_find_by_id()`, and callbacks return safely if the object has been freed.
  - Added safety checks and detailed error logging for invalid IDs and missing objects.

---

## Related Issue

- Fixes #4074

---

## Impact

- Improves stability and reliability of AMF during high-load conditions.
- Eliminates several crash scenarios caused by unhandled SBI HTTP methods and unsafe timer operations.

---

## Testing

- Tested with heavy load scenarios involving multiple simultaneous registrations and deregistrations.
- Verified that AMF no longer crashes when receiving unexpected `PATCH` or `DELETE` requests.
- Verified that timer callbacks do not access freed memory and safely exit if the object no longer exists.
