### PR TITLE
[AMF] fix checking for correct serving TAI

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2531,7 +2531,9 @@ int amf_find_served_tai(ogs_5gs_tai_t *nr_tai)
             ogs_assert(list1->tai[j].type == OGS_TAI1_TYPE);
             ogs_assert(list1->tai[j].num <= OGS_MAX_NUM_OF_TAI);
 
-            if (list1->tai[j].tac.v <= nr_tai->tac.v &&
+            if (memcmp(&list1->tai[j].plmn_id,
+                    &nr_tai->plmn_id, OGS_PLMN_ID_LEN) == 0 &&
+                list1->tai[j].tac.v <= nr_tai->tac.v &&
                 nr_tai->tac.v < (list1->tai[j].tac.v+list1->tai[j].num))
                 return i;
         }


### PR DESCRIPTION
In case gNB sends a NGSetupRequest with a TAI that AMF does not serve, AMF would in some cases respond with a NGSetupSuccess instead of NGSetupFailure.
This is because of a missing check for correct PLMN.

For example, AMF was configured with the following:
PLMN 001-01:
    tac: [1000-1100]
PLMN 999-93:
    tac: [2000-2200]

gNB sent NGSetupRequest for PLMN 999-93 and with TAC 1050. AMF would only check the TAC, instead of also PLMN.