### PR TITLE
amf: snapshot RAN-UE ID in SBI transaction to avoid race during SM Context Update

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2672,6 +2672,16 @@ void ogs_sbi_xact_remove(ogs_sbi_xact_t *xact)
     if (xact->target_apiroot)
         ogs_free(xact->target_apiroot);
 
+    /*
+     * Release optional user context attached to the transaction.
+     * The transaction owns this memory and is responsible for
+     * freeing it when the transaction is destroyed.
+     */
+    if (xact->user_data) {
+        if (xact->user_data_free)
+            xact->user_data_free(xact->user_data);
+    }
+
     ogs_list_remove(&sbi_object->xact_list, xact);
     ogs_pool_id_free(&xact_pool, xact);
 }

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -270,14 +270,30 @@ typedef struct ogs_sbi_xact_s {
 
     ogs_pool_id_t assoc_stream_id;
 
+    /*
+     * Optional user context attached to this SBI transaction.
+     *
+     * This pointer allows NF-specific code to associate arbitrary
+     * data with the transaction. The memory is owned by the
+     * transaction and will be released automatically when the
+     * transaction is removed via ogs_sbi_xact_remove().
+     *
+     * Typical usage:
+     *   - Store a snapshot of context identifiers needed when the
+     *     asynchronous SBI response arrives.
+     *   - Example: AMF stores a snapshot of RAN-UE ID because the
+     *     session's current RAN-UE may change before the response
+     *     (e.g., NG context release / re-establishment).
+     */
+    void *user_data;
+    void (*user_data_free)(void *user_data);
+
     int state;
     char *target_apiroot;
 
     ogs_sbi_object_t *sbi_object;
     ogs_pool_id_t sbi_object_id;
 
-#define OGS_SBI_MAX_NUM_OF_ASSOC_ID 4
-    ogs_pool_id_t assoc_id[OGS_SBI_MAX_NUM_OF_ASSOC_ID];
 } ogs_sbi_xact_t;
 
 typedef struct ogs_sbi_nf_service_s {

--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -69,7 +69,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
     ogs_sbi_xact_t *sbi_xact = NULL;
     ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
     int state = AMF_CREATE_SM_CONTEXT_NO_STATE;
-    ogs_pool_id_t assoc_ran_ue_id = OGS_INVALID_POOL_ID;
+    ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
     ogs_sbi_stream_t *stream = NULL;
     ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *sbi_request = NULL;
@@ -541,7 +541,12 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
                     sbi_object_id <= OGS_MAX_POOL_ID);
 
-            assoc_ran_ue_id = sbi_xact->assoc_id[AMF_ASSOC_RAN_UE_ID];
+            if (sbi_xact->user_data) {
+                amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
+
+                if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+                    ran_ue_id = ctx->ran_ue_id;
+            }
 
             ogs_sbi_xact_remove(sbi_xact);
 
@@ -591,9 +596,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
             ogs_assert(OGS_FSM_STATE(&amf_ue->sm));
 
-            if (assoc_ran_ue_id >= OGS_MIN_POOL_ID &&
-                    assoc_ran_ue_id <= OGS_MAX_POOL_ID)
-                ran_ue = ran_ue_find_by_id(assoc_ran_ue_id);
+            if (ran_ue_id >= OGS_MIN_POOL_ID && ran_ue_id <= OGS_MAX_POOL_ID)
+                ran_ue = ran_ue_find_by_id(ran_ue_id);
 
             SWITCH(sbi_message.h.resource.component[2])
             CASE(OGS_SBI_RESOURCE_NAME_MODIFY)
@@ -662,7 +666,12 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
                     sbi_object_id <= OGS_MAX_POOL_ID);
 
-            assoc_ran_ue_id = sbi_xact->assoc_id[AMF_ASSOC_RAN_UE_ID];
+            if (sbi_xact->user_data) {
+                amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
+
+                if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+                    ran_ue_id = ctx->ran_ue_id;
+            }
 
             state = sbi_xact->state;
 
@@ -682,9 +691,8 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
 
             ogs_assert(OGS_FSM_STATE(&amf_ue->sm));
 
-            if (assoc_ran_ue_id >= OGS_MIN_POOL_ID &&
-                    assoc_ran_ue_id <= OGS_MAX_POOL_ID)
-                ran_ue = ran_ue_find_by_id(assoc_ran_ue_id);
+            if (ran_ue_id >= OGS_MIN_POOL_ID && ran_ue_id <= OGS_MAX_POOL_ID)
+                ran_ue = ran_ue_find_by_id(ran_ue_id);
 
             amf_nnssf_nsselection_handle_get(
                     amf_ue, ran_ue, sess, state, &sbi_message);
@@ -793,7 +801,12 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
             ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
                     sbi_object_id <= OGS_MAX_POOL_ID);
 
-            assoc_ran_ue_id = sbi_xact->assoc_id[AMF_ASSOC_RAN_UE_ID];
+            if (sbi_xact->user_data) {
+                amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
+
+                if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+                    ran_ue_id = ctx->ran_ue_id;
+            }
 
             service_type = sbi_xact->service_type;
             requester_nf_type = sbi_xact->requester_nf_type;
@@ -869,13 +882,13 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 ogs_error("[%s:%s:%d:%d] Cannot receive SBI message",
                         amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
 
-                if (assoc_ran_ue_id < OGS_MIN_POOL_ID &&
-                        assoc_ran_ue_id > OGS_MAX_POOL_ID) {
-                    ogs_error("No assoc RAN-UE id [%d]", assoc_ran_ue_id);
+                if (ran_ue_id < OGS_MIN_POOL_ID ||
+                    ran_ue_id > OGS_MAX_POOL_ID) {
+                    ogs_error("No assoc RAN-UE id [%d]", ran_ue_id);
                     break;
                 }
 
-                ran_ue = ran_ue_find_by_id(assoc_ran_ue_id);
+                ran_ue = ran_ue_find_by_id(ran_ue_id);
                 if (!ran_ue) {
                     ogs_error("[%s:%s:%d:%d] "
                             "NG Context has already been removed",

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -916,25 +916,31 @@ typedef struct amf_sess_s {
     ogs_pool_id_t   amf_ue_id;
 
     /*
-     * RAN-UE identifier associated with this session.
+     * RAN-UE identifier currently associated with this session.
+     *
+     * NOTE:
+     * This field represents the latest RAN UE NGAP ID known for the session.
+     * It may change during procedures such as NG context release and
+     * re-establishment.
      *
      * IMPORTANT:
      * - During SBI Client operations (e.g., AMF sending requests to SMF/PCF),
-     *   the RAN-UE may change before the asynchronous SBI response arrives
-     *   (e.g., NG Context release/re-establishment). Because of this, the
-     *   SBI transaction (ogs_sbi_xact_t) stores its own snapshot of the
-     *   RAN-UE ID inside xact->assoc_id[].
+     *   the RAN-UE may change before the asynchronous SBI response arrives.
+     *   To avoid using a stale or incorrect RAN-UE, the SBI transaction
+     *   (ogs_sbi_xact_t) stores a snapshot in xact->user_data.
      *
-     *   When processing SBI Client responses, the AMF must use the snapshot
-     *   stored in xact->assoc_id[AMF_ASSOC_RAN_UE_ID] instead of
-     *   this session field.
+     *   When handling SBI Client responses, the AMF MUST use the snapshot
+     *   stored in the SBI transaction instead of this session field.
      *
      * - For SBI Server operations (e.g., Namf callbacks where the AMF
      *   receives requests from SMF), there is no transaction-specific
      *   snapshot. In such cases, the current session value (sess->ran_ue_id)
      *   is used.
+     *
+     * This design helps prevent RAN-UE mismatches observed in Issue #2839,
+     * where concurrent UE procedures could result in NAS being sent to the
+     * wrong RAN UE.
      */
-#define AMF_ASSOC_RAN_UE_ID 1
     ogs_pool_id_t   ran_ue_id;
 
     ogs_s_nssai_t s_nssai;

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -39,6 +39,8 @@ void amf_nnrf_handle_nf_discover(
     ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
 
+    ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
+
     OpenAPI_search_result_t *SearchResult = NULL;
 
     ogs_assert(recvmsg);
@@ -74,9 +76,16 @@ void amf_nnrf_handle_nf_discover(
         amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
         ogs_assert(amf_ue);
 
-        ogs_assert(xact->assoc_id[AMF_ASSOC_RAN_UE_ID] >= OGS_MIN_POOL_ID &&
-                xact->assoc_id[AMF_ASSOC_RAN_UE_ID] <= OGS_MAX_POOL_ID);
-        ran_ue = ran_ue_find_by_id(xact->assoc_id[AMF_ASSOC_RAN_UE_ID]);
+        if (xact->user_data) {
+            amf_sbi_xact_ctx_t *ctx = xact->user_data;
+
+            if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+                ran_ue_id = ctx->ran_ue_id;
+        }
+
+        ogs_assert(ran_ue_id >= OGS_MIN_POOL_ID &&
+                ran_ue_id <= OGS_MAX_POOL_ID);
+        ran_ue = ran_ue_find_by_id(ran_ue_id);
         ogs_assert(ran_ue);
     } else {
         ogs_fatal("(NF discover) Not implemented [%s:%d]",

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -154,6 +154,11 @@ int amf_ue_sbi_discover_and_send(
     return OGS_OK;
 }
 
+static void amf_sbi_xact_ctx_free(void *data)
+{
+    ogs_free(data);
+}
+
 int amf_sess_sbi_discover_and_send(
         ogs_sbi_service_type_e service_type,
         ogs_sbi_discovery_option_t *discovery_option,
@@ -168,6 +173,32 @@ int amf_sess_sbi_discover_and_send(
     ogs_assert(sess);
     ogs_assert(build);
 
+/*
+ * RAN-UE identifier currently associated with this session.
+ *
+ * NOTE:
+ * This field represents the latest RAN UE NGAP ID known for the session.
+ * It may change during procedures such as NG context release and
+ * re-establishment.
+ *
+ * IMPORTANT:
+ * - During SBI Client operations (e.g., AMF sending requests to SMF/PCF),
+ *   the RAN-UE may change before the asynchronous SBI response arrives.
+ *   To avoid using a stale or incorrect RAN-UE, the SBI transaction
+ *   (ogs_sbi_xact_t) stores a snapshot in xact->user_data.
+ *
+ *   When handling SBI Client responses, the AMF MUST use the snapshot
+ *   stored in the SBI transaction instead of this session field.
+ *
+ * - For SBI Server operations (e.g., Namf callbacks where the AMF
+ *   receives requests from SMF), there is no transaction-specific
+ *   snapshot. In such cases, the current session value (sess->ran_ue_id)
+ *   is used.
+ *
+ * This design helps prevent RAN-UE mismatches observed in Issue #2839,
+ * where concurrent UE procedures could result in NAS being sent to the
+ * wrong RAN UE.
+ */
     if (ran_ue) {
         sess->ran_ue_id = ran_ue->id;
     } else
@@ -179,24 +210,33 @@ int amf_sess_sbi_discover_and_send(
     if (!xact) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
         r = nas_5gs_send_back_gsm_message(
-                ran_ue_find_by_id(sess->ran_ue_id), sess,
+                ran_ue, sess,
                 OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
         return OGS_ERROR;
     }
 
-    xact->state = state;
+    /* Bind per-xact AMF context */
+    if (ran_ue) {
+        amf_sbi_xact_ctx_t *ctx = NULL;
 
-    if (ran_ue)
-        xact->assoc_id[AMF_ASSOC_RAN_UE_ID] = ran_ue->id;
+        ctx = ogs_calloc(1, sizeof(*ctx));
+        ogs_assert(ctx);
+
+        ctx->ran_ue_id = ran_ue->id;
+        xact->user_data = ctx;
+        xact->user_data_free = amf_sbi_xact_ctx_free;
+    }
+
+    xact->state = state;
 
     rv = ogs_sbi_discover_and_send(xact);
     if (rv != OGS_OK) {
         ogs_error("amf_sess_sbi_discover_and_send() failed");
         ogs_sbi_xact_remove(xact);
         r = nas_5gs_send_back_gsm_message(
-                ran_ue_find_by_id(sess->ran_ue_id), sess,
+                ran_ue, sess,
                 OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED, AMF_NAS_BACKOFF_TIME);
         ogs_expect(r == OGS_OK);
         ogs_assert(r != OGS_ERROR);
@@ -223,6 +263,8 @@ static int client_discover_cb(
     ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
 
+    ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
+
     ogs_sbi_discovery_option_t *v_discovery_option = NULL;
 
     int current_state, next_state = AMF_CREATE_SM_CONTEXT_NO_STATE;
@@ -238,9 +280,15 @@ static int client_discover_cb(
         return OGS_ERROR;
     }
 
-    if (xact->assoc_id[AMF_ASSOC_RAN_UE_ID] >= OGS_MIN_POOL_ID &&
-        xact->assoc_id[AMF_ASSOC_RAN_UE_ID] <= OGS_MAX_POOL_ID)
-        ran_ue = ran_ue_find_by_id(xact->assoc_id[AMF_ASSOC_RAN_UE_ID]);
+    if (xact->user_data) {
+        amf_sbi_xact_ctx_t *ctx = xact->user_data;
+
+        if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+            ran_ue_id = ctx->ran_ue_id;
+    }
+
+    if (ran_ue_id >= OGS_MIN_POOL_ID && ran_ue_id <= OGS_MAX_POOL_ID)
+        ran_ue = ran_ue_find_by_id(ran_ue_id);
 
     service_type = xact->service_type;
     ogs_assert(service_type);
@@ -505,10 +553,19 @@ int amf_sess_sbi_discover_by_nsi(
         return OGS_ERROR;
     }
 
-    xact->state = state;
+    /* Bind per-xact AMF context */
+    if (ran_ue) {
+        amf_sbi_xact_ctx_t *ctx = NULL;
 
-    if (ran_ue)
-        xact->assoc_id[AMF_ASSOC_RAN_UE_ID] = ran_ue->id;
+        ctx = ogs_calloc(1, sizeof(*ctx));
+        ogs_assert(ctx);
+
+        ctx->ran_ue_id = ran_ue->id;
+        xact->user_data = ctx;
+        xact->user_data_free = amf_sbi_xact_ctx_free;
+    }
+
+    xact->state = state;
 
     return ogs_sbi_client_send_request(
             client, client_discover_cb, xact->request,

--- a/src/amf/sbi-path.h
+++ b/src/amf/sbi-path.h
@@ -31,6 +31,17 @@
 extern "C" {
 #endif
 
+typedef struct amf_sbi_xact_ctx_s {
+    /*
+     * Snapshot of the RAN-UE identifier associated with the
+     * SBI transaction at the time the request was sent.
+     *
+     * This is required because the session's current RAN-UE
+     * may change before the asynchronous response arrives.
+     */
+    ogs_pool_id_t ran_ue_id;
+} amf_sbi_xact_ctx_t;
+
 int amf_sbi_open(void);
 void amf_sbi_close(void);
 


### PR DESCRIPTION
Several users reported intermittent AMF crashes when SM Context Update procedures overlap with NG context release or a new Registration procedure. In these situations the RAN-UE associated with a session may change before the asynchronous SBI response arrives.

Typical trigger scenarios include:

  * UEContextReleaseRequest followed by a new Registration Request
  * PDU Session Update overlapping with UE deactivation or handover
  * Registration Request arriving while a previous Service Request is still being processed

In these cases the AMF may send an Update SM Context request to the SMF while the NG context is being released or replaced. When the asynchronous SBI response arrives later, the AMF uses the session's current ran_ue pointer. However, that pointer may already have been switched to a new RAN-UE or cleared due to the release procedure.

As a result, the AMF may reference the wrong RAN-UE context or an inconsistent state, eventually triggering an assertion such as:

  amf_nsmf_pdusession_handle_update_sm_context:
      Assertion `ran_ue->deactivation.group' failed

The root cause is that SBI client transactions do not preserve the RAN-UE association at the time the request was sent. Because SBI operations are asynchronous, the session context may change before the response is processed.

This patch introduces a generic mechanism to attach user-defined context to an SBI transaction:

  - Add `user_data` and `user_data_free` to `ogs_sbi_xact_t`
  - Allow NF-specific code to store per-transaction context
  - Ensure the memory is released automatically when the transaction is removed

The AMF now stores a snapshot of the RAN-UE ID in the SBI transaction when sending an Update SM Context request. When the SBI response is processed, the AMF retrieves the RAN-UE using this snapshot instead of the session's current ran_ue pointer. This guarantees that the response is associated with the correct RAN context even if the session state has changed in the meantime.

This approach avoids race conditions between asynchronous SBI responses and NG context lifecycle events, preventing the AMF from accessing an incorrect or partially released RAN-UE context.

Reported-by:
  multiple users on v2.7.6 environments

Issues: #4174, #4274