### PR TITLE
sbi: cleanup NRF subscriptions before NF re-registration

### DIFF
--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -335,6 +335,9 @@ typedef struct ogs_sbi_subscription_data_s {
     ogs_timer_t *t_validity;                /* check validation */
     ogs_timer_t *t_patch;                   /* for sending PATCH */
 
+#define OGS_SBI_SUBSCRIPTION_DELETE_SENT  (1 << 0)
+    uint32_t flags;                         /* Subscription lifecycle flags */
+
     char *id;                               /* SubscriptionId */
     char *req_nf_instance_id;               /* reqNfInstanceId */
     OpenAPI_nf_type_e req_nf_type;          /* reqNfType */
@@ -640,6 +643,8 @@ void ogs_sbi_subscription_data_remove(
         ogs_sbi_subscription_data_t *subscription_data);
 void ogs_sbi_subscription_data_remove_all_by_nf_instance_id(
         char *nf_instance_id);
+void ogs_sbi_subscription_data_delete_and_remove_all_by_nf_instance_id(
+        const char *nf_instance_id);
 void ogs_sbi_subscription_data_remove_all(void);
 ogs_sbi_subscription_data_t *ogs_sbi_subscription_data_find(char *id);
 

--- a/lib/sbi/nf-sm.c
+++ b/lib/sbi/nf-sm.c
@@ -432,6 +432,20 @@ void ogs_sbi_nf_state_registered(ogs_fsm_t *s, ogs_event_t *e)
                     NF_INSTANCE_ID(ogs_sbi_self()->nf_instance),
                     OpenAPI_nf_type_ToString(
                         NF_INSTANCE_TYPE(ogs_sbi_self()->nf_instance)));
+
+
+        /*
+         * In case of NF re-registration due to heartbeat loss, clear any
+         * local subscription bookkeeping tied to the current NF instance id.
+         *
+         * This prevents unbounded growth of subscription_data entries when
+         * re-registration and re-subscription loops happen (e.g., docker-compose
+         * timing/race), which could otherwise exhaust subscription_data_pool.
+         */
+            if (ogs_sbi_self()->nf_instance && ogs_sbi_self()->nf_instance->id)
+                ogs_sbi_subscription_data_delete_and_remove_all_by_nf_instance_id(
+                        ogs_sbi_self()->nf_instance->id);
+
             OGS_FSM_TRAN(s, &ogs_sbi_nf_state_will_register);
             break;
 

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -842,6 +842,13 @@ bool nrf_nnrf_handle_nf_status_unsubscribe(
         return false;
     }
 
+    ogs_info("[%s] Removing local subscription data after NRF unsubscribe "
+            "[duration:%lld,validity:%d.%06d]",
+            subscription_data->id,
+            (long long)subscription_data->validity_duration,
+            (int)ogs_time_sec(subscription_data->validity_duration),
+            (int)ogs_time_usec(subscription_data->validity_duration));
+
     ogs_assert(subscription_data->id);
     ogs_sbi_subscription_data_remove(subscription_data);
 


### PR DESCRIPTION
When an NF loses heartbeat and enters re-registration, existing NRF subscription states tied to the previous NF instance remain both remotely (NRF) and locally (subscription_data pool).

In environments with repeated heartbeat loss or timing races (e.g., docker-compose deployments), this leads to continuous re-subscription loops and unbounded growth of
subscription_data entries, eventually exhausting the pool and triggering assertion failures in ogs_sbi_subscription_data_add().

This patch introduces a pre-registration cleanup mechanism:

- Send DELETE requests for all subscriptions associated with the NF instance before re-registration.
- Perform asynchronous local cleanup in the unsubscribe response handler (avoiding use-after-free and double free).
- Add duplicate DELETE guard using subscription flags.
- Improve logging visibility for subscription cleanup flow.

This ensures that stale NRF subscription states are removed and prevents subscription_data pool exhaustion during re-registration loops.

Issues: #4207