### PR TITLE
sgwc: validate PAA IE length to prevent buffer overflow in CreateSessionResponse

### DIFF
--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -152,6 +152,11 @@ void sgwc_s5c_handle_create_session_response(
     if (rsp->pdn_address_allocation.presence == 0) {
         ogs_error("No PDN Address Allocation [Cause:%d]", session_cause);
         cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
+    } else if (rsp->pdn_address_allocation.len < OGS_PAA_IPV4_LEN ||
+            rsp->pdn_address_allocation.len > OGS_PAA_IPV4V6_LEN) {
+        ogs_error("Invalid PAA IE [Length:%d]",
+                rsp->pdn_address_allocation.len);
+        cause_value = OGS_GTP2_CAUSE_INVALID_LENGTH;
     } else {
         memcpy(&sess->paa, rsp->pdn_address_allocation.data,
                 rsp->pdn_address_allocation.len);


### PR DESCRIPTION
Validate the PDN Address Allocation (PAA) IE length in sgwc_s5c_handle_create_session_response() before copying it into sess->paa.

Previously, the code directly performed:

    memcpy(&sess->paa, rsp->pdn_address_allocation.data,
           rsp->pdn_address_allocation.len);

without validating the IE length. A malicious or malformed CreateSessionResponse (S5-C) from a PGW with an oversized PAA IE length could trigger a buffer overflow and crash SGW-C (remote DoS).

This patch adds explicit length validation and rejects responses with invalid PAA IE length, returning
OGS_GTP2_CAUSE_INVALID_LENGTH instead of proceeding.

Issue originally reported in #4282.

An initial fix was submitted in PR #4330 but was reverted in #4331 due to issues. This commit provides a corrected and validated implementation.

Fixes: #4282