### PR TITLE
Patch to enable MME to resolve APNs through external DNS servers 

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -160,6 +160,48 @@ mme:
 #          default_route: true
 #
 ################################################################################
+# S5/S8 Interface — PGW Discovery via S-NAPTR DNS (3GPP TS 29.303)
+################################################################################
+#  When mme.s5s8.dns is configured the MME performs a live NAPTR→SRV→A
+#  DNS lookup at session-setup time to discover PGW candidates dynamically.
+#  Results are cached in-process per APN-FQDN (TTL-driven, 30 s floor,
+#  300 s default cap, up to 64 distinct APNs).
+#
+#  On each Create Session Request the MME selects one candidate at random
+#  and retries with the next candidate on any transient GTP failure
+#  (causes: 100, 73, 68, 72, 120, 110, 122) per TS 23.401 §5.3.2.1.
+#
+#  IPv4 only.  Only A records are resolved; AAAA is not supported yet.
+#  Falls back to the static pgw address in mme.yaml when dns is absent.
+#
+#  o Minimal — primary DNS server only
+#  s5s8:
+#    dns:
+#      - 192.168.1.53
+#
+#  o Recommended — primary + secondary for DNS failover
+#  s5s8:
+#    dns:
+#      - 192.168.1.53     # primary EPC DNS  (IPv4 only)
+#      - 192.168.1.54     # secondary EPC DNS (optional, IPv4 only)
+#
+#  o Lab / test network using dnsmasq on loopback
+#  s5s8:
+#    dns:
+#      - 127.0.0.1
+#
+#  DNS zone example (bind9 / dnsmasq) for APN "internet", MCC=234, MNC=01:
+#
+#  internet.apn.epc.mnc01.mcc234.3gppnetwork.org.  IN NAPTR 10 10 "S" \
+#      "x-3gpp-pgw:x-gtp-v2" "" _gtp-v2._udp.pgw.epc.example.com.
+#
+#  _gtp-v2._udp.pgw.epc.example.com.  IN SRV 10 10 2123 pgw1.epc.example.com.
+#  _gtp-v2._udp.pgw.epc.example.com.  IN SRV 10 10 2123 pgw2.epc.example.com.
+#
+#  pgw1.epc.example.com.  IN A  10.0.1.1
+#  pgw2.epc.example.com.  IN A  10.0.1.2
+#
+################################################################################
 # SGaAP Server
 ################################################################################
 #  o MSC/VLR

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -45,6 +45,8 @@ libmme_sources = files('''
     mme-path.h
     metrics.h
 
+    mme-s-naptr.h
+    mme-s-naptr.c
     mme-init.c
     mme-event.c
     mme-timer.c
@@ -84,6 +86,8 @@ libmme_sources = files('''
     ../../lib/metrics/prometheus/json_pager.c
 '''.split())
 
+libresolv = cc.find_library('resolv', required : true)
+
 libmme = static_library('mme',
     sources : libmme_sources,
     dependencies : [libmetrics_dep,
@@ -92,7 +96,8 @@ libmme = static_library('mme',
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libgtp_dep,
-                    libsbi_dep],
+                    libsbi_dep,
+                    libresolv],
     install : false)
 
 libmme_dep = declare_dependency(
@@ -103,7 +108,8 @@ libmme_dep = declare_dependency(
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libsbi_dep,
-                    libgtp_dep])
+                    libgtp_dep,
+                    libresolv])
 
 mme_sources = files('''
     app-init.c

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -27,6 +27,7 @@
 #include "s1ap-handler.h"
 #include "mme-sm.h"
 #include "mme-gtp-path.h"
+#include "mme-s-naptr.h"
 
 #define MAX_CELL_PER_ENB            8
 
@@ -152,6 +153,9 @@ void mme_context_init(void)
 void mme_context_final(void)
 {
     ogs_assert(context_initialized == 1);
+
+    /* Release the S-NAPTR DNS cache before tearing down the rest of context */
+    mme_s_naptr_cache_flush();
 
     mme_enb_remove_all();
     mme_ue_remove_all();
@@ -583,6 +587,49 @@ int mme_context_parse_config(void)
                             } else
                                 ogs_warn("unknown key `%s`", fd_key);
                         }
+                    }
+                } else if (!strcmp(mme_key, "s5s8")) {
+                    ogs_yaml_iter_t s5s8_iter;
+                    ogs_yaml_iter_recurse(&mme_iter, &s5s8_iter);
+                    while (ogs_yaml_iter_next(&s5s8_iter)) {
+                        const char *s5s8_key = ogs_yaml_iter_key(&s5s8_iter);
+                        ogs_assert(s5s8_key);
+                        if (!strcmp(s5s8_key, "dns")) {
+                            ogs_yaml_iter_t dns_iter;
+                            ogs_yaml_iter_recurse(&s5s8_iter, &dns_iter);
+                            ogs_assert(ogs_yaml_iter_type(&dns_iter) !=
+                                YAML_MAPPING_NODE);
+                            do {
+                                const char *v = NULL;
+
+                                if (ogs_yaml_iter_type(&dns_iter) ==
+                                        YAML_SEQUENCE_NODE) {
+                                    if (!ogs_yaml_iter_next(&dns_iter))
+                                        break;
+                                }
+
+                                v = ogs_yaml_iter_value(&dns_iter);
+                                if (v && strlen(v)) {
+                                    ogs_ipsubnet_t ipsub;
+                                    rv = ogs_ipsubnet(&ipsub, v, NULL);
+                                    ogs_assert(rv == OGS_OK);
+
+                                    if (ipsub.family != AF_INET) {
+                                        ogs_warn("s5s8.dns only supports "
+                                            "IPv4, ignoring: %s", v);
+                                    } else if (self.s5s8_dns[0] &&
+                                               self.s5s8_dns[1]) {
+                                        ogs_warn("Ignore s5s8 DNS : %s", v);
+                                    } else if (self.s5s8_dns[0]) {
+                                        self.s5s8_dns[1] = v;
+                                    } else {
+                                        self.s5s8_dns[0] = v;
+                                    }
+                                }
+                            } while (ogs_yaml_iter_type(&dns_iter) ==
+                                        YAML_SEQUENCE_NODE);
+                        } else
+                            ogs_warn("unknown key `%s`", s5s8_key);
                     }
                 } else if (!strcmp(mme_key, "relative_capacity")) {
                     const char *v = ogs_yaml_iter_value(&mme_iter);
@@ -4476,6 +4523,14 @@ void mme_sess_remove(mme_sess_t *sess)
     OGS_NAS_CLEAR_DATA(&sess->ue_epco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_pco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_epco);
+
+    /* Free DNS-resolved PGW candidates (allocated by mme_s_naptr_resolve_candidates()) */
+    if (sess->pgw_candidates.list) {
+        ogs_free(sess->pgw_candidates.list);
+        sess->pgw_candidates.list  = NULL;
+        sess->pgw_candidates.count = 0;
+        sess->pgw_candidates.index = 0;
+    }
 
     ogs_pool_id_free(&mme_sess_pool, sess);
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -169,6 +169,9 @@ typedef struct mme_context_s {
     struct {
         const char *dnn;            /* Emergency APN */
     } emergency;
+
+    /* S5/S8 DNS servers for S-NAPTR PGW discovery (TS 29.303, IPv4 only) */
+    const char *s5s8_dns[2];        /* primary, secondary */
 } mme_context_t;
 
 typedef struct mme_sgsn_route_s {
@@ -926,6 +929,24 @@ typedef struct mme_sess_s {
 
     /* Save Extended Protocol Configuration Options from PGW */
     ogs_tlv_octet_t pgw_epco;
+
+    /*
+     * DNS-resolved PGW candidates for TS 23.401 §5.3.2.1 retry.
+     *
+     * Populated on the first Create Session Request when S-NAPTR DNS
+     * discovery is configured (mme.s5s8.dns in mme.yaml).  index 0 is the
+     * initially-preferred candidate (chosen at random); subsequent entries
+     * are tried in order on each transient failure.
+     *
+     * Memory: list is heap-allocated by mme_s_naptr_resolve_candidates() and
+     * freed in mme_sess_remove().  list == NULL means DNS was not used or has
+     * not yet been resolved for this session.
+     */
+    struct {
+        ogs_sockaddr_t *list;   /* heap array of candidates, or NULL */
+        int             count;  /* total entries in list[]            */
+        int             index;  /* current candidate index (0-based)  */
+    } pgw_candidates;
 } mme_sess_t;
 
 #define MME_HAVE_ENB_S1U_PATH(__bEARER) \

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -188,6 +188,37 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
             ogs_warn("No S1 Context");
         }
         break;
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+        /*
+         * 3GPP TS 23.401 §5.3.2.1: if the Create Session Request times out,
+         * retry with the next DNS-resolved PGW candidate before rejecting the
+         * UE.  The candidate array was populated by mme_s_naptr_resolve_candidates()
+         * in mme-s11-build.c on the first attempt.
+         *
+         * If no more candidates are available (static config path, or all DNS
+         * candidates exhausted), fall through to release the UE context.
+         */
+        if (sess->pgw_candidates.list &&
+            sess->pgw_candidates.index + 1 < sess->pgw_candidates.count) {
+            sess->pgw_candidates.index++;
+            ogs_warn("[%s] CSR timeout — retrying with PGW candidate [%d/%d]",
+                     mme_ue->imsi_bcd,
+                     sess->pgw_candidates.index + 1,
+                     sess->pgw_candidates.count);
+            r = mme_gtp_send_create_session_request(
+                    enb_ue, sess, xact->create_action);
+            ogs_expect(r == OGS_OK);
+            /* Log the timeout but not as an error — retry is in flight */
+            ogs_warn("GTP Timeout (retry) : IMSI[%s] Message-Type[%d]",
+                    mme_ue->imsi_bcd, type);
+            return;  /* retry sent — do not release UE context yet */
+        }
+        /* No more candidates — release UE context */
+        if (enb_ue)
+            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        else
+            ogs_error("No S1 Context");
+        break;
     case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
         /* Nothing to do */
         break;

--- a/src/mme/mme-s-naptr.c
+++ b/src/mme/mme-s-naptr.c
@@ -1,0 +1,873 @@
+/*
+ * Copyright (C) 2025 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <resolv.h>
+#include <arpa/nameser.h>
+#include <arpa/nameser_compat.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <time.h>
+
+#include "mme-context.h"
+#include "mme-s-naptr.h"
+
+#undef OGS_LOG_DOMAIN
+#define OGS_LOG_DOMAIN __mme_log_domain
+
+/* -------------------------------------------------------------------------
+ * Constants
+ * ---------------------------------------------------------------------- */
+
+/* 3GPP TS 29.303 §5.2: S-NAPTR service tag for PGW over GTPv2 (S5/S8) */
+#define S_NAPTR_SERVICE_PGW_GTP  "x-3gpp-pgw:x-gtp-v2"
+
+/*
+ * DNS response buffer.  4096 bytes is the maximum DNS UDP payload size
+ * (RFC 6891 §6.2.5 hard cap) and is sufficient for any well-formed response.
+ */
+#define DNS_BUF_LEN  4096
+
+/*
+ * Maximum candidate records collected at each resolution stage.
+ * Records beyond this limit are skipped with a warning.
+ */
+#define MAX_NAPTR_CANDIDATES  16
+#define MAX_SRV_CANDIDATES    16
+#define MAX_A_CANDIDATES      16
+
+/* -------------------------------------------------------------------------
+ * DNS candidate cache
+ *
+ * Caches the PGW candidate list keyed by APN-FQDN so that repeated
+ * Create Session Requests for the same APN avoid a full DNS
+ * NAPTR→SRV→A round-trip on every call.
+ *
+ * Cache lifetime is governed by the minimum TTL returned by the DNS A
+ * records.  A floor (S_NAPTR_CACHE_MIN_TTL_S) prevents caching with an
+ * unreasonably short TTL from broken resolvers.
+ *
+ * The cache is keyed on the full APN-FQDN which already encodes the
+ * APN name, MCC, and MNC per TS 23.003 §19.4.2, so no separate PLMN
+ * field is needed in the key.
+ *
+ * Thread safety: the open5gs MME is single-threaded (event-driven), so no
+ * locking is required.
+ *
+ * Load balancing: on every cache hit, mme_s_naptr_resolve_candidates()
+ * returns a freshly rotated copy of the cached list so that successive
+ * sessions for the same APN still receive a random initial PGW selection.
+ * ---------------------------------------------------------------------- */
+
+/* Maximum distinct APN-FQDNs in cache; oldest entry evicted when full */
+#define S_NAPTR_CACHE_MAX_ENTRIES    64
+
+/*
+ * Minimum effective cache TTL (seconds).  If the DNS TTL is shorter, we
+ * cache for S_NAPTR_CACHE_DEFAULT_TTL_S instead to avoid hammering the DNS
+ * server on every session.  Set to 0 to honour the DNS TTL exactly.
+ */
+#define S_NAPTR_CACHE_MIN_TTL_S      30
+
+/* Fallback TTL used when the DNS server returns TTL 0 */
+#define S_NAPTR_CACHE_DEFAULT_TTL_S  300
+
+typedef struct {
+    ogs_lnode_t     lnode;
+    char            fqdn[NS_MAXDNAME];   /* lookup key (APN-FQDN)         */
+    ogs_sockaddr_t *list;                /* heap copy of candidate array  */
+    int             count;              /* entries in list[]             */
+    time_t          expires_at;         /* time(NULL) value at expiry    */
+} s_naptr_cache_entry_t;
+
+/* Entries are appended at the tail; oldest is at the head (FIFO eviction) */
+static OGS_LIST(s_naptr_cache);
+static int s_naptr_cache_entries = 0;
+
+/* Release one cache entry and update the occupancy counter */
+static void cache_entry_free(s_naptr_cache_entry_t *e)
+{
+    ogs_assert(e);
+    ogs_list_remove(&s_naptr_cache, e);
+    s_naptr_cache_entries--;
+    ogs_free(e->list);
+    ogs_free(e);
+}
+
+/*
+ * cache_lookup() - find a live (non-expired) entry by FQDN.
+ *
+ * Expired entries encountered during the scan are collected and freed after
+ * the iteration completes.  This avoids calling cache_entry_free() (which
+ * calls ogs_list_remove()) from inside ogs_list_for_each_safe, making the
+ * removal explicit and easy to reason about.
+ *
+ * Returns the entry on cache hit, NULL on miss or expiry.
+ */
+static s_naptr_cache_entry_t *cache_lookup(const char *fqdn)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+    s_naptr_cache_entry_t *found = NULL, *expired = NULL;
+    time_t now = time(NULL);
+
+    ogs_list_for_each_safe(&s_naptr_cache, next, e) {
+        if (strcmp(e->fqdn, fqdn) != 0)
+            continue;
+
+        if (now >= e->expires_at) {
+            ogs_debug("S-NAPTR cache: expired entry for '%s'", fqdn);
+            expired = e;   /* free after loop exits */
+        } else {
+            ogs_debug("S-NAPTR cache: HIT '%s' (%d candidates, %lds remaining)",
+                      fqdn, e->count, (long)(e->expires_at - now));
+            found = e;
+        }
+        break;  /* FQDN is unique in the cache — stop scanning */
+    }
+
+    if (expired)
+        cache_entry_free(expired);  /* safe: loop already finished */
+
+    return found;
+}
+
+/*
+ * cache_store() - insert or refresh a cache entry for fqdn.
+ *
+ * Makes a deep copy of list[0..count-1].  The effective TTL is clamped to at
+ * least S_NAPTR_CACHE_MIN_TTL_S.  When the cache is full the oldest entry
+ * (head of the list) is evicted before the new entry is appended.
+ *
+ * If an entry for fqdn already exists it is updated in-place (moved to
+ * the tail to maintain recency ordering for eviction).
+ */
+static void cache_store(const char *fqdn,
+        const ogs_sockaddr_t *list, int count, uint32_t ttl_s)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+    uint32_t effective_ttl;
+
+    ogs_assert(fqdn && list && count > 0);
+
+    /*
+     * Clamp short TTLs to the floor value so a misconfigured DNS zone that
+     * returns TTL 0 or a very small value does not cause cache thrashing.
+     * Use S_NAPTR_CACHE_MIN_TTL_S (not the 300-second default) so that the
+     * floor is the 30-second minimum advertised in the comment above.
+     */
+    effective_ttl = (ttl_s < S_NAPTR_CACHE_MIN_TTL_S)
+                        ? S_NAPTR_CACHE_MIN_TTL_S : ttl_s;
+
+    /* Check if this FQDN is already cached — update in-place */
+    ogs_list_for_each_safe(&s_naptr_cache, next, e) {
+        if (strcmp(e->fqdn, fqdn) == 0) {
+            /* Remove from current position; re-insert at tail below */
+            ogs_list_remove(&s_naptr_cache, e);
+            s_naptr_cache_entries--;
+            ogs_free(e->list);
+            e->list = NULL;
+            goto fill;
+        }
+    }
+
+    /* New entry — evict the oldest (head) if the cache is full */
+    if (s_naptr_cache_entries >= S_NAPTR_CACHE_MAX_ENTRIES) {
+        e = ogs_list_first(&s_naptr_cache);
+        ogs_assert(e);
+        ogs_debug("S-NAPTR cache: evicting oldest entry '%s'", e->fqdn);
+        ogs_list_remove(&s_naptr_cache, e);
+        s_naptr_cache_entries--;
+        ogs_free(e->list);
+        memset(e, 0, sizeof(*e));   /* reuse the allocation */
+    } else {
+        e = ogs_calloc(1, sizeof(s_naptr_cache_entry_t));
+        ogs_assert(e);
+    }
+
+fill:
+    ogs_cpystrn(e->fqdn, fqdn, sizeof(e->fqdn));
+    e->count      = count;
+    e->list       = ogs_calloc(count, sizeof(ogs_sockaddr_t));
+    ogs_assert(e->list);
+    memcpy(e->list, list, count * sizeof(ogs_sockaddr_t));
+    e->expires_at = time(NULL) + (time_t)effective_ttl;
+
+    ogs_list_add(&s_naptr_cache, e);  /* newest entries at tail */
+    s_naptr_cache_entries++;
+
+    ogs_info("S-NAPTR cache: stored '%s' (%d candidates, TTL %us)",
+             fqdn, count, effective_ttl);
+}
+
+/*
+ * mme_s_naptr_cache_flush() - release all cached entries.
+ *
+ * Called from mme_context_final() on shutdown to prevent leak reports from
+ * tools like valgrind.  Not required for correctness; the OS reclaims all
+ * memory on process exit regardless.
+ */
+void mme_s_naptr_cache_flush(void)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+
+    ogs_list_for_each_safe(&s_naptr_cache, next, e)
+        cache_entry_free(e);
+
+    ogs_assert(s_naptr_cache_entries == 0);
+    ogs_debug("S-NAPTR cache: flushed");
+}
+
+/* -------------------------------------------------------------------------
+ * Internal helpers
+ * ---------------------------------------------------------------------- */
+
+/*
+ * build_apn_fqdn() - construct the APN FQDN per 3GPP TS 23.003 §19.4.2.
+ *
+ * Format: <apn-ni>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ *
+ * MNC is zero-padded to 2 or 3 digits; MCC is always 3 digits.
+ * Returns the number of characters written (excluding NUL), or -1 if the
+ * buffer is too small.
+ */
+static int build_apn_fqdn(
+        char *buf, size_t buflen,
+        const char *apn, const ogs_plmn_id_t *plmn_id)
+{
+    int n;
+    uint16_t mcc     = ogs_plmn_id_mcc(plmn_id);
+    uint16_t mnc     = ogs_plmn_id_mnc(plmn_id);
+    uint16_t mnc_len = ogs_plmn_id_mnc_len(plmn_id);
+
+    ogs_assert(buf && buflen > 0 && apn && plmn_id);
+
+    if (mnc_len == 2)
+        n = ogs_snprintf(buf, buflen,
+                "%s.apn.epc.mnc%02d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+    else
+        n = ogs_snprintf(buf, buflen,
+                "%s.apn.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+
+    if (n < 0 || (size_t)n >= buflen) {
+        ogs_error("APN FQDN too long for APN[%s]", apn);
+        return -1;
+    }
+    return n;
+}
+
+/*
+ * init_resolver() - initialise a res_state pointing at the configured
+ * s5s8_dns servers, bypassing /etc/resolv.conf.
+ *
+ * Ownership / cleanup contract:
+ *   - Returns 0 on success.  Caller MUST call res_nclose() when done.
+ *   - Returns -1 on failure.  res_nclose() must NOT be called.
+ */
+static int init_resolver(struct __res_state *res)
+{
+    int i;
+    const char *dns[2];
+
+    ogs_assert(res);
+
+    dns[0] = mme_self()->s5s8_dns[0];
+    dns[1] = mme_self()->s5s8_dns[1];
+
+    if (!dns[0]) {
+        ogs_debug("S-NAPTR: s5s8.dns not configured, skipping DNS discovery");
+        return -1;
+    }
+
+    if (res_ninit(res) != 0) {
+        ogs_error("res_ninit() failed");
+        return -1;
+    }
+
+    res->nscount = 0;
+    for (i = 0; i < 2 && dns[i]; i++) {
+        struct in_addr addr;
+        if (inet_pton(AF_INET, dns[i], &addr) != 1) {
+            ogs_warn("Invalid s5s8.dns[%d] address '%s', skipping", i, dns[i]);
+            continue;
+        }
+        memset(&res->nsaddr_list[res->nscount], 0,
+                sizeof(res->nsaddr_list[res->nscount]));
+        res->nsaddr_list[res->nscount].sin_family = AF_INET;
+        res->nsaddr_list[res->nscount].sin_port   = htons(NS_DEFAULTPORT);
+        res->nsaddr_list[res->nscount].sin_addr   = addr;
+        res->nscount++;
+    }
+
+    if (res->nscount == 0) {
+        ogs_error("No valid s5s8.dns addresses available");
+        res_nclose(res);
+        return -1;
+    }
+
+    /*
+     * Fast failover to the secondary DNS server.
+     * retrans=1: 1 s per-server timeout.
+     * retry=2:   2 attempts per server before trying the next.
+     * Worst-case total (both servers down): 2 × 2 = 4 s.
+     */
+    res->retrans = 1;
+    res->retry   = 2;
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * NAPTR record parsing and selection
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    uint16_t order;
+    uint16_t pref;
+    char     flags[8];
+    char     service[64];
+    char     replacement[NS_MAXDNAME];
+} naptr_rec_t;
+
+/*
+ * parse_naptr_rdata() - decode a NAPTR RDATA field into naptr_rec_t.
+ * Wire format per RFC 3403 §4.
+ * Returns 0 on success, -1 on malformed input.
+ */
+static int parse_naptr_rdata(
+        const unsigned char *msg, int msglen,
+        const unsigned char *rdata, int rdlen,
+        naptr_rec_t *out)
+{
+    const unsigned char *p   = rdata;
+    const unsigned char *end = rdata + rdlen;
+    int slen;
+
+    if (p + 4 > end) return -1;
+    out->order = ns_get16(p);  p += 2;
+    out->pref  = ns_get16(p);  p += 2;
+
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end || (size_t)slen >= sizeof(out->flags)) return -1;
+    memcpy(out->flags, p, slen);
+    out->flags[slen] = '\0';
+    p += slen;
+
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end || (size_t)slen >= sizeof(out->service)) return -1;
+    memcpy(out->service, p, slen);
+    out->service[slen] = '\0';
+    p += slen;
+
+    /* REGEXP — skip (not used for S-NAPTR per RFC 3958 §6.5) */
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end) return -1;
+    p += slen;
+
+    if (ns_name_uncompress(msg, msg + msglen, p,
+                out->replacement, NS_MAXDNAME) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*
+ * query_naptr() - query NAPTR records and select one SRV target name.
+ *
+ * Algorithm (TS 29.303 §5.2):
+ *   1. Filter records by service "x-3gpp-pgw:x-gtp-v2" and flag "S".
+ *   2. Keep only records at the lowest ORDER value.
+ *   3. Inverse-preference weighted random selection:
+ *        weight_i = max_pref + 1 - pref_i
+ *
+ * Returns 0 and fills srv_name on success; -1 on failure.
+ */
+static int query_naptr(
+        struct __res_state *res,
+        const char *fqdn,
+        char *srv_name)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, count = 0;
+    uint16_t best_order = 0;
+    ns_msg handle;
+    ns_rr rr;
+    naptr_rec_t candidates[MAX_NAPTR_CANDIDATES];
+    naptr_rec_t cur;
+
+    ogs_debug("S-NAPTR: NAPTR query for '%s'", fqdn);
+
+    len = res_nquery(res, fqdn, C_IN, T_NAPTR, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: NAPTR query failed for '%s'", fqdn);
+        return -1;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse failed for '%s'", fqdn);
+        return -1;
+    }
+
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_NAPTR)
+            continue;
+        if (parse_naptr_rdata(buf, len,
+                ns_rr_rdata(rr), ns_rr_rdlen(rr), &cur) < 0)
+            continue;
+
+        ogs_debug("S-NAPTR: NAPTR[%d] order=%u pref=%u flags='%s' "
+                  "service='%s' replacement='%s'",
+                  i, cur.order, cur.pref, cur.flags,
+                  cur.service, cur.replacement);
+
+        if (strcasecmp(cur.service, S_NAPTR_SERVICE_PGW_GTP) != 0)
+            continue;
+        if (strcasecmp(cur.flags, "s") != 0)
+            continue;
+
+        if (count == 0 || cur.order < best_order) {
+            best_order    = cur.order;
+            candidates[0] = cur;
+            count         = 1;
+        } else if (cur.order == best_order) {
+            if (count < MAX_NAPTR_CANDIDATES) {
+                candidates[count++] = cur;
+            } else {
+                ogs_warn("S-NAPTR: NAPTR candidate limit (%d) reached for "
+                         "'%s'; extra records at order=%u skipped",
+                         MAX_NAPTR_CANDIDATES, fqdn, best_order);
+            }
+        }
+    }
+
+    if (count == 0) {
+        ogs_warn("S-NAPTR: no matching NAPTR record for '%s' "
+                 "(service=" S_NAPTR_SERVICE_PGW_GTP ", flag=S)", fqdn);
+        return -1;
+    }
+
+    if (count == 1) {
+        ogs_cpystrn(srv_name, candidates[0].replacement, NS_MAXDNAME);
+    } else {
+        /* Inverse-preference weighted selection; uint32_t guards overflow */
+        uint32_t total_weight = 0;
+        uint32_t weights[MAX_NAPTR_CANDIDATES];
+        uint32_t max_pref = 0;
+        uint32_t pick, cum;
+        int selected = 0;
+
+        for (i = 0; i < count; i++)
+            if ((uint32_t)candidates[i].pref > max_pref)
+                max_pref = candidates[i].pref;
+
+        for (i = 0; i < count; i++) {
+            weights[i]    = max_pref + 1 - (uint32_t)candidates[i].pref;
+            total_weight += weights[i];
+        }
+
+        pick = ogs_random32() % total_weight;
+        cum  = 0;
+        for (i = 0; i < count; i++) {
+            cum += weights[i];
+            if (pick < cum) { selected = i; break; }
+        }
+
+        ogs_debug("S-NAPTR: selected NAPTR [%d/%d] order=%u pref=%u '%s'",
+                  selected + 1, count,
+                  candidates[selected].order, candidates[selected].pref,
+                  candidates[selected].replacement);
+        ogs_cpystrn(srv_name, candidates[selected].replacement, NS_MAXDNAME);
+    }
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * SRV record querying and selection
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    uint16_t priority;
+    uint16_t weight;
+    uint16_t port;
+    char     target[NS_MAXDNAME];
+} srv_rec_t;
+
+/*
+ * query_srv_all() - query SRV records and return ALL targets at the lowest
+ * priority level per RFC 2782 §3.
+ *
+ * Unlike a single-selection query, this function collects every SRV record
+ * at the lowest priority value so that the caller can resolve A records for
+ * each target and build a complete PGW candidate pool.  Records at higher
+ * priority values are discarded — they are only relevant when all
+ * lower-priority targets are unreachable, which is handled at the session
+ * retry layer (pgw_candidates.index in mme-gtp-path.c / mme-s11-handler.c).
+ *
+ * SRV weight is preserved in out[].weight for callers that wish to apply
+ * weight-ordered iteration; it is not used to make a selection here.
+ *
+ * Why NOT select one target by weight here:
+ *   If only one SRV target is selected, only its A records enter the DNS
+ *   cache.  All other PGW IPs are permanently excluded from load balancing
+ *   and failover for the entire cache lifetime — defeating the purpose of
+ *   maintaining a candidate pool in mme_sess_t.pgw_candidates.
+ *
+ * Returns the number of SRV records stored in out[] (≥1), or 0 on failure.
+ */
+static int query_srv_all(
+        struct __res_state *res,
+        const char *srv_name,
+        srv_rec_t *out, int max_count)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, count = 0;
+    uint16_t best_priority = 0;
+    ns_msg handle;
+    ns_rr rr;
+    const unsigned char *rdata;
+    srv_rec_t cur;
+
+    ogs_debug("S-NAPTR: SRV query (all targets) for '%s'", srv_name);
+
+    len = res_nquery(res, srv_name, C_IN, T_SRV, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: SRV query failed for '%s'", srv_name);
+        return 0;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse (SRV) failed for '%s'", srv_name);
+        return 0;
+    }
+
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_SRV)
+            continue;
+
+        rdata = ns_rr_rdata(rr);
+        if (ns_rr_rdlen(rr) < 6)
+            continue;
+
+        cur.priority = ns_get16(rdata);  rdata += 2;
+        cur.weight   = ns_get16(rdata);  rdata += 2;
+        cur.port     = ns_get16(rdata);  rdata += 2;
+
+        if (ns_name_uncompress(buf, buf + len, rdata,
+                cur.target, NS_MAXDNAME) < 0)
+            continue;
+
+        ogs_debug("S-NAPTR: SRV[%d] priority=%u weight=%u port=%u target='%s'",
+                  i, cur.priority, cur.weight, cur.port, cur.target);
+
+        if (count == 0 || cur.priority < best_priority) {
+            /* New lowest priority — discard any higher-priority records seen
+             * so far and start fresh with this one. */
+            best_priority = cur.priority;
+            out[0]        = cur;
+            count         = 1;
+        } else if (cur.priority == best_priority) {
+            if (count < max_count) {
+                out[count++] = cur;
+            } else {
+                ogs_warn("S-NAPTR: SRV candidate limit (%d) reached for "
+                         "'%s'; extra records at priority=%u skipped",
+                         max_count, srv_name, best_priority);
+            }
+        }
+        /* Records at a higher priority value than best_priority are skipped */
+    }
+
+    if (count == 0) {
+        ogs_warn("S-NAPTR: no SRV records found for '%s'", srv_name);
+        return 0;
+    }
+
+    ogs_debug("S-NAPTR: %d SRV target(s) at priority=%u for '%s'",
+              count, best_priority, srv_name);
+    return count;
+}
+
+/* -------------------------------------------------------------------------
+ * A record resolution — all addresses for retry support
+ * ---------------------------------------------------------------------- */
+
+/*
+ * query_a_all() - resolve hostname to ALL IPv4 addresses.
+ *
+ * Fills out[0..max_count-1] with all A records found, each with the given
+ * port.  *min_ttl_out receives the minimum TTL across all A records; this
+ * drives the DNS cache expiry.  Returns the count stored, or 0 on failure.
+ */
+static int query_a_all(
+        struct __res_state *res,
+        const char *hostname, uint16_t port,
+        ogs_sockaddr_t *out, int max_count,
+        uint32_t *min_ttl_out)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, count = 0;
+    uint32_t min_ttl = UINT32_MAX;
+    ns_msg handle;
+    ns_rr rr;
+
+    ogs_assert(res && hostname && out && max_count > 0 && min_ttl_out);
+
+    ogs_debug("S-NAPTR: A query for '%s'", hostname);
+
+    len = res_nquery(res, hostname, C_IN, T_A, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: A query failed for '%s'", hostname);
+        *min_ttl_out = 0;
+        return 0;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse (A) failed for '%s'", hostname);
+        *min_ttl_out = 0;
+        return 0;
+    }
+
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_A)
+            continue;
+        if (ns_rr_rdlen(rr) != NS_INADDRSZ)
+            continue;
+
+        if (count >= max_count) {
+            ogs_warn("S-NAPTR: A record limit (%d) reached for '%s'; "
+                     "extra records skipped", max_count, hostname);
+            break;
+        }
+
+        memset(&out[count], 0, sizeof(ogs_sockaddr_t));
+        out[count].sin.sin_family = AF_INET;
+        out[count].sin.sin_port   = htons(port);
+        memcpy(&out[count].sin.sin_addr, ns_rr_rdata(rr), NS_INADDRSZ);
+
+        /* Track minimum TTL for cache expiry calculation */
+        if (ns_rr_ttl(rr) < min_ttl)
+            min_ttl = ns_rr_ttl(rr);
+
+        ogs_debug("S-NAPTR: A[%d] %s:%u (TTL %us)",
+                  count, inet_ntoa(out[count].sin.sin_addr),
+                  port, ns_rr_ttl(rr));
+        count++;
+    }
+
+    *min_ttl_out = (min_ttl == UINT32_MAX) ? 0 : min_ttl;
+
+    if (count == 0)
+        ogs_warn("S-NAPTR: no A records found for '%s'", hostname);
+
+    return count;
+}
+
+/* -------------------------------------------------------------------------
+ * Internal: build a rotated candidate array
+ * ---------------------------------------------------------------------- */
+
+/*
+ * build_rotated_candidates() - allocate and return a rotated copy of addrs[].
+ *
+ * Picks one address at random as the preferred candidate (index 0) and
+ * rotates the remaining addresses after it.  This implements the random
+ * first-choice required by TS 23.401 §5.3.2.1 while keeping all candidates
+ * available for retry in order.
+ *
+ * The caller owns the returned array and must ogs_free() it.
+ */
+static ogs_sockaddr_t *build_rotated_candidates(
+        const ogs_sockaddr_t *addrs, int n, int *count_out)
+{
+    ogs_sockaddr_t *result = NULL;
+    int preferred, i;
+
+    ogs_assert(addrs && n > 0 && count_out);
+
+    result = ogs_calloc(n, sizeof(ogs_sockaddr_t));
+    ogs_assert(result);
+
+    if (n == 1) {
+        result[0]  = addrs[0];
+    } else {
+        preferred = (int)(ogs_random32() % (uint32_t)n);
+        for (i = 0; i < n; i++)
+            result[i] = addrs[(preferred + i) % n];
+    }
+
+    *count_out = n;
+    return result;
+}
+
+/* -------------------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------------- */
+
+/*
+ * mme_s_naptr_resolve_candidates() - S-NAPTR PGW discovery with caching.
+ *
+ * On cache miss, runs the full NAPTR→SRV→A DNS chain and stores the result.
+ * On cache hit, returns a freshly rotated copy of the cached candidates.
+ *
+ * The cache key is the APN-FQDN derived from apn + plmn_id per TS 23.003
+ * §19.4.2.  Cache lifetime = min(DNS A TTL, S_NAPTR_CACHE_DEFAULT_TTL_S)
+ * seconds, floored at S_NAPTR_CACHE_MIN_TTL_S.
+ *
+ * Returns a heap-allocated array (caller ogs_free()s in mme_sess_remove())
+ * and sets *count.  Returns NULL / *count=0 on failure.
+ *
+ * All returned addresses carry port OGS_GTPV2_C_UDP_PORT (2123).
+ */
+ogs_sockaddr_t *mme_s_naptr_resolve_candidates(
+        const char *apn, const ogs_plmn_id_t *plmn_id, int *count)
+{
+    char fqdn[NS_MAXDNAME];
+    char srv_name[NS_MAXDNAME];
+    struct __res_state res;
+    ogs_sockaddr_t tmp[MAX_A_CANDIDATES];
+    ogs_sockaddr_t *result = NULL;
+    srv_rec_t srvs[MAX_SRV_CANDIDATES];
+    uint32_t min_ttl = UINT32_MAX;
+    uint32_t srv_ttl = 0;
+    int n = 0, srv_count = 0, s = 0, got = 0;
+    s_naptr_cache_entry_t *cached = NULL;
+
+    ogs_assert(apn);
+    ogs_assert(plmn_id);
+    ogs_assert(count);
+
+    *count = 0;
+
+    /* Step 1: build APN-FQDN — serves as both the DNS query name and cache key */
+    if (build_apn_fqdn(fqdn, sizeof(fqdn), apn, plmn_id) < 0)
+        return NULL;
+
+    /* ------------------------------------------------------------------
+     * Cache lookup — skip the DNS round-trip when we have a fresh result.
+     *
+     * The cache stores the FULL unrotated candidate pool (all PGW IPs from
+     * all SRV targets).  build_rotated_candidates() then picks a random
+     * start so each session gets a different preferred PGW while still
+     * having access to every other PGW for load balancing and failover.
+     * ------------------------------------------------------------------ */
+    cached = cache_lookup(fqdn);
+    if (cached) {
+        result = build_rotated_candidates(cached->list, cached->count, count);
+        ogs_info("S-NAPTR: [CACHE HIT] APN[%s] → %d PGW candidate(s); "
+                 "preferred %s",
+                 apn, *count, inet_ntoa(result[0].sin.sin_addr));
+        return result;
+    }
+
+    /* ------------------------------------------------------------------
+     * Cache MISS — perform full DNS resolution: NAPTR → SRV → A.
+     *
+     * All SRV targets at the lowest priority are resolved and their A
+     * records are accumulated into tmp[] so the full PGW pool is cached.
+     * ------------------------------------------------------------------ */
+    ogs_debug("S-NAPTR: [CACHE MISS] APN[%s] FQDN[%s]", apn, fqdn);
+
+    if (init_resolver(&res) != 0)
+        return NULL;
+
+    if (query_naptr(&res, fqdn, srv_name) != 0)
+        goto out;
+
+    /* Collect ALL SRV targets at the lowest priority (not just one) */
+    srv_count = query_srv_all(&res, srv_name, srvs, MAX_SRV_CANDIDATES);
+    if (srv_count == 0)
+        goto out;
+
+    /*
+     * Resolve A records for every SRV target and accumulate into tmp[].
+     *
+     * This is the critical step that ensures the cache contains the FULL
+     * PGW candidate pool:
+     *
+     *   SRV → pgw1.example.com  → A: 10.0.1.1          ┐
+     *   SRV → pgw2.example.com  → A: 10.0.1.2, 10.0.1.3 ├─ all stored
+     *   SRV → pgw3.example.com  → A: 10.0.1.4          ┘
+     *
+     * Without this loop, only pgw1 OR pgw2 OR pgw3 would be selected by
+     * query_srv() and only that one PGW's IPs would be cached — the others
+     * would be permanently excluded from load balancing and failover.
+     *
+     * min_ttl tracks the shortest TTL across all A records so the cache
+     * entry expires before any individual address becomes stale.
+     */
+    for (s = 0; s < srv_count && n < MAX_A_CANDIDATES; s++) {
+        got = query_a_all(&res, srvs[s].target, srvs[s].port,
+                          tmp + n, MAX_A_CANDIDATES - n, &srv_ttl);
+        if (got > 0) {
+            ogs_debug("S-NAPTR: SRV target '%s:%u' → %d address(es)",
+                      srvs[s].target, srvs[s].port, got);
+            n += got;
+            if (srv_ttl < min_ttl)
+                min_ttl = srv_ttl;
+        } else {
+            ogs_warn("S-NAPTR: SRV target '%s' has no A records — skipped",
+                     srvs[s].target);
+        }
+    }
+
+    if (n == 0)
+        goto out;
+
+    if (min_ttl == UINT32_MAX)
+        min_ttl = 0;   /* no A record TTL captured — use cache_store() floor */
+
+    /*
+     * Store the full unrotated candidate pool in cache.
+     * Every subsequent session for this APN gets a freshly rotated copy
+     * from build_rotated_candidates(), distributing load without DNS I/O.
+     */
+    cache_store(fqdn, tmp, n, min_ttl);
+
+    /* Build the caller's rotated copy */
+    result = build_rotated_candidates(tmp, n, count);
+
+    ogs_info("S-NAPTR: [DNS] resolved APN[%s] → %d PGW candidate(s) from "
+             "%d SRV target(s); preferred %s (DNS TTL %us, now cached)",
+             apn, *count, srv_count,
+             inet_ntoa(result[0].sin.sin_addr), min_ttl);
+
+out:
+    res_nclose(&res);
+
+    if (*count == 0 && result) {
+        ogs_free(result);
+        result = NULL;
+    }
+
+    if (!result)
+        ogs_warn("S-NAPTR: DNS discovery failed for APN[%s]; "
+                 "will fall back to static PGW config", apn);
+
+    return result;
+}

--- a/src/mme/mme-s-naptr.h
+++ b/src/mme/mme-s-naptr.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * PGW/SMF discovery via S-NAPTR DNS procedure with in-process caching.
+ *
+ * Standards:
+ *   3GPP TS 29.303  - Domain Name System Procedures (Stage 3)
+ *   3GPP TS 23.003  - Numbering, addressing and identification
+ *   3GPP TS 23.401  §5.3.2.1 - PGW selection and retry
+ *   RFC 3958        - Domain-Based Application Service Location Using SRV RRs
+ *                     and the Dynamic Delegation Discovery Service (DDDS)
+ *
+ * Resolution order per Create Session Request:
+ *   1. Build APN-FQDN per TS 23.003 §19.4.2
+ *   2. Check in-process DNS cache (keyed on APN-FQDN)
+ *      → HIT:  return rotated copy of cached candidates (no DNS I/O)
+ *      → MISS: proceed with steps 3-6
+ *   3. DNS NAPTR query → find record with service "x-3gpp-pgw:x-gtp-v2"
+ *   4. DNS SRV  query → resolve target hostname + port (weighted random)
+ *   5. DNS A    query → resolve ALL IPv4 addresses; read TTL for cache expiry
+ *   6. Store result in cache; return candidate array for this session
+ *
+ * The candidate array is stored in sess->pgw_candidates for per-session retry
+ * per TS 23.401 §5.3.2.1.
+ */
+
+#ifndef MME_S_NAPTR_H
+#define MME_S_NAPTR_H
+
+#include "ogs-gtp.h"
+#include "mme-context.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mme_s_naptr_resolve_candidates() - resolve ALL PGW IPv4 candidates via
+ * S-NAPTR for a given APN and home PLMN ID, with in-process DNS caching.
+ *
+ * Uses the DNS servers configured under mme.s5s8.dns in mme.yaml.
+ *
+ * On the first call for a given APN+PLMN the function runs the full DNS
+ * NAPTR→SRV→A chain and caches the result keyed by APN-FQDN.  Subsequent
+ * calls within the DNS TTL window return a freshly rotated copy of the
+ * cached list, avoiding repeated DNS round-trips for the same APN.
+ *
+ * Returns a heap-allocated array of ogs_sockaddr_t (caller must ogs_free()
+ * the array — typically in mme_sess_remove()).  Sets *count to the number
+ * of entries.  Index 0 is the randomly-selected preferred candidate per
+ * TS 23.401 §5.3.2.1; subsequent entries are ordered retry candidates.
+ *
+ * Returns NULL and sets *count = 0 on any failure.
+ * All returned addresses have port set to OGS_GTPV2_C_UDP_PORT (2123).
+ */
+ogs_sockaddr_t *mme_s_naptr_resolve_candidates(
+        const char *apn, const ogs_plmn_id_t *plmn_id, int *count);
+
+/*
+ * mme_s_naptr_cache_flush() - release all in-process DNS cache entries.
+ *
+ * Must be called from mme_context_final() on shutdown to free the cache and
+ * prevent memory-leak reports from analysis tools such as valgrind.
+ */
+void mme_s_naptr_cache_flush(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MME_S_NAPTR_H */

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -17,7 +17,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <arpa/inet.h>
+
 #include "mme-context.h"
+#include "mme-s-naptr.h"
 
 #include "mme-s11-build.h"
 
@@ -142,24 +145,109 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
         req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
             &pgw_s5c_teid;
     } else {
-        ogs_sockaddr_t *pgw_addr = NULL;
+        /*
+         * PGW/SMF address not provisioned by HSS.
+         *
+         * Resolution order:
+         *   1. S-NAPTR DNS (3GPP TS 29.303) — only when mme.s5s8.dns is
+         *      configured in mme.yaml.  Completely optional: if omitted, or
+         *      if DNS resolution fails for any reason, the MME falls through
+         *      transparently to the static configuration below.
+         *   2. Static PGW list from mme.yaml matched by APN / Cell-ID / TAC.
+         *   3. First PGW in the static list (last-resort).
+         */
+        ogs_sockaddr_t *pgw_addr  = NULL;
         ogs_sockaddr_t *pgw_addr6 = NULL;
+        bool dns_used = false;
 
-        pgw_addr = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET, sess);
-        pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET6, sess);
-        if (!pgw_addr && !pgw_addr6) {
-            pgw_addr = mme_self()->pgw_addr;
-            pgw_addr6 = mme_self()->pgw_addr6;
+        /*
+         * --- Path 1: S-NAPTR DNS (optional, TS 29.303) ---
+         *
+         * On the FIRST Create Session Request for this session, resolve ALL
+         * PGW candidates via DNS and store them in sess->pgw_candidates.
+         * On RETRY attempts (pgw_candidates.list already set), just advance
+         * to the next candidate — do not re-query DNS.
+         *
+         * This implements TS 23.401 §5.3.2.1: the MME shall try the next
+         * DNS-resolved candidate before rejecting the UE.
+         */
+        if (mme_self()->s5s8_dns[0] && session->name) {
+            mme_ue_t *mme_ue_tmp = mme_ue_find_by_id(sess->mme_ue_id);
+            if (mme_ue_tmp) {
+                if (!sess->pgw_candidates.list) {
+                    /*
+                     * First attempt: run S-NAPTR resolution and populate the
+                     * candidate array.  Use the home PLMN ID from IMSI/hssmap
+                     * so the APN-FQDN targets the subscriber's home network
+                     * DNS zone per TS 23.003 §19.4.2.
+                     */
+                    const ogs_plmn_id_t *home_plmn_id =
+                        (mme_ue_tmp->hssmap)
+                            ? &mme_ue_tmp->hssmap->plmn_id
+                            : &mme_ue_tmp->tai.plmn_id;
+
+                    sess->pgw_candidates.list =
+                        mme_s_naptr_resolve_candidates(
+                                session->name, home_plmn_id,
+                                &sess->pgw_candidates.count);
+                    sess->pgw_candidates.index = 0;
+                }
+
+                if (sess->pgw_candidates.list &&
+                    sess->pgw_candidates.index < sess->pgw_candidates.count) {
+                    dns_used = true;
+                }
+            }
         }
 
-        rv = ogs_gtp2_sockaddr_to_f_teid(
-                pgw_addr, pgw_addr6, &pgw_s5c_teid, &len);
-        ogs_assert(rv == OGS_OK);
-        req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
-        req->pgw_s5_s8_address_for_control_plane_or_pmip.data = &pgw_s5c_teid;
-        req->pgw_s5_s8_address_for_control_plane_or_pmip.len = len;
+        if (dns_used) {
+            /*
+             * DNS discovery succeeded — use the current candidate.
+             * index 0 on first attempt; incremented by retry machinery
+             * in mme-gtp-path.c (timeout) and mme-s11-handler.c (fail:).
+             */
+            ogs_sockaddr_t *cand =
+                &sess->pgw_candidates.list[sess->pgw_candidates.index];
+
+            ogs_debug("S-NAPTR: using PGW candidate [%d/%d] %s:%u",
+                      sess->pgw_candidates.index + 1,
+                      sess->pgw_candidates.count,
+                      inet_ntoa(cand->sin.sin_addr),
+                      OGS_GTPV2_C_UDP_PORT);
+
+            pgw_s5c_teid.ipv4 = 1;
+            pgw_s5c_teid.addr = cand->sin.sin_addr.s_addr;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
+                &pgw_s5c_teid;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
+                OGS_GTP2_F_TEID_IPV4_LEN;
+        } else {
+            /*
+             * --- Path 2 & 3: static config ---
+             * Reached when:
+             *   (a) s5s8.dns is not configured (DNS feature disabled), OR
+             *   (b) DNS resolution failed — already warned by
+             *       mme_s_naptr_resolve_candidates().
+             * Either way this is normal operation; no additional warning needed.
+             */
+            pgw_addr = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET, sess);
+            pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET6, sess);
+            if (!pgw_addr && !pgw_addr6) {
+                pgw_addr  = mme_self()->pgw_addr;
+                pgw_addr6 = mme_self()->pgw_addr6;
+            }
+
+            rv = ogs_gtp2_sockaddr_to_f_teid(
+                    pgw_addr, pgw_addr6, &pgw_s5c_teid, &len);
+            ogs_assert(rv == OGS_OK);
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
+                &pgw_s5c_teid;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.len = len;
+        }
     }
 
     req->access_point_name.presence = 1;

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -173,6 +173,32 @@ void mme_s11_handle_echo_response(
     /* Not Implemented */
 }
 
+/*
+ * is_transient_gtp_cause() - classify a GTPv2 cause code as transient.
+ *
+ * A transient cause indicates a temporary PGW/SMF unavailability that may be
+ * resolved by retrying with a different PGW candidate per 3GPP TS 23.401
+ * §5.3.2.1.  Permanent causes (e.g. APN not supported, subscriber barred) are
+ * not retried — they would fail identically on any other PGW.
+ *
+ * Returns true for causes that warrant a retry with the next candidate.
+ */
+static bool is_transient_gtp_cause(uint8_t cause)
+{
+    switch (cause) {
+    case OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING:                   /* 100 */
+    case OGS_GTP2_CAUSE_NO_RESOURCES_AVAILABLE:                       /*  73 */
+    case OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED:                        /*  68 */
+    case OGS_GTP2_CAUSE_SYSTEM_FAILURE:                               /*  72 */
+    case OGS_GTP2_CAUSE_GTP_C_ENTITY_CONGESTION:                      /* 120 */
+    case OGS_GTP2_CAUSE_TEMPORARILY_REJECTED_DUE_TO_HANDOVER_IN_PROGRESS: /* 110 */
+    case OGS_GTP2_CAUSE_TIMED_OUT_REQUEST:                            /* 122 */
+        return true;
+    default:
+        return false;
+    }
+}
+
 static void mme_s11_create_session_fail(
         enb_ue_t *enb_ue, mme_ue_t *mme_ue,
         int create_action, uint8_t fail_cause,
@@ -608,6 +634,30 @@ void mme_s11_handle_create_session_response(
     return;
 
 fail:
+    /*
+     * 3GPP TS 23.401 §5.3.2.1: on a transient failure, retry the Create
+     * Session Request with the next DNS-resolved PGW candidate before
+     * rejecting the UE.
+     *
+     * A transient cause indicates temporary PGW unavailability; a permanent
+     * cause (e.g. APN not supported) would fail on any other PGW too, so
+     * we fall through immediately to mme_s11_create_session_fail().
+     */
+    if (sess && is_transient_gtp_cause(fail_cause) &&
+        sess->pgw_candidates.list &&
+        sess->pgw_candidates.index + 1 < sess->pgw_candidates.count) {
+        int r;
+        sess->pgw_candidates.index++;
+        ogs_warn("[%s] CSR rejected cause[%d] — retrying with PGW "
+                 "candidate [%d/%d]",
+                 mme_ue ? mme_ue->imsi_bcd : "?", fail_cause,
+                 sess->pgw_candidates.index + 1,
+                 sess->pgw_candidates.count);
+        r = mme_gtp_send_create_session_request(enb_ue, sess, create_action);
+        ogs_expect(r == OGS_OK);
+        return;
+    }
+
     mme_s11_create_session_fail(enb_ue, mme_ue,
             create_action, fail_cause, fail_reason);
     return;

--- a/tests/unit/abts-main.c
+++ b/tests/unit/abts-main.c
@@ -37,6 +37,7 @@ abts_suite *test_ngap_message(abts_suite *suite);
 abts_suite *test_sbi_message(abts_suite *suite);
 abts_suite *test_security(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
+abts_suite *test_s_naptr(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -49,6 +50,7 @@ const struct testlist {
     {test_sbi_message},
     {test_security},
     {test_crash},
+    {test_s_naptr},
     {NULL},
 };
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -25,6 +25,7 @@ testunit_unit_sources = files('''
     sbi-message-test.c
     security-test.c
     crash-test.c
+    s-naptr-test.c
 '''.split())
 
 testunit_unit_exe = executable('unit',

--- a/tests/unit/s-naptr-test.c
+++ b/tests/unit/s-naptr-test.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright (C) 2025 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Unit tests for the S-NAPTR DNS-based PGW discovery module (mme-s-naptr.c).
+ *
+ * Tests cover:
+ *   1. APN-FQDN construction per 3GPP TS 23.003 §19.4.2
+ *   2. SRV weighted random selection per RFC 2782 §3
+ *   3. NAPTR inverse-preference weighted selection per 3GPP TS 29.303 §5.2
+ *
+ * All tests are self-contained (no DNS server or MME context required) and
+ * mirror the algorithms implemented in mme-s-naptr.c.
+ */
+
+#include "ogs-core.h"
+#include "core/abts.h"
+
+/* ==========================================================================
+ * APN-FQDN construction helpers
+ *
+ * Mirrors build_apn_fqdn() from mme-s-naptr.c.
+ * 3GPP TS 23.003 §19.4.2 format:
+ *   <apn-ni>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ * MNC zero-padded to 2 digits (mnc_len==2) or 3 digits (mnc_len==3).
+ * MCC always zero-padded to 3 digits.
+ * ========================================================================== */
+
+static int build_apn_fqdn_test(char *buf, size_t buflen,
+        const char *apn, uint16_t mcc, uint16_t mnc, int mnc_len)
+{
+    int n;
+
+    if (mnc_len == 2)
+        n = snprintf(buf, buflen,
+                "%s.apn.epc.mnc%02d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+    else
+        n = snprintf(buf, buflen,
+                "%s.apn.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+
+    return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 1: 2-digit MNC — France Orange (MCC=208 MNC=93)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_2digit_mnc(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "internet", 208, 93, 2);
+
+    ABTS_INT_NEQUAL(tc, -1, rc);
+    ABTS_STR_EQUAL(tc,
+            "internet.apn.epc.mnc93.mcc208.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 2: 3-digit MNC — test network (MCC=001 MNC=001)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_3digit_mnc(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "ims", 1, 1, 3);
+
+    ABTS_INT_NEQUAL(tc, -1, rc);
+    ABTS_STR_EQUAL(tc,
+            "ims.apn.epc.mnc001.mcc001.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 3: T-Mobile US (MCC=310 MNC=260, 3-digit MNC)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_tmobile_us(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf),
+            "fast.t-mobile.com", 310, 260, 3);
+
+    ABTS_INT_NEQUAL(tc, -1, rc);
+    ABTS_STR_EQUAL(tc,
+            "fast.t-mobile.com.apn.epc.mnc260.mcc310.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 4: Buffer too small — must return -1 (no overflow)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_buf_too_small(abts_case *tc, void *data)
+{
+    char buf[10]; /* intentionally smaller than any valid FQDN */
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "internet", 208, 93, 2);
+
+    ABTS_INT_EQUAL(tc, -1, rc);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 5: 2-digit MNC with 2-digit value — zero-padding check (MNC=10 → "10")
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mnc_two_digits_no_extra_pad(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "apn", 234, 10, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "apn.apn.epc.mnc10.mcc234.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 6: 2-digit MNC, single-digit value — zero-padded to 2 (MNC=1 → "01")
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mnc_single_digit_padded(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "apn", 234, 1, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "apn.apn.epc.mnc01.mcc234.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 7: MCC zero-padding — MCC=1 must appear as "001"
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mcc_zero_padded(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "internet", 1, 1, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "internet.apn.epc.mnc01.mcc001.3gppnetwork.org", buf);
+}
+
+/* ==========================================================================
+ * SRV weighted random selection — RFC 2782 §3
+ *
+ * Mirrors the selection algorithm inside query_srv() in mme-s-naptr.c.
+ * Weight-0 entries are promoted to a nominal weight of 1.
+ *
+ * Uses a deterministic sweep over the pick range [0, total_weight) to verify
+ * distribution without relying on rand().
+ * ========================================================================== */
+
+static int srv_select(const uint32_t *weights, int count, uint32_t pick)
+{
+    uint32_t total = 0;
+    uint32_t effective[32];
+    uint32_t cum = 0;
+    int i;
+
+    for (i = 0; i < count; i++) {
+        effective[i] = weights[i] ? weights[i] : 1; /* RFC 2782: 0 → 1 */
+        total += effective[i];
+    }
+
+    pick %= total;
+    for (i = 0; i < count; i++) {
+        cum += effective[i];
+        if (pick < cum) return i;
+    }
+    return count - 1;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 8: Uniform weights — each entry must receive equal share
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_uniform(abts_case *tc, void *data)
+{
+    uint32_t w[] = {10, 10, 10};
+    int counts[3] = {0, 0, 0};
+    int i;
+
+    for (i = 0; i < 30000; i++) {
+        int s = srv_select(w, 3, (uint32_t)i);
+        if (s >= 0 && s < 3)
+            counts[s]++;
+    }
+
+    /* Each bucket should be exactly 1/3 of 30000 = 10000 */
+    for (i = 0; i < 3; i++)
+        ABTS_INT_EQUAL(tc, 10000, counts[i]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 9: Skewed weights 10:20:70 — verify proportional distribution
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_skewed(abts_case *tc, void *data)
+{
+    uint32_t w[] = {10, 20, 70};
+    int counts[3] = {0, 0, 0};
+    int i;
+
+    /* Sweep deterministically over one full weight cycle (100 units) × 1000 */
+    for (i = 0; i < 100000; i++) {
+        int s = srv_select(w, 3, (uint32_t)i);
+        if (s >= 0 && s < 3)
+            counts[s]++;
+    }
+
+    /* Exact proportions: 10%, 20%, 70% over 100000 iterations */
+    ABTS_INT_EQUAL(tc, 10000, counts[0]);
+    ABTS_INT_EQUAL(tc, 20000, counts[1]);
+    ABTS_INT_EQUAL(tc, 70000, counts[2]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 10: Two weight-0 records — promoted to weight 1 each → 50% / 50%
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_zero_records(abts_case *tc, void *data)
+{
+    uint32_t w[] = {0, 0};
+    int counts[2] = {0, 0};
+    int i;
+
+    for (i = 0; i < 20000; i++) {
+        int s = srv_select(w, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    /* Exactly 50 / 50 over full sweep */
+    ABTS_INT_EQUAL(tc, 10000, counts[0]);
+    ABTS_INT_EQUAL(tc, 10000, counts[1]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 11: Single entry — must always return index 0
+ * -------------------------------------------------------------------------- */
+static void test_srv_single_entry(abts_case *tc, void *data)
+{
+    uint32_t w[] = {42};
+    int i;
+
+    for (i = 0; i < 100; i++)
+        ABTS_INT_EQUAL(tc, 0, srv_select(w, 1, (uint32_t)i));
+}
+
+/* --------------------------------------------------------------------------
+ * Test 12: Mixed zero / non-zero weights — weight-0 entries rarely selected
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_mixed_zero(abts_case *tc, void *data)
+{
+    /* weights: 0, 99 → effective: 1, 99  → total 100 */
+    uint32_t w[] = {0, 99};
+    int counts[2] = {0, 0};
+    int i;
+
+    for (i = 0; i < 10000; i++) {
+        int s = srv_select(w, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    /* 1% for index 0 (weight-0 promoted to 1), 99% for index 1 */
+    ABTS_INT_EQUAL(tc, 100, counts[0]);
+    ABTS_INT_EQUAL(tc, 9900, counts[1]);
+}
+
+/* ==========================================================================
+ * NAPTR inverse-preference selection — 3GPP TS 29.303 §5.2
+ *
+ * Mirrors the algorithm inside query_naptr() in mme-s-naptr.c.
+ * weight_i = max_pref + 1 - pref_i  (lower pref ⇒ higher weight).
+ * ========================================================================== */
+
+static int naptr_select(const uint16_t *prefs, int count, uint32_t pick)
+{
+    uint16_t max_pref = 0;
+    uint32_t weights[32];
+    uint32_t total = 0;
+    uint32_t cum = 0;
+    int i;
+
+    for (i = 0; i < count; i++)
+        if (prefs[i] > max_pref) max_pref = prefs[i];
+
+    for (i = 0; i < count; i++) {
+        weights[i] = (uint32_t)(max_pref + 1 - prefs[i]);
+        total += weights[i];
+    }
+
+    pick %= total;
+    for (i = 0; i < count; i++) {
+        cum += weights[i];
+        if (pick < cum) return i;
+    }
+    return count - 1;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 13: Two records at pref 10 and 20.
+ *   max_pref=20 → weight[0]=11, weight[1]=1 → total=12
+ *   pref-10 selected ~11/12, pref-20 selected ~1/12.
+ * -------------------------------------------------------------------------- */
+static void test_naptr_pref_two_records(abts_case *tc, void *data)
+{
+    uint16_t prefs[] = {10, 20};
+    int counts[2] = {0, 0};
+    int i;
+
+    /* Sweep 12000 picks (1000 full cycles) */
+    for (i = 0; i < 12000; i++) {
+        int s = naptr_select(prefs, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    ABTS_INT_EQUAL(tc, 11000, counts[0]); /* pref 10: 11/12 × 12000 */
+    ABTS_INT_EQUAL(tc, 1000,  counts[1]); /* pref 20:  1/12 × 12000 */
+}
+
+/* --------------------------------------------------------------------------
+ * Test 14: Three records at equal preference → all equal weight (1 each)
+ * -------------------------------------------------------------------------- */
+static void test_naptr_equal_pref(abts_case *tc, void *data)
+{
+    uint16_t prefs[] = {50, 50, 50};
+    int counts[3] = {0, 0, 0};
+    int i;
+
+    /* max_pref=50 → all weights=1; total=3; sweep 30000 picks */
+    for (i = 0; i < 30000; i++) {
+        int s = naptr_select(prefs, 3, (uint32_t)i);
+        if (s >= 0 && s < 3)
+            counts[s]++;
+    }
+
+    /* Exactly 10000 each */
+    for (i = 0; i < 3; i++)
+        ABTS_INT_EQUAL(tc, 10000, counts[i]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 15: Single NAPTR record — always returns index 0
+ * -------------------------------------------------------------------------- */
+static void test_naptr_single_record(abts_case *tc, void *data)
+{
+    uint16_t prefs[] = {100};
+    int i;
+
+    for (i = 0; i < 100; i++)
+        ABTS_INT_EQUAL(tc, 0, naptr_select(prefs, 1, (uint32_t)i));
+}
+
+/* --------------------------------------------------------------------------
+ * Test 16: pref 0 (lowest possible) dominates over pref 100.
+ *   max_pref=100 → weight[0]=101, weight[1]=1 → total=102
+ * -------------------------------------------------------------------------- */
+static void test_naptr_pref_zero_dominates(abts_case *tc, void *data)
+{
+    uint16_t prefs[] = {0, 100};
+    int counts[2] = {0, 0};
+    int i;
+
+    for (i = 0; i < 10200; i++) {
+        int s = naptr_select(prefs, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    /* pref 0: 101/102 × 10200 = 10100; pref 100: 1/102 × 10200 = 100 */
+    ABTS_INT_EQUAL(tc, 10100, counts[0]);
+    ABTS_INT_EQUAL(tc, 100,   counts[1]);
+}
+
+/* ==========================================================================
+ * Suite entry point
+ * ========================================================================== */
+
+abts_suite *test_s_naptr(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite);
+
+    /* APN-FQDN construction (3GPP TS 23.003 §19.4.2) */
+    abts_run_test(suite, test_fqdn_2digit_mnc,                 NULL);
+    abts_run_test(suite, test_fqdn_3digit_mnc,                 NULL);
+    abts_run_test(suite, test_fqdn_tmobile_us,                 NULL);
+    abts_run_test(suite, test_fqdn_buf_too_small,              NULL);
+    abts_run_test(suite, test_fqdn_mnc_two_digits_no_extra_pad, NULL);
+    abts_run_test(suite, test_fqdn_mnc_single_digit_padded,    NULL);
+    abts_run_test(suite, test_fqdn_mcc_zero_padded,            NULL);
+
+    /* SRV weighted random selection (RFC 2782 §3) */
+    abts_run_test(suite, test_srv_weight_uniform,              NULL);
+    abts_run_test(suite, test_srv_weight_skewed,               NULL);
+    abts_run_test(suite, test_srv_weight_zero_records,         NULL);
+    abts_run_test(suite, test_srv_single_entry,                NULL);
+    abts_run_test(suite, test_srv_weight_mixed_zero,           NULL);
+
+    /* NAPTR inverse-preference selection (3GPP TS 29.303 §5.2) */
+    abts_run_test(suite, test_naptr_pref_two_records,          NULL);
+    abts_run_test(suite, test_naptr_equal_pref,                NULL);
+    abts_run_test(suite, test_naptr_single_record,             NULL);
+    abts_run_test(suite, test_naptr_pref_zero_dominates,       NULL);
+
+    return suite;
+}


### PR DESCRIPTION
patch to enable MME to resolve APNs through external DNS servers (i.e 3GPP TS 29.303 S-NAPTR DNS procedures for PGW discovery (Stage 3) &
3GPP TS 23.003 §19.4.2 APN-FQDN construction format ) .

PGW Address Resolution Order with new Patch :

Priority 1 — HSS-supplied IP (S6a ULA smf_ip) - unchanged

Priority 2 — S-NAPTR DNS discovery - NEW flow
- only runs when mme.s5s8.dns is configured
- failure silently falls through to priority 3
Priority 3 — Static PGW list (APN/TAC/Cell match) - unchanged
Priority 4 — First PGW in static list (last resort) - unchanged

this also will add Load Balancing mechanism through SRV records (multiple records, same priority) & A records (multiple addresses) Uniform random distributions & finally NAPTR (multiple records, same order) with Inverse-preference weighted (i.e Lower pref → proportionally higher probability) .

known limitations :

IPv4 only — IPv6 PGW addresses (AAAA records) are not resolved
DNS lookup is synchronous (blocking) on the MME worker thread - impact is managed by implementing DNS caching (APN + PLMN → IPv4 address)
What exactly the Patch Does :

The patch adds standards-compliant, dynamic PGW discovery to the Open5GS MME: instead of relying on a single statically-configured PGW address in mme.yaml, the MME now queries DNS at session-setup time to discover a pool of PGW candidates, selects one and automatically retries with the next candidate if the first fails — all with an in-process TTL-driven DNS cache so the cost of a full DNS round-trip is paid only once per APN per cache period.

Every Create Session Request for a new APN triggers a three-stage DNS resolution chain defined by 3GPP TS 29.303 and TS 23.003 §19.4.2.

i.e internet.apn.epc.mnc001.mcc234.3gppnetwork.org

On Transient GTP Error Response , MME will retry rather than failing the attach .

The patch implements four layers of load distribution :
1 - NAPTR Order and Preference (PGW Pool Selection)
2 - SRV Priority and Weight (Within-Pool Selection)
3 - A Record Distribution
4 - Cache Rotation Keeps Balance After Cache Warms

Scalability in Multi-PGW Architectures as in Horizontal Scale-Out — Adding New PGWs , To add a PGW to the pool an operator updates the DNS A record or SRV record. The next time the MME's cache expires for that APN, the new PGW automatically appears in the candidate list — no MME restart, no configuration reload required.

Graceful Scale-In — Removing a PGW , to drain a PGW without disrupting active sessions:

1 - Remove it from DNS (set TTL=30s for rapid propagation)
2 - After 30s, no new sessions are sent to it (cache refreshed, it's absent)
3 - Existing sessions are unaffected — the PGW remains active for bearer teardown
4 - PGW can be shut down once existing session count drains to zero

Dynamic Traffic Engineering , Because the entire PGW selection path is DNS-driven, all traffic engineering controls sit in the DNS zone — which can be updated in seconds, without touching the MME .