### PR TITLE
amf: clean up stranded sess on 404 from SMF sm-contexts modify

### DIFF
--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -986,6 +986,36 @@ int amf_nsmf_pdusession_handle_update_sm_context(
             return OGS_ERROR;
         }
 
+        /*
+         * 404 Not Found from SMF on an Update SM Context request means the
+         * SMF no longer holds the session we are pointing at. Most common
+         * causes:
+         *   - SMF restart while AMF survived (session state lost peer-side)
+         *   - Cross-RAT race (session was superseded by a 4G↔5G swap)
+         *   - Upstream N1N2 leak mitigation released the session while AMF
+         *     still retained the smContextRef for a stale PSI slot
+         *
+         * Without cleanup on this side, AMF keeps the dead smContextRef on
+         * the sess and retransmits Update SM Context on every subsequent
+         * Service Request (activate/deactivate) or other N2 event, each
+         * answered with another 404 — a ghost-PSI retry loop that blocks
+         * the UE from establishing a fresh session on this PSI.
+         *
+         * Treat the 404 as authoritative: drop the AMF-side sess so the
+         * next UE request builds a fresh sm_context_ref. No NGAP
+         * ErrorIndication — the RAN is not involved in this consistency
+         * reconciliation.
+         */
+        if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_NOT_FOUND) {
+            ogs_warn("[%s:%d] SMF 404 on sm-contexts/%s/modify [state:%d] "
+                    "— releasing stranded AMF sess",
+                    amf_ue->supi, sess->psi,
+                    sess->sm_context_ref ? sess->sm_context_ref : "?",
+                    state);
+            AMF_SESS_CLEAR(sess);
+            return OGS_OK;
+        }
+
         SmContextUpdateError = recvmsg->SmContextUpdateError;
         if (!SmContextUpdateError) {
             ogs_error("[%d:%d] No SmContextUpdateError [%d]",


### PR DESCRIPTION
# AMF: clean up stranded sess on 404 from SMF sm-contexts/modify

## Summary

Single-commit fix that closes a tight 404-retry loop on the AMF side
when the SMF has lost a PDU session that the AMF still references.
Without this fix the AMF retries `Update SM Context` on a dead
`smContextRef` indefinitely (one round per Service Request, Path
Switch, Handover, deactivate/activate, …) and the corresponding PSI
slot stays bound to the dead reference, blocking the UE from
re-establishing on that PSI.

The patch is symmetric to two existing 404-handling paths already
upstream:

- `src/smf/namf-handler.c` — SMF locally releases a stranded session
  on AMF 404 during N1N2 establishment (the *opposite* direction of
  this fix).
- `src/amf/context.c amf_ue_remove()` — AMF proactive SMF-release
  sweep on UE removal.

This commit completes the matrix for the third path that did not yet
have 404 cleanup: *AMF receiving 404 from SMF on
`sm-contexts/{smContextRef}/modify` after the session has been
established*.

## Problem

When any of the following happens:

- The SMF is restarted while the AMF retains the UE context.
- A cross-RAT race evicts the 5G `smf_sess_t` (4G ↔ 5G transition
  without clean detach).
- An upstream leak-mitigation path locally releases the session on
  the SMF side (e.g. PFCP failure recovery).

… the AMF holds an `smContextRef` value that the SMF no longer knows.
On the AMF's *next* event for that session — Service Request,
Handover, Path Switch, deactivate/activate, etc. — the AMF issues
`Nsmf_PDUSession_UpdateSMContext` with that ref. The SMF answers
`404 Not Found` (per TS 29.502 §5.2.2.4.4).

The existing AMF response handler at `src/amf/nsmf-handler.c` treats
the 404 as a generic transport-style failure: it sends an NGAP
`ErrorIndication` to the gNB and returns *without* clearing
`sess->sm_context_ref`. Result: the same 404 fires on the next event,
typically every ~5 seconds. The UE-side PSI slot remains bound to a
dead ref and the UE cannot re-establish on that PSI.

### Evidence from a deployment

A Samsung xCover7 UE in our deployment exhibited a 5-second
`sm-contexts/modify → 404` loop for **12+ hours** after an SMF
restart evicted its session mid-Service-Request cycle. The AMF's
`PSI=1` slot stayed bound to a dead `smContextRef=32` and the UE
could not re-use `PSI=1` for new session establishment until an
operator manually released the AMF context via an admin endpoint.
After this patch, the same 404 triggers automatic local cleanup and
the UE re-establishes on the very next Service Request — verified in
the field, recovery time ~5 s.

## Fix

In the SmContextUpdate response handler, before falling into the
generic `SmContextUpdateError` path, check explicitly for
`OGS_SBI_HTTP_STATUS_NOT_FOUND`. On 404, treat the response as
authoritative — the SMF does not have the session, so the AMF must
not either:

- Call `AMF_SESS_CLEAR(sess)` to drop the local 5G PDU session.
- Return `OGS_OK` so the caller stops the retry loop.
- *Do not* send NGAP `ErrorIndication`. The RAN is not part of
  this consistency reconciliation, and the UE will recover
  naturally on the next Service Request by re-establishing on the
  freed PSI slot.

The code path is purely additive: a single early `if (404)` branch
ahead of the existing error handling. Any non-404 response continues
through the unchanged error path.

## Notes for reviewers

A few details worth surfacing explicitly to save a round of
clarification:

1. **`OGS_OK` return is a deliberate choice.** Other non-2xx paths
   in the same function return `OGS_ERROR`, but the 404 case is an
   *expected* recovery state, not a protocol violation. The sole
   caller in `src/amf/amf-sm.c::amf_state_operational()` ignores
   the return value of
   `amf_nsmf_pdusession_handle_update_sm_context()` (no assignment,
   no branch on it), so practical behaviour is identical to
   returning `OGS_ERROR`. `OGS_OK` is selected purely to reflect
   the intent: "handled, no error to propagate".

2. **`AMF_SESS_CLEAR()` semantics are consistent with all other
   call sites.** The macro is defensive: if any active SBI
   transaction is still associated with the session, it logs
   `"SBI running"` and skips `amf_sess_remove()`. The same
   defensive behaviour is exercised by every other call site
   (`src/amf/amf-sm.c::amf_state_operational()`, three more sites
   in `src/amf/nsmf-handler.c`). This patch does not change the
   macro; it just adds another caller. In the response-handler
   context the response transaction is already removed from
   `xact_list` by the framework before the handler runs, so
   `amf_sess_remove()` proceeds normally.

3. **Scope is intentionally limited to `modify`.** A 404 on
   `sm-contexts/{ref}/release` is already handled correctly by the
   existing release path (the cleanup happens regardless), and a
   404 on `create` indicates an NF-discovery / routing problem
   rather than a stranded-session inconsistency. Both cases are
   out of scope for this patch and remain on their existing code
   paths.

## Spec references

- **TS 29.502 §5.2.2.4.4** — `Nsmf_PDUSession_UpdateSMContext`
  service operation, including the `404 Not Found` semantics for a
  missing SM context reference.
- **TS 23.502 §4.3.6.2** — Service Request procedure (one of the
  triggers that produces the offending `Update SM Context`).

## Backward compatibility

- Default behaviour for non-404 responses is unchanged.
- No new YAML knobs.
- No NGAP signal change visible to the gNB on the *non-404* path.
  On the 404 path, the previously-emitted ErrorIndication is now
  suppressed — but it was non-actionable anyway (the gNB cannot fix
  an SMF inconsistency), so its removal is a quality improvement
  rather than a behaviour regression.

## Extended production validation

5 days of continuous AMF uptime since deploy with no recurrence of
the `sm-contexts/modify → 404` 5-second-loop pattern that motivated
the patch. The pre-deploy 12-hour Samsung xCover7 incident
referenced above is the longest single observed instance; shorter
recurrences across other device types (Apple, Quectel, NB-IoT
modules) had been typical whenever an SMF restart evicted a session
mid-cycle.
