### PR TITLE
MME: Defer UE context removal on implicit detach without S1 context

### DIFF
--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -546,6 +546,19 @@ struct mme_ue_s {
     /* flag: 1 = allow restoration of context, 0 = disallow */
     bool            can_restore_context;
 
+    /*
+     * ue_context_will_remove:
+     *
+     * Set when the UE context must be removed locally after the current
+     * EMM event completes, but we must not free the UE context inside
+     * the ongoing procedure.
+     *
+     * This flag is used to defer UE context removal to a dedicated EMM
+     * state (emm_state_ue_context_will_remove) to avoid use-after-free
+     * and double-free scenarios in implicit detach paths.
+     */
+    bool            ue_context_will_remove;
+
     /* Memento of context fields */
     mme_ue_memento_t memento;
 

--- a/src/mme/mme-sm.h
+++ b/src/mme/mme-sm.h
@@ -43,6 +43,7 @@ void emm_state_authentication(ogs_fsm_t *s, mme_event_t *e);
 void emm_state_security_mode(ogs_fsm_t *s, mme_event_t *e);
 void emm_state_initial_context_setup(ogs_fsm_t *s, mme_event_t *e);
 void emm_state_registered(ogs_fsm_t *s, mme_event_t *e);
+void emm_state_ue_context_will_remove(ogs_fsm_t *s, mme_event_t *e);
 void emm_state_exception(ogs_fsm_t *s, mme_event_t *e);
 
 void esm_state_initial(ogs_fsm_t *s, mme_event_t *e);


### PR DESCRIPTION
**Problem**

When the implicit detach timer expires, the MME may initiate local UE context removal if no S1 context exists.

In the previous implementation, mme_ue_remove() could be triggered directly from mme_send_delete_session_or_detach() in this path.

This leads to a structural issue:

- The UE context may be freed while the EMM FSM is still processing the implicit detach timer event.
- Subsequent FSM operations (state transition, ENTRY/EXIT signals) may access the freed mme_ue.
- This results in assertion failures or crashes such as:

  emm_state_registered: Assertion `mme_ue' failed

**Analysis**

Implicit detach handling executes within the EMM FSM context. Immediate UE context removal from this path violates the FSM lifecycle assumption that the context remains valid until the event handling and state transition complete.

This creates a use-after-free risk and can also cause double-free depending on concurrent removal paths.

**Solution**

Introduce deferred UE context removal via FSM:

1. Add a new flag: mme_ue->ue_context_will_remove

2. Modify mme_send_delete_session_or_detach():
   - If no S1 context exists, do not remove immediately.
   - Set ue_context_will_remove = true instead.

3. In implicit detach timer handling:
   - Check the flag and select the next state accordingly.

4. Introduce a new FSM state: emm_state_ue_context_will_remove

   - UE context removal is performed safely on ENTRY_SIG.

This ensures:

- UE context is not freed inside the original EMM handler.
- FSM lifecycle is preserved.
- Removal happens after state transition.

**Impact**

- Prevents crashes caused by use-after-free during implicit detach.
- Avoids double-free scenarios.
- Aligns UE context lifecycle with FSM design.

This change only affects implicit detach paths where S1 context does not exist and does not alter normal detach procedures.

Fixes: #4298