### PR TITLE
sgwc/smf: handle late or orphan GTPv2 responses without abort

### DIFF
--- a/src/sgwc/sgwc-sm.c
+++ b/src/sgwc/sgwc-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019,2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -151,17 +151,17 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
             break;
         }
 
-        if (gtp_message.h.teid_presence && gtp_message.h.teid != 0) {
+        if (gtp_message.h.teid_presence && gtp_message.h.teid != 0)
             /* Cause is not "Context not found" */
             sgwc_ue = sgwc_ue_find_by_teid(gtp_message.h.teid);
-        } else if (gtp_xact->local_teid) { /* rx no TEID or TEID=0 */
+
+        if (!sgwc_ue && gtp_xact->local_teid) /* rx no TEID or TEID=0 */
             /* 3GPP TS 29.274 5.5.2: we receive TEID=0 under some
              * conditions, such as cause "Session context not found". In those
              * cases, we still want to identify the local session which
              * originated the message, so try harder by using the TEID we
              * locally stored in xact when sending the original request: */
             sgwc_ue = sgwc_ue_find_by_teid(gtp_xact->local_teid);
-        }
 
         switch(gtp_message.h.type) {
         case OGS_GTP2_ECHO_REQUEST_TYPE:
@@ -250,16 +250,16 @@ void sgwc_state_operational(ogs_fsm_t *s, sgwc_event_t *e)
             break;
         }
 
-        if (gtp_message.h.teid_presence && gtp_message.h.teid != 0) {
+        if (gtp_message.h.teid_presence && gtp_message.h.teid != 0)
             sess = sgwc_sess_find_by_teid(gtp_message.h.teid);
-        } else if (gtp_xact->local_teid) { /* rx no TEID or TEID=0 */
+
+        if (!sess && gtp_xact->local_teid) /* rx no TEID or TEID=0 */
             /* 3GPP TS 29.274 5.5.2: we receive TEID=0 under some
              * conditions, such as cause "Session context not found". In those
              * cases, we still want to identify the local session which
              * originated the message, so try harder by using the TEID we
              * locally stored in xact when sending the original request: */
             sess = sgwc_sess_find_by_teid(gtp_xact->local_teid);
-        }
 
         switch(gtp_message.h.type) {
         case OGS_GTP2_ECHO_REQUEST_TYPE:

--- a/src/smf/smf-sm.c
+++ b/src/smf/smf-sm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
  *
  * This file is part of Open5GS.
  *
@@ -127,16 +127,16 @@ void smf_state_operational(ogs_fsm_t *s, smf_event_t *e)
         }
         e->gtp_xact_id = gtp_xact ? gtp_xact->id : OGS_INVALID_POOL_ID;
 
-        if (gtp2_message.h.teid_presence && gtp2_message.h.teid != 0) {
+        if (gtp2_message.h.teid_presence && gtp2_message.h.teid != 0)
             sess = smf_sess_find_by_teid(gtp2_message.h.teid);
-        } else if (gtp_xact->local_teid) { /* rx no TEID or TEID=0 */
+
+        if (!sess && gtp_xact->local_teid) /* rx no TEID or TEID=0 */
             /* 3GPP TS 29.274 5.5.2: we receive TEID=0 under some
              * conditions, such as cause "Session context not found". In those
              * cases, we still want to identify the local session which
              * originated the message, so try harder by using the TEID we
              * locally stored in xact when sending the original request: */
             sess = smf_sess_find_by_teid(gtp_xact->local_teid);
-        }
 
         switch(gtp2_message.h.type) {
         case OGS_GTP2_ECHO_REQUEST_TYPE:


### PR DESCRIPTION
Prevent SGW-C and SMF from aborting when receiving late or orphan GTPv2 bearer responses (Create/Update/Delete Bearer).

This change removes fatal assertions on missing UE/session contexts and instead treats such cases as "Context Not Found" per 3GPP TS 29.274.

In addition, improve FSM-level UE/session lookup by retrying context identification using the locally stored TEID when the received TEID is missing, zero, or no longer valid. This aligns the behavior with TS 29.274 §5.5.2 and allows graceful handling of late responses after context cleanup.

Together, these changes ensure that late or orphan GTPv2 responses never crash SGW-C or SMF and are handled gracefully.

Issues: #4225