### PR TITLE
 Fix MME crash (SIGABRT) on TAU with BCS mismatch and active_flag=1

### DIFF
--- a/src/mme/mme-path.c
+++ b/src/mme/mme-path.c
@@ -416,6 +416,22 @@ void mme_send_tau_accept_and_check_release(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
     ogs_assert(mme_ue);
     ogs_assert(enb_ue);
 
+    /*
+     * If BCS mismatch deleted all sessions, InitialContextSetup is impossible
+     * (requires E-RABs). Fall back to DownlinkNASTransport to deliver TAU
+     * Accept without bearer setup. The UE reported no bearers via BCS,
+     * so it can re-establish PDN connectivity after TAU completes.
+     */
+    if (mme_ue->tracking_area_update_accept_proc ==
+            S1AP_ProcedureCode_id_InitialContextSetup &&
+            ogs_list_count(&mme_ue->sess_list) == 0) {
+        ogs_warn("[%s] No sessions after BCS cleanup; "
+                "downgrade InitialContextSetup to DownlinkNASTransport",
+                mme_ue->imsi_bcd);
+        mme_ue->tracking_area_update_accept_proc =
+            S1AP_ProcedureCode_id_downlinkNASTransport;
+    }
+
     r = nas_eps_send_tau_accept(mme_ue,
             mme_ue->tracking_area_update_accept_proc);
     ogs_expect(r == OGS_OK);


### PR DESCRIPTION
     When a UE sends TAU Request with active_flag=1 and a Bearer Context
     Status that mismatches MME state, the BCS cleanup deletes all sessions
     but the stored procedure remains InitialContextSetup. Building an
     Initial Context Setup Request with zero E-RABs returns NULL, hitting
     ogs_assert and killing the process — disconnecting all eNBs.

     Guard in mme_send_tau_accept_and_check_release(): if no sessions remain
     after BCS cleanup, downgrade to DownlinkNASTransport so TAU Accept is
     delivered without requiring bearers.