### PR TITLE
pfcp: use find_or_add in Create FAR/QER/URR handlers and make Remove idempotent

### DIFF
--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -1149,7 +1149,9 @@ ogs_pfcp_far_t *ogs_pfcp_handle_create_far(ogs_pfcp_sess_t *sess,
     far->apply_action = message->apply_action.u16;
 
     far->dst_if = 0;
+    far->dst_if_type_presence = false;
     memset(&far->outer_header_creation, 0, sizeof(far->outer_header_creation));
+    far->outer_header_creation_len = 0;
 
     if (far->dnn) {
         ogs_free(far->dnn);
@@ -1600,6 +1602,21 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_create_urr(ogs_pfcp_sess_t *sess,
     urr->rep_triggers.reptri_5 = (message->reporting_triggers.u24 >> 16) & 0xFF;
     urr->rep_triggers.reptri_6 = (message->reporting_triggers.u24 >> 8) & 0xFF;
     urr->rep_triggers.reptri_7 = message->reporting_triggers.u24 & 0xFF;
+
+    /* Clear optional/presence-driven fields to prevent stale state
+     * when find_or_add() returns an already-existing URR */
+    urr->meas_period = 0;
+    memset(&urr->vol_threshold, 0, sizeof(urr->vol_threshold));
+    memset(&urr->vol_quota, 0, sizeof(urr->vol_quota));
+    urr->event_threshold = 0;
+    urr->event_quota = 0;
+    urr->time_threshold = 0;
+    urr->time_quota = 0;
+    urr->quota_holding_time = 0;
+    memset(&urr->dropped_dl_traffic_threshold, 0,
+            sizeof(urr->dropped_dl_traffic_threshold));
+    urr->quota_validity_time = 0;
+    memset(&urr->meas_info, 0, sizeof(urr->meas_info));
 
     if (message->measurement_period.presence) {
         urr->meas_period = message->measurement_period.u32;


### PR DESCRIPTION
## Summary

- Change `ogs_pfcp_handle_create_far()`, `ogs_pfcp_handle_create_qer()`, and `ogs_pfcp_handle_create_urr()` to use `find_or_add` instead of `find`, matching the existing `ogs_pfcp_handle_create_pdr()` behavior
- Make `ogs_pfcp_handle_remove_pdr/far/qer/urr()` idempotent: removing a non-existent entry now returns success with a warning instead of failing with an error

## Problem

When a PFCP control plane sends a Session Modification Request containing Create FAR, Create QER, or Create URR IEs for IDs that were not previously created during PDR processing, the UPF rejects them with errors like `Cannot find QER-ID[3] in PDR`.

This happens because `ogs_pfcp_handle_create_pdr()` uses `ogs_pfcp_pdr_find_or_add()` (which creates entries if they don't exist), but the other three create handlers use `find()`-only variants that expect entries to already exist.

Some PFCP control plane implementations send Create URR/QER/FAR in Session Modification without a corresponding Create PDR that would have pre-created these entries via the PDR's associated ID references. The resulting PFCP error responses cascade into GTP-U Error Indications, causing bearer teardowns and PDN disconnections.

## Changes

**Create handlers** (`lib/pfcp/handler.c`):
- `ogs_pfcp_handle_create_far()`: `ogs_pfcp_far_find()` → `ogs_pfcp_far_find_or_add()`
- `ogs_pfcp_handle_create_qer()`: `ogs_pfcp_qer_find()` → `ogs_pfcp_qer_find_or_add()`
- `ogs_pfcp_handle_create_urr()`: `ogs_pfcp_urr_find()` → `ogs_pfcp_urr_find_or_add()`

**Remove handlers** (`lib/pfcp/handler.c`):
- `ogs_pfcp_handle_remove_pdr/far/qer/urr()`: Return success with `ogs_warn()` instead of failing with `ogs_error()` + `SESSION_CONTEXT_NOT_FOUND` when the entry doesn't exist, since the desired end state (entry removed) is already achieved.

## Test plan

- [x] Verified with a commercial PFCP control plane (PGW-C) that sends Create URR/QER in Session Modification for IDs not referenced by any PDR
- [x] IMS PDN stable for 12+ minutes after fix (was disconnecting every 1-2 minutes before)
- [x] VoLTE calls held for 2.5+ minutes without dropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)