### PR TITLE
[UPF] Implement UE-to-UE hairpin in the GTP-U path

### DIFF
--- a/tests/registration/multi-ue-test.c
+++ b/tests/registration/multi-ue-test.c
@@ -239,6 +239,29 @@ static void test1_func(abts_case *tc, void *data)
     }
 
     for (i = 0; i < NUM_OF_TEST_UE; i++) {
+        int target = (i + 1) % NUM_OF_TEST_UE;
+        char dst_ip[OGS_ADDRSTRLEN];
+        test_sess_t *dst_sess = NULL;
+
+        sess = test_sess_find_by_psi(test_ue[i], 5);
+        ogs_assert(sess);
+        qos_flow = test_qos_flow_find_by_qfi(sess, 1);
+        ogs_assert(qos_flow);
+
+        dst_sess = test_sess_find_by_psi(test_ue[target], 5);
+        ogs_assert(dst_sess);
+        inet_ntop(AF_INET, &dst_sess->ue_ip.addr,
+                dst_ip, sizeof(dst_ip));
+
+        rv = test_gtpu_send_ping(gtpu, qos_flow, dst_ip);
+        ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+        recvbuf = test_gtpu_read(gtpu);
+        ABTS_PTR_NOTNULL(tc, recvbuf);
+        ogs_pkbuf_free(recvbuf);
+    }
+
+    for (i = 0; i < NUM_OF_TEST_UE; i++) {
         /* Send PDU session establishment request */
         sess = test_sess_find_by_psi(test_ue[i], 5);
         ogs_assert(sess);


### PR DESCRIPTION
When traffic from UE is destined to an other UE on the same UPF, the packet shouldn't be sent to the TUN interface, but should be re-encapsulated and forwarded via the destination UE's GTP-U tunnel.

Before, in the gtp-path.c there was a TODO placeholder for this.

Added logic:
- Look up the destination UE session by inner packet dest IP
- Find a matching downlink PDR with FAR
- Fall back to lowest precedence PDR
- URR accounting
- Forward using ogs_pfcp_up_handle_pdr() or fall through to TUN  if no matching PDR found

The tap device check was moved after the hairpin check:
- Because for hairpinned traffic the TAP is not relevant
- If TAP push happens before the PDR rule check, then we'd need to strip it later in the UE-to-UE block

Additionally, the multi-ue-test was extended with each UE pinging the next UE.