### PR TITLE
mme: Delete session when default E-RAB setup fails

### DIFF
--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -115,7 +115,7 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 
     bearer = sgwc_bearer_find_by_id(bearer_id);
     if (!bearer) {
-        ogs_error("Bearer has already been removed [%d]", type);
+        ogs_warn("Bearer has already been removed [%d]", type);
         return;
     }
 

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -42,7 +42,7 @@ static void gtp_bearer_timeout(ogs_gtp_xact_t *xact, void *data)
 
     bearer = smf_bearer_find_by_id(bearer_id);
     if (!bearer) {
-        ogs_error("Bearer has already been removed [%d]", type);
+        ogs_warn("Bearer has already been removed [%d]", type);
         return;
     }
 

--- a/tests/volte/session-test.c
+++ b/tests/volte/session-test.c
@@ -688,12 +688,336 @@ static void test2_func(abts_case *tc, void *data)
     test_ue_remove(test_ue);
 }
 
+static void test_issues4141_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    ogs_s1ap_message_t message;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "1032548691");
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x1079baf;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_COMBINED_EPS_IMSI_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* eNB connects to MME */
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    /* eNB connects to SGW */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send S1-Setup Reqeust */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive S1-Setup Response */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_session(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.drx_parameter = 1;
+    test_ue->attach_request_param.ms_network_capability = 1;
+    test_ue->attach_request_param.tmsi_status = 1;
+    test_ue->attach_request_param.mobile_station_classmark_2 = 1;
+    test_ue->attach_request_param.ue_usage_setting = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response */
+    sess->esm_information_param.pco = 1;
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Initial Context Setup Request +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Initial Context Setup Response */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    test_ue->nr_cgi.cell_id = 0x1234502;
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send PDN Connectivity Request */
+    sess = test_sess_add_by_apn(test_ue, "ims", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+    sess->pti = 5;
+
+    sess->pdn_connectivity_param.apn = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, true, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive E-RABSetupRequest +
+     * Activate default EPS bearer context request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            S1AP_ProcedureCode_id_E_RABSetup,
+            test_ue->s1ap_procedure_code);
+
+    /* Send E-RABSetupResponse */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 6);
+    ogs_assert(bearer);
+    sendbuf = test_s1ap_build_e_rab_failed_setup_response(
+            bearer,
+            S1AP_Cause_PR_radioNetwork,
+            S1AP_CauseRadioNetwork_failure_in_radio_interface_procedure);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(100);
+
+    /* Again - Send PDN Connectivity Request */
+    sess->pti = 6;
+
+    sess->pdn_connectivity_param.apn = 1;
+    sess->pdn_connectivity_param.pco = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, true, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive E-RABSetupRequest +
+     * Activate default EPS bearer context request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            S1AP_ProcedureCode_id_E_RABSetup,
+            test_ue->s1ap_procedure_code);
+
+    /* Send E-RABSetupResponse */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 8);
+    ogs_assert(bearer);
+    sendbuf = test_s1ap_build_e_rab_setup_response(bearer);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Activate default EPS bearer context accept */
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, true);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive E-RABSetupRequest +
+     * Activate dedicated EPS bearer context request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            S1AP_ProcedureCode_id_E_RABSetup,
+            test_ue->s1ap_procedure_code);
+
+    /* Send Activate dedicated EPS bearer context accept */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 9);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_dedicated_eps_bearer_context_accept(bearer);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send E-RABSetupResponse */
+    sendbuf = test_s1ap_build_e_rab_setup_response(bearer);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* DELAY is needed in dedicated EPS bearer */
+    ogs_msleep(100);
+
+    /* Send GTP-U ICMP Packet */
+    rv = test_gtpu_send_ping(gtpu, bearer, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = test_gtpu_read(gtpu);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send UE Context Release Request */
+    sendbuf = test_s1ap_build_ue_context_release_request(test_ue,
+            S1AP_Cause_PR_radioNetwork, S1AP_CauseRadioNetwork_user_inactivity);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from MME */
+    testenb_s1ap_close(s1ap);
+
+    /* eNB disonncect from SGW */
+    test_gtpu_close(gtpu);
+
+    test_ue_remove(test_ue);
+}
+
 abts_suite *test_session(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
 
     abts_run_test(suite, test1_func, NULL);
     abts_run_test(suite, test2_func, NULL);
+    abts_run_test(suite, test_issues4141_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
When the MME receives an E-RAB Setup Response with failure for the default bearer, the PDN session remains in MME/SGWC context even though it was never activated. As a result, when the UE retries PDN Connectivity Request for the same APN, the MME prints "APN duplicated [ims]" and rejects the request.

This patch fixes the issue by sending a Delete Session Request toward SGWC when the default E-RAB setup fails. The failed PDN session is then removed, allowing the UE to reattempt PDN connectivity for the same APN.

Added a new regression test (test_issues4141_func) that reproduces the scenario:
 - First PDN Connectivity Request for IMS fails (E-RAB setup failure)
 - MME sends Delete Session Request
 - Second PDN Connectivity Request for IMS succeeds normally

Issue: #4141