### PR TITLE
mme: avoid crash on late ESM/NAS handling after UE context release

### DIFF
--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -40,14 +40,22 @@ int esm_handle_pdn_connectivity_request(
     const char *emergency_dnn = mme_self()->emergency.dnn;
     bool emergency;
 
-    ogs_assert(bearer);
-    sess = mme_sess_find_by_id(bearer->sess_id);
-    ogs_assert(sess);
-    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
-    ogs_assert(mme_ue);
-    ogs_assert(enb_ue);
-
     ogs_assert(req);
+
+    if (!bearer) {
+        ogs_error("No bearer context");
+        return OGS_NOTFOUND;
+    }
+    sess = mme_sess_find_by_id(bearer->sess_id);
+    if (!sess) {
+        ogs_warn("Session context has already been removed");
+        return OGS_NOTFOUND;
+    }
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue) {
+        ogs_warn("UE(mme-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
 
     ogs_assert(MME_UE_HAVE_IMSI(mme_ue));
 
@@ -215,12 +223,17 @@ int esm_handle_information_response(
     int r;
     mme_ue_t *mme_ue = NULL;
 
-    ogs_assert(sess);
-    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
-    ogs_assert(mme_ue);
-    ogs_assert(enb_ue);
-
     ogs_assert(rsp);
+
+    if (!sess) {
+        ogs_warn("Session context has already been removed");
+        return OGS_NOTFOUND;
+    }
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue) {
+        ogs_warn("UE(mme-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
 
     if (rsp->presencemask &
             OGS_NAS_EPS_ESM_INFORMATION_RESPONSE_ACCESS_POINT_NAME_PRESENT) {
@@ -313,12 +326,20 @@ int esm_handle_bearer_resource_allocation_request(
     mme_ue_t *mme_ue = NULL;
     mme_sess_t *sess = NULL;
 
-    ogs_assert(bearer);
+    if (!bearer) {
+        ogs_error("No bearer context");
+        return OGS_NOTFOUND;
+    }
     sess = mme_sess_find_by_id(bearer->sess_id);
-    ogs_assert(sess);
+    if (!sess) {
+        ogs_warn("Session context has already been removed");
+        return OGS_NOTFOUND;
+    }
     mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
-    ogs_assert(mme_ue);
-    ogs_assert(enb_ue);
+    if (!mme_ue) {
+        ogs_warn("UE(mme-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
 
     r = nas_eps_send_bearer_resource_allocation_reject(
             mme_ue, sess->pti, OGS_NAS_ESM_CAUSE_NETWORK_FAILURE);
@@ -333,10 +354,15 @@ int esm_handle_bearer_resource_modification_request(
 {
     mme_ue_t *mme_ue = NULL;
 
-    ogs_assert(bearer);
+    if (!bearer) {
+        ogs_error("No bearer context");
+        return OGS_NOTFOUND;
+    }
     mme_ue = mme_ue_find_by_id(bearer->mme_ue_id);
-    ogs_assert(mme_ue);
-    ogs_assert(enb_ue);
+    if (!mme_ue) {
+        ogs_warn("UE(mme-ue) context has already been removed");
+        return OGS_NOTFOUND;
+    }
 
     ogs_assert(OGS_OK ==
         mme_gtp_send_bearer_resource_command(bearer, message));

--- a/src/mme/esm-sm.c
+++ b/src/mme/esm-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -103,7 +103,11 @@ void esm_state_inactive(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue)
+            ogs_warn("No eNB-UE context; dropping ESM message(type:%d) "
+                    "IMSI[%s] PTI[%d] EBI[%d]",
+                    message->esm.h.message_type,
+                    mme_ue->imsi_bcd, sess->pti, bearer->ebi);
 
         switch (message->esm.h.message_type) {
         case OGS_NAS_EPS_PDN_CONNECTIVITY_REQUEST:
@@ -148,12 +152,9 @@ void esm_state_inactive(ogs_fsm_t *s, mme_event_t *e)
             CLEAR_BEARER_TIMER(bearer->t3489);
 
             h.type = e->nas_type;
-            enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
             if (h.integrity_protected == 0) {
                 ogs_error("[%s] No Integrity Protected", mme_ue->imsi_bcd);
-
-                ogs_assert(enb_ue);
 
                 r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                         OGS_NAS_EMM_CAUSE_SECURITY_MODE_REJECTED_UNSPECIFIED,
@@ -171,8 +172,6 @@ void esm_state_inactive(ogs_fsm_t *s, mme_event_t *e)
 
             if (!SECURITY_CONTEXT_IS_VALID(mme_ue)) {
                 ogs_warn("[%s] No Security Context", mme_ue->imsi_bcd);
-
-                ogs_assert(enb_ue);
 
                 r = nas_eps_send_attach_reject(enb_ue, mme_ue,
                         OGS_NAS_EMM_CAUSE_SECURITY_MODE_REJECTED_UNSPECIFIED,
@@ -309,13 +308,17 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
+        if (!enb_ue)
+            ogs_warn("No eNB-UE context; dropping ESM message(type:%d) "
+                    "IMSI[%s] PTI[%d] EBI[%d]",
+                    message->esm.h.message_type,
+                    mme_ue->imsi_bcd, sess->pti, bearer->ebi);
 
         switch (message->esm.h.message_type) {
         case OGS_NAS_EPS_PDN_CONNECTIVITY_REQUEST:
             ogs_debug("PDN Connectivity request");
             ogs_debug("    IMSI[%s] PTI[%d] EBI[%d]",
                     mme_ue->imsi_bcd, sess->pti, bearer->ebi);
-            ogs_assert(enb_ue);
             rv = esm_handle_pdn_connectivity_request(
                     enb_ue, bearer, &message->esm.pdn_connectivity_request,
                     e->create_action);
@@ -331,7 +334,6 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
             ogs_debug("    IMSI[%s] PTI[%d] EBI[%d]",
                     mme_ue->imsi_bcd, sess->pti, bearer->ebi);
 
-            ogs_assert(enb_ue);
             if (MME_HAVE_SGW_S1U_PATH(sess)) {
                 sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
                 ogs_assert(sgw_ue);
@@ -373,7 +375,6 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
             ogs_debug("Bearer resource allocation request");
             ogs_debug("    IMSI[%s] PTI[%d] EBI[%d]",
                     mme_ue->imsi_bcd, sess->pti, bearer->ebi);
-            ogs_assert(enb_ue);
             esm_handle_bearer_resource_allocation_request(
                     enb_ue, bearer, message);
             break;
@@ -381,7 +382,6 @@ void esm_state_active(ogs_fsm_t *s, mme_event_t *e)
             ogs_debug("Bearer resource modification request");
             ogs_debug("    IMSI[%s] PTI[%d] EBI[%d]",
                     mme_ue->imsi_bcd, sess->pti, bearer->ebi);
-            ogs_assert(enb_ue);
             esm_handle_bearer_resource_modification_request(
                     enb_ue, bearer, message);
             break;
@@ -428,7 +428,11 @@ void esm_state_pdn_will_disconnect(ogs_fsm_t *s, mme_event_t *e)
         ogs_assert(message);
 
         enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-        ogs_assert(enb_ue);
+        if (!enb_ue)
+            ogs_warn("No eNB-UE context; dropping ESM message(type:%d) "
+                    "IMSI[%s] PTI[%d] EBI[%d]",
+                    message->esm.h.message_type,
+                    mme_ue->imsi_bcd, sess->pti, bearer->ebi);
 
         switch (message->esm.h.message_type) {
         case OGS_NAS_EPS_DEACTIVATE_EPS_BEARER_CONTEXT_ACCEPT:

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -271,7 +271,6 @@ int mme_gtp_send_create_session_request(
     mme_ue_t *mme_ue = NULL;
     sgw_ue_t *sgw_ue = NULL;
 
-    ogs_assert(enb_ue);
     mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     ogs_assert(mme_ue);
     sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
@@ -301,7 +300,10 @@ int mme_gtp_send_create_session_request(
     }
     xact->create_action = create_action;
     xact->local_teid = mme_ue->gn.mme_gn_teid;
-    xact->enb_ue_id = enb_ue->id;
+    if (enb_ue)
+        xact->enb_ue_id = enb_ue->id;
+    else
+        xact->enb_ue_id = OGS_INVALID_POOL_ID;
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect(rv == OGS_OK);
@@ -321,7 +323,6 @@ int mme_gtp_send_modify_bearer_request(
     ogs_gtp2_header_t h;
     ogs_pkbuf_t *pkbuf = NULL;
 
-    ogs_assert(enb_ue);
     ogs_assert(mme_ue);
     sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     ogs_assert(sgw_ue);
@@ -345,7 +346,10 @@ int mme_gtp_send_modify_bearer_request(
     }
     xact->modify_action = modify_action;
     xact->local_teid = mme_ue->gn.mme_gn_teid;
-    xact->enb_ue_id = enb_ue->id;
+    if (enb_ue)
+        xact->enb_ue_id = enb_ue->id;
+    else
+        xact->enb_ue_id = OGS_INVALID_POOL_ID;
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect(rv == OGS_OK);

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -272,7 +272,10 @@ void mme_s11_handle_create_session_response(
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
         }
-        mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        if (enb_ue)
+            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        else
+            ogs_error("No S1 Context");
         return;
     }
 
@@ -330,7 +333,10 @@ void mme_s11_handle_create_session_response(
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
         }
-        mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        if (enb_ue)
+            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        else
+            ogs_error("No S1 Context");
         return;
     }
 
@@ -362,7 +368,11 @@ void mme_s11_handle_create_session_response(
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
             }
-            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+            if (enb_ue)
+                mme_send_delete_session_or_mme_ue_context_release(
+                        enb_ue, mme_ue);
+            else
+                ogs_error("No S1 Context");
             return;
         }
     }
@@ -382,7 +392,10 @@ void mme_s11_handle_create_session_response(
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
         }
-        mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        if (enb_ue)
+            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        else
+            ogs_error("No S1 Context");
         return;
     }
 
@@ -421,7 +434,11 @@ void mme_s11_handle_create_session_response(
         bearer = mme_bearer_find_by_ue_ebi(mme_ue,
                 rsp->bearer_contexts_created[i].eps_bearer_id.u8);
         if (!bearer) {
-            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+            if (enb_ue)
+                mme_send_delete_session_or_mme_ue_context_release(
+                        enb_ue, mme_ue);
+            else
+                ogs_error("No S1 Context");
             return;
         }
 
@@ -1702,10 +1719,8 @@ void mme_s11_handle_downlink_data_notification(
  *   included in Downlink Data Notification is "Error Indication received
  *   from RNC/eNodeB/S4-SGSN"
  */
-            enb_ue_t *enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
-            ogs_assert(enb_ue);
-
-            r = s1ap_send_ue_context_release_command(enb_ue,
+            r = s1ap_send_ue_context_release_command(
+                    enb_ue_find_by_id(mme_ue->enb_ue_id),
                     S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release,
                     S1AP_UE_CTX_REL_S1_PAGING, 0);
             ogs_expect(r == OGS_OK);
@@ -1777,7 +1792,10 @@ void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        mme_send_delete_session_or_mme_ue_context_release(source_ue, mme_ue);
+        if (source_ue)
+            mme_send_delete_session_or_mme_ue_context_release(source_ue, mme_ue);
+        else
+            ogs_error("ENB-S1 Context has already been removed");
         return;
     }
 
@@ -1792,7 +1810,10 @@ void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
-        mme_send_delete_session_or_mme_ue_context_release(source_ue, mme_ue);
+        if (source_ue)
+            mme_send_delete_session_or_mme_ue_context_release(source_ue, mme_ue);
+        else
+            ogs_error("ENB-S1 Context has already been removed");
         return;
     }
 
@@ -1803,7 +1824,11 @@ void mme_s11_handle_create_indirect_data_forwarding_tunnel_response(
 
     if (session_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("[%s] GTP Cause [VALUE:%d]", mme_ue->imsi_bcd, session_cause);
-        mme_send_delete_session_or_mme_ue_context_release(source_ue, mme_ue);
+        if (source_ue)
+            mme_send_delete_session_or_mme_ue_context_release(
+                    source_ue, mme_ue);
+        else
+            ogs_error("ENB-S1 Context has already been removed");
         return;
     }
 


### PR DESCRIPTION
Handle late or out-of-order ESM/NAS events more safely by removing assert-based assumptions on runtime UE/S1 contexts.

Replace fatal assertions with defensive runtime checks in ESM, NAS, GTP, and S11 paths so that late messages received after bearer/session or eNB-UE context release do not terminate the MME process.

This allows ongoing GTP/S11 procedures to continue or clean up safely while gracefully handling missing S1 context, improving robustness under real-world race conditions.

Issues: #4236