### PR TITLE
Raise minimum required meson version

### DIFF
--- a/lib/core/meson.build
+++ b/lib/core/meson.build
@@ -155,11 +155,7 @@ else
 endif
 
 # Check for /dev/urandom
-if meson.version().version_compare('>=0.47.0')
-     dev_urandom = run_command('[', '-c', '/dev/urandom', ']', check: false)
-else
-     dev_urandom = run_command('[', '-c', '/dev/urandom', ']')
-endif
+dev_urandom = run_command('[', '-c', '/dev/urandom', ']', check: false)
 if dev_urandom.returncode() == 0
     libcore_conf.set_quoted('OGS_DEV_RANDOM', '/dev/urandom',
                     description: 'a suitable file to read random data from')

--- a/lib/metrics/meson.build
+++ b/lib/metrics/meson.build
@@ -26,30 +26,21 @@ libmetrics_dependencies = [libapp_dep]
 #metrics_impl_optval = get_option('metrics_impl')
 
 #if metrics_impl_optval == 'prometheus'
-if meson.version().version_compare('>=0.51.0')
-# Note: This requires meson >= 0.51.0:
-# 0.47.0: {'check arg in run_command'}
-# 0.50.0: {'CMake Module'}
-# 0.51.0: {'subproject'}
 
-    libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.40')
+libmicrohttpd_dep = dependency('libmicrohttpd', version: '>=0.9.40')
 
-    cmake = import('cmake')
+cmake = import('cmake')
 # Ubuntu Bionic cannot parse meson's dictionary
 # because the meson version is less than v0.47.0.
 #
 # We will change to using meson's dictionary
 # after April 2023 when Ubuntu bionic is deprecated.
 #
-#    if meson.version().version_compare('>=0.55.0')
-#      opt_var = cmake.subproject_options()
-#      opt_var.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': libdir})
-#      prometheus_client_c_proj = cmake.subproject(
-#        'prometheus-client-c', options: opt_var)
-#    else
-#      prometheus_client_c_proj = cmake.subproject('prometheus-client-c')
-#    endif
-    prometheus_client_c_proj = cmake.subproject('prometheus-client-c')
+#    opt_var = cmake.subproject_options()
+#    opt_var.add_cmake_defines({'CMAKE_INSTALL_LIBDIR': libdir})
+#    prometheus_client_c_proj = cmake.subproject(
+#      'prometheus-client-c', options: opt_var)
+prometheus_client_c_proj = cmake.subproject('prometheus-client-c')
 
 #
 # @acetcom
@@ -61,36 +52,11 @@ if meson.version().version_compare('>=0.51.0')
 # doesn't exist and fail:
 #
 #    missing_include_dir = join_paths(meson.current_source_dir(), '../../subprojects/prometheus-client-c/__CMake_build')
-#    if meson.version().version_compare('>=0.47.0')
-#        run_command('mkdir', '-p', missing_include_dir, check: true)
-#    else
-#        run_command('mkdir', '-p', missing_include_dir)
-#    endif
-    libprom_dep = prometheus_client_c_proj.dependency('prom')
+#    run_command('mkdir', '-p', missing_include_dir, check: true)
+libprom_dep = prometheus_client_c_proj.dependency('prom')
 
-    libmetrics_dependencies = libmetrics_dependencies + [libprom_dep, libmicrohttpd_dep]
-    libmetrics_file_list = libmetrics_file_list + ' prometheus/context.c'
-else
-    libprom_sources = files('''
-        void/context.c
-    '''.split())
-
-    libprom_inc = include_directories('.')
-
-    libprom = library('void_prom',
-        sources : libprom_sources,
-        version : libogslib_version,
-        include_directories : [libprom_inc, libinc],
-        dependencies : libapp_dep,
-        install : true)
-
-    libprom_dep = declare_dependency(
-        link_with : libprom,
-        include_directories : [libprom_inc, libinc],
-        dependencies : libapp_dep)
-
-    libmetrics_dependencies = libmetrics_dependencies + [libprom_dep]
-endif
+libmetrics_dependencies = libmetrics_dependencies + [libprom_dep, libmicrohttpd_dep]
+libmetrics_file_list = libmetrics_file_list + ' prometheus/context.c'
 
 libmetrics_sources = files(libmetrics_file_list.split())
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project('open5gs', 'c', 'cpp',
     version : '2.7.6',
     license : 'AGPL-3.0-or-later',
-    meson_version : '>= 0.43.0',
+    meson_version : '>= 0.55.0',
     default_options : [
         'warning_level=1',
         'c_std=gnu89',
@@ -42,11 +42,7 @@ git = find_program('git', required: false)
 #python = import('python')
 #python3 = python.find_installation('python3')
 python3 = find_program('python3', 'python')
-if meson.version().version_compare('>=0.55.0')
 python3_exe = join_paths(python3.full_path())
-else
-python3_exe = join_paths(python3.path())
-endif
 mkdir_p = 'import os; os.makedirs("@0@", exist_ok=True) if not os.environ.get("DESTDIR") else False;'
 symlink = 'import os; os.symlink("@0@", "@1@") if not os.environ.get("DESTDIR") and not os.path.islink("@1@") else False;'
 install_conf = 'import os; import shutil; shutil.copy("@0@", "@1@") if not os.environ.get("DESTDIR") and not os.path.isfile(os.path.join("@1@", os.path.split("@0@")[1])) else False;'
@@ -154,8 +150,7 @@ message('\n'.join([
 if cppcheck.found()
     run_target('analyze-cppcheck',
     command : [ 'misc/static-code-analyze.sh',
-        meson.version().version_compare('>=0.55.0') ?
-          cppcheck.full_path() : cppcheck.path(),
+        cppcheck.full_path(),
         meson.current_build_dir(),
         meson.current_source_dir()
         ]
@@ -165,8 +160,7 @@ endif
 if clangtidy.found()
     run_target('analyze-clang-tidy',
     command : [ 'misc/static-code-analyze.sh',
-        meson.version().version_compare('>=0.55.0') ?
-          clangtidy.full_path() : clangtidy.path(),
+        clangtidy.full_path(),
         meson.current_build_dir(),
         meson.current_source_dir()
         ]

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project('open5gs', 'c', 'cpp',
     version : '2.8.0',
     license : 'AGPL-3.0-or-later',
-    meson_version : '>= 0.43.0',
+    meson_version : '>= 0.55.0',
     default_options : [
         'warning_level=1',
         'c_std=gnu89',
@@ -42,11 +42,7 @@ git = find_program('git', required: false)
 #python = import('python')
 #python3 = python.find_installation('python3')
 python3 = find_program('python3', 'python')
-if meson.version().version_compare('>=0.55.0')
 python3_exe = join_paths(python3.full_path())
-else
-python3_exe = join_paths(python3.path())
-endif
 mkdir_p = 'import os; os.makedirs("@0@", exist_ok=True) if not os.environ.get("DESTDIR") else False;'
 symlink = 'import os; os.symlink("@0@", "@1@") if not os.environ.get("DESTDIR") and not os.path.islink("@1@") else False;'
 install_conf = 'import os; import shutil; shutil.copy("@0@", "@1@") if not os.environ.get("DESTDIR") and not os.path.isfile(os.path.join("@1@", os.path.split("@0@")[1])) else False;'
@@ -154,8 +150,7 @@ message('\n'.join([
 if cppcheck.found()
     run_target('analyze-cppcheck',
     command : [ 'misc/static-code-analyze.sh',
-        meson.version().version_compare('>=0.55.0') ?
-          cppcheck.full_path() : cppcheck.path(),
+        cppcheck.full_path(),
         meson.current_build_dir(),
         meson.current_source_dir()
         ]
@@ -165,8 +160,7 @@ endif
 if clangtidy.found()
     run_target('analyze-clang-tidy',
     command : [ 'misc/static-code-analyze.sh',
-        meson.version().version_compare('>=0.55.0') ?
-          clangtidy.full_path() : clangtidy.path(),
+        clangtidy.full_path(),
         meson.current_build_dir(),
         meson.current_source_dir()
         ]

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,11 +19,7 @@ srcinc = include_directories('.')
 
 package_version = 'v' + meson.project_version()
 if git.found()
-    if meson.version().version_compare('>=0.47.0')
-        git_version = run_command('git', ['describe', '--abbrev=7', '--dirty=+'], check: false)
-    else
-        git_version = run_command('git', ['describe', '--abbrev=7', '--dirty=+'])
-    endif
+    git_version = run_command('git', ['describe', '--abbrev=7', '--dirty=+'], check: false)
     if git_version.returncode() == 0
         package_version = git_version.stdout().strip()
     endif


### PR DESCRIPTION
Fix WARNING: Project specifies a minimum meson_version '>= 0.43.0' but uses features which were added in newer versions:
 * 0.54.0: {'fallback arg in dependency'}

To remove some additional version checks, the version is raised a bit higher than necessary to fix that warning.