### PR TITLE
fix: crash if no associated sgwu in sgwc

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -418,14 +418,20 @@ void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
         ogs_pfcp_self()->pfcp_node =
             ogs_list_last(&ogs_pfcp_self()->pfcp_peer_list);
 
-    /* setup GTP session with selected SGW-U */
-    ogs_pfcp_self()->pfcp_node =
-        selected_sgwu_node(ogs_pfcp_self()->pfcp_node, sess);
-    ogs_assert(ogs_pfcp_self()->pfcp_node);
-    OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
-    ogs_debug("UE using SGW-U on IP %s",
-            ogs_sockaddr_to_string_static(
-                ogs_pfcp_self()->pfcp_node->addr_list));
+    if (ogs_pfcp_self()->pfcp_node) {
+
+        /* setup GTP session with selected SGW-U */
+        ogs_pfcp_self()->pfcp_node =
+            selected_sgwu_node(ogs_pfcp_self()->pfcp_node, sess);
+        ogs_assert(ogs_pfcp_self()->pfcp_node);
+        OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
+        ogs_debug("UE using SGW-U on IP %s",
+                ogs_sockaddr_to_string_static(
+                    ogs_pfcp_self()->pfcp_node->addr_list));
+    } else {
+        ogs_error("No suitable SGWU found for session");
+        ogs_assert(sess->pfcp_node == NULL);
+    }
 }
 
 int sgwc_sess_remove(sgwc_sess_t *sess)

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -291,6 +291,16 @@ void sgwc_s11_handle_create_session_request(
     /* Select SGW-U based on UE Location Information */
     sgwc_sess_select_sgwu(sess);
 
+    if (!sess->pfcp_node) {
+        ogs_error("[%s:%s] No SGWU available for session",
+                  sgwc_ue->imsi_bcd, sess->session.name);
+        ogs_gtp_send_error_message(
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
+                OGS_GTP2_CAUSE_SYSTEM_FAILURE);
+        return;
+    }
+
     /* Check if selected SGW-U is associated with SGW-C */
     ogs_assert(sess->pfcp_node);
     if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {


### PR DESCRIPTION
This fixes a crash when no sgwu is associated with sgwc when a ue tries to setup a bearer.
This is similar to the issue from here: https://github.com/open5gs/open5gs/issues/3907