### PR TITLE
[MME] Send paging outcome before removing UE context (#4063)

### DIFF
--- a/src/amf/connected_gnbs.c
+++ b/src/amf/connected_gnbs.c
@@ -82,7 +82,10 @@ static inline size_t append_safe(char *buf, size_t off, size_t buflen, const cha
     if (!buf || off == (size_t)-1 || off >= buflen) return (size_t)-1;
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    int n = ogs_vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic pop
     va_end(ap);
     if (n < 0 || (size_t)n >= buflen - off) return (size_t)-1;
     return off + (size_t)n;

--- a/src/mme/connected_enbs.c
+++ b/src/mme/connected_enbs.c
@@ -66,7 +66,10 @@ static inline size_t append_safe(char *buf, size_t off, size_t buflen, const cha
     if (!buf || off == (size_t)-1 || off >= buflen) return (size_t)-1;
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    int n = ogs_vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic pop
     va_end(ap);
     if (n < 0 || (size_t)n >= buflen - off) return (size_t)-1;
     return off + (size_t)n;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -810,6 +810,15 @@ struct mme_ue_s {
     mme_hssmap_t    *hssmap;
 };
 
+#define MME_UE_REMOVE_WITH_PAGING_FAIL(__mME) \
+    do { \
+        if (MME_PAGING_ONGOING(__mME)) { \
+            ogs_error("Paging is ON-Going [%d]", (__mME)->paging.type); \
+            mme_send_after_paging(__mME, false); \
+        } \
+        mme_ue_remove(__mME); \
+    } while(0)
+
 #define SESSION_CONTEXT_IS_AVAILABLE(__mME) \
     ((__mME) && \
      ((__mME)->sgw_ue_id >= OGS_MIN_POOL_ID) && \

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -87,7 +87,7 @@ void mme_send_delete_session_or_detach(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
                         S1AP_UE_CTX_REL_UE_CONTEXT_REMOVE, 0));
             } else {
                 ogs_warn("[%s] MME-UE Context Removed", mme_ue->imsi_bcd);
-                mme_ue_remove(mme_ue);
+                MME_UE_REMOVE_WITH_PAGING_FAIL(mme_ue);
             }
         }
         break;

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -828,7 +828,7 @@ void mme_s11_handle_delete_session_response(
     } else if (action == OGS_GTP_DELETE_SEND_RELEASE_WITH_UE_CONTEXT_REMOVE) {
         if (mme_sess_count(mme_ue) == 1) /* Last Session */ {
             if (ECM_IDLE(mme_ue)) {
-                mme_ue_remove(mme_ue);
+                MME_UE_REMOVE_WITH_PAGING_FAIL(mme_ue);
 
                 /* mme_sess_remove() should not be called here
                  * since mme_ue_remove() has already been executed. */

--- a/src/smf/connected_ues.c
+++ b/src/smf/connected_ues.c
@@ -79,7 +79,10 @@ static inline size_t append_safe(char *buf, size_t off, size_t buflen, const cha
     if (!buf || off == (size_t)-1 || off >= buflen) return (size_t)-1;
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    int n = ogs_vsnprintf(buf + off, buflen - off, fmt, ap);
+#pragma GCC diagnostic pop
     va_end(ap);
     if (n < 0 || (size_t)n >= buflen - off) return (size_t)-1;
     return off + (size_t)n;


### PR DESCRIPTION
When the UE context was removed (e.g. after implicit detach or Delete Session response), ongoing paging procedures were not finalized. This caused the MME to skip sending the appropriate paging outcome (e.g. Downlink Data Notification ACK, Create Bearer Response, Update Bearer Response, Delete Bearer Response, SGSAP Paging Reject, etc.) depending on the paging type.

As a result, the SGW or MSC/VLR could continue retransmitting, and the MME produced spurious "Unknown timer[T3413]" errors.

This patch introduces `MME_UE_REMOVE_WITH_PAGING_FAIL`, which:
- Checks if paging is ongoing before removing the UE context
- Calls `mme_send_after_paging()` to send the correct outcome message (Unable to page UE or equivalent cause) according to paging type
- Removes the UE context afterwards

This change ensures that all paging procedures are completed with a proper response as required by 3GPP specifications, improving network interoperability and eliminating misleading timer errors.