### PR TITLE
[UDM] Prevent udm_ue memory exhaustion

### DIFF
--- a/src/udm/udm-sm.c
+++ b/src/udm/udm-sm.c
@@ -38,6 +38,7 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
 {
     int rv;
     const char *api_version = NULL;
+    char *supi = NULL;
 
     ogs_sbi_stream_t *stream = NULL;
     ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
@@ -175,8 +176,12 @@ void udm_state_operational(ogs_fsm_t *s, udm_event_t *e)
             }
 
             if (!udm_ue) {
-                udm_ue = udm_ue_find_by_suci_or_supi(
-                        message.h.resource.component[0]);
+                supi = ogs_supi_from_supi_or_suci(
+                    message.h.resource.component[0]);
+                if (supi) {
+                    udm_ue = udm_ue_find_by_supi(supi);
+                }
+                ogs_free(supi);
                 if (!udm_ue) {
                     SWITCH(message.h.method)
                     CASE(OGS_SBI_HTTP_METHOD_POST)


### PR DESCRIPTION
Good Day,

I have noticed that when running the UDM for a long period of time, the udm_ue pool runs out of memory.  I observed that the same device would register using a recalculated SUCI.  As these unique SUCIs created a new udm_ue, the pool ran out.  This will resolve the issue by decoding the SUCI to the SUPI to ensure that the udm_ue is indexed on the SUPI.