### PR TITLE
Add Baicells Aurora 243 to hardware list

### DIFF
--- a/docs/_docs/hardware/01-genodebs.md
+++ b/docs/_docs/hardware/01-genodebs.md
@@ -14,6 +14,7 @@ If you have tested radio hardware from a vendor not listed with Open5GS, please 
  * Airspan AirSpeed 2900
  * Airspan AirStrand 2200
  * ASKEY SCE2200 5G SUB-6 SMALL CELL
+ * Baicells Aurora 243
  * BTI Wireless nCELL-F2240 5G NR Femtocell (n78)
  * CableFree Small Cell Outdoor radios (5G n77, n78 and other bands)
  * CableFree Small Cell Indoor radios (5G n77, n78 and other bands)


### PR DESCRIPTION
Have run the Aurora 243 using Open5gs for 5G SA core services for a few weeks now.