### PR TITLE
mme: Handle implicit detach when ENB-UE context is already removed

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -262,8 +262,6 @@ void emm_state_registered(ogs_fsm_t *s, mme_event_t *e)
          * detach timer such that the sum of the timer values is greater than
          * timer T3346.
          */
-            ogs_debug("[%s] Starting Implicit Detach timer",
-                mme_ue->imsi_bcd);
             ogs_timer_start(mme_ue->t_implicit_detach.timer,
                 ogs_time_from_sec(mme_self()->time.t3412.value + 240));
             break;
@@ -280,11 +278,8 @@ void emm_state_registered(ogs_fsm_t *s, mme_event_t *e)
             if (MME_CURRENT_P_TMSI_IS_AVAILABLE(mme_ue)) {
                 ogs_assert(OGS_OK == sgsap_send_detach_indication(mme_ue));
             } else {
-                enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-                if (enb_ue)
-                    mme_send_delete_session_or_detach(enb_ue, mme_ue);
-                else
-                    ogs_error("ENB-S1 Context has already been removed");
+                mme_send_delete_session_or_detach(
+                        enb_ue_find_by_id(mme_ue->enb_ue_id), mme_ue);
             }
 
             OGS_FSM_TRAN(s, &emm_state_de_registered);

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -362,7 +362,6 @@ int mme_gtp_send_delete_session_request(
     ogs_gtp_xact_t *xact = NULL;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_assert(enb_ue);
     ogs_assert(action);
     ogs_assert(sess);
     mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
@@ -388,7 +387,10 @@ int mme_gtp_send_delete_session_request(
     }
     xact->delete_action = action;
     xact->local_teid = mme_ue->gn.mme_gn_teid;
-    xact->enb_ue_id = enb_ue->id;
+    if (enb_ue)
+        xact->enb_ue_id = enb_ue->id;
+    else
+        xact->enb_ue_id = OGS_INVALID_POOL_ID;
     ogs_debug("delete_session_request - xact:%p, sess:%p", xact, sess);
 
     rv = ogs_gtp_xact_commit(xact);
@@ -403,7 +405,6 @@ void mme_gtp_send_delete_all_sessions(
     mme_sess_t *sess = NULL, *next_sess = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
-    ogs_assert(enb_ue);
     ogs_assert(mme_ue);
     sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);

--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -29,7 +29,6 @@ void mme_send_delete_session_or_detach(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
 {
     int r, xact_count;
     ogs_assert(mme_ue);
-    ogs_assert(enb_ue);
 
     xact_count = mme_ue_xact_count(mme_ue, OGS_GTP_LOCAL_ORIGINATOR);
 

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -729,11 +729,6 @@ void mme_s11_handle_delete_session_response(
         return;
     }
 
-    if (!enb_ue) {
-        ogs_error("ENB-S1 Context has already been removed");
-        return;
-    }
-
     if (!mme_ue) {
         ogs_error("MME-UE Context has already been removed");
         return;
@@ -883,6 +878,11 @@ void mme_s11_handle_delete_session_response(
     } else if (action == OGS_GTP_DELETE_SEND_TAU_ACCEPT) {
 
         MME_SESS_CLEAR(sess);
+
+        if (!enb_ue) {
+            ogs_error("ENB-S1 Context has already been removed");
+            return;
+        }
 
         GTP_COUNTER_CHECK(mme_ue, GTP_COUNTER_DELETE_SESSION_BY_TAU,
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -2158,7 +2158,7 @@ void s1ap_handle_ue_context_release_action(enb_ue_t *enb_ue)
         CLEAR_MME_UE_ALL_TIMERS(mme_ue);
 
         if (OGS_FSM_CHECK(&mme_ue->sm, emm_state_registered)) {
-            ogs_debug("Mobile Reachable timer started for IMSI[%s]",
+            ogs_info("Mobile Reachable timer started for IMSI[%s]",
                 mme_ue->imsi_bcd);
         /*
          * TS 24.301


### PR DESCRIPTION
When a CPE (4G router) loses power abruptly without sending a Detach Request, the ENB-UE context is removed first, causing the implicit detach process to fail. This leaves sessions active in SMF/UPF/SGWC/SGWU.

Changes:
- Allow mme_send_delete_session_or_detach() to accept NULL enb_ue
- Remove enb_ue assertion in mme_gtp_send_delete_session_request()
- Conditionally set xact->enb_ue_id only when enb_ue is present
- Remove enb_ue assertion in mme_gtp_send_delete_all_sessions()
- Move ENB-UE context check in mme_s11_handle_delete_session_response() after session cleanup to ensure proper resource release
- Change log level to INFO for Mobile Reachable timer in registered state

This ensures that implicit detach proceeds correctly even when the ENB-UE context has already been released, allowing proper cleanup of core network sessions.

Fixes session leak issue reported in GitHub issue #4194