### PR TITLE
mme: Fix crash caused by inconsistent ESM/EMM session state during TAU + Attach

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -1061,7 +1061,7 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
 
 void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
 {
-    int r, rv;
+    int r, rv, xact_count;
     mme_ue_t *mme_ue = NULL;
     enb_ue_t *enb_ue = NULL;
     ogs_nas_eps_message_t *message = NULL;
@@ -1097,6 +1097,8 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
             ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
             break;
         }
+
+        xact_count = mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR);
 
         switch (message->emm.h.message_type) {
         case OGS_NAS_EPS_AUTHENTICATION_RESPONSE:
@@ -1162,7 +1164,15 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
                 break;
             }
 
-            mme_s6a_send_air(enb_ue, mme_ue, NULL);
+            mme_gtp_send_delete_all_sessions(enb_ue, mme_ue,
+                OGS_GTP_DELETE_SEND_AUTHENTICATION_REQUEST);
+
+            if (!MME_SESSION_RELEASE_PENDING(mme_ue) &&
+                mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR) ==
+                    xact_count) {
+                mme_s6a_send_air(enb_ue, mme_ue, NULL);
+            }
+
             OGS_FSM_TRAN(s, &emm_state_authentication);
             break;
         case OGS_NAS_EPS_EMM_STATUS:
@@ -1250,7 +1260,7 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e)
 
 void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
 {
-    int r, rv;
+    int r, rv, xact_count;
     mme_ue_t *mme_ue = NULL;
     enb_ue_t *enb_ue = NULL;
     ogs_nas_eps_message_t *message = NULL;
@@ -1289,6 +1299,8 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
             ogs_log_hexdump(OGS_LOG_ERROR, e->pkbuf->data, e->pkbuf->len);
             break;
         }
+
+        xact_count = mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR);
 
         if (message->emm.h.security_header_type
                 == OGS_NAS_SECURITY_HEADER_FOR_SERVICE_REQUEST_MESSAGE) {
@@ -1405,7 +1417,15 @@ void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e)
                 break;
             }
 
-            mme_s6a_send_air(enb_ue, mme_ue, NULL);
+            mme_gtp_send_delete_all_sessions(enb_ue, mme_ue,
+                OGS_GTP_DELETE_SEND_AUTHENTICATION_REQUEST);
+
+            if (!MME_SESSION_RELEASE_PENDING(mme_ue) &&
+                mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR) ==
+                    xact_count) {
+                mme_s6a_send_air(enb_ue, mme_ue, NULL);
+            }
+
             OGS_FSM_TRAN(s, &emm_state_authentication);
             break;
         case OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST:


### PR DESCRIPTION
When a UE performs TAU followed by a new Attach Request after a failed Security Mode Command, the MME may crash while handling the subsequent ESM Information Response. This occurs when multiple ESM sessions already exist (e.g., default EPS session + PDN connectivity session), and the internal session state is not properly reset.

In this scenario, the ESM handler incorrectly assumes that only one session should exist and triggers the assertion:

    "There should only be one SESSION"

This patch adds additional protection during the EMM authentication and security_mode states by:

  * Deleting all existing GTP sessions before triggering a new AIR
  * Recording the GTP transaction count and validating that no new transactions were created during cleanup
  * Sending AIR only when session release is not pending and the transaction count remains unchanged

These checks prevent ESM/EMM state inconsistencies and avoid the crash in esm_handle_information_response().

Fixes: crash in TAU + Security failure + Attach sequence

Issues: #4172