### PR TITLE
[metrics] fix memory leak

### DIFF
--- a/lib/metrics/prometheus/context.c
+++ b/lib/metrics/prometheus/context.c
@@ -295,6 +295,7 @@ mhd_server_access_handler(void *cls, struct MHD_Connection *connection,
         MHD_add_response_header(rsp, "Content-Type", "text/plain; version=0.0.4; charset=utf-8");
         ret = MHD_queue_response(connection, MHD_HTTP_OK, rsp);
         MHD_destroy_response(rsp);
+        prom_free((void *)buf);
         return (_MHD_Result)ret;
     }
 


### PR DESCRIPTION
Each time Prometheus scraper queried the metrics, there was a memory leak. Depending on the amount of metrics, this could amount to some 5MB/h of memory leakage (in case of a scrape every 10 second).