### PR TITLE
AMF: Skip GMM reject for Deregistration Request to avoid SBI timeout crash

### DIFF
--- a/src/amf/nas-path.c
+++ b/src/amf/nas-path.c
@@ -932,6 +932,9 @@ int nas_5gs_send_gmm_reject(
         rv = nas_5gs_send_service_reject(ran_ue, amf_ue, gmm_cause);
         ogs_expect(rv == OGS_OK);
         break;
+    case OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE: 
+        ogs_warn("Skip GMM reject for Deregistration Request [%d]", amf_ue->nas.message_type); 
+        break;
     default:
         ogs_error("Unknown message type [%d]", amf_ue->nas.message_type);
         rv = OGS_ERROR;


### PR DESCRIPTION
Hello, and thank you for your work.

When I generated a high volume of traffic, the AMF crashed with the following log:

```
12/01 16:00:20.961: [amf] DEBUG:     IP[10.244.1.211] RAN_ID[8] (../src/amf/ngap-handler.c:1687)
12/01 16:00:20.961: [amf] INFO: UE Context Release [Action:2] (../src/amf/ngap-handler.c:1733)
12/01 16:00:20.961: [amf] INFO:     RAN_UE_NGAP_ID[12821] AMF_UE_NGAP_ID[13421] (../src/amf/ngap-handler.c:1734)
12/01 16:00:20.961: [amf] INFO:     SUCI[suci-0-208-93-0000-0-0-0000005490] (../src/amf/ngap-handler.c:1738)
12/01 16:00:20.961: [amf] DEBUG:     Action: NG normal release (../src/amf/ngap-handler.c:1757)
12/01 16:00:20.961: [amf] INFO: [Removed] Number of gNB-UEs is now 4925 (../src/amf/context.c:2796)
12/01 16:00:20.961: [amf] DEBUG: amf_state_operational(): OGS_EVENT_NAME_SBI_CLIENT (../src/amf/amf-sm.c:84)
12/01 16:00:20.961: [amf] DEBUG: [imsi-208930000002691] Service accept (../src/amf/nas-path.c:247)
12/01 16:00:20.961: [gmm] DEBUG: [imsi-208930000002691]    PDU Session Status : 0200 (../src/amf/gmm-build.c:234)
12/01 16:00:20.961: [gmm] DEBUG: [imsi-208930000002691]    PDU Session Reactivation Result : 0000 (../src/amf/gmm-build.c:244)
12/01 16:00:20.961: [amf] DEBUG: InitialContextSetupRequest(UE) (../src/amf/ngap-build.c:470)
12/01 16:00:20.961: [amf] DEBUG:     RAN_UE_NGAP_ID[16920] AMF_UE_NGAP_ID[18198] (../src/amf/ngap-build.c:619)
12/01 16:00:20.961: [amf] DEBUG:     IP[10.244.1.211] RAN_ID[8] (../src/amf/ngap-path.c:64)
12/01 16:00:20.961: [amf] DEBUG: amf_state_operational(): OGS_EVENT_NAME_SBI_TIMER (../src/amf/amf-sm.c:84)
12/01 16:00:20.961: [amf] ERROR: [imsi-208930000007881:suci-0-208-93-0000-0-0-0000007881] Cannot receive SBI message (../src/amf/amf-sm.c:784)
12/01 16:00:20.961: [amf] WARNING: [suci-0-208-93-0000-0-0-0000007881] Registration reject [90] (../src/amf/nas-path.c:213)
12/01 16:00:20.961: [amf] DEBUG: DownlinkNASTransport (../src/amf/ngap-build.c:314)
12/01 16:00:20.961: [amf] DEBUG:     RAN_UE_NGAP_ID[14295] AMF_UE_NGAP_ID[15059] (../src/amf/ngap-build.c:357)
12/01 16:00:20.961: [amf] DEBUG:     IP[10.244.1.211] RAN_ID[8] (../src/amf/ngap-path.c:64)
12/01 16:00:20.961: [amf] DEBUG: amf_state_operational(): OGS_EVENT_NAME_SBI_TIMER (../src/amf/amf-sm.c:84)
12/01 16:00:20.961: [amf] ERROR: [imsi-208930000003037:suci-0-208-93-0000-0-0-0000003037] Cannot receive SBI message (../src/amf/amf-sm.c:784)
12/01 16:00:20.961: [amf] ERROR: Unknown message type [69] (../src/amf/nas-path.c:936)
12/01 16:00:20.961: [amf] ERROR: nas_5gs_send_gmm_reject_from_sbi: Expectation `rv == OGS_OK' failed. (../src/amf/nas-path.c:982)
12/01 16:00:20.961: [amf] ERROR: amf_state_operational: Expectation `r == OGS_OK' failed. (../src/amf/amf-sm.c:815)
12/01 16:00:20.961: [amf] FATAL: amf_state_operational: Assertion `r != OGS_ERROR' failed. (../src/amf/amf-sm.c:816)
12/01 16:00:20.961: [core] FATAL: backtrace() returned 7 addresses (../lib/core/ogs-abort.c:37)
open5gs-amfd(+0x4388a) [0x55702614588a]
/opt/open5gs/lib/x86_64-linux-gnu/libogscore.so.2(ogs_fsm_dispatch+0x10f) [0x7fb5b9e18922]
open5gs-amfd(+0x929a) [0x55702610b29a]
/opt/open5gs/lib/x86_64-linux-gnu/libogscore.so.2(+0x10707) [0x7fb5b9e09707]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7ea7) [0x7fb5b9185ea7]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7fb5b90a5adf]
/entrypoint.sh: line 43:     7 Aborted                 (core dumped) $@
```

The crash is caused by nas_5gs_send_gmm_reject() in nas-path.c returning OGS_ERROR when amf_ue->nas.message_type is neither a Registration Request nor a Service Request.

In this scenario, nas_5gs_send_gmm_reject_from_sbi() is invoked because the AMF NF hit an SBI timeout with another NF. 
When the UE initiates a Deregistration Request, the deregistration procedure also involves SBI transactions. If an SBI timeout occurs during deregistration, the AMF eventually calls nas_5gs_send_gmm_reject_from_sbi(), which in turn calls nas_5gs_send_gmm_reject(). Since the original NAS message type is Deregistration Request (message type 69), the function falls into the default branch, logs Unknown message type [69], sets rv = OGS_ERROR, and returns it. This propagates back to the AMF state machine, where ogs_assert(r != OGS_ERROR) fails, causing the AMF to abort.

This PR adds an explicit case for OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE in nas_5gs_send_gmm_reject() and skips sending a GMM reject for deregistration. Instead, it logs a warning and returns success, preventing the AMF crash.

According to 3GPP TS 24.501, there is no NAS 5GMM message type for Deregistration Reject; the deregistration procedure only defines Deregistration Request and Deregistration Accept. Likewise, 3GPP TS 29.524 does not define a specific error-cause mapping for deregistration in the same way it does for Registration and Service procedures.
Therefore, skipping GMM reject generation for deregistration on SBI timeout is consistent with the current 3GPP specifications and avoids an unnecessary AMF crash.