### PR TITLE
amf,mme: Reject authentication after repeated synch failures

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -428,6 +428,9 @@ struct amf_ue_s {
     int             security_context_available;
     int             mac_failed;
 
+    /* Authentication synch failure counter */
+    uint8_t auth_synch_fail_count;
+
     /* flag: 1 = allow restoration of context, 0 = disallow */
     bool            can_restore_context;
 

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2043,6 +2043,7 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
+        amf_ue->auth_synch_fail_count = 0;
         break;
     case OGS_FSM_EXIT_SIG:
         break;
@@ -2114,7 +2115,17 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
                 return;
 
             case OGS_5GMM_CAUSE_SYNCH_FAILURE:
-                ogs_warn("Authentication failure(Synch failure)");
+                ogs_warn("[%s] Authentication failure(Synch failure[count=%d])",
+                        amf_ue->suci, amf_ue->auth_synch_fail_count);
+
+                amf_ue->auth_synch_fail_count++;
+
+                if (amf_ue->auth_synch_fail_count >= 2) {
+                    ogs_warn("[%s] Too many authentication synch failures, "
+                            "sending AUTHENTICATION REJECT", amf_ue->suci);
+                    break;
+                }
+
                 if (authentication_failure_parameter->length != OGS_AUTS_LEN) {
                     ogs_error("Invalid AUTS Length [%d]",
                             authentication_failure_parameter->length);

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -540,6 +540,9 @@ struct mme_ue_s {
     int             security_context_available;
     int             mac_failed;
 
+    /* Authentication synch failure counter */
+    uint8_t auth_synch_fail_count;
+
     /* flag: 1 = allow restoration of context, 0 = disallow */
     bool            can_restore_context;
 

--- a/tests/attach/auth-test.c
+++ b/tests/attach/auth-test.c
@@ -331,9 +331,9 @@ static void test1_func(abts_case *tc, void *data)
     ABTS_PTR_NOTNULL(tc, recvbuf);
     tests1ap_recv(test_ue, recvbuf);
 
-    /* Send Authentication failure - MAC failure */
+    /* Send Authentication failure - SYNCH failure */
     emmbuf = testemm_build_authentication_failure(
-            test_ue, OGS_NAS_EMM_CAUSE_MAC_FAILURE, 0);
+            test_ue, OGS_NAS_EMM_CAUSE_SYNCH_FAILURE, 0x11223344);
     ABTS_PTR_NOTNULL(tc, emmbuf);
     sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
     ABTS_PTR_NOTNULL(tc, sendbuf);

--- a/tests/registration/auth-test.c
+++ b/tests/registration/auth-test.c
@@ -349,7 +349,7 @@ static void test1_func(abts_case *tc, void *data)
 
     /* Send Authentication failure - MAC failure */
     gmmbuf = testgmm_build_authentication_failure(
-            test_ue, OGS_5GMM_CAUSE_MAC_FAILURE, 0);
+            test_ue, OGS_5GMM_CAUSE_SYNCH_FAILURE, 0x11223344);
     ABTS_PTR_NOTNULL(tc, gmmbuf);
     sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
     ABTS_PTR_NOTNULL(tc, sendbuf);


### PR DESCRIPTION
Limit authentication retries on repeated synchronization failures.

When the UE reports consecutive authentication failures with "synchronization failure" cause, AMF and MME now track the failure count per authentication procedure and send AUTHENTICATION REJECT after two attempts, instead of retrying indefinitely.

The counter is reset on authentication state entry.

This aligns the behavior with 3GPP authentication procedures and prevents infinite authentication loops caused by persistent synchronization failures.

Issues: #4238