### PR TITLE
Fix subnet validation before acessing it.

### DIFF
--- a/docs/_pages/features.md
+++ b/docs/_pages/features.md
@@ -21,6 +21,7 @@ Open5GS is a C-language Open Source implementation of 5GC and EPC, i.e. the core
 - VoLTE(Voice over LTE) with HSS-Cx interface
 - VoNR(Voice over NR)
 - 5G Roaming
+- Non-NAT bridge
 
 #### Known Limitations
 ---

--- a/lib/core/ogs-sockaddr.c
+++ b/lib/core/ogs-sockaddr.c
@@ -799,6 +799,26 @@ int ogs_ipsubnet(ogs_ipsubnet_t *ipsub,
     return OGS_OK;
 }
 
+int ogs_macaddress(uint8_t *mac_addr,
+        const char *macaddressstr)
+{
+    if(strlen(macaddressstr) != 17) {
+        ogs_error("Bad ether address %s", macaddressstr);
+        return OGS_ERROR;
+    }
+    if(sscanf(macaddressstr, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+        mac_addr + 0,
+        mac_addr + 1,
+        mac_addr + 2,
+        mac_addr + 3,
+        mac_addr + 4,
+        mac_addr + 5) != 6) {
+        ogs_error("Bad ether address %s", macaddressstr);
+        return OGS_ERROR;
+    }
+    return OGS_OK;
+}
+
 char *ogs_gethostname(ogs_sockaddr_t *addr)
 {
     return addr->hostname;

--- a/lib/core/ogs-sockaddr.h
+++ b/lib/core/ogs-sockaddr.h
@@ -120,6 +120,9 @@ bool ogs_sockaddr_check_any_match(
 int ogs_ipsubnet(ogs_ipsubnet_t *ipsub,
         const char *ipstr, const char *mask_or_numbits);
 
+int ogs_macaddress(uint8_t *mac_addr,
+        const char *macaddressstr);
+
 char *ogs_gethostname(ogs_sockaddr_t *addr);
 char *ogs_ipstrdup(ogs_sockaddr_t *addr);
 char *ogs_sockaddr_to_string_static(ogs_sockaddr_t *sa_list);

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -758,6 +758,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         ogs_pfcp_subnet_t *subnet = NULL;
                         const char *ipstr = NULL;
                         const char *gateway = NULL;
+                        const char *mac_address = NULL;
                         const char *mask_or_numbits = NULL;
                         const char *dnn = NULL;
                         const char *dev = self.tun_ifname;
@@ -798,6 +799,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                                 }
                             } else if (!strcmp(subnet_key, "gateway")) {
                                 gateway = ogs_yaml_iter_value(&subnet_iter);
+                            } else if (!strcmp(subnet_key, "mac_address")) {
+                                mac_address = ogs_yaml_iter_value(&subnet_iter);
                             } else if (!strcmp(subnet_key, "apn") ||
                                         !strcmp(subnet_key, "dnn")) {
                                 dnn = ogs_yaml_iter_value(&subnet_iter);
@@ -842,7 +845,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         }
 
                         subnet = ogs_pfcp_subnet_add(
-                                ipstr, mask_or_numbits, gateway, dnn, dev);
+                                ipstr, mask_or_numbits, gateway, dnn, dev, mac_address);
                         ogs_assert(subnet);
 
                         subnet->num_of_range = num;
@@ -2386,7 +2389,7 @@ ogs_pfcp_dev_t *ogs_pfcp_dev_find_by_ifname(const char *ifname)
 
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
         const char *ipstr, const char *mask_or_numbits,
-        const char *gateway, const char *dnn, const char *ifname)
+        const char *gateway, const char *dnn, const char *ifname, const char *mac_address)
 {
     int rv;
     ogs_pfcp_dev_t *dev = NULL;
@@ -2449,6 +2452,12 @@ ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
 
     if (gateway) {
         rv = ogs_ipsubnet(&subnet->gw, gateway, NULL);
+        ogs_assert(rv == OGS_OK);
+    }
+
+    if (mac_address) {
+        subnet->bridge = true;
+        rv = ogs_macaddress((uint8_t *)&subnet->mac_addr, mac_address);
         ogs_assert(rv == OGS_OK);
     }
 

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -367,6 +367,8 @@ typedef struct ogs_pfcp_subnet_s {
     ogs_ipsubnet_t  sub;                    /* Subnet : 2001:db8:cafe::0/48 */
     ogs_ipsubnet_t  gw;                     /* Gateway : 2001:db8:cafe::1 */
     char            dnn[OGS_MAX_DNN_LEN+1]; /* DNN : "internet", "volte", .. */
+    uint8_t         mac_addr[6];            /* Gateway MAC address: 48:A9:8A:8C:E1:15 */
+    bool            bridge;                 /* Bridge mode enable? */
 
 #define OGS_MAX_NUM_OF_SUBNET_RANGE 16
     struct {
@@ -511,7 +513,8 @@ ogs_pfcp_dev_t *ogs_pfcp_dev_find_by_ifname(const char *ifname);
 
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_add(
         const char *ipstr, const char *mask_or_numbits,
-        const char *gateway, const char *dnn, const char *ifname);
+        const char *gateway, const char *dnn, const char *ifname,
+        const char *mac_address);
 ogs_pfcp_subnet_t *ogs_pfcp_subnet_next(ogs_pfcp_subnet_t *subnet);
 void ogs_pfcp_subnet_remove(ogs_pfcp_subnet_t *subnet);
 void ogs_pfcp_subnet_remove_all(void);

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -55,6 +55,21 @@
 
 #define UPF_GTP_HANDLED     1
 
+#include <err.h>
+
+uint8_t *pfcp_ue_mac_addr(uint32_t ip);
+uint8_t *pfcp_ue_mac_addr(uint32_t ip) {
+    uint8_t *ue_mac_addr = malloc(6);
+    ue_mac_addr[0] = 0x0e;
+    ue_mac_addr[1] = 0x00;
+    ue_mac_addr[2] = ip;
+    ue_mac_addr[3] = ip >> 8;
+    ue_mac_addr[4] = ip >> 16;
+    ue_mac_addr[5] = ip >> 24;
+    
+    return ue_mac_addr;
+}
+
 const uint8_t proxy_mac_addr[] = { 0x0e, 0x00, 0x00, 0x00, 0x00, 0x01 };
 
 static ogs_pkbuf_pool_t *packet_pool = NULL;
@@ -126,12 +141,25 @@ static void _gtpv1_tun_recv_common_cb(
             if (is_arp_req(recvbuf->data, recvbuf->len) &&
                     upf_sess_find_by_ipv4(
                         arp_parse_target_addr(recvbuf->data, recvbuf->len))) {
+                ogs_pfcp_subnet_t *subnet;
+                subnet = ogs_pfcp_find_subnet(AF_INET);
                 replybuf = ogs_pkbuf_alloc(packet_pool, OGS_MAX_PKT_LEN);
                 ogs_assert(replybuf);
                 ogs_pkbuf_reserve(replybuf, OGS_TUN_MAX_HEADROOM);
                 ogs_pkbuf_put(replybuf, OGS_MAX_PKT_LEN-OGS_TUN_MAX_HEADROOM);
-                size = arp_reply(replybuf->data, recvbuf->data, recvbuf->len,
-                    proxy_mac_addr);
+
+                /* In bridge mode, create a MAC address based on UE IP */
+                /* In normal mode, use a fixed MAC address */
+                if(subnet && subnet->bridge) {
+                    uint8_t *ue_mac_addr;
+                    ue_mac_addr = pfcp_ue_mac_addr(arp_parse_target_addr(recvbuf->data, recvbuf->len));
+                    size = arp_reply(replybuf->data, recvbuf->data, recvbuf->len,
+                        ue_mac_addr);
+                    free(ue_mac_addr);
+                } else {
+                    size = arp_reply(replybuf->data, recvbuf->data, recvbuf->len,
+                        proxy_mac_addr);
+                }
                 ogs_pkbuf_trim(replybuf, size);
                 ogs_info("[SEND] reply to ARP request: %u", size);
             } else {
@@ -139,12 +167,19 @@ static void _gtpv1_tun_recv_common_cb(
             }
         } else if (eth_type == ETHERTYPE_IPV6 &&
                     is_nd_req(recvbuf->data, recvbuf->len)) {
+            ogs_pfcp_subnet_t *subnet;
+            subnet = ogs_pfcp_find_subnet(AF_INET6);
             replybuf = ogs_pkbuf_alloc(packet_pool, OGS_MAX_PKT_LEN);
             ogs_assert(replybuf);
             ogs_pkbuf_reserve(replybuf, OGS_TUN_MAX_HEADROOM);
             ogs_pkbuf_put(replybuf, OGS_MAX_PKT_LEN-OGS_TUN_MAX_HEADROOM);
-            size = nd_reply(replybuf->data, recvbuf->data, recvbuf->len,
-                proxy_mac_addr);
+
+            /* In bridge mode, create a MAC address based on UE IP */
+            /* In normal mode, use a fixed MAC address */
+            if(subnet->bridge == false) {
+                size = nd_reply(replybuf->data, recvbuf->data, recvbuf->len,
+                    proxy_mac_addr);
+            }
             ogs_pkbuf_trim(replybuf, size);
             ogs_info("[SEND] reply to ND solicit: %u", size);
         }
@@ -725,9 +760,21 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                 ogs_pkbuf_push(pkbuf, sizeof(eth_type));
                 memcpy(pkbuf->data, &eth_type, sizeof(eth_type));
                 ogs_pkbuf_push(pkbuf, ETHER_ADDR_LEN);
-                memcpy(pkbuf->data, proxy_mac_addr, ETHER_ADDR_LEN);
-                ogs_pkbuf_push(pkbuf, ETHER_ADDR_LEN);
-                memcpy(pkbuf->data, dev->mac_addr, ETHER_ADDR_LEN);
+
+                /* In bridge mode, use the MAC address from the gateway */
+                /* In normal mode, use the MAC address from the interface */
+                if(subnet->bridge) {
+                    uint8_t *ue_mac_addr;
+                    ue_mac_addr = pfcp_ue_mac_addr(sess->ipv4->addr[0]);
+                    memcpy(pkbuf->data, ue_mac_addr, ETHER_ADDR_LEN);
+                    ogs_pkbuf_push(pkbuf, ETHER_ADDR_LEN);
+                    memcpy(pkbuf->data, subnet->mac_addr, ETHER_ADDR_LEN);
+                    free(ue_mac_addr);
+                } else {
+                    memcpy(pkbuf->data, proxy_mac_addr, ETHER_ADDR_LEN);
+                    ogs_pkbuf_push(pkbuf, ETHER_ADDR_LEN);
+                    memcpy(pkbuf->data, dev->mac_addr, ETHER_ADDR_LEN);
+                }
             }
 
             /* TODO: if destined to another UE, hairpin back out. */


### PR DESCRIPTION
Same as PR #3668, with a small fix to validate the existence of the subnet in src/upf/gpt-path.c (line 153) to prevent the UPF from crashing.