### PR TITLE
smf: Prevent crash when Diameter session context is lost and recover gracefully

### DIFF
--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -138,7 +138,17 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         size_t sidlen = strlen(sess->gx_sid);
         ret = fd_sess_fromsid_msg((os0_t)sess->gx_sid, sidlen, &session, &new);
         ogs_assert(ret == 0);
-        ogs_assert(new == 0);
+        if (new) {
+            ogs_error("Gx Session [%s] missing in Diameter stack. "
+                    "Releasing PDU Session to recover.", sess->gx_sid);
+            ret = fd_msg_free(req);
+            ogs_assert(ret == 0);
+
+            ogs_free(sess->gx_sid);
+            sess->gx_sid = NULL;
+
+            return;
+        }
 
         ogs_debug("    Found Gx Session-Id: [%s]", sess->gx_sid);
 

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -673,7 +673,17 @@ void smf_gy_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         size_t sidlen = strlen(sess->gy_sid);
         ret = fd_sess_fromsid_msg((os0_t)sess->gy_sid, sidlen, &session, &new);
         ogs_assert(ret == 0);
-        ogs_assert(new == 0);
+        if (new) {
+            ogs_error("Gy Session [%s] missing in Diameter stack. "
+                    "Releasing PDU Session to recover.", sess->gy_sid);
+            ret = fd_msg_free(req);
+            ogs_assert(ret == 0);
+
+            ogs_free(sess->gy_sid);
+            sess->gy_sid = NULL;
+
+            return;
+        }
 
         ogs_debug("    Found Gy Session-Id: [%s]", sess->gy_sid);
         /* Add Session-Id to the message */

--- a/src/smf/s6b-path.c
+++ b/src/smf/s6b-path.c
@@ -128,7 +128,17 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
         size_t sidlen = strlen(sess->s6b_sid);
         ret = fd_sess_fromsid_msg((os0_t)sess->s6b_sid, sidlen, &session, &new);
         ogs_assert(ret == 0);
-        ogs_assert(new == 0);
+        if (new) {
+            ogs_error("S6b Session [%s] missing in Diameter stack. "
+                    "Releasing PDU Session to recover.", sess->s6b_sid);
+            ret = fd_msg_free(req);
+            ogs_assert(ret == 0);
+
+            ogs_free(sess->s6b_sid);
+            sess->s6b_sid = NULL;
+
+            return;
+        }
 
         ogs_debug("    Found S6b Session-Id: [%s]", sess->s6b_sid);
 
@@ -594,7 +604,17 @@ void smf_s6b_send_str(smf_sess_t *sess, ogs_gtp_xact_t *xact, uint32_t cause)
     sidlen = strlen(sess->s6b_sid);
     ret = fd_sess_fromsid_msg((os0_t)sess->s6b_sid, sidlen, &session, &new);
     ogs_assert(ret == 0);
-    ogs_assert(new == 0);
+    if (new) {
+        ogs_error("S6b Session [%s] missing in Diameter stack. "
+                "Releasing PDU Session to recover.", sess->s6b_sid);
+        ret = fd_msg_free(req);
+        ogs_assert(ret == 0);
+
+        ogs_free(sess->s6b_sid);
+        sess->s6b_sid = NULL;
+
+        return;
+    }
 
     ogs_debug("    Found S6b Session-Id: [%s]", sess->s6b_sid);
 


### PR DESCRIPTION

In long-running deployments, a mismatch can occur between SMF’s stored Gx/Gy/S6b Session-Id and the freeDiameter session table, typically after peer reconnection, watchdog timeout, or internal cleanup. In such cases `fd_sess_fromsid_msg()` may return `new != 0`, indicating that the Diameter stack created a new session instance instead of retrieving the existing one.

Previously, this condition triggered `ogs_assert(new == 0)` which caused a fatal crash of the SMF (and potentially SGWC), interrupting normal operation.

This patch replaces the assertion with a graceful recovery path:
- Log an error indicating that the Diameter session has been lost
- Free the pending request message and stored Session-Id
- Return early to trigger PDU session release handling by the upper layer
- Avoid process termination and maintain service continuity

This significantly improves robustness in long-running and fault-tolerant deployments with commercial-grade operational requirements.

Issues: #4195