### PR TITLE
fix(mme/upf): M_TMSI=0x0 fallback + source IP spoofing passthrough for private LTE (CBRS/iPhone)

### DIFF
--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -506,6 +506,19 @@ void s1ap_handle_initial_ue_message(mme_enb_t *enb, ogs_s1ap_message_t *message)
             nas_guti.m_tmsi = be32toh(nas_guti.m_tmsi);
 
             mme_ue = mme_ue_find_by_guti(&nas_guti);
+            if (!mme_ue && nas_guti.m_tmsi == 0) {
+                /* M_TMSI=0x0 fallback: iPhone on private LTE sends zero M_TMSI.
+                 * Try to find the single registered UE instead of forcing reattach. */
+                mme_ue_t *iter_ue = NULL;
+                ogs_list_for_each(&mme_self()->mme_ue_list, iter_ue) {
+                    if (MME_UE_HAVE_IMSI(iter_ue)) {
+                        mme_ue = iter_ue;
+                        ogs_warn("[%s] M_TMSI=0x0 fallback: found registered UE",
+                                mme_ue->imsi_bcd);
+                        break;
+                    }
+                }
+            }
             if (!mme_ue) {
                 ogs_info("Unknown UE by S_TMSI[G:%d,C:%d,M_TMSI:0x%x]",
                         nas_guti.mme_gid, nas_guti.mme_code, nas_guti.m_tmsi);

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -527,7 +527,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                         be32toh(src_addr[0]), be32toh(sess->ipv4->addr[0]));
                     ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
 
-                    goto cleanup;
+                    ogs_warn("[PASS] Allowing mismatched source IP"); // spoofing check disabled
                 }
             }
 
@@ -611,7 +611,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                             be32toh(sess->ipv6->addr[3]));
                     ogs_log_hexdump(OGS_LOG_ERROR, pkbuf->data, pkbuf->len);
 
-                    goto cleanup;
+                    ogs_warn("[PASS] Allowing mismatched source IPv6"); // spoofing check disabled
                 }
             }
 


### PR DESCRIPTION
## Summary

Two fixes for private LTE (CBRS) deployments where iPhones exhibit problematic behavior on unrecognized private PLMNs. These patches eliminate a destructive attach/detach cycle that renders the network unusable.

## Problem

On private LTE networks (e.g., CBRS Band 48 with PLMN 315-010), iPhones send `M_TMSI=0x0` (zero) in every Service Request after waking from idle. This triggers a cascade:

1. **MME** can't find UE by GUTI (M_TMSI=0 matches nothing) → forces full reattach → new IP assigned
2. **UPF** drops all packets from the old IP as source spoofing (UE still has sockets bound to old IP)
3. UE re-attaches every 10-90 seconds, all connections break on each cycle

This is an iPhone-specific behavior on private networks without a carrier bundle. The assigned M_TMSI (e.g., `0xc00005fe`) is correctly stored by the MME but discarded by iOS. Installing an Apple Private Mobile Network `.mobileconfig` profile does **not** fix this.

## Changes

### 1. MME: M_TMSI=0x0 fallback lookup (`src/mme/s1ap-handler.c`)

When `mme_ue_find_by_guti()` returns NULL **and** the M_TMSI is exactly `0x0`, the MME now iterates `mme_ue_list` to find a registered UE with a known IMSI. This allows the Service Request to succeed without a full reattach, preserving the existing IP assignment and bearer contexts.

```c
if (!mme_ue && nas_guti.m_tmsi == 0) {
    mme_ue_t *iter_ue = NULL;
    ogs_list_for_each(&mme_self()->mme_ue_list, iter_ue) {
        if (MME_UE_HAVE_IMSI(iter_ue)) {
            mme_ue = iter_ue;
            ogs_warn("[%s] M_TMSI=0x0 fallback: found registered UE",
                    mme_ue->imsi_bcd);
            break;
        }
    }
}
```

**Limitation:** Finds the first registered UE — designed for small private networks. For multi-UE scenarios, this could be extended to match against recent eNB-UE associations or NAS identity.

### 2. UPF: Warn instead of drop on source IP mismatch (`src/upf/gtp-path.c`)

Changed the source IP spoofing check from a hard drop (`goto cleanup`) to a warning log for both IPv4 and IPv6 paths. Packets with mismatched source IPs are passed through instead of silently dropped.

This is appropriate for private/enterprise deployments where the UPF is not internet-facing and source IP mismatches are caused by legitimate UE behavior (reattach with new IP while old sockets drain).

## Testing

- **Platform:** Open5GS 2.7.6 on Ubuntu 22.04
- **Radio:** Baicells Nova 430i (CBRS Band 48, 3550-3560 MHz GAA via CloudCore Domain Proxy)
- **UE:** iPhone Air with CBRS eSIM (PLMN 315-010)
- **Before patch:** UE reattaching every 10-90 seconds, all connections breaking, network unusable
- **After patch:** Zero reattach cycles, stable 50-90 Mbps DL / 10 Mbps UL, connections persist across idle/wake transitions

## MME Log Comparison

**Before (every 10-90s):**
```
[mme] Unknown UE by S_TMSI[G:1,C:1,M_TMSI:0x0]
[emm] Service request: Not registered[]
[mme] UE Context Release [Action:3]
[mme] Attach request: known UE by IMSI[315019999000002]  ← full reattach, new IP
```

**After:**
```
[mme] [315019999000002] M_TMSI=0x0 fallback: found registered UE
[emm] Service request  ← succeeds, same IP preserved
```

## Notes

- The M_TMSI=0x0 behavior appears specific to iOS on private PLMNs without carrier bundles. Android UEs may not exhibit this.
- For carrier/public deployments, the UPF spoofing check should remain as-is (DROP) to prevent IP spoofing attacks. Consider making it configurable.
- A more robust solution would be an MME configuration option to handle M_TMSI=0 cases explicitly, or a per-UE fallback lookup table.