### PR TITLE
Fixed compatibility issue in webui for nodejs versions >= 18

### DIFF
--- a/webui/server/index.js
+++ b/webui/server/index.js
@@ -1,4 +1,4 @@
-process.env.DB_URI = process.env.DB_URI || 'mongodb://localhost/open5gs';
+process.env.DB_URI = process.env.DB_URI || 'mongodb://127.0.0.1/open5gs';
 
 const _hostname = process.env.HOSTNAME || 'localhost';
 const port = process.env.PORT || 9999;


### PR DESCRIPTION
Changed mongodb default url from localhost to 127.0.0.1 as specified in https://mongoosejs.com/docs/connections.html. This fix compatibility issues between webui and nodejs 18+ versions.