### PR TITLE
Fix UDM SDM GET plmn-id attribute value in roaming scenarios

### DIFF
--- a/src/amf/nudm-build.c
+++ b/src/amf/nudm-build.c
@@ -162,7 +162,7 @@ ogs_sbi_request_t *amf_nudm_sdm_build_get(amf_ue_t *amf_ue, void *data)
     message.h.resource.component[1] = data;
 
     message.param.plmn_id_presence = true;
-    memcpy(&message.param.plmn_id, &amf_ue->home_plmn_id,
+    memcpy(&message.param.plmn_id, &amf_ue->nr_tai.plmn_id,
             sizeof(message.param.plmn_id));
 
     request = ogs_sbi_build_request(&message);

--- a/src/smf/nudm-build.c
+++ b/src/smf/nudm-build.c
@@ -42,7 +42,7 @@ ogs_sbi_request_t *smf_nudm_sdm_build_get(smf_sess_t *sess, void *data)
             sizeof(message.param.s_nssai));
 
     message.param.plmn_id_presence = true;
-    memcpy(&message.param.plmn_id, &sess->home_plmn_id,
+    memcpy(&message.param.plmn_id, &sess->serving_plmn_id,
             sizeof(message.param.plmn_id));
 
     if (sess->session.name)


### PR DESCRIPTION
Changes the plmn-id attribute value to visiting PLMN for the nudm_sdm GET requests to comply with 3GPP specs. 
 Fixes issue #4315 