### PR TITLE
sgwc: validate PAA IE length in CreateSessionResponse to prevent heap overflow

### DIFF
--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -153,16 +153,23 @@ void sgwc_s5c_handle_create_session_response(
         ogs_error("No PDN Address Allocation [Cause:%d]", session_cause);
         cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
     } else {
-        memcpy(&sess->paa, rsp->pdn_address_allocation.data,
+        if(rsp->pdn_address_allocation.len > OGS_PAA_IPV4V6_LEN){
+            ogs_error("PAA IE Length (%u) exceeds maximum (%d)", "rejecting CreateSessionResponse",
+                rsp->pdn_address_allocation.len, OGS_PAA_IPV4V6_LEN);
+            cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_INCORRECT;    
+        } else{
+            memcpy(&sess->paa, rsp->pdn_address_allocation.data,
                 rsp->pdn_address_allocation.len);
-        sess->session.session_type = sess->paa.session_type;
-        if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
-        } else if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV6) {
-        } else if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4V6) {
-        } else {
-            ogs_error("Unknown session-type [%d]", sess->session.session_type);
-            cause_value = OGS_GTP2_CAUSE_PREFERRED_PDN_TYPE_NOT_SUPPORTED;
+            sess->session.session_type = sess->paa.session_type;
+            if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4) {
+            } else if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV6) {
+            } else if (sess->session.session_type == OGS_PDU_SESSION_TYPE_IPV4V6) {
+            } else {
+                ogs_error("Unknown session-type [%d]", sess->session.session_type);
+                cause_value = OGS_GTP2_CAUSE_PREFERRED_PDN_TYPE_NOT_SUPPORTED;
+            }
         }
+        
     }
 
     if (rsp->cause.presence == 0) {


### PR DESCRIPTION
The PAA IE length field in a GTPv2-C CreateSessionResponse on S5-C is
read directly from the network and passed to memcpy without a bounds
check:

`memcpy(&sess->paa, rsp->pdn_address_allocation.data, rsp->pdn_address_allocation.len);
`

A malicious or buggy PGW can set the IE Length to an arbitrary value.
Since `sizeof(sess->paa) == OGS_PAA_IPV4V6_LEN` (22 bytes), an oversized
length corrupts adjacent heap memory and crashes SGW-C (SIGSEGV).

Add a bounds check against `OGS_PAA_IPV4V6_LEN` before the memcpy. If the
declared length exceeds the maximum defined in TS 29.274 §8.14, set
cause `MANDATORY_IE_INCORRECT` and return without copying.

Fixes #4282