### PR TITLE
AMF : Prevent null session reference at sending partial-handover error

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -4313,7 +4313,7 @@ void ngap_handle_handover_notification(
      * send partial-handover error
      */
     if (xact_count == amf_sess_xact_count(amf_ue)) {
-        ogs_error("No SMF session were processed [%d]", sess->psi);
+        ogs_error("No SMF sessions were processed");
         r = ngap_send_error_indication2(source_ue,
                 NGAP_Cause_PR_radioNetwork,
                 NGAP_CauseRadioNetwork_partial_handover);


### PR DESCRIPTION
During some test, AMF crashed due to segfault, with following logs.

```
 (../lib/sbi/client.c:555)
12/09 10:39:59.071: [sbi] DEBUG: [200:POST] http://open-scp-sbi:7777/nsmf-pdusession/v1/sm-contexts/173/modify (../lib/sbi/client.c:743)
12/09 10:39:59.071: [sbi] DEBUG: RECEIVED[26] (../lib/sbi/client.c:754)
12/09 10:39:59.071: [sbi] DEBUG: {"upCnxState":"ACTIVATED"} (../lib/sbi/client.c:757)
12/09 10:39:59.071: [amf] DEBUG: amf_state_operational(): AMF_EVENT_NGAP_MESSAGE (../src/amf/amf-sm.c:84)
12/09 10:39:59.071: [amf] DEBUG: ngap_state_operational(): AMF_EVENT_NGAP_MESSAGE (../src/amf/ngap-sm.c:55)
12/09 10:39:59.071: [amf] INFO: InitialUEMessage (../src/amf/ngap-handler.c:437)
12/09 10:39:59.071: [amf] DEBUG:     IP[10.244.1.124] RAN_ID[8] (../src/amf/ngap-handler.c:463)
12/09 10:39:59.071: [amf] INFO: [Added] Number of gNB-UEs is now 9645 (../src/amf/context.c:2789)
12/09 10:39:59.071: [amf] INFO:     RAN_UE_NGAP_ID[30067] AMF_UE_NGAP_ID[18060] TAC[7] CellID[0x8000] (../src/amf/ngap-handler.c:598)
12/09 10:39:59.071: [amf] DEBUG: amf_state_operational(): AMF_EVENT_NGAP_MESSAGE (../src/amf/amf-sm.c:84)
12/09 10:39:59.071: [amf] DEBUG: ngap_state_operational(): AMF_EVENT_NGAP_MESSAGE (../src/amf/ngap-sm.c:55)
12/09 10:39:59.071: [amf] DEBUG: HandoverNotify (../src/amf/ngap-handler.c:4082)
12/09 10:39:59.071: [amf] DEBUG:     IP[10.244.1.124] RAN_ID[9] (../src/amf/ngap-handler.c:4101)
12/09 10:39:59.071: [amf] DEBUG:     Source : RAN_UE_NGAP_ID[29080] AMF_UE_NGAP_ID[14389]  (../src/amf/ngap-handler.c:4190)
12/09 10:39:59.071: [amf] DEBUG:     Source : TAC[7] CellID[0x8000] (../src/amf/ngap-handler.c:4193)
12/09 10:39:59.071: [amf] DEBUG:     Target : RAN_UE_NGAP_ID[6851] AMF_UE_NGAP_ID[16250]  (../src/amf/ngap-handler.c:4196)
12/09 10:39:59.071: [amf] DEBUG:     Target : TAC[7] CellID[0x9000] (../src/amf/ngap-handler.c:4199)
12/09 10:39:59.071: [amf] DEBUG: UEContextReleaseCommand (../src/amf/ngap-path.c:403)
12/09 10:39:59.071: [amf] DEBUG:     RAN_UE_NGAP_ID[29080] AMF_UE_NGAP_ID[14389] (../src/amf/ngap-path.c:404)
12/09 10:39:59.071: [amf] DEBUG:     Group[1] Cause[2] Action[4] Duration[300000] (../src/amf/ngap-path.c:411)
12/09 10:39:59.071: [amf] DEBUG: UEContextReleaseCommand (../src/amf/ngap-build.c:1225)
12/09 10:39:59.071: [amf] WARNING: Session Context is not in SMF [1] (../src/amf/ngap-handler.c:4222)
/entrypoint.sh: line 43:     7 Segmentation fault      (core dumped) $@
```

The root cause was ogs_list_for_each(&amf_ue->sess_list, sess) block made sess variable to be NULL at the end, but the following if block references sess->psi, raising segfault.
This PR revises that situation.

Thanks