### PR TITLE
mme: fix Served TAI lookup for TAC range configuration

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -5006,7 +5006,7 @@ int mme_find_served_tai(ogs_eps_tai_t *tai)
             ogs_assert(list1->tai[j].type == OGS_TAI1_TYPE);
             ogs_assert(list1->tai[j].num <= OGS_MAX_NUM_OF_TAI);
 
-            if (memcmp(&list0->tai[j].plmn_id,
+            if (memcmp(&list1->tai[j].plmn_id,
                         &tai->plmn_id, OGS_PLMN_ID_LEN) == 0 &&
                     list1->tai[j].tac <= tai->tac &&
                     tai->tac < (list1->tai[j].tac+list1->tai[j].num))


### PR DESCRIPTION
mme_find_served_tai() incorrectly compares the PLMN-ID of TAC range entries using list0->tai[j].plmn_id instead of list1->tai[j].plmn_id.

When TAC ranges are configured in mme.tai (e.g. tac: [1-11]), the range entries are stored in list1. However, the lookup logic mistakenly reads the PLMN from list0 while validating list1 entries, which can cause the Served TAI match to fail even though the TAC is within the configured range.

As a result, eNB S1 Setup may fail with:

  Cannot find Served TAI. Check 'mme.tai' configuration

This patch fixes the comparison to use list1->tai[j].plmn_id so that TAC range entries are matched correctly.

Fixes TAC range configuration such as:

  tac: [1-11]

Issues: #4345