### PR TITLE
fix: store gnb_id_length for /ue-status endpoint

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1343,6 +1343,22 @@ int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id)
     return OGS_OK;
 }
 
+void amf_gnb_set_gnb_id_length(amf_gnb_t *gnb, uint8_t gnb_id_length)
+{
+    ogs_assert(gnb);
+
+    /* Per 3GPP TS 38.413, gNB ID length is between 22 and 32 bits. Accept
+     * only values in that range; ignore anything out-of-spec so that
+     * consumers can rely on a nonzero value meaning "validated". */
+    if (gnb_id_length < 22 || gnb_id_length > 32) {
+        ogs_warn("Ignoring out-of-range gNB ID length [%u]",
+                (unsigned)gnb_id_length);
+        return;
+    }
+
+    gnb->gnb_id_length = gnb_id_length;
+}
+
 int amf_gnb_sock_type(ogs_sock_t *sock)
 {
     ogs_socknode_t *snode = NULL;

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -141,6 +141,9 @@ typedef struct amf_gnb_s {
 
     bool            gnb_id_presence;
     uint32_t        gnb_id;     /* gNB_ID received from gNB */
+    uint8_t         gnb_id_length; /* gNB_ID BIT STRING length (22..32),
+                                    * derived from NGAP GlobalGNB-ID.
+                                    * 0 if not yet populated. */
     ogs_plmn_id_t   plmn_id;    /* gNB PLMN-ID received from gNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */
 
@@ -965,6 +968,7 @@ void amf_gnb_remove_all(void);
 amf_gnb_t *amf_gnb_find_by_addr(ogs_sockaddr_t *addr);
 amf_gnb_t *amf_gnb_find_by_gnb_id(uint32_t gnb_id);
 int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id);
+void amf_gnb_set_gnb_id_length(amf_gnb_t *gnb, uint8_t gnb_id_length);
 int amf_gnb_sock_type(ogs_sock_t *sock);
 amf_gnb_t *amf_gnb_find_by_id(ogs_pool_id_t id);
 

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -425,6 +425,15 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
 
     amf_gnb_set_gnb_id(gnb, gnb_id);
 
+    /* Capture the gNB ID bit length from the NGAP BIT STRING so that the
+     * NR Cell Identity (36-bit = gNB ID || Cell ID) can be split correctly
+     * later on. The NGAP gNB-ID IE is a BIT STRING of SIZE(22..32). */
+    if (globalGNB_ID->gNB_ID.present == NGAP_GNB_ID_PR_gNB_ID) {
+        BIT_STRING_t *bs = &globalGNB_ID->gNB_ID.choice.gNB_ID;
+        uint8_t bits = (uint8_t)(bs->size * 8 - bs->bits_unused);
+        amf_gnb_set_gnb_id_length(gnb, bits);
+    }
+
     gnb->state.ng_setup_success = true;
     r = ngap_send_ng_setup_response(gnb);
     ogs_expect(r == OGS_OK);
@@ -4557,6 +4566,12 @@ void ngap_handle_ran_configuration_update(
                 OGS_ADDR(gnb->sctp.addr, buf), gnb_id);
 
         amf_gnb_set_gnb_id(gnb, gnb_id);
+
+        if (globalGNB_ID->gNB_ID.present == NGAP_GNB_ID_PR_gNB_ID) {
+            BIT_STRING_t *bs = &globalGNB_ID->gNB_ID.choice.gNB_ID;
+            uint8_t bits = (uint8_t)(bs->size * 8 - bs->bits_unused);
+            amf_gnb_set_gnb_id_length(gnb, bits);
+        }
     }
 
     if (SupportedTAList) {

--- a/src/amf/ue-info.c
+++ b/src/amf/ue-info.c
@@ -222,9 +222,27 @@ static int add_gnb(cJSON *parent, const amf_ue_t *ue)
 
     ran_ue_t *ran = ran_ue_find_by_id(ue->ran_ue_id);
     if (ran) {
-        uint64_t nci = ue->nr_cgi.cell_id & 0xFFFFFFFFFULL; /* 36-bit */
-        uint32_t gnb_id  = (uint32_t)((nci >> 14) & 0x3FFFFF);
-        uint32_t cell_id = (uint32_t)(nci & 0x3FFF);
+        /*
+         * NCI (36-bit) = (gNB ID << cell_id_bits) | Cell ID, where gNB
+         * ID length is operator-configurable (22..32 bits). Use the
+         * gNB ID and bit length captured from the NGAP GlobalGNB-ID
+         * BIT STRING at NG Setup time so the split is correct for any
+         * idLength (e.g. UERANSIM defaults to 32). If the gNB context
+         * is not available, fall back to the legacy 22-bit assumption.
+         */
+        uint64_t nci     = ue->nr_cgi.cell_id & 0xFFFFFFFFFULL; /* 36-bit */
+        uint32_t gnb_id;
+        uint32_t cell_id;
+
+        amf_gnb_t *gnb_ctx = amf_gnb_find_by_id(ran->gnb_id);
+        if (gnb_ctx && gnb_ctx->gnb_id_presence && gnb_ctx->gnb_id_length) {
+            int cell_id_bits = 36 - gnb_ctx->gnb_id_length;
+            gnb_id  = gnb_ctx->gnb_id;
+            cell_id = (uint32_t)(nci & ((1ULL << cell_id_bits) - 1));
+        } else {
+            gnb_id  = (uint32_t)((nci >> 14) & 0x3FFFFF);
+            cell_id = (uint32_t)(nci & 0x3FFF);
+        }
 
         cJSON *a = cJSON_CreateNumber((double)ran->amf_ue_ngap_id);
         cJSON *r = cJSON_CreateNumber((double)ran->ran_ue_ngap_id);
@@ -294,9 +312,23 @@ static int add_location(cJSON *parent, const amf_ue_t *ue)
         if (!p) { cJSON_Delete(cgi); cJSON_Delete(loc); return -1; }
         cJSON_AddItemToObjectCS(cgi, "plmn", p);
 
+        /*
+         * Same bit-split rationale as add_gnb(): prefer the gNB ID and
+         * bit length cached at NG Setup time; otherwise fall back to
+         * the legacy 22-bit assumption.
+         */
         uint64_t nci     = ue->nr_cgi.cell_id & 0xFFFFFFFFFULL; /* 36-bit */
         uint32_t gnb_id  = (uint32_t)((nci >> 14) & 0x3FFFFF);
         uint32_t cell_id = (uint32_t)(nci & 0x3FFF);
+
+        ran_ue_t *ran_loc = ran_ue_find_by_id(ue->ran_ue_id);
+        amf_gnb_t *gnb_ctx = ran_loc ?
+                amf_gnb_find_by_id(ran_loc->gnb_id) : NULL;
+        if (gnb_ctx && gnb_ctx->gnb_id_presence && gnb_ctx->gnb_id_length) {
+            int cell_id_bits = 36 - gnb_ctx->gnb_id_length;
+            gnb_id  = gnb_ctx->gnb_id;
+            cell_id = (uint32_t)(nci & ((1ULL << cell_id_bits) - 1));
+        }
 
         cJSON *n = cJSON_CreateNumber((double)nci);
         cJSON *g = cJSON_CreateNumber((double)gnb_id);


### PR DESCRIPTION
Previously the gnb is length was always assumed to be 22bit.
This fix stores the gnb id received via NGAP in the gnb context and uses it to calculate the Cell-ID and GNB-ID  in ue-info / add_gnb function.

Test procedure:
Unpatched core: 
1. Start UERANSIM with open5gs default settings (gnb-id lenght 32 bit) -> /ue-info returns gnb-id 0 (instead of 1)
2. Start UERANSIM with patched config (gnb-id length 22 bit) -> /ue-info returns gnb-id 1
Patched core:
1. Start UERANSIM with open5gs default settings (gnb-id lenght 32 bit) -> /ue-info returns gnb-id 1