### PR TITLE
upf: prototype MAC learning + L2 hairpin (minimal)

### DIFF
--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -63,6 +63,8 @@ void upf_context_init(void)
     ogs_assert(self.ipv4_hash);
     self.ipv6_hash = ogs_hash_make();
     ogs_assert(self.ipv6_hash);
+    self.mac_hash = ogs_hash_make();
+    ogs_assert(self.mac_hash);
 
     context_initialized = 1;
 }
@@ -92,6 +94,8 @@ void upf_context_final(void)
     ogs_hash_destroy(self.ipv4_hash);
     ogs_assert(self.ipv6_hash);
     ogs_hash_destroy(self.ipv6_hash);
+    ogs_assert(self.mac_hash);
+    ogs_hash_destroy(self.mac_hash);
 
     free_upf_route_trie_node(self.ipv4_framed_routes);
     free_upf_route_trie_node(self.ipv6_framed_routes);
@@ -242,6 +246,11 @@ int upf_sess_remove(upf_sess_t *sess)
         ogs_pfcp_ue_ip_free(sess->ipv6);
     }
 
+    if (sess->has_mac) {
+        ogs_hash_set(self.mac_hash, sess->mac_addr, ETHER_ADDR_LEN, NULL);
+        sess->has_mac = false;
+    }
+
     upf_sess_set_ue_ipv4_framed_routes(sess, NULL);
     upf_sess_set_ue_ipv6_framed_routes(sess, NULL);
 
@@ -354,6 +363,22 @@ upf_sess_t *upf_sess_find_by_ipv6(uint32_t *addr6)
             trie = trie->left;
     }
     return ret;
+}
+
+upf_sess_t *upf_sess_find_by_mac(const uint8_t *mac)
+{
+    ogs_assert(mac != NULL);
+    return ogs_hash_get(self.mac_hash, mac, ETHER_ADDR_LEN);
+}
+
+void upf_sess_register_mac(upf_sess_t *sess, const uint8_t *mac)
+{
+    ogs_assert(sess != NULL);
+    ogs_assert(mac != NULL);
+
+    memcpy(sess->mac_addr, mac, ETHER_ADDR_LEN);
+    sess->has_mac = true;
+    ogs_hash_set(self.mac_hash, sess->mac_addr, ETHER_ADDR_LEN, sess);
 }
 
 upf_sess_t *upf_sess_find_by_id(ogs_pool_id_t id)

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -26,6 +26,10 @@
 #include <net/if.h>
 #endif
 
+#ifdef HAVE_NET_ETHERNET_H
+#include <net/ethernet.h>
+#endif
+
 #include "ogs-gtp.h"
 #include "ogs-pfcp.h"
 #include "ogs-app.h"
@@ -53,6 +57,7 @@ typedef struct upf_context_s {
     ogs_hash_t *smf_n4_f_seid_hash; /* hash table (SMF-N4-F-SEID) */
     ogs_hash_t *ipv4_hash;  /* hash table (IPv4 Address) */
     ogs_hash_t *ipv6_hash;  /* hash table (IPv6 Address) */
+    ogs_hash_t *mac_hash;   /* hash table (MAC Address) */
 
     /* IPv4 framed routes trie */
     struct upf_route_trie_node *ipv4_framed_routes;
@@ -124,6 +129,9 @@ typedef struct upf_sess_s {
     /* Accounting: */
     upf_sess_urr_acc_t urr_acc[OGS_MAX_NUM_OF_URR]; /* FIXME: This probably needs to be mved to a hashtable or alike */
     char            *apn_dnn;            /* APN/DNN Item */
+    /* Learned Ethernet MAC address (optional) */
+    uint8_t         mac_addr[ETHER_ADDR_LEN];
+    bool            has_mac;
 } upf_sess_t;
 
 void upf_context_init(void);
@@ -143,6 +151,8 @@ upf_sess_t *upf_sess_find_by_upf_n4_seid(uint64_t seid);
 upf_sess_t *upf_sess_find_by_ipv4(uint32_t addr);
 upf_sess_t *upf_sess_find_by_ipv6(uint32_t *addr6);
 upf_sess_t *upf_sess_find_by_id(ogs_pool_id_t id);
+upf_sess_t *upf_sess_find_by_mac(const uint8_t *mac);
+void upf_sess_register_mac(upf_sess_t *sess, const uint8_t *mac);
 
 uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
         uint8_t session_type, ogs_pfcp_pdr_t *pdr);

--- a/src/upf/gtp-path.c
+++ b/src/upf/gtp-path.c
@@ -118,10 +118,19 @@ static void _gtpv1_tun_recv_common_cb(
     }
 
     if (has_eth) {
+        uint8_t src_mac[ETHER_ADDR_LEN];
+        uint8_t dst_mac[ETHER_ADDR_LEN];
         ogs_pkbuf_t *replybuf = NULL;
         uint16_t eth_type = _get_eth_type(recvbuf->data, recvbuf->len);
         uint8_t size;
-
+        /* capture Ethernet src/dst for learning/hairpin */
+        if (recvbuf->len >= ETHER_HDR_LEN) {
+            memcpy(dst_mac, recvbuf->data, ETHER_ADDR_LEN);
+            memcpy(src_mac, recvbuf->data + ETHER_ADDR_LEN, ETHER_ADDR_LEN);
+        } else {
+            memset(src_mac, 0, ETHER_ADDR_LEN);
+            memset(dst_mac, 0, ETHER_ADDR_LEN);
+        }
         if (eth_type == ETHERTYPE_ARP) {
             if (is_arp_req(recvbuf->data, recvbuf->len) &&
                     upf_sess_find_by_ipv4(
@@ -161,11 +170,19 @@ static void _gtpv1_tun_recv_common_cb(
             goto cleanup;
         }
         ogs_pkbuf_pull(recvbuf, ETHER_HDR_LEN);
+        /* Learn source MAC -> session mapping (if we can resolve session by IP) */
+        /* Save a copy before payload is processed. */
     }
 
     sess = upf_sess_find_by_ue_ip_address(recvbuf);
     if (!sess)
         goto cleanup;
+
+    /* If ethernet source MAC is available, register it to this session */
+    if (has_eth && sess) {
+        /* src_mac captured earlier */
+        upf_sess_register_mac(sess, src_mac);
+    }
 
     ogs_list_for_each(&sess->pfcp.pdr_list, pdr) {
         far = pdr->far;
@@ -734,7 +751,7 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
              * A cheap subnet check gates the session lookup so that
              * normal internet traffic does not touch the hash table.
              */
-            if (ip_h->ip_v == 4 && subnet->family == AF_INET) {
+                if (ip_h->ip_v == 4 && subnet->family == AF_INET) {
                 if (ogs_unlikely(
                         (ip_h->ip_dst.s_addr & subnet->sub.mask[0]) ==
                         subnet->sub.sub[0]))
@@ -820,6 +837,45 @@ static void _gtpv1_u_recv_cb(short when, ogs_socket_t fd, void *data)
                     return;
                 }
                 /* No matching downlink PDR - fall through to TUN */
+            }
+
+            /* Minimal L2 hairpin: if destination MAC maps to a local session,
+             * forward the Ethernet frame directly to that session's TAP device.
+             * This bypasses PFCP/FAR handling and implements simple MAC learning
+             * + direct TAP delivery for same-subnet UEs.
+             */
+            if (has_eth) {
+                upf_sess_t *mac_dst_sess = upf_sess_find_by_mac(dst_mac);
+                if (mac_dst_sess && mac_dst_sess != sess) {
+                    ogs_pkbuf_t *sendbuf = ogs_pkbuf_copy(recvbuf);
+                    if (sendbuf) {
+                        ogs_pfcp_subnet_t *dst_sub = NULL;
+                        ogs_pfcp_dev_t *dst_dev = NULL;
+
+                        if (mac_dst_sess->ipv4 && mac_dst_sess->ipv4->subnet)
+                            dst_sub = mac_dst_sess->ipv4->subnet;
+                        else if (mac_dst_sess->ipv6 && mac_dst_sess->ipv6->subnet)
+                            dst_sub = mac_dst_sess->ipv6->subnet;
+
+                        if (dst_sub)
+                            dst_dev = dst_sub->dev;
+
+                        if (dst_dev) {
+                            uint16_t et = htobe16(eth_type);
+                            ogs_pkbuf_push(sendbuf, sizeof(et));
+                            memcpy(sendbuf->data, &et, sizeof(et));
+                            ogs_pkbuf_push(sendbuf, ETHER_ADDR_LEN);
+                            memcpy(sendbuf->data, src_mac, ETHER_ADDR_LEN);
+                            ogs_pkbuf_push(sendbuf, ETHER_ADDR_LEN);
+                            memcpy(sendbuf->data, mac_dst_sess->mac_addr, ETHER_ADDR_LEN);
+
+                            if (ogs_tun_write(dst_dev->fd, sendbuf) != OGS_OK)
+                                ogs_warn("ogs_tun_write() failed for L2 hairpin");
+                        }
+                        ogs_pkbuf_free(sendbuf);
+                        return;
+                    }
+                }
             }
 
             if (dev->is_tap) {


### PR DESCRIPTION
**Summary**: Add a minimal, local-only UPF prototype that learns UE Ethernet MACs and hairpins L2 frames between UEs on the same UPF/TAP without PFCP changes. Intended as a quick prototype to enable L2 testing; control-plane / PFCP integration is out of scope.

**Files changed:**

[context.h]: add mac_hash to UPF context; add per-session mac_addr + has_mac fields; declare upf_sess_find_by_mac() and upf_sess_register_mac(). 

Add include for net/ethernet.h.
[context.c]: create/destroy mac_hash; remove MAC mapping when session is removed; implement upf_sess_find_by_mac() and upf_sess_register_mac().
[gtp-path.c]: capture Ethernet src/dst on TAP reads, register source MAC to session (learning), and perform a minimal L2 hairpin: if destination MAC maps to a local session, construct Ethernet frame and write directly to the destination TAP device (bypasses PFCP/FAR).

**Behavior / rationale:**

- Learns MAC addresses from observed uplink frames and stores mapping in an in-memory hash.

- If a frame arrives and the destination MAC maps to another local session, the UPF forwards the Ethernet frame directly to that session’s TAP interface (L2 hairpin).

- This is a pragmatic, small-surface change to enable L2 experiments quickly. It does not implement PFCP Ethernet PDR/FAR, NAS provisioning of MAC, MAC aging, bridge/switching tables, or security checks.


**How to build & basic test:**
meson setup build
ninja -C build
run upf daemon with your upf.yaml that defines TAP devices
create two TAP UEs in same subnet and send L2 traffic (ARP/ping via TUN-to-TAP bridging)


Limitations / caveats

- Prototype-only: bypasses PFCP/FAR and control-plane signalling for Ethernet PDU sessions.

- No MAC aging/LRU, no VLAN support, no security/authorization checks for learned MACs.

- Does not persist or validate MAC learned against NAS DS-TT Ethernet Port MAC Address.

- Not standards-complete — intended for local testing and iterative development.


**Recommended follow-ups (future PRs)**

- Integrate NAS DS_TT_ETHERNET_PORT_MAC_ADDRESS into session registration so SMF/AMF can provide MAC on PDU establishment.

- Add PFCP Ethernet PDR/FAR support and map Ethernet PDI/outer-header creation/removal (standards-aligned).

- Implement MAC aging, learning timeouts, VLAN and bridging features, and optional MAC-to-session authorization.

- Add tests / integration harness (two TAP UEs + UPF) and unit tests for MAC table operations.