### PR TITLE
MME/S6a: Always set Initial-Attach-Indicator flag in ULR

### DIFF
--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -1368,6 +1368,7 @@ void mme_s6a_send_ulr(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     ret = fd_msg_avp_new(ogs_diam_s6a_ulr_flags, 0, &avp);
     ogs_assert(ret == 0);
     val.u32 = OGS_DIAM_S6A_ULR_S6A_S6D_INDICATOR;
+    val.u32 |= OGS_DIAM_S6A_ULR_INITIAL_ATTACH_IND;
     ret = fd_msg_avp_setvalue(avp, &val);
     ogs_assert(ret == 0);
     ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);


### PR DESCRIPTION
According to 3GPP TS 29.272 (5.2.1.1.2), when an Update Location Request is sent due to an initial attach, the MME shall set the "Initial-Attach-Indicator" flag in the ULR-Flags IE. This ensures that the HSS updates the MME identity and prevents ULA rejection with UNKNOWN_SERVING_NODE when UE moves between MMEs or when GUTI mismatch occurs.

Commercial MME/HSS implementations (e.g., Cisco StarOS) also set the Initial-Attach-Indicator flag by default to handle UEs that do not reset their GUTI when changing networks.

This patch hardcodes the Initial-Attach-Indicator bit for all ULR messages to align with expected practical behavior and resolve attach failures caused by HSS identity mismatch.

Issues: #4165