### PR TITLE
[SBI] Accept matching smfInfo blocks during SMF discovery

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2163,6 +2163,7 @@ bool ogs_sbi_discovery_option_is_matched(
     bool need_smf_slice = false;
     bool need_smf_tai = false;
     bool smf_match_found = false;
+    bool smf_info_checked = false;
 
     if (nf_instance->nf_type == OpenAPI_nf_type_SMF) {
         need_smf_slice =
@@ -2185,8 +2186,10 @@ bool ogs_sbi_discovery_option_is_matched(
                     &discovery_option->guami) == false)
                 return false;
             break;
-        case OpenAPI_nf_type_SMF:
+        case OpenAPI_nf_type_SMF: {
             bool match = true;
+
+            smf_info_checked = true;
 
             if (need_smf_slice) {
                 match = ogs_sbi_check_smf_info_slice(&nf_info->smf,
@@ -2202,12 +2205,13 @@ bool ogs_sbi_discovery_option_is_matched(
             if (match)
                 smf_match_found = true;
             break;
+        }
         default:
             break;
         }
     }
 
-    if (nf_instance->nf_type == OpenAPI_nf_type_SMF &&
+    if (nf_instance->nf_type == OpenAPI_nf_type_SMF && smf_info_checked &&
         (need_smf_slice || need_smf_tai) && smf_match_found == false)
         return false;
 


### PR DESCRIPTION
**Problem**

In a setup with a single AMF and multiple SMFs, the AMF was failing to select an appropriate SMF, resulting in _No SMF Instance_ errors.

The root cause was in `ogs_sbi_discovery_option_is_matched()`. This function incorrectly required every `smfInfo` block advertised in an SMF's profile to match the request's filters (S-NSSAI, DNN, TAI). This "AND" logic returned `false` as soon as a single block failed to match.

This logic fails for common configurations where an SMF supports multiple, distinct service areas or DNNs. For example, consider an SMF configured with the following `smfInfo`:

```
info:
  - s_nssai:
      - sst: 1
        dnn:
          - dnn-1
    tai:
      - plmn_id:
          mcc: 999
          mnc: 99
        tac: 123
  - s_nssai:
      - sst: 1
        dnn:
          - dnn-2
```



The intent here is to select this SMF if the request is for:

1. `dnn-1` AND a matching TAI (e.g., TAC 123)
2. OR `dnn-2` (with no TAI restriction)

With the previous logic, a request for `dnn-2` would fail because the function would also check the first block, which does have a TAI filter. Since the request for `dnn-2` might not match the TAI from the first block, the entire SMF instance would be rejected.

**Solution**

This PR updates `ogs_sbi_discovery_option_is_matched()` to implement the correct "OR" logic as specified by the 3GPP standards for NF discovery.

The function now iterates through each `smfInfo` block in the SMF's profile. It considers the SMF instance a match if any single block satisfies all the filters present in the discovery request. 

Note that the existing matching behavior for all other NF types is preserved and remains unaffected by this change.

