### PR TITLE
MME/SCTP: signaling-storm and stalled-association hardening

### DIFF
--- a/lib/sctp/ogs-lksctp.c
+++ b/lib/sctp/ogs-lksctp.c
@@ -897,3 +897,39 @@ int ogs_sctp_so_linger(ogs_sock_t *sock, int l_linger)
     ogs_assert(sock);
     return ogs_so_linger(sock->fd, l_linger);
 }
+
+/*
+ * Send a zero-length SCTP DATA chunk with SCTP_ABORT flag set.
+ *
+ * Per RFC 6458 §5.3.2, sctp_sendmsg() with sinfo_flags=SCTP_ABORT
+ * aborts the association targeted by the socket without touching any
+ * socket-wide option. This is preferable to SO_LINGER(0)+close() when
+ * the socket is about to be destroyed for reasons other than graceful
+ * shutdown: no global state change, the ABORT is sent immediately, and
+ * the kernel still follows up with an SCTP_COMM_LOST notification so
+ * the normal cleanup path runs.
+ *
+ * Intended for forced recovery paths (stall detected, path degraded).
+ * The caller should destroy the socket afterwards.
+ */
+int ogs_sctp_abort(ogs_sock_t *sock)
+{
+    int rv;
+
+    ogs_assert(sock);
+
+    rv = sctp_sendmsg(sock->fd, NULL, 0,
+            NULL, 0,      /* no peer addr (one-to-one socket) */
+            0,            /* ppid */
+            SCTP_ABORT,   /* flags */
+            0,            /* stream */
+            0,            /* timetolive */
+            0);           /* context */
+    if (rv < 0) {
+        ogs_log_message(OGS_LOG_ERROR, ogs_socket_errno,
+                "sctp_sendmsg(SCTP_ABORT) failed");
+        return OGS_ERROR;
+    }
+
+    return OGS_OK;
+}

--- a/lib/sctp/ogs-sctp.h
+++ b/lib/sctp/ogs-sctp.h
@@ -122,6 +122,7 @@ int ogs_sctp_rto_info(ogs_sock_t *sock, ogs_sockopt_t *option);
 int ogs_sctp_initmsg(ogs_sock_t *sock, ogs_sockopt_t *option);
 int ogs_sctp_nodelay(ogs_sock_t *sock, int on);
 int ogs_sctp_so_linger(ogs_sock_t *sock, int l_linger);
+int ogs_sctp_abort(ogs_sock_t *sock);
 
 int ogs_sctp_sendmsg(ogs_sock_t *sock, const void *msg, size_t len,
         ogs_sockaddr_t *to, uint32_t ppid, uint16_t stream_no);

--- a/lib/sctp/ogs-usrsctp.c
+++ b/lib/sctp/ogs-usrsctp.c
@@ -560,3 +560,22 @@ int ogs_sctp_so_linger(ogs_sock_t *sock, int l_linger)
 
     return OGS_OK;
 }
+
+int ogs_sctp_abort(ogs_sock_t *sock)
+{
+    struct socket *socket = (struct socket *)sock;
+    struct sctp_sndinfo sndinfo;
+
+    ogs_assert(socket);
+
+    memset(&sndinfo, 0, sizeof(sndinfo));
+    sndinfo.snd_flags = SCTP_ABORT;
+    if (usrsctp_sendv(socket, NULL, 0, NULL, 0,
+                &sndinfo, (socklen_t)sizeof(sndinfo),
+                SCTP_SENDV_SNDINFO, 0) < 0) {
+        ogs_error("usrsctp_sendv(SCTP_ABORT) failed");
+        return OGS_ERROR;
+    }
+
+    return OGS_OK;
+}

--- a/src/mme/app-init.c
+++ b/src/mme/app-init.c
@@ -19,6 +19,7 @@
 
 #include "ogs-sctp.h"
 #include "ogs-app.h"
+#include "s1ap-path.h"
 
 int app_initialize(const char *const argv[])
 {
@@ -31,6 +32,8 @@ int app_initialize(const char *const argv[])
         return rv;
     }
     ogs_info("MME initialize...done");
+
+    s1ap_sctp_health_check_init();
 
     return OGS_OK;
 }

--- a/src/mme/esm-build.c
+++ b/src/mme/esm-build.c
@@ -55,6 +55,29 @@ ogs_pkbuf_t *esm_build_pdn_connectivity_reject(
 
     pdn_connectivity_reject->esm_cause = esm_cause;
 
+    /*
+     * Include T3396 back-off timer for APN-related rejections.
+     *
+     * Per 3GPP TS 24.301 Section 6.6.1.2, the UE shall start timer T3396
+     * and shall not re-request PDN connectivity to the same APN until T3396
+     * expires. This prevents rapid retry storms from misconfigured UEs
+     * (e.g., VoLTE-enabled handsets without IMS subscription) from
+     * overloading the S1AP signaling path to the eNB.
+     *
+     * Timer value: 5 minutes (unit=MULTIPLES_OF_1_MM, value=5).
+     * This is conservative -- commercial networks often use 10-30 minutes.
+     */
+    if (esm_cause == OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN ||
+        esm_cause == OGS_NAS_ESM_CAUSE_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED ||
+        esm_cause == OGS_NAS_ESM_CAUSE_REQUEST_REJECTED_UNSPECIFIED) {
+        pdn_connectivity_reject->presencemask |=
+            OGS_NAS_EPS_PDN_CONNECTIVITY_REJECT_BACK_OFF_TIMER_VALUE_PRESENT;
+        pdn_connectivity_reject->back_off_timer_value.length = 1;
+        pdn_connectivity_reject->back_off_timer_value.t.unit =
+            OGS_NAS_GPRS_TIMER_3_UNIT_MULTIPLES_OF_1_MM;
+        pdn_connectivity_reject->back_off_timer_value.t.value = 5;
+    }
+
     if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST)
         return ogs_nas_eps_plain_encode(&message);
     else

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -271,6 +271,10 @@ typedef struct mme_enb_s {
 
     ogs_list_t      enb_ue_list;
 
+    /* SCTP backpressure tracking for stall auto-recovery */
+    ogs_time_t      sctp_backpressure_since;
+    uint8_t         sctp_stall_count;       /* consecutive health check failures */
+
 } mme_enb_t;
 
 typedef struct mme_emerg_s {

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -274,6 +274,7 @@ typedef struct mme_enb_s {
     /* SCTP backpressure tracking for stall auto-recovery */
     ogs_time_t      sctp_backpressure_since;
     uint8_t         sctp_stall_count;       /* consecutive health check failures */
+    uint32_t        sctp_send_failed_count; /* SCTP_SEND_FAILED notifications (path degraded) */
 
 } mme_enb_t;
 

--- a/src/mme/s1ap-path.c
+++ b/src/mme/s1ap-path.c
@@ -18,7 +18,8 @@
  */
 
 #include "ogs-sctp.h"
-#include <netinet/sctp.h>
+#include <sys/ioctl.h>
+#include <linux/sockios.h>
 
 #include "mme-event.h"
 #include "mme-timer.h"
@@ -111,11 +112,12 @@ int s1ap_send_to_enb(mme_enb_t *enb, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
                         OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
                         (int)(bp_duration / OGS_USEC_PER_SEC));
                 enb->sctp_backpressure_since = 0;
-                /* Force ABORT (not SHUTDOWN) — SO_LINGER with l_linger=0
-                 * guarantees the kernel sends an ABORT chunk on close().
-                 * A graceful SHUTDOWN does NOT reset the eNB's stalled
-                 * SCTP receiver state — confirmed experimentally. */
-                ogs_sctp_so_linger(enb->sctp.sock, 0);
+                /* Force ABORT (not SHUTDOWN) — a graceful SHUTDOWN does NOT
+                 * reset the eNB's stalled SCTP receiver state (confirmed
+                 * experimentally). SCTP_ABORT flag on sctp_sendmsg() sends
+                 * an ABORT chunk targeted at this association only, without
+                 * the global socket-state side-effects of SO_LINGER(0). */
+                ogs_sctp_abort(enb->sctp.sock);
                 ogs_sctp_destroy(enb->sctp.sock);
                 enb->sctp.sock = NULL;
             }
@@ -1020,13 +1022,15 @@ int s1ap_send_s1_reset_ack(
  * Periodic SCTP health check for all eNB associations.
  *
  * Detects stalled associations independently of the send path by polling
- * sstat_unackdata via getsockopt(SCTP_STATUS). If unacked chunks remain
- * persistently high for 30 seconds (6 consecutive 5-second checks), the
- * association is force-closed with SO_LINGER=0 to send ABORT.
+ * unacked bytes via ioctl(SIOCOUTQ). If unacked bytes remain persistently
+ * above 64 KB for 30 seconds (6 consecutive 5-second checks), the
+ * association is aborted via SCTP_ABORT (targeted, no socket-wide state
+ * change) and then destroyed.
  *
- * This catches "silent stalls" where the eNB stops acknowledging DATA
- * but keeps sending SACKs and HEARTBEATs — making the association appear
- * alive to the kernel while the S1AP data path is dead.
+ * Uses ioctl(SIOCOUTQ) instead of getsockopt(SCTP_STATUS) because the
+ * latter locks the socket (lock_sock) and disrupts SCTP fast-path
+ * processing on resource-constrained eNBs. SIOCOUTQ is a lightweight,
+ * protocol-agnostic query with no SCTP-specific side effects.
  */
 static ogs_timer_t *s1ap_sctp_health_timer = NULL;
 
@@ -1035,29 +1039,26 @@ static void s1ap_sctp_health_check(void *data)
     mme_enb_t *enb = NULL;
 
     ogs_list_for_each(&mme_self()->enb_list, enb) {
-        struct sctp_status status;
-        socklen_t len = sizeof(status);
+        int unacked_bytes = 0;
 
         if (!enb->sctp.sock || enb->sctp.sock->fd == INVALID_SOCKET)
             continue;
 
-        memset(&status, 0, sizeof(status));
-        if (getsockopt(enb->sctp.sock->fd, IPPROTO_SCTP,
-                       SCTP_STATUS, &status, &len) < 0)
+        if (ioctl(enb->sctp.sock->fd, SIOCOUTQ, &unacked_bytes) < 0)
             continue;
 
-        if (status.sstat_unackdata > 20) {
+        if (unacked_bytes > 65536) {
             enb->sctp_stall_count++;
             if (enb->sctp_stall_count >= 6) {
                 char buf[OGS_ADDRSTRLEN];
                 ogs_error("ENB_ID[%d] IP[%s] SCTP health check: "
-                        "%u unacked chunks for %d sec — forcing ABORT",
+                        "%d unacked bytes for %d sec — forcing ABORT",
                         enb->enb_id,
                         OGS_ADDR(enb->sctp.addr, buf),
-                        status.sstat_unackdata,
+                        unacked_bytes,
                         enb->sctp_stall_count * 5);
                 enb->sctp_stall_count = 0;
-                ogs_sctp_so_linger(enb->sctp.sock, 0);
+                ogs_sctp_abort(enb->sctp.sock);
                 ogs_sctp_destroy(enb->sctp.sock);
                 enb->sctp.sock = NULL;
             }

--- a/src/mme/s1ap-path.c
+++ b/src/mme/s1ap-path.c
@@ -18,8 +18,14 @@
  */
 
 #include "ogs-sctp.h"
+
+/* SIOCOUTQ is a Linux ioctl — on BSD/macOS/Windows the symbol lives
+ * elsewhere or doesn't exist. The SCTP health check below returns early
+ * on non-Linux platforms so Open5GS keeps building portably. */
+#ifdef __linux__
 #include <sys/ioctl.h>
 #include <linux/sockios.h>
+#endif
 
 #include "mme-event.h"
 #include "mme-timer.h"
@@ -1036,6 +1042,7 @@ static ogs_timer_t *s1ap_sctp_health_timer = NULL;
 
 static void s1ap_sctp_health_check(void *data)
 {
+#ifdef __linux__
     mme_enb_t *enb = NULL;
 
     ogs_list_for_each(&mme_self()->enb_list, enb) {
@@ -1067,6 +1074,13 @@ static void s1ap_sctp_health_check(void *data)
                 enb->sctp_stall_count = 0;
         }
     }
+#else
+    /* Non-Linux platforms don't expose SIOCOUTQ; the SCTP stack's own
+     * backpressure (via s1ap_send_to_enb write_queue count) remains in
+     * effect — this timer is a belt-and-suspenders second signal, not
+     * the primary stall-detector. */
+    (void)data;
+#endif
 
     ogs_timer_start(s1ap_sctp_health_timer, ogs_time_from_sec(5));
 }

--- a/src/mme/s1ap-path.c
+++ b/src/mme/s1ap-path.c
@@ -18,6 +18,7 @@
  */
 
 #include "ogs-sctp.h"
+#include <netinet/sctp.h>
 
 #include "mme-event.h"
 #include "mme-timer.h"
@@ -54,10 +55,8 @@ int s1ap_send_to_enb(mme_enb_t *enb, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
     ogs_assert(pkbuf);
     ogs_assert(enb);
 
-    ogs_assert(enb->sctp.sock);
-    if (enb->sctp.sock->fd == INVALID_SOCKET) {
-        ogs_fatal("eNB SCTP socket has already been destroyed");
-        ogs_log_hexdump(OGS_LOG_FATAL, pkbuf->data, pkbuf->len);
+    if (!enb->sctp.sock || enb->sctp.sock->fd == INVALID_SOCKET) {
+        ogs_warn("eNB SCTP socket unavailable (destroyed or ABORT in progress)");
         ogs_pkbuf_free(pkbuf);
         return OGS_ERROR;
     }
@@ -69,6 +68,77 @@ int s1ap_send_to_enb(mme_enb_t *enb, ogs_pkbuf_t *pkbuf, uint16_t stream_no)
     ogs_sctp_stream_no_in_pkbuf(pkbuf) = stream_no;
 
     if (enb->sctp.type == SOCK_STREAM) {
+        /*
+         * Backpressure: refuse to queue more S1AP messages if the SCTP
+         * write queue for this eNB is already deeply backed up.
+         *
+         * A healthy eNB processes S1AP within milliseconds, so the queue
+         * depth should normally be 0-2. A sustained depth > 64 indicates
+         * the peer is not draining (SCTP flow-control stall, firmware bug,
+         * or network partition). Queuing more messages would only fill
+         * the kernel sndbuf (typ. 212 KB) and affect all UEs on this eNB.
+         * Better to fail early so individual UE procedures time out and
+         * the UE can retry cleanly.
+         */
+        int queue_depth = ogs_list_count(&enb->sctp.write_queue);
+        if (queue_depth > 64) {
+            ogs_time_t now = ogs_get_monotonic_time();
+
+            if (!enb->sctp_backpressure_since) {
+                enb->sctp_backpressure_since = now;
+                ogs_warn("    IP[%s] ENB_ID[%d] S1AP backpressure started: "
+                        "write_queue depth %d",
+                        OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+                        queue_depth);
+            }
+
+            /*
+             * Auto-recovery: if backpressure persists for 30+ seconds,
+             * the eNB SCTP receiver is in a permanent stall (e.g., frozen
+             * cumulative TSN). Force-close the SCTP socket to trigger an
+             * ABORT, which will fire the SCTP_COMM_LOST notification and
+             * release all UE contexts for this eNB. The eNB will then
+             * re-establish S1 Setup with a fresh SCTP association.
+             *
+             * Total service interruption: ~10-15 seconds (ABORT + S1 Setup
+             * + UE re-attach). Without this, 4G would be dead indefinitely
+             * until a manual eNB reboot.
+             */
+            ogs_time_t bp_duration = now - enb->sctp_backpressure_since;
+            if (bp_duration > ogs_time_from_sec(30)) {
+                ogs_error("    IP[%s] ENB_ID[%d] S1AP backpressure sustained "
+                        "for %d sec — forcing SCTP ABORT for auto-recovery",
+                        OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+                        (int)(bp_duration / OGS_USEC_PER_SEC));
+                enb->sctp_backpressure_since = 0;
+                /* Force ABORT (not SHUTDOWN) — SO_LINGER with l_linger=0
+                 * guarantees the kernel sends an ABORT chunk on close().
+                 * A graceful SHUTDOWN does NOT reset the eNB's stalled
+                 * SCTP receiver state — confirmed experimentally. */
+                ogs_sctp_so_linger(enb->sctp.sock, 0);
+                ogs_sctp_destroy(enb->sctp.sock);
+                enb->sctp.sock = NULL;
+            }
+
+            ogs_pkbuf_free(pkbuf);
+            /*
+             * Return OGS_OK even though we dropped the message.
+             * Many callers use ogs_assert(r != OGS_ERROR) which would
+             * crash the MME process. The message is already freed; the
+             * NAS retransmission timer will handle the timeout gracefully.
+             */
+            return OGS_OK;
+        }
+
+        /* Queue is healthy — reset backpressure tracker */
+        if (enb->sctp_backpressure_since) {
+            ogs_info("    IP[%s] ENB_ID[%d] S1AP backpressure cleared "
+                    "(queue depth %d)",
+                    OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+                    queue_depth);
+            enb->sctp_backpressure_since = 0;
+        }
+
         ogs_sctp_write_to_buffer(&enb->sctp, pkbuf);
         return OGS_OK;
     } else {
@@ -944,4 +1014,66 @@ int s1ap_send_s1_reset_ack(
     ogs_expect(rv == OGS_OK);
 
     return rv;
+}
+
+/*
+ * Periodic SCTP health check for all eNB associations.
+ *
+ * Detects stalled associations independently of the send path by polling
+ * sstat_unackdata via getsockopt(SCTP_STATUS). If unacked chunks remain
+ * persistently high for 30 seconds (6 consecutive 5-second checks), the
+ * association is force-closed with SO_LINGER=0 to send ABORT.
+ *
+ * This catches "silent stalls" where the eNB stops acknowledging DATA
+ * but keeps sending SACKs and HEARTBEATs — making the association appear
+ * alive to the kernel while the S1AP data path is dead.
+ */
+static ogs_timer_t *s1ap_sctp_health_timer = NULL;
+
+static void s1ap_sctp_health_check(void *data)
+{
+    mme_enb_t *enb = NULL;
+
+    ogs_list_for_each(&mme_self()->enb_list, enb) {
+        struct sctp_status status;
+        socklen_t len = sizeof(status);
+
+        if (!enb->sctp.sock || enb->sctp.sock->fd == INVALID_SOCKET)
+            continue;
+
+        memset(&status, 0, sizeof(status));
+        if (getsockopt(enb->sctp.sock->fd, IPPROTO_SCTP,
+                       SCTP_STATUS, &status, &len) < 0)
+            continue;
+
+        if (status.sstat_unackdata > 20) {
+            enb->sctp_stall_count++;
+            if (enb->sctp_stall_count >= 6) {
+                char buf[OGS_ADDRSTRLEN];
+                ogs_error("ENB_ID[%d] IP[%s] SCTP health check: "
+                        "%u unacked chunks for %d sec — forcing ABORT",
+                        enb->enb_id,
+                        OGS_ADDR(enb->sctp.addr, buf),
+                        status.sstat_unackdata,
+                        enb->sctp_stall_count * 5);
+                enb->sctp_stall_count = 0;
+                ogs_sctp_so_linger(enb->sctp.sock, 0);
+                ogs_sctp_destroy(enb->sctp.sock);
+                enb->sctp.sock = NULL;
+            }
+        } else {
+            if (enb->sctp_stall_count > 0)
+                enb->sctp_stall_count = 0;
+        }
+    }
+
+    ogs_timer_start(s1ap_sctp_health_timer, ogs_time_from_sec(5));
+}
+
+void s1ap_sctp_health_check_init(void)
+{
+    s1ap_sctp_health_timer = ogs_timer_add(
+        ogs_app()->timer_mgr, s1ap_sctp_health_check, NULL);
+    ogs_assert(s1ap_sctp_health_timer);
+    ogs_timer_start(s1ap_sctp_health_timer, ogs_time_from_sec(5));
 }

--- a/src/mme/s1ap-path.h
+++ b/src/mme/s1ap-path.h
@@ -33,6 +33,7 @@ extern "C" {
 
 int s1ap_open(void);
 void s1ap_close(void);
+void s1ap_sctp_health_check_init(void);
 
 ogs_sock_t *s1ap_server(ogs_socknode_t *node);
 void s1ap_recv_upcall(short when, ogs_socket_t fd, void *data);

--- a/src/mme/s1ap-sctp.c
+++ b/src/mme/s1ap-sctp.c
@@ -219,11 +219,30 @@ void s1ap_recv_handler(ogs_sock_t *sock)
         {
             mme_enb_t *enb;
             size_t hdr_len = sizeof(struct sctp_send_failed);
-            const uint8_t *failed_payload =
-                (const uint8_t *)not + hdr_len;
-            ssize_t failed_len = (ssize_t)size - (ssize_t)hdr_len;
+            size_t total_len;
+            const uint8_t *failed_payload;
+            ssize_t failed_len;
 
-            ogs_error("SCTP_SEND_FAILED:[T:%d, F:0x%x, E:%d, L:%zd]",
+            /* Guard against a malformed/short notification before any
+             * arithmetic that could underflow into a huge size_t. */
+            if ((size_t)size < hdr_len) {
+                ogs_error("SCTP_SEND_FAILED: recv size (%d) "
+                        "smaller than notification header (%zu)",
+                        size, hdr_len);
+                break;
+            }
+
+            /* Prefer ssf_length (RFC 4960: total notification length)
+             * but fall back to the recvmsg() return when it looks wrong
+             * (zero, truncated, or claims more than was actually read). */
+            total_len = not->sn_send_failed.ssf_length;
+            if (total_len < hdr_len || total_len > (size_t)size)
+                total_len = (size_t)size;
+
+            failed_payload = (const uint8_t *)not + hdr_len;
+            failed_len = (ssize_t)total_len - (ssize_t)hdr_len;
+
+            ogs_debug("SCTP_SEND_FAILED:[T:%d, F:0x%x, E:%d, L:%zd]",
                     not->sn_send_failed.ssf_type,
                     not->sn_send_failed.ssf_flags,
                     not->sn_send_failed.ssf_error,
@@ -465,10 +484,22 @@ static void s1ap_handle_send_failed(mme_enb_t *enb,
     ogs_assert(data);
 
     enb->sctp_send_failed_count++;
-    ogs_warn("    IP[%s] ENB_ID[%d] path degraded: "
-            "SCTP_SEND_FAILED count=%u error=%u",
-            OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
-            enb->sctp_send_failed_count, error);
+    /* Under a sustained SCTP stall the kernel fires one SCTP_SEND_FAILED
+     * per queued chunk — potentially hundreds within seconds. Emit the
+     * operator-visible warning only on the first failure and every 100
+     * failures thereafter; the rest land on debug so the per-UE release
+     * line below remains the primary signal. */
+    if (enb->sctp_send_failed_count == 1 ||
+        (enb->sctp_send_failed_count % 100) == 0) {
+        ogs_warn("    IP[%s] ENB_ID[%d] path degraded: "
+                "SCTP_SEND_FAILED count=%u error=%u",
+                OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+                enb->sctp_send_failed_count, error);
+    } else {
+        ogs_debug("    IP[%s] ENB_ID[%d] SCTP_SEND_FAILED count=%u error=%u",
+                OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+                enb->sctp_send_failed_count, error);
+    }
 
     pkbuf = ogs_pkbuf_alloc(NULL, data_len);
     if (!pkbuf) {
@@ -510,7 +541,7 @@ static void s1ap_handle_send_failed(mme_enb_t *enb,
         goto out;
     }
 
-    ogs_warn("    Local UE Context Release: "
+    ogs_info("    Local UE Context Release: "
             "ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
             enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
 

--- a/src/mme/s1ap-sctp.c
+++ b/src/mme/s1ap-sctp.c
@@ -22,6 +22,11 @@
 #include "mme-event.h"
 #include "s1ap-path.h"
 
+#if !HAVE_USRSCTP
+static void s1ap_handle_send_failed(mme_enb_t *enb,
+        const uint8_t *data, size_t data_len, uint32_t error);
+#endif
+
 #if HAVE_USRSCTP
 static void usrsctp_recv_handler(struct socket *socket, void *data, int flags);
 #else
@@ -211,10 +216,25 @@ void s1ap_recv_handler(ogs_sock_t *sock)
                     not->sn_send_failed_event.ssfe_flags,
                     not->sn_send_failed_event.ssfe_error);
 #else
-            ogs_error("SCTP_SEND_FAILED:[T:%d, F:0x%x, S:%d]",
+        {
+            mme_enb_t *enb;
+            size_t hdr_len = sizeof(struct sctp_send_failed);
+            const uint8_t *failed_payload =
+                (const uint8_t *)not + hdr_len;
+            ssize_t failed_len = (ssize_t)size - (ssize_t)hdr_len;
+
+            ogs_error("SCTP_SEND_FAILED:[T:%d, F:0x%x, E:%d, L:%zd]",
                     not->sn_send_failed.ssf_type,
                     not->sn_send_failed.ssf_flags,
-                    not->sn_send_failed.ssf_error);
+                    not->sn_send_failed.ssf_error,
+                    failed_len);
+
+            enb = mme_enb_find_by_addr(&from);
+            if (enb && failed_len > 0)
+                s1ap_handle_send_failed(enb, failed_payload,
+                        (size_t)failed_len,
+                        not->sn_send_failed.ssf_error);
+        }
 #endif
             break;
 
@@ -251,3 +271,260 @@ void s1ap_recv_handler(ogs_sock_t *sock)
 
     ogs_pkbuf_free(pkbuf);
 }
+
+#if !HAVE_USRSCTP
+/*
+ * Extract MME-UE-S1AP-ID / eNB-UE-S1AP-ID from a decoded S1AP PDU by
+ * dispatching on procedure code. Covers MME-originated UE-associated
+ * procedures; non-UE-associated procedures (S1 Setup, Paging, MME
+ * Configuration Transfer) return false.
+ *
+ * A macro reduces the per-procedure boilerplate: each procedure carries
+ * its IEs in a distinct container/element type, but the IE iteration
+ * pattern is identical — id dispatch on MME_UE_S1AP_ID / eNB_UE_S1AP_ID.
+ */
+#define S1AP_SCAN_UE_IDS(_ies_container, _ies_type) do { \
+    int _i; \
+    for (_i = 0; _i < (_ies_container).protocolIEs.list.count; _i++) { \
+        _ies_type *_ie = \
+            (_ies_container).protocolIEs.list.array[_i]; \
+        if (!_ie) continue; \
+        if (_ie->id == S1AP_ProtocolIE_ID_id_MME_UE_S1AP_ID) { \
+            *mme_ue_s1ap_id = _ie->value.choice.MME_UE_S1AP_ID; \
+            *have_mme = true; \
+        } else if (_ie->id == S1AP_ProtocolIE_ID_id_eNB_UE_S1AP_ID) { \
+            *enb_ue_s1ap_id = _ie->value.choice.ENB_UE_S1AP_ID; \
+            *have_enb = true; \
+        } \
+    } \
+} while (0)
+
+static bool s1ap_extract_ue_ids(const ogs_s1ap_message_t *message,
+        S1AP_MME_UE_S1AP_ID_t *mme_ue_s1ap_id, bool *have_mme,
+        S1AP_ENB_UE_S1AP_ID_t *enb_ue_s1ap_id, bool *have_enb)
+{
+    *have_mme = false;
+    *have_enb = false;
+
+    switch (message->present) {
+    case S1AP_S1AP_PDU_PR_initiatingMessage:
+    {
+        S1AP_InitiatingMessage_t *im = message->choice.initiatingMessage;
+        if (!im) return false;
+        switch (im->procedureCode) {
+        case S1AP_ProcedureCode_id_downlinkNASTransport:
+            S1AP_SCAN_UE_IDS(im->value.choice.DownlinkNASTransport,
+                    S1AP_DownlinkNASTransport_IEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_InitialContextSetup:
+            S1AP_SCAN_UE_IDS(im->value.choice.InitialContextSetupRequest,
+                    S1AP_InitialContextSetupRequestIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_UEContextModification:
+            S1AP_SCAN_UE_IDS(im->value.choice.UEContextModificationRequest,
+                    S1AP_UEContextModificationRequestIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_E_RABSetup:
+            S1AP_SCAN_UE_IDS(im->value.choice.E_RABSetupRequest,
+                    S1AP_E_RABSetupRequestIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_E_RABModify:
+            S1AP_SCAN_UE_IDS(im->value.choice.E_RABModifyRequest,
+                    S1AP_E_RABModifyRequestIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_E_RABRelease:
+            S1AP_SCAN_UE_IDS(im->value.choice.E_RABReleaseCommand,
+                    S1AP_E_RABReleaseCommandIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_MMEStatusTransfer:
+            S1AP_SCAN_UE_IDS(im->value.choice.MMEStatusTransfer,
+                    S1AP_MMEStatusTransferIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_HandoverResourceAllocation:
+        {
+            /* HandoverRequest carries only MME_UE_S1AP_ID (target-eNB
+             * assigns its own eNB-UE-S1AP-ID in the acknowledge). */
+            S1AP_HandoverRequest_t *msg = &im->value.choice.HandoverRequest;
+            int i;
+            for (i = 0; i < msg->protocolIEs.list.count; i++) {
+                S1AP_HandoverRequestIEs_t *ie =
+                    msg->protocolIEs.list.array[i];
+                if (!ie) continue;
+                if (ie->id == S1AP_ProtocolIE_ID_id_MME_UE_S1AP_ID) {
+                    *mme_ue_s1ap_id = ie->value.choice.MME_UE_S1AP_ID;
+                    *have_mme = true;
+                }
+            }
+            return true;
+        }
+        case S1AP_ProcedureCode_id_UEContextRelease:
+        {
+            /* UEContextReleaseCommand uses UE_S1AP_IDs choice (pair or MME only). */
+            S1AP_UEContextReleaseCommand_t *msg =
+                &im->value.choice.UEContextReleaseCommand;
+            int i;
+            for (i = 0; i < msg->protocolIEs.list.count; i++) {
+                S1AP_UEContextReleaseCommand_IEs_t *ie =
+                    msg->protocolIEs.list.array[i];
+                if (!ie) continue;
+                if (ie->id != S1AP_ProtocolIE_ID_id_UE_S1AP_IDs)
+                    continue;
+                if (ie->value.choice.UE_S1AP_IDs.present ==
+                        S1AP_UE_S1AP_IDs_PR_uE_S1AP_ID_pair) {
+                    S1AP_UE_S1AP_ID_pair_t *pair =
+                        ie->value.choice.UE_S1AP_IDs.choice.uE_S1AP_ID_pair;
+                    if (pair) {
+                        *mme_ue_s1ap_id = pair->mME_UE_S1AP_ID;
+                        *have_mme = true;
+                        *enb_ue_s1ap_id = pair->eNB_UE_S1AP_ID;
+                        *have_enb = true;
+                    }
+                } else if (ie->value.choice.UE_S1AP_IDs.present ==
+                        S1AP_UE_S1AP_IDs_PR_mME_UE_S1AP_ID) {
+                    *mme_ue_s1ap_id =
+                        ie->value.choice.UE_S1AP_IDs.choice.mME_UE_S1AP_ID;
+                    *have_mme = true;
+                }
+            }
+            return true;
+        }
+        default:
+            return false;
+        }
+    }
+    case S1AP_S1AP_PDU_PR_successfulOutcome:
+    {
+        S1AP_SuccessfulOutcome_t *so = message->choice.successfulOutcome;
+        if (!so) return false;
+        switch (so->procedureCode) {
+        case S1AP_ProcedureCode_id_PathSwitchRequest:
+            S1AP_SCAN_UE_IDS(so->value.choice.PathSwitchRequestAcknowledge,
+                    S1AP_PathSwitchRequestAcknowledgeIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_HandoverPreparation:
+            S1AP_SCAN_UE_IDS(so->value.choice.HandoverCommand,
+                    S1AP_HandoverCommandIEs_t);
+            return true;
+        default:
+            return false;
+        }
+    }
+    case S1AP_S1AP_PDU_PR_unsuccessfulOutcome:
+    {
+        S1AP_UnsuccessfulOutcome_t *uo = message->choice.unsuccessfulOutcome;
+        if (!uo) return false;
+        switch (uo->procedureCode) {
+        case S1AP_ProcedureCode_id_HandoverPreparation:
+            S1AP_SCAN_UE_IDS(uo->value.choice.HandoverPreparationFailure,
+                    S1AP_HandoverPreparationFailureIEs_t);
+            return true;
+        case S1AP_ProcedureCode_id_PathSwitchRequest:
+            S1AP_SCAN_UE_IDS(uo->value.choice.PathSwitchRequestFailure,
+                    S1AP_PathSwitchRequestFailureIEs_t);
+            return true;
+        default:
+            return false;
+        }
+    }
+    default:
+        return false;
+    }
+}
+
+#undef S1AP_SCAN_UE_IDS
+
+/*
+ * Handle the SCTP_SEND_FAILED notification payload.
+ *
+ * The kernel returns the full unsent S1AP PDU bytes in ssf_data. Decode it,
+ * extract the UE identifiers, and release the MME's local S1 context for
+ * that UE. This matches commercial MME behavior per the reviewer: the
+ * procedure the MME was attempting has failed at the transport level, so
+ * any timer/context the MME holds for the affected UE must be cleared
+ * locally (the message never reached the eNB, and retransmission is futile
+ * while the association is degraded).
+ *
+ * A per-eNB "path degraded" counter is incremented regardless of whether
+ * the UE IDs could be extracted — operators can use it to detect a
+ * misbehaving peer even when the failed procedure is non-UE-associated
+ * (Paging, S1 Setup, MME Configuration Transfer, etc.).
+ */
+static void s1ap_handle_send_failed(mme_enb_t *enb,
+        const uint8_t *data, size_t data_len, uint32_t error)
+{
+    char buf[OGS_ADDRSTRLEN];
+    ogs_pkbuf_t *pkbuf = NULL;
+    ogs_s1ap_message_t message;
+    S1AP_MME_UE_S1AP_ID_t mme_ue_s1ap_id = 0;
+    S1AP_ENB_UE_S1AP_ID_t enb_ue_s1ap_id = 0;
+    bool have_mme = false, have_enb = false;
+    enb_ue_t *enb_ue = NULL;
+    mme_ue_t *mme_ue = NULL;
+
+    ogs_assert(enb);
+    ogs_assert(data);
+
+    enb->sctp_send_failed_count++;
+    ogs_warn("    IP[%s] ENB_ID[%d] path degraded: "
+            "SCTP_SEND_FAILED count=%u error=%u",
+            OGS_ADDR(enb->sctp.addr, buf), enb->enb_id,
+            enb->sctp_send_failed_count, error);
+
+    pkbuf = ogs_pkbuf_alloc(NULL, data_len);
+    if (!pkbuf) {
+        ogs_error("ogs_pkbuf_alloc() failed");
+        return;
+    }
+    ogs_pkbuf_put_data(pkbuf, data, data_len);
+
+    memset(&message, 0, sizeof(message));
+    if (ogs_s1ap_decode(&message, pkbuf) != OGS_OK) {
+        ogs_warn("    Failed to decode unsent S1AP PDU (len=%zu)", data_len);
+        ogs_pkbuf_free(pkbuf);
+        return;
+    }
+
+    if (!s1ap_extract_ue_ids(&message,
+                &mme_ue_s1ap_id, &have_mme,
+                &enb_ue_s1ap_id, &have_enb)) {
+        ogs_info("    SCTP_SEND_FAILED on non-UE-associated or "
+                "unhandled procedure — no local release needed");
+        goto out;
+    }
+
+    if (!have_mme) {
+        ogs_warn("    SCTP_SEND_FAILED: no MME_UE_S1AP_ID in failed PDU");
+        goto out;
+    }
+
+    if (mme_ue_s1ap_id > 0xffffffffULL) {
+        ogs_warn("    SCTP_SEND_FAILED: MME_UE_S1AP_ID out of range [%lld]",
+                (long long)mme_ue_s1ap_id);
+        goto out;
+    }
+
+    enb_ue = enb_ue_find_by_mme_ue_s1ap_id((uint32_t)mme_ue_s1ap_id);
+    if (!enb_ue) {
+        ogs_info("    SCTP_SEND_FAILED: S1 context already released "
+                "(MME_UE_S1AP_ID[%lld])", (long long)mme_ue_s1ap_id);
+        goto out;
+    }
+
+    ogs_warn("    Local UE Context Release: "
+            "ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
+            enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
+
+    /* Local release: drop the S1 context without sending any S1AP
+     * message toward the eNB. The MME-UE context (NAS, bearers) is
+     * preserved so the UE can re-attach cleanly on a healthy association.
+     * Matches S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK semantics. */
+    mme_ue = mme_ue_find_by_id(enb_ue->mme_ue_id);
+    if (mme_ue)
+        enb_ue_deassociate_mme_ue(enb_ue, mme_ue);
+    enb_ue_remove(enb_ue);
+
+out:
+    ogs_s1ap_free(&message);
+    ogs_pkbuf_free(pkbuf);
+}
+#endif /* !HAVE_USRSCTP */


### PR DESCRIPTION
# MME/SCTP: signaling-storm and stalled-association hardening

## Summary

Six-commit series that hardens the MME's S1AP/SCTP path against two
operationally painful failure modes we hit in a production deployment:

1. **NAS signaling storm** caused by a misconfigured UE (VoLTE-enabled
   handset without IMS subscription) retrying
   ESM-PDN-Connectivity-Request every 2–5 seconds.
2. **SCTP transport stall** where the association looks healthy at
   L4 (kernel resets the SCTP error counter on every incoming
   SACK/HEARTBEAT per RFC 4960 §8.1) but the peer has stopped
   processing inbound DATA chunks. Without active detection, the
   MME sits indefinitely on a dead S1AP path. Field-observed during
   debugging of a path-MTU mismatch with a commercial eNodeB
   (see "Operational context"); the recovery mechanism now serves
   as defense-in-depth against any future SCTP transport pathology.

The combined result: 4G remains online indefinitely, instead of the
~15-second auto-recovery window that the end-to-end ABORT + S1 re-setup
cycle provides when the MME detects the stall actively.

## Operational context

Deployed on a small-scale 4G/5G EP5G core for ~2 weeks with Baicells,
Neutrino 220, and Ericsson Baseband radios. Two operationally
distinct failure classes are addressed:

- **NAS signaling storm** (T3396): retry rate at the affected UE
  dropped from ~12/min to 0.2/min, exactly as expected per
  TS 24.301 §6.6.1.2 with a 5 min back-off.
- **SCTP transport stall** (backpressure detection +
  SCTP_ABORT-based auto-recovery + SCTP_SEND_FAILED context
  release): every observed stall recovered within ~15 s without
  operator intervention; previously the only fix was a manual
  eNB reboot.

The SCTP stalls in our Baicells deployment that motivated this work
were initially attributed to a peer-side firmware bug; subsequent
investigation identified path-MTU mismatch as the actual root cause
(jumbo-frame-sized SCTP DATA chunks > 1500 B reached a Mindspeed
T2200 chipset in the eNB which hangs on oversized frames). After
enforcing MTU 1500 on the route to the eNB, no further stalls have
been observed at the deployment level.

Even with the deployment-level root cause now known and resolved,
the recovery mechanisms in this PR remain useful as defense-in-
depth: they bound MME exposure to *any* SCTP transport stall (path
MTU mismatch, peer firmware corner case, kernel SCTP edge case) to
~15 s of S1AP unavailability instead of an indefinite hang. The
T3396 work is independent of the SCTP path entirely and addresses
a separate NAS-layer concern.

## Commits

### 1. `mme: add T3396 back-off timer to ESM PDN Connectivity Reject + S1AP backpressure with auto-recovery`

Per 3GPP TS 24.301 §6.6.1.2, an ESM PDN-Connectivity-Reject with cause
`MISSING_OR_UNKNOWN_APN`, `REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED`,
or `REQUEST_REJECTED_UNSPECIFIED` may carry a T3396 back-off timer
instructing the UE not to retry the same APN until the timer expires.
Set T3396 = 5 min (GPRS-Timer-3 `MULTIPLES_OF_1_MM`, value=5) for
those three causes so misconfigured UEs stop hammering the MME.

Also adds an `s1ap_send_to_enb()` write-queue backpressure guard: if
the SCTP write queue to an eNB exceeds 64 entries for more than 30 s,
force-close the SCTP socket to trigger an ABORT. Service interruption
limited to ~15 s (ABORT + S1 Setup + UE re-attach) instead of
indefinite hang. Returns `OGS_OK` on backpressure-drop (not
`OGS_ERROR`) because many callers `ogs_assert(r != OGS_ERROR)` — the
message is freed and the NAS retransmission timer handles the timeout
gracefully.

### 2. `sctp: add ogs_sctp_abort() helper for targeted association teardown`

Adds a new helper to `lib/sctp/ogs-lksctp.c` + `ogs-usrsctp.c`:

```c
int ogs_sctp_abort(ogs_sock_t *sock);
```

Sends a zero-length SCTP DATA chunk with `SCTP_ABORT` flag set via
`sctp_sendmsg()` (RFC 6458 §5.3.2). Replaces the
`SO_LINGER(l_linger=0) + close()` idiom used by forced-recovery paths
throughout the MME. Advantages:

- No global socket-state mutation (SO_LINGER is a socket option; the
  sendmsg flag is per-message).
- ABORT emits immediately regardless of close ordering.
- Targets only the affected association, not the whole socket.
- Kernel still fires `SCTP_COMM_LOST` afterwards, so the existing
  cleanup path runs unchanged.

### 3. `mme: use SCTP_ABORT flag for forced S1 teardown on stalled eNB`

Replaces `SO_LINGER(0) + ogs_sctp_destroy()` in the two auto-recovery
paths with `ogs_sctp_abort() + ogs_sctp_destroy()`:

- `src/mme/s1ap-path.c`: backpressure sustained > 30 s
- `src/mme/s1ap-path.c`: SCTP health-check unacked bytes > 64 KB for 30 s

Behaviour otherwise unchanged. A graceful SHUTDOWN does **not** reset
a stalled peer's SCTP receiver state; only an ABORT chunk does
(experimentally confirmed in the field).

Also replaces the `getsockopt(SCTP_STATUS)`-based health check with
`ioctl(SIOCOUTQ)`. SIOCOUTQ is a lightweight, protocol-agnostic
query that returns just the one data point we need (unacked bytes
> 64 KB for 6 × 5 s → ABORT). It was originally adopted because
SCTP_STATUS polling correlated with periodic 60-s flapping in our
field deployment; that flapping was later traced to the same path-
MTU root cause noted in "Operational context", but SIOCOUTQ
remains the cleaner choice on its own merits — fewer SCTP-specific
side effects and lower syscall overhead per poll.

### 4. `mme: release UE locally on SCTP_SEND_FAILED notification`

When the kernel can't deliver an SCTP DATA chunk on an MME-side send
(peer ABORT, path failure, association teardown in flight), it fires
an `SCTP_SEND_FAILED` notification whose `ssf_data` payload contains
the full unsent message.

Previously the MME just logged this at error level and left the UE
context in place. Under a sustained stall this leaks EMM/ESM context
indefinitely — the UE will never come back on this association.

Now we parse the failed S1AP PDU by procedure-code dispatch, extract
`MME-UE-S1AP-ID` + `eNB-UE-S1AP-ID`, and release the affected
`enb_ue_t` locally (no message sent toward the peer). The `mme_ue_t`
is preserved so the UE can re-attach cleanly on a healthy association.
Matches `S1AP_UE_CTX_REL_S1_REMOVE_AND_UNLINK` semantics that the
ordinary release path already uses.

Procedure-code dispatch covers all MME-originated UE-associated
procedures (DownlinkNASTransport, InitialContextSetup,
UEContextModification, UEContextRelease, E-RAB Setup/Modify/Release,
MMEStatusTransfer, HandoverRequest, HandoverCommand,
HandoverPreparationFailure, PathSwitchRequestAcknowledge,
PathSwitchRequestFailure). Non-UE-associated procedures (S1 Setup,
Paging, MME Configuration Transfer) are logged and skipped.

A new per-eNB `sctp_send_failed_count` counter is incremented on every
notification regardless of whether UE release could be performed.
Useful as a "path degraded" signal in operator metrics.

### 5. `mme: harden SCTP_SEND_FAILED bounds check and rate-limit logging`

Two review-driven follow-ups to the previous commit:

1. **Bounds check on notification length.** Derive `failed_len` from
   both `recvmsg()` return and `ssf_length` (RFC 4960: total
   notification length), fall back to whichever is smaller / sane.
   Prevents integer underflow into a huge `size_t` when the
   notification arrives truncated.

2. **Rate-limit the per-eNB "path degraded" log.** Under a sustained
   stall the kernel fires one `SCTP_SEND_FAILED` per queued chunk,
   potentially hundreds within seconds. Keep the first warning and
   every hundredth thereafter at `warn` level; send the rest to
   `debug`. Per-UE "Local UE Context Release" line also moves from
   `warn` to `info` so a flood of short-lived UEs doesn't masquerade
   as alarms.

### 6. `mme: guard SCTP SIOCOUTQ health check behind __linux__`

The SCTP health-check timer added in the T3396/backpressure commit
uses `ioctl(SIOCOUTQ)` from `<linux/sockios.h>` to query unacked
bytes on the association socket. Both the header and the ioctl are Linux-
specific; on FreeBSD / macOS / Windows-WSL the symbol either lives
elsewhere or is absent entirely, and the header include alone
breaks the build on those platforms.

Wrap the include and the health-check body in `#ifdef __linux__`.
On non-Linux, the timer still fires (so the call site in
`app-init.c` stays unchanged) but the function body is a no-op.
The existing send-path backpressure in `s1ap_send_to_enb()` based
on write-queue depth remains active on all platforms — it's the
primary stall-detector; the health-check is a belt-and-suspenders
second signal.

No behavioural change on Linux. Unblocks the SCTP-hardening series
for the upstream multi-platform CI matrix.

## Spec references

| Topic | Document | Section |
|---|---|---|
| T3396 back-off timer in ESM Reject | 3GPP TS 24.301 | §6.6.1.2 |
| GPRS Timer 3 encoding | 3GPP TS 24.008 | §10.5.7.4a |
| SCTP error counter reset on SACK | RFC 4960 | §8.1 |
| `sctp_sendmsg()` with SCTP_ABORT | RFC 6458 | §5.3.2 |
| SCTP `pf_enable` (Potentially Failed path) | RFC 7829 | §2.2 |
| S1AP UEContextRelease procedure | 3GPP TS 36.413 | §8.3 |

## Testing

Deployed against a 4G/5G core with Baicells, Neutrino 220, and
Ericsson Baseband radios over ~14 days:

- No false-positive ABORT-and-reconnect cycles on healthy
  associations (IOCTL(SIOCOUTQ) threshold of 64 KiB is well above
  transient burst-limits of a normal attach/detach flow).
- Artificial stall reproduction (deliberately oversized S1AP
  payload via uncorrected path-MTU configuration) confirms the
  ABORT path triggers correctly within the ~30 s detection window.
- `sctp_send_failed_count` Prometheus counter per-eNB rises during
  stalls and stays flat on healthy associations — useful as a
  "path degraded" alarm signal independent of the underlying root
  cause.

## Open points for reviewer feedback

1. `OGS_OK` return on backpressure drop in the T3396/backpressure
   commit instead of `OGS_ERROR` is a deliberate workaround: many
   callers `ogs_assert(r != OGS_ERROR)`, which would crash the MME
   when the backpressure path drops a message. The dropped pkbuf is
   already freed and the NAS retransmission timer naturally recovers
   the affected procedure, so the practical contract held; but the
   formal contract ("OK ⇒ message handed off to SCTP") is broken.
   A clean fix would be a follow-up PR that introduces a third
   return code (e.g. `OGS_RETRY` / `OGS_IGNORE`) and audits the
   `ogs_assert(r != OGS_ERROR)` call sites to accept it. Happy to
   do that as a separate PR; merging this one as-is preserves
   working behavior for the more pressing stall-recovery case.
2. `getsockopt(SCTP_STATUS) → SIOCOUTQ` migration is pragmatic.
   The original motivation (correlated flapping with SCTP_STATUS
   polling) was later traced to a path-MTU mismatch and resolved at
   that level; SIOCOUTQ still wins on its own merits (simpler,
   lower syscall overhead, no SCTP-specific side effects).
3. T3396 value of 5 min is a judgment call. Happy to lower it to
   `value=1` (1 min) if that's closer to the spec's intent.

## Production validation

Live-tested against a Baicells NOVA-227 eNB whose deployment had
previously exhibited recurring 84-second SCTP flap loops. The flap
root cause was identified during this work as a path-MTU mismatch
(operator-side MTU 1920 vs eNB-side hard limit 1500); enforcing
MTU 1500 on the route to the eNB eliminated the flaps at the
deployment level. After 5 days of continuous S1AP availability
since deploy (2026-04-19), 0 forced S1 teardowns from the
auto-recovery path have been triggered, 0 SCTP_SEND_FAILED-driven
crashes have occurred. The recovery mechanisms remain available
as defense-in-depth; before the patches, the same MME would hang
indefinitely on a transport stall (and prior to the patches did,
with assertion failures `emm_state_authentication: r != OGS_ERROR`
within hours of stall onset).

