### PR TITLE
Fix DNN Operator-Identifier format and refactor OI parsing for HR roaming interop

### DIFF
--- a/lib/core/ogs-compat.h
+++ b/lib/core/ogs-compat.h
@@ -61,6 +61,8 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include <ctype.h>
+
 #endif
 
 #endif

--- a/lib/core/ogs-strings.c
+++ b/lib/core/ogs-strings.c
@@ -420,3 +420,22 @@ char *ogs_trimcharacter(char *str, char to_remove)
     return ogs_right_trimcharacter(
             ogs_left_trimcharacter(str, to_remove), to_remove);
 }
+
+char *ogs_strrstr(const char *haystack, const char *needle)
+{
+    char *result = NULL;
+    char *p = (char *)haystack;
+
+    if (!haystack || !needle)
+        return NULL;
+
+    if (*needle == '\0')
+        return (char *)haystack;
+
+    while ((p = strstr(p, needle)) != NULL) {
+        result = p;
+        p++;
+    }
+
+    return result;
+}

--- a/lib/core/ogs-strings.h
+++ b/lib/core/ogs-strings.h
@@ -149,6 +149,8 @@ char *ogs_left_trimcharacter(char *str, char to_remove);
 char *ogs_right_trimcharacter(char *str, char to_remove);
 char *ogs_trimcharacter(char *str, char to_remove);
 
+char *ogs_strrstr(const char *haystack, const char *needle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -246,7 +246,8 @@ char *ogs_home_network_domain_from_plmn_id(const ogs_plmn_id_t *plmn_id);
 char *ogs_epc_domain_from_plmn_id(const ogs_plmn_id_t *plmn_id);
 char *ogs_nrf_fqdn_from_plmn_id(const ogs_plmn_id_t *plmn_id);
 char *ogs_nssf_fqdn_from_plmn_id(const ogs_plmn_id_t *plmn_id);
-char *ogs_home_network_domain_from_fqdn(char *fqdn);
+char *ogs_dnn_oi_from_plmn_id(const ogs_plmn_id_t *plmn_id);
+char *ogs_dnn_oi_from_fqdn(char *fqdn);
 uint16_t ogs_plmn_id_mnc_from_fqdn(char *fqdn);
 uint16_t ogs_plmn_id_mcc_from_fqdn(char *fqdn);
 

--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2907,7 +2907,7 @@ bool ogs_sbi_fqdn_in_vplmn(char *fqdn)
         return false;
     }
 
-    if (ogs_home_network_domain_from_fqdn(fqdn) == NULL) {
+    if (ogs_dnn_oi_from_fqdn(fqdn) == NULL) {
         return false;
     }
 

--- a/src/amf/nsmf-build.c
+++ b/src/amf/nsmf-build.c
@@ -95,15 +95,13 @@ ogs_sbi_request_t *amf_nsmf_pdusession_build_create_sm_context(
      * is absent, the serving core network operator shall be assumed.
      */
     if (ogs_sbi_plmn_id_in_vplmn(&amf_ue->home_plmn_id) == true) {
-        char *home_network_domain =
-            ogs_home_network_domain_from_plmn_id(&amf_ue->home_plmn_id);
-        ogs_assert(home_network_domain);
+        char *dnn_oi = ogs_dnn_oi_from_plmn_id(&amf_ue->home_plmn_id);
+        ogs_assert(dnn_oi);
 
-        SmContextCreateData.dnn =
-            ogs_msprintf("%s.%s", sess->dnn, home_network_domain);
+        SmContextCreateData.dnn = ogs_msprintf("%s.%s", sess->dnn, dnn_oi);
         ogs_assert(SmContextCreateData.dnn);
 
-        ogs_free(home_network_domain);
+        ogs_free(dnn_oi);
 
     } else {
 

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -234,7 +234,7 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
     uint16_t fqdn_port = 0;
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
 
-    char *home_network_domain = NULL;
+    char *dnn_oi = NULL;
 
     ogs_assert(sess);
     pcf_ue_sm = pcf_ue_sm_find_by_id(sess->pcf_ue_sm_id);
@@ -369,22 +369,20 @@ bool pcf_npcf_smpolicycontrol_handle_create(pcf_sess_t *sess,
      * The DNN of the PDU session, a full DNN with both the Network Identifier
      * and Operator Identifier, or a DNN with the Network Identifier only
      */
-    home_network_domain = ogs_home_network_domain_from_fqdn(
-            SmPolicyContextData->dnn);
+    dnn_oi = ogs_dnn_oi_from_fqdn(SmPolicyContextData->dnn);
 
-    if (home_network_domain) {
-        char dnn_network_identifer[OGS_MAX_DNN_LEN+1];
+    if (dnn_oi) {
+        char dnn_ni[OGS_MAX_DNN_LEN+1];
         uint16_t mcc = 0, mnc = 0;
 
-        ogs_assert(home_network_domain > SmPolicyContextData->dnn);
+        ogs_assert(dnn_oi > SmPolicyContextData->dnn);
 
-        ogs_cpystrn(dnn_network_identifer, SmPolicyContextData->dnn,
-            ogs_min(OGS_MAX_DNN_LEN,
-                home_network_domain - SmPolicyContextData->dnn));
+        ogs_cpystrn(dnn_ni, SmPolicyContextData->dnn,
+            ogs_min(OGS_MAX_DNN_LEN, dnn_oi - SmPolicyContextData->dnn));
 
         if (sess->dnn)
             ogs_free(sess->dnn);
-        sess->dnn = ogs_strdup(dnn_network_identifer);
+        sess->dnn = ogs_strdup(dnn_ni);
         ogs_assert(sess->dnn);
 
         if (sess->full_dnn)

--- a/src/smf/npcf-build.c
+++ b/src/smf/npcf-build.c
@@ -115,17 +115,16 @@ ogs_sbi_request_t *smf_npcf_smpolicycontrol_build_create(
      * and Operator Identifier, or a DNN with the Network Identifier only
      */
     if (ogs_sbi_supi_in_vplmn(smf_ue->supi) == true) {
-        char *home_network_domain = NULL;
+        char *dnn_oi = NULL;
 
-        home_network_domain =
-            ogs_home_network_domain_from_plmn_id(&sess->home_plmn_id);
-        ogs_assert(home_network_domain);
+        dnn_oi = ogs_dnn_oi_from_plmn_id(&sess->home_plmn_id);
+        ogs_assert(dnn_oi);
 
         SmPolicyContextData.dnn =
-            ogs_msprintf("%s.%s", sess->session.name, home_network_domain);
+            ogs_msprintf("%s.%s", sess->session.name, dnn_oi);
         ogs_assert(SmPolicyContextData.dnn);
 
-        ogs_free(home_network_domain);
+        ogs_free(dnn_oi);
 
     } else {
         SmPolicyContextData.dnn = ogs_strdup(sess->session.name);

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -43,7 +43,7 @@ bool smf_nsmf_handle_create_sm_context(
     char *fqdn = NULL;
     uint16_t fqdn_port = 0;
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
-    char *home_network_domain = NULL;
+    char *dnn_oi = NULL;
 
     OpenAPI_sm_context_create_data_t *SmContextCreateData = NULL;
     OpenAPI_nr_location_t *NrLocation = NULL;
@@ -353,22 +353,20 @@ bool smf_nsmf_handle_create_sm_context(
      * the full DNN in LBO and non-roaming scenarios. If the Operator Identifier
      * is absent, the serving core network operator shall be assumed.
      */
-    home_network_domain =
-        ogs_home_network_domain_from_fqdn(SmContextCreateData->dnn);
+    dnn_oi = ogs_dnn_oi_from_fqdn(SmContextCreateData->dnn);
 
-    if (home_network_domain) {
-        char dnn_network_identifer[OGS_MAX_DNN_LEN+1];
+    if (dnn_oi) {
+        char dnn_ni[OGS_MAX_DNN_LEN+1];
         uint16_t mcc = 0, mnc = 0;
 
-        ogs_assert(home_network_domain > SmContextCreateData->dnn);
+        ogs_assert(dnn_oi > SmContextCreateData->dnn);
 
-        ogs_cpystrn(dnn_network_identifer, SmContextCreateData->dnn,
-            ogs_min(OGS_MAX_DNN_LEN,
-                home_network_domain - SmContextCreateData->dnn));
+        ogs_cpystrn(dnn_ni, SmContextCreateData->dnn,
+            ogs_min(OGS_MAX_DNN_LEN, dnn_oi - SmContextCreateData->dnn));
 
         if (sess->session.name)
             ogs_free(sess->session.name);
-        sess->session.name = ogs_strdup(dnn_network_identifer);
+        sess->session.name = ogs_strdup(dnn_ni);
         ogs_assert(sess->session.name);
 
         if (sess->full_dnn)
@@ -1255,7 +1253,7 @@ bool smf_nsmf_handle_create_data_in_hsmf(
     char *fqdn = NULL;
     uint16_t fqdn_port = 0;
     ogs_sockaddr_t *addr = NULL, *addr6 = NULL;
-    char *home_network_domain = NULL;
+    char *dnn_oi = NULL;
 
     OpenAPI_pdu_session_create_data_t *PduSessionCreateData = NULL;
     OpenAPI_nr_location_t *NrLocation = NULL;
@@ -1325,21 +1323,19 @@ bool smf_nsmf_handle_create_data_in_hsmf(
         return false;
     }
 
-    home_network_domain =
-        ogs_home_network_domain_from_fqdn(PduSessionCreateData->dnn);
+    dnn_oi = ogs_dnn_oi_from_fqdn(PduSessionCreateData->dnn);
 
-    if (home_network_domain) {
-        char dnn_network_identifer[OGS_MAX_DNN_LEN+1];
+    if (dnn_oi) {
+        char dnn_ni[OGS_MAX_DNN_LEN+1];
 
-        ogs_assert(home_network_domain > PduSessionCreateData->dnn);
+        ogs_assert(dnn_oi > PduSessionCreateData->dnn);
 
-        ogs_cpystrn(dnn_network_identifer, PduSessionCreateData->dnn,
-            ogs_min(OGS_MAX_DNN_LEN,
-                home_network_domain - PduSessionCreateData->dnn));
+        ogs_cpystrn(dnn_ni, PduSessionCreateData->dnn,
+            ogs_min(OGS_MAX_DNN_LEN, dnn_oi - PduSessionCreateData->dnn));
 
         if (sess->session.name)
             ogs_free(sess->session.name);
-        sess->session.name = ogs_strdup(dnn_network_identifer);
+        sess->session.name = ogs_strdup(dnn_ni);
         ogs_assert(sess->session.name);
 
         if (sess->full_dnn)

--- a/tests/unit/proto-message-test.c
+++ b/tests/unit/proto-message-test.c
@@ -49,29 +49,29 @@ static void proto_message_test1(abts_case *tc, void *data)
 
 static void proto_message_test2(abts_case *tc, void *data)
 {
-    char *home_network_domain = NULL;
+    char *dnn_oi = NULL;
     char *full_dnn = NULL;
     char dnn_ni[OGS_MAX_DNN_LEN+1];
     ogs_plmn_id_t plmn_id1, plmn_id2;
 
     ogs_plmn_id_build(&plmn_id1, 456, 123, 3);
-    home_network_domain = ogs_home_network_domain_from_plmn_id(&plmn_id1);
+    dnn_oi = ogs_dnn_oi_from_plmn_id(&plmn_id1);
     ABTS_STR_EQUAL(tc,
-            "5gc.mnc123.mcc456.3gppnetwork.org", home_network_domain);
-    full_dnn = ogs_msprintf("internet.realm.%s", home_network_domain);
+            "mnc123.mcc456.gprs", dnn_oi);
+    full_dnn = ogs_msprintf("internet.realm.%s", dnn_oi);
     ABTS_STR_EQUAL(tc,
-            "internet.realm.5gc.mnc123.mcc456.3gppnetwork.org", full_dnn);
+            "internet.realm.mnc123.mcc456.gprs", full_dnn);
     ABTS_STR_EQUAL(tc,
-            home_network_domain, ogs_home_network_domain_from_fqdn(full_dnn));
+            dnn_oi, ogs_dnn_oi_from_fqdn(full_dnn));
 
     ogs_cpystrn(dnn_ni, full_dnn,
             ogs_min(OGS_MAX_DNN_LEN,
-                ogs_home_network_domain_from_fqdn(full_dnn) - full_dnn));
+                ogs_dnn_oi_from_fqdn(full_dnn) - full_dnn));
     ABTS_STR_EQUAL(tc, "internet.realm", dnn_ni);
 
     ABTS_INT_EQUAL(tc, 456, ogs_plmn_id_mcc_from_fqdn(full_dnn));
     ABTS_INT_EQUAL(tc, 123, ogs_plmn_id_mnc_from_fqdn(full_dnn));
-    ogs_free(home_network_domain);
+    ogs_free(dnn_oi);
     ogs_free(full_dnn);
 }
 


### PR DESCRIPTION
Align full-DNN construction with 3GPP TS 23.003 §9.1.2 by switching the Operator Identifier format from "5gc.mncXXX.mccYYY.3gppnetwork.org" to "mncXXX.mccYYY.gprs". Introduce new helper utilities to extract and build OI (Operator Identifier) from both PLMN-ID and FQDN, and replace the legacy `ogs_home_network_domain_from_fqdn()` usage in AMF/SMF/PCF paths.

This resolves DNN misalignment in vSMF–hSMF PDU Session Create that caused interop issues with external 5G core vendors during HR roaming.

Includes updates across AMF/SMF/PCF, unit tests, and supporting helpers.

Issues: #4096