### PR TITLE
[AMF/MME] Add size validation for NGAP/S1AP IE fields to prevent crashes (#4087)

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2944,6 +2944,56 @@ void ngap_handle_path_switch_request(
     eUTRAintegrityProtectionAlgorithms =
         &UESecurityCapabilities->eUTRAintegrityProtectionAlgorithms;
 
+    if (nRencryptionAlgorithms->size != sizeof(nr_ea)) {
+        ogs_error("Invalid nRencryptionAlgorithms->size = %d (expected %d)",
+                (int)nRencryptionAlgorithms->size,
+                (int)sizeof(nr_ea));
+        r = ngap_send_error_indication(
+                gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
+                NGAP_Cause_PR_protocol,
+                NGAP_CauseProtocol_message_not_compatible_with_receiver_state);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
+    if (nRintegrityProtectionAlgorithms->size != sizeof(nr_ia)) {
+        ogs_error("Invalid nRintegrityProtectionAlgorithms->size = %d "
+                "(expected %d)",
+                (int)nRintegrityProtectionAlgorithms->size,
+                (int)sizeof(nr_ia));
+        r = ngap_send_error_indication(
+                gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
+                NGAP_Cause_PR_protocol,
+                NGAP_CauseProtocol_message_not_compatible_with_receiver_state);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
+    if (eUTRAencryptionAlgorithms->size != sizeof(eutra_ea)) {
+        ogs_error("Invalid eUTRAencryptionAlgorithms->size = %d (expected %d)",
+                (int)eUTRAencryptionAlgorithms->size,
+                (int)sizeof(eutra_ea));
+        r = ngap_send_error_indication(
+                gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
+                NGAP_Cause_PR_protocol,
+                NGAP_CauseProtocol_message_not_compatible_with_receiver_state);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
+    if (eUTRAintegrityProtectionAlgorithms->size != sizeof(eutra_ia)) {
+        ogs_error("Invalid eUTRAintegrityProtectionAlgorithms->size = %d "
+                "(expected %d)",
+                (int)eUTRAintegrityProtectionAlgorithms->size,
+                (int)sizeof(eutra_ia));
+        r = ngap_send_error_indication(
+                gnb, &ran_ue->ran_ue_ngap_id, &ran_ue->amf_ue_ngap_id,
+                NGAP_Cause_PR_protocol,
+                NGAP_CauseProtocol_message_not_compatible_with_receiver_state);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
     memcpy(&nr_ea, nRencryptionAlgorithms->buf, sizeof(nr_ea));
     nr_ea = be16toh(nr_ea);
     nr_ea0 = amf_ue->ue_security_capability.nr_ea0;
@@ -4411,6 +4461,19 @@ void ngap_handle_ran_configuration_update(
                 pLMNIdentity = (NGAP_PLMNIdentity_t *)
                         &BroadcastPLMNItem->pLMNIdentity;
                 ogs_assert(pLMNIdentity);
+
+                if (pLMNIdentity->size != sizeof(ogs_plmn_id_t)) {
+                    ogs_error("Invalid PLMNIdentity size = %d (expected %d)",
+                            (int)pLMNIdentity->size,
+                            (int)sizeof(ogs_plmn_id_t));
+                    group = NGAP_Cause_PR_protocol;
+                    cause = NGAP_CauseProtocol_semantic_error;
+                    r = ngap_send_ran_configuration_update_failure(
+                            gnb, group, cause);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+                    return;
+                }
 
                 memcpy(&gnb->supported_ta_list[i].bplmn_list[j].plmn_id,
                         pLMNIdentity->buf, sizeof(ogs_plmn_id_t));

--- a/src/mme/s1ap-path.c
+++ b/src/mme/s1ap-path.c
@@ -879,27 +879,16 @@ int s1ap_send_error_indication(
     return rv;
 }
 
-int s1ap_send_error_indication2(
-        mme_ue_t *mme_ue, S1AP_Cause_PR group, long cause)
+int s1ap_send_error_indication1(
+        enb_ue_t *enb_ue, S1AP_Cause_PR group, long cause)
 {
     int rv;
     mme_enb_t *enb;
-    enb_ue_t *enb_ue;
 
     S1AP_MME_UE_S1AP_ID_t mme_ue_s1ap_id;
     S1AP_ENB_UE_S1AP_ID_t enb_ue_s1ap_id;
 
-    if (!mme_ue) {
-        ogs_error("UE(mme-ue) context has already been removed");
-        return OGS_NOTFOUND;
-    }
-
-    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-    if (!enb_ue) {
-        ogs_error("S1 context has already been removed");
-        return OGS_NOTFOUND;
-    }
-
+    ogs_assert(enb_ue);
     enb = mme_enb_find_by_id(enb_ue->enb_id);
     if (!enb) {
         ogs_error("eNB has already been removed");
@@ -914,6 +903,25 @@ int s1ap_send_error_indication2(
     ogs_expect(rv == OGS_OK);
 
     return rv;
+}
+
+int s1ap_send_error_indication2(
+        mme_ue_t *mme_ue, S1AP_Cause_PR group, long cause)
+{
+    enb_ue_t *enb_ue;
+
+    if (!mme_ue) {
+        ogs_error("UE(mme-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
+
+    enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+    if (!enb_ue) {
+        ogs_error("S1 context has already been removed");
+        return OGS_NOTFOUND;
+    }
+
+    return s1ap_send_error_indication1(enb_ue, group, cause);
 }
 
 int s1ap_send_s1_reset_ack(

--- a/src/mme/s1ap-path.h
+++ b/src/mme/s1ap-path.h
@@ -97,6 +97,8 @@ int s1ap_send_error_indication(
         S1AP_MME_UE_S1AP_ID_t *mme_ue_s1ap_id,
         S1AP_ENB_UE_S1AP_ID_t *enb_ue_s1ap_id,
         S1AP_Cause_PR group, long cause);
+int s1ap_send_error_indication1(
+        enb_ue_t *enb_ue, S1AP_Cause_PR group, long cause);
 int s1ap_send_error_indication2(
         mme_ue_t *mme_ue, S1AP_Cause_PR group, long cause);
 int s1ap_send_s1_reset_ack(


### PR DESCRIPTION
- Added explicit size checks for critical IE fields (PLMNIdentity, TAC, GTP-TEID, Cell-ID, UE security capability algorithms, etc.) before memcpy() operations.
- When size mismatch is detected, log an error and return an Error Indication (or Setup Failure) with appropriate protocol cause (semantic_error or message_not_compatible_with_receiver_state).
- Introduced s1ap_send_error_indication1(enb_ue_t *enb_ue, ...) as a helper for cases where ENB UE context is available directly. s1ap_send_error_indication2(mme_ue_t *mme_ue, ...) now delegates to the new function, reducing code duplication.
- Replaced ogs_assert() checks with graceful error handling paths to avoid abnormal process termination.

This improves robustness against malformed or non-compliant NGAP/S1AP messages and prevents potential AMF/MME crashes.