### PR TITLE
[SBI] Fix double-free

### DIFF
--- a/lib/sbi/path.c
+++ b/lib/sbi/path.c
@@ -660,7 +660,12 @@ bool ogs_sbi_send_request_to_nf_instance(
 #endif
     }
 
-    return ogs_sbi_send_request_with_sepp_discovery(client, xact);
+    if (ogs_sbi_send_request_with_sepp_discovery(client, xact) == false) {
+        ogs_sbi_xact_remove(xact);
+        return false;
+    }
+
+    return true;
 }
 
 bool ogs_sbi_send_request_with_sepp_discovery(
@@ -687,7 +692,6 @@ bool ogs_sbi_send_request_with_sepp_discovery(
             ogs_error("No SEPP(%p) and NRF(%p) [%s]",
                     sepp_client, nrf_client, client->fqdn);
 
-            ogs_sbi_xact_remove(xact);
             return false;
 
         } else if (!sepp_client) {
@@ -697,7 +701,6 @@ bool ogs_sbi_send_request_with_sepp_discovery(
             xact->target_apiroot = ogs_sbi_client_apiroot(client);
             if (!xact->target_apiroot) {
                 ogs_error("ogs_strdup(xact->target_apiroot) failed");
-                ogs_sbi_xact_remove(xact);
                 return false;
             }
 
@@ -705,7 +708,6 @@ bool ogs_sbi_send_request_with_sepp_discovery(
                         OpenAPI_nf_type_SEPP, xact->requester_nf_type, NULL);
             if (!nrf_request) {
                 ogs_error("ogs_nnrf_disc_build_discover() failed");
-                ogs_sbi_xact_remove(xact);
                 return false;
             }
 
@@ -714,7 +716,6 @@ bool ogs_sbi_send_request_with_sepp_discovery(
                     OGS_UINT_TO_POINTER(xact->id));
             if (rc == false) {
                 ogs_error("ogs_sbi_client_send_request() failed");
-                ogs_sbi_xact_remove(xact);
             }
 
             ogs_sbi_request_free(nrf_request);
@@ -728,7 +729,6 @@ bool ogs_sbi_send_request_with_sepp_discovery(
             OGS_UINT_TO_POINTER(xact->id));
     if (rc == false) {
         ogs_error("ogs_sbi_send_request_to_client() failed");
-        ogs_sbi_xact_remove(xact);
     }
 
     return rc;

--- a/tests/af/sbi-path.c
+++ b/tests/af/sbi-path.c
@@ -84,6 +84,7 @@ void af_sbi_discover_and_send(
     r = ogs_sbi_discover_and_send(xact);
     if (r != OGS_OK) {
         ogs_error("af_sbi_discover_and_send() failed");
+        ogs_sbi_xact_remove(xact);
         return;
     }
 }


### PR DESCRIPTION
Bug:

A double-free scenario in the error handling path:

When ogs_sbi_send_request_with_sepp_discovery failed, it called ogs_sbi_xact_remove(xact) internally.
The function then returned false to its caller. The caller (smf_sbi_discover_and_send) also called ogs_sbi_xact_remove(xact) on failure.
This caused the discovery_option structure to be freed twice, leading to the valgrind error:
```
==90== Invalid read of size 8
==90==    at 0x49AFBB6: ogs_sbi_discovery_option_free (message.c:3633)
==90==    by 0x49CC100: ogs_sbi_xact_remove (context.c:2674)
==90==    by 0x407DDDC: smf_sbi_discover_and_send (sbi-path.c:392)
```

Fix:

Now the function follows proper resource ownership semantics: the caller who creates the transaction is responsible for cleanup when the function fails, making the error handling consistent and preventing double-free issues.

Added missing cleanup to ogs_sbi_send_request_to_nf_instance and af_sbi_discover_and_send.