### PR TITLE
[MME] Add flag to disable IMS over PS in S1 mode

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -256,6 +256,9 @@ int ogs_app_parse_global_conf(ogs_yaml_iter_t *parent)
                 } else if (!strcmp(parameter_key, "fake_csfb")) {
                     global_conf.parameter.fake_csfb =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(parameter_key, "no_ims")) {
+                    global_conf.parameter.no_ims =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else if (!strcmp(parameter_key,
                             "no_ipv4v6_local_addr_in_packet_filter")) {
                     global_conf.parameter.

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -70,6 +70,7 @@ typedef struct ogs_global_conf_s {
 
         int use_openair;
         int fake_csfb;
+	int no_ims;
         int use_upg_vpp;
         int no_ipv4v6_local_addr_in_packet_filter;
 

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -235,7 +235,11 @@ ogs_pkbuf_t *emm_build_attach_accept(
     } else {
         eps_network_feature_support->length = 1;
     }
+    if (ogs_global_conf()->parameter.no_ims == true) {
+    	eps_network_feature_support->ims_voice_over_ps_session_in_s1_mode = 0;
+    } else {
     eps_network_feature_support->ims_voice_over_ps_session_in_s1_mode = 1;
+    }
     eps_network_feature_support->extended_protocol_configuration_options = 1;
     if (mme_self()->emergency.dnn)
         eps_network_feature_support->emergency_bearer_services_in_s1_mode = 1;
@@ -680,8 +684,13 @@ ogs_pkbuf_t *emm_build_tau_accept(mme_ue_t *mme_ue)
     } else {
         tau_accept->eps_network_feature_support.length = 1;
     }
-    tau_accept->eps_network_feature_support.
-        ims_voice_over_ps_session_in_s1_mode = 1;
+    if (ogs_global_conf()->parameter.no_ims == true) {
+    	tau_accept->eps_network_feature_support.
+        	ims_voice_over_ps_session_in_s1_mode = 0;
+    } else {
+        tau_accept->eps_network_feature_support.
+                ims_voice_over_ps_session_in_s1_mode = 1;
+    }
     tau_accept->eps_network_feature_support.
         extended_protocol_configuration_options = 1;
 


### PR DESCRIPTION
In case there are large amount of UEs with VoLTE enabled, but the network does not have an IMS APN, nor IMS services, it makes sense to disable IMS voice over PS in S1 mode in the attach/TAU accept message, thus preventing these UEs to try and activate an IMS PDN endlessly.

To resolve this, a new flag is introduced:

```
global:
  parameter:
    no_ims: true
```

If this flag is set to 'true', the MME will respond with an Attach accept or TAU accept, which has the EPS network feature:
"IMS voice over PS session in S1 mode" set to "Not supported".

By default this flag is false, thus not modifying the original behavior.