### PR TITLE
amf: Add local release in case of NGAP EI

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -4902,30 +4902,34 @@ void ngap_handle_error_indication(amf_gnb_t *gnb, ogs_ngap_message_t *message)
 
     if (ran_ue) {
         amf_ue_t *amf_ue = NULL;
+        int xact_count = 0;
 
-        ogs_warn("    Performing local release for"
-                " RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+        ogs_warn("    Performing local release for "
+                "RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
                 (long long)ran_ue->ran_ue_ngap_id,
                 (long long)ran_ue->amf_ue_ngap_id);
 
         amf_ue = amf_ue_find_by_id(ran_ue->amf_ue_id);
         if (amf_ue) {
-            int xact_count = amf_sess_xact_count(amf_ue);
+            CLEAR_AMF_UE_ALL_TIMERS(amf_ue);
+
+            xact_count = amf_sess_xact_count(amf_ue);
 
             amf_sbi_send_deactivate_all_sessions(
                     ran_ue, amf_ue,
-                    AMF_UPDATE_SM_CONTEXT_DEACTIVATED_LOCAL,
-                    NGAP_Cause_PR_nas,
-                    NGAP_CauseNas_normal_release);
+                    AMF_REMOVE_N2_CONTEXT_BY_ERROR_INDICATION,
+                    Cause->present, (int)Cause->choice.radioNetwork);
 
             if (amf_sess_xact_count(amf_ue) == xact_count) {
-                ran_ue->ue_ctx_rel_action =
-                    NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK;
-                ngap_handle_ue_context_release_action(ran_ue);
+                ogs_debug("    SUPI[%s]", amf_ue->supi);
+                amf_ue_deassociate_ran_ue(amf_ue, ran_ue);
+                ran_ue_remove(ran_ue);
+                ogs_timer_start(amf_ue->mobile_reachable.timer,
+                        ogs_time_from_sec(
+                            amf_self()->time.t3512.value + 240));
             }
         } else {
-            ran_ue->ue_ctx_rel_action = NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE;
-            ngap_handle_ue_context_release_action(ran_ue);
+            ran_ue_remove(ran_ue);
         }
     }
 }

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -19,7 +19,6 @@
 
 #include "nsmf-handler.h"
 #include "nas-path.h"
-#include "ngap-handler.h"
 #include "ngap-path.h"
 #include "sbi-path.h"
 
@@ -636,26 +635,6 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                     }
                 }
 
-            } else if (state ==
-                            AMF_UPDATE_SM_CONTEXT_DEACTIVATED_LOCAL) {
-                /*
-                 * ErrorIndication-triggered local release:
-                 * Sessions have been deactivated; perform the release
-                 * action directly without sending UEContextReleaseCommand
-                 * since the RAN context is already considered lost.
-                 */
-
-                if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
-                    if (ran_ue) {
-                        ran_ue->ue_ctx_rel_action =
-                            NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK;
-                        ngap_handle_ue_context_release_action(ran_ue);
-                    } else {
-                        ogs_warn("[%s] RAN-NG Context has already been removed",
-                                amf_ue->supi);
-                    }
-                }
-
             } else if (state == AMF_UPDATE_SM_CONTEXT_REGISTRATION_REQUEST) {
 
                 /* Not reached here */
@@ -819,6 +798,23 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                                 amf_self()->time.t3512.value + 240));
                 }
 
+            } else if (state == AMF_REMOVE_N2_CONTEXT_BY_ERROR_INDICATION) {
+                if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
+
+                    if (ran_ue) {
+                        ogs_debug("    SUPI[%s]", amf_ue->supi);
+                        amf_ue_deassociate_ran_ue(amf_ue, ran_ue);
+                        ran_ue_remove(ran_ue);
+                    } else {
+                        ogs_warn("[%s] RAN-NG Context has already been removed",
+                                amf_ue->supi);
+                    }
+
+                    ogs_timer_start(amf_ue->mobile_reachable.timer,
+                            ogs_time_from_sec(
+                                amf_self()->time.t3512.value + 240));
+                }
+                
             } else if (state == AMF_REMOVE_S1_CONTEXT_BY_RESET_ALL) {
                 if (AMF_SESSION_SYNC_DONE(amf_ue, state)) {
 

--- a/src/amf/sbi-path.h
+++ b/src/amf/sbi-path.h
@@ -46,7 +46,6 @@ bool amf_sbi_send_request(
 #define AMF_UPDATE_SM_CONTEXT_ACTIVATED                 11
 #define AMF_UPDATE_SM_CONTEXT_SETUP_FAIL                12
 #define AMF_UPDATE_SM_CONTEXT_DEACTIVATED               13
-#define AMF_UPDATE_SM_CONTEXT_DEACTIVATED_LOCAL         25
 #define AMF_UPDATE_SM_CONTEXT_REGISTRATION_REQUEST      14
 #define AMF_UPDATE_SM_CONTEXT_SERVICE_REQUEST           15
 #define AMF_UPDATE_SM_CONTEXT_MODIFIED                  16
@@ -64,6 +63,7 @@ bool amf_sbi_send_request(
 #define AMF_REMOVE_S1_CONTEXT_BY_LO_CONNREFUSED         51
 #define AMF_REMOVE_S1_CONTEXT_BY_RESET_ALL              52
 #define AMF_REMOVE_S1_CONTEXT_BY_RESET_PARTIAL          53
+#define AMF_REMOVE_N2_CONTEXT_BY_ERROR_INDICATION       54
 
 /*
  * TS23.502


### PR DESCRIPTION
Hi, thank you for your work.
I am submitting this PR to implement the local release of UE-associated logical connections upon receiving an NGAP Error Indication (EI) message, as specified in 3GPP TS 38.413, Section 10.6. 

<img width="796" height="564" alt="image" src="https://github.com/user-attachments/assets/8ab9c021-34e7-4113-8d7a-8635887f3204" />

Currently, the Open5GS AMF lacks the logic to handle the local release of the logical connection even when the NGAP EI message implies a UE-associated connection by including AP IDs. To address this, I have added the necessary handling to trigger a local release based on the AP IDs provided in the message, aligning the behavior with other implementations such as free5gc (e.g., in their internal NGAP handler). 

For this initial implementation, I have focused on ensuring the release behavior occurs within the AMF states. However, I am still evaluating whether related PDU sessions should also be deactivated during this local release process, and I would appreciate your guidance on whether to extend the scope or keep it focused on the AMF states for now. 

Thank you, always