### PR TITLE
core/sbi: Prevent DoS in requester-features parsing (uint64 overflow)

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -1059,6 +1059,11 @@ int ogs_sbi_parse_request(
             if (v) {
                 discovery_option->requester_features =
                     ogs_uint64_from_string_hexadecimal(v);
+                if (ogs_errno == EINVAL || ogs_errno == ERANGE) {
+                    ogs_error("ogs_uint64_from_string_hexadecimal() failed");
+                    ogs_sbi_discovery_option_free(discovery_option);
+                    return OGS_ERROR;
+                }
                 discovery_option_presence = true;
             }
         }
@@ -1281,7 +1286,6 @@ int ogs_sbi_parse_request(
 
     if (parse_content(message, &request->http) != OGS_OK) {
         ogs_error("parse_content() failed");
-        ogs_sbi_message_free(message);
         return OGS_ERROR;
     }
 


### PR DESCRIPTION
Replace strtoll() with strtoull() in ogs_uint64_from_string() and remove fatal abort on conversion errors to prevent remote crash via malformed SupportedFeatures/requester-features values.

The previous implementation could trigger OGS_LOG_FATAL and ogs_assert_if_reached() when strtoll() detected ERANGE, allowing a malicious or buggy peer to cause a denial-of-service by sending an overly large hexadecimal value.

Changes:
- Use strtoull() for proper unsigned parsing.
- Add strict endptr validation (no digits, trailing garbage).
- Handle ERANGE and invalid inputs gracefully without abort().
- Normalize errno handling: success paths set errno=0.
- In ogs_sbi_parse_request(), reject invalid requester-features (EINVAL/ERANGE) and return OGS_ERROR instead of proceeding.

Empty string is treated as valid (0), consistent with 3GPP SupportedFeatures pattern ('^[A-Fa-f0-9]*$').

This ensures malformed requester-features values no longer crash NRF and are properly rejected during SBI request parsing.

Issues: #4263