### PR TITLE
[SMF] Index every UE in both imsi_hash and supi_hash

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1074,6 +1074,7 @@ static smf_ue_t *smf_ue_add(void)
 smf_ue_t *smf_ue_add_by_supi(char *supi)
 {
     smf_ue_t *smf_ue;
+    const char *bare;
 
     ogs_assert(supi);
 
@@ -1086,12 +1087,70 @@ smf_ue_t *smf_ue_add_by_supi(char *supi)
     ogs_assert(smf_ue->supi);
     ogs_hash_set(self.supi_hash, smf_ue->supi, strlen(smf_ue->supi), smf_ue);
 
+    /*
+     * Also index this UE in imsi_hash so a later 4G attach via
+     * smf_ue_find_by_imsi() returns the same smf_ue_t rather than
+     * creating a second one for the same physical subscriber.
+     *
+     * SUPI per 3GPP TS 23.003 §5 takes several forms ("imsi-<digits>",
+     * "nai-…", "gli-…", "gci-…"); only the IMSI form has a meaningful
+     * BCD encoding compatible with the GTPv2-C Create Session Request
+     * IMSI IE produced on the 4G path. For non-IMSI SUPIs the UE stays
+     * indexed only in supi_hash — a 4G attach cannot collide with a
+     * non-IMSI 5G context on the same physical subscriber anyway.
+     *
+     * Without this dual indexing, 4G and 5G attaches for the same UE
+     * end up on distinct smf_ue_t objects whose sess_list is not
+     * visible to the other RAT's session-create code, so a stale
+     * source-RAT PDU session can linger across a 4G<->5G transition
+     * in violation of TS 23.501 §5.6.1 ("at most one active PDU
+     * session per (SUPI, DNN)").
+     *
+     * Input validation is mandatory before BCD encoding because supi
+     * is sourced from external SBI traffic and ogs_bcd_to_buffer()
+     * performs no bounds check: it writes (strlen(in)+1)/2 bytes into
+     * smf_ue->imsi[OGS_MAX_IMSI_LEN] and treats every byte as a digit
+     * via (in[i] - 0x30). An over-length or non-digit SUPI would
+     * corrupt the surrounding context_t fields.
+     */
+    bare = supi;
+    if (strncmp(bare, "imsi-", 5) == 0) {
+        size_t digit_count, i;
+        bool valid;
+
+        bare += 5;
+        digit_count = strlen(bare);
+        valid = digit_count > 0 && digit_count <= OGS_MAX_IMSI_LEN * 2;
+        for (i = 0; valid && i < digit_count; i++) {
+            if (bare[i] < '0' || bare[i] > '9')
+                valid = false;
+        }
+
+        if (valid) {
+            int imsi_len = 0;
+            ogs_bcd_to_buffer(bare, smf_ue->imsi, &imsi_len);
+            if (imsi_len > 0) {
+                smf_ue->imsi_len = imsi_len;
+                ogs_buffer_to_bcd(smf_ue->imsi, smf_ue->imsi_len,
+                        smf_ue->imsi_bcd);
+                ogs_hash_set(self.imsi_hash, smf_ue->imsi,
+                        smf_ue->imsi_len, smf_ue);
+            }
+        } else {
+            ogs_error("SUPI [%s] IMSI portion length %zu invalid "
+                    "(must be 1..%d numeric digits) — skipping "
+                    "imsi_hash dual-index",
+                    supi, digit_count, OGS_MAX_IMSI_LEN * 2);
+        }
+    }
+
     return smf_ue;
 }
 
 smf_ue_t *smf_ue_add_by_imsi(uint8_t *imsi, int imsi_len)
 {
     smf_ue_t *smf_ue;
+    char supi[OGS_MAX_IMSI_BCD_LEN + sizeof("imsi-")];
 
     ogs_assert(imsi);
     ogs_assert(imsi_len);
@@ -1103,6 +1162,17 @@ smf_ue_t *smf_ue_add_by_imsi(uint8_t *imsi, int imsi_len)
     memcpy(smf_ue->imsi, imsi, smf_ue->imsi_len);
     ogs_buffer_to_bcd(smf_ue->imsi, smf_ue->imsi_len, smf_ue->imsi_bcd);
     ogs_hash_set(self.imsi_hash, smf_ue->imsi, smf_ue->imsi_len, smf_ue);
+
+    /*
+     * Also index this UE in supi_hash so a later 5G attach via
+     * smf_ue_find_by_supi() returns the same smf_ue_t. Mirror of
+     * the companion logic in smf_ue_add_by_supi(); see there for
+     * the full rationale and spec references.
+     */
+    ogs_snprintf(supi, sizeof(supi), "imsi-%s", smf_ue->imsi_bcd);
+    smf_ue->supi = ogs_strdup(supi);
+    ogs_assert(smf_ue->supi);
+    ogs_hash_set(self.supi_hash, smf_ue->supi, strlen(smf_ue->supi), smf_ue);
 
     return smf_ue;
 }


### PR DESCRIPTION
When a UE attaches on 4G, smf_ue_add_by_imsi() registers the UE in imsi_hash keyed by raw BCD IMSI bytes. When the same physical UE later attaches on 5G via SBI, smf_ue_add_by_supi() registers a *second* smf_ue_t in supi_hash keyed by the "imsi-<digits>" SUPI string. The two objects are never reconciled: each has its own sess_list, and neither RAT's session-create code path is aware of the sessions on the other.

Consequence: across a 4G<->5G transition without a clean Detach, the SMF can retain a stale source-RAT PDU session that the target-RAT attach does not displace, because the target-RAT cleanup operates on a different smf_ue_t. This violates TS 23.501 §5.6.1 ("at most one active PDU Session per (SUPI, DNN)") and TS 23.502 §4.11.1.2.3 (source-RAT SM context release obligation during EPS<->5GS mobility).

Observed in deployment: a UE registered on both 4G (via MME S11) and 5G (via AMF SBI) for the same DNN ends up with two PDU sessions on the SMF. AMF has psi=N for DNN "internet", MME has ebi=M for APN "internet" on the same IMSI, and the SMF holds both — one on each smf_ue_t. Neither shows as an orphan against its own peer NF; the inconsistency is only visible when looking across both RATs simultaneously.

Fix: register every UE in both hash maps at creation time. Each add-path still takes its native identifier form (raw BCD bytes in add_by_imsi(), SUPI string in add_by_supi()), but also computes and registers the other form so that subsequent lookups on either hash return the same object. Conversion uses ogs_bcd_to_buffer() / ogs_buffer_to_bcd() and a 3GPP TS 23.003 §5 "imsi-"-prefixed SUPI string.

### Why no change to the removal path

`smf_ue_remove()` already unsets both hash entries conditionally on `smf_ue->supi` and `smf_ue->imsi_len` being populated. After this patch every UE has both populated, so removal stays symmetric without any modification to that function.

### Why the nsmf-handler re-population of `smf_ue->imsi` is safe

`src/smf/nsmf-handler.c` populates `smf_ue->imsi` / `imsi_len` again from the SBI request body in the create-sm-context and pdu-session-create paths (after `smf_ue_add_by_supi()` has run). This is safe because both paths derive the BCD bytes from the same SUPI digit string deterministically — the bytes written are identical to the bytes this patch installs at add-time, so the imsi_hash key remains stable across the re-population.

### Defensive validation against malformed SUPIs

`ogs_bcd_to_buffer()` performs no bounds check (it writes `(strlen(in)+1)/2` bytes into the caller's buffer) and treats every input byte as a digit via `(in[i] - 0x30)`. Because the SUPI string arrives over SBI from external NFs, an over-length or non-digit `imsi-…` prefix would corrupt `smf_ue->imsi[OGS_MAX_IMSI_LEN]` and the surrounding `context_t` fields. The patch therefore:

- Skips `imsi_hash` dual-indexing entirely when the SUPI does not start with `"imsi-"` (NAI/GLI/GCI per TS 23.003 §5 cannot be BCD-encoded; the UE remains correctly indexed in `supi_hash`, and a 4G attach cannot collide with a non-IMSI 5G context anyway).
- Validates the digit portion against `OGS_MAX_IMSI_LEN * 2` and rejects any non-digit byte before invoking `ogs_bcd_to_buffer()`. Invalid input emits an `ogs_error` and skips the dual-index without aborting the UE registration.

After the fix, cross-RAT orphan cleanup on a single smf_ue_t's sess_list sees both 4G and 5G sessions uniformly, and the existing session-uniqueness guard in smf_sess_add_by_psi() / smf_sess_add_by_apn() has a chance to run against the true prior session regardless of which RAT created it.

### Production validation

Deployed to a 4G+5G production EP5G core on 2026-04-20 (under our local
patch-stack ahead of submitting this upstream). 4 days 6 hours of
continuous SMF uptime since, 0 restarts, 0 SIGSEGVs, 0 assertion
failures. An external 3-way consistency reconciler (SMF /pdu-info vs
AMF /ue-info vs MME /ue-info) running on a 15-minute cadence has
reported 0 cross-RAT duplicate detections (`(SUPI, DNN)`-uniqueness
invariant per TS 23.501 §5.6.1 holds in every sweep). Pre-deploy
baseline had a recurring cross-RAT duplicate every few days driven by
the hash-map split this PR addresses.
