### PR TITLE
Add roaming type toggle via command line

### DIFF
--- a/misc/db/open5gs-dbctl
+++ b/misc/db/open5gs-dbctl
@@ -808,7 +808,7 @@ if [ "$1" = "lbo_roaming_allowed" ]; then
         if [ $LBO_ALLOWED = "1" ]; then
             LBO_ALLOWED_BOOL=true
         else
-            BOOL_VALUE=false
+            LBO_ALLOWED_BOOL=false
         fi
         mongosh --eval "db.subscribers.updateOne({ \"imsi\": \"$IMSI\"},
             {\$set: { \"slice.0.session.0.lbo_roaming_allowed\": $LBO_ALLOWED_BOOL


### PR DESCRIPTION
Added an alternative way to change roaming type besides webui: added `lbo_roaming_allowed` command in open5gs-dbctl.
```
lbo_roaming_allowed {imsi lbo_roaming_allowed={0,1}}: Change roaming type for a specific subscriber: 0 = HR roaming, 1 = LBO roaming (default)"
```