### PR TITLE
[SMF] Validate pduSessionId range on SBI session-create paths

### DIFF
--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -149,6 +149,11 @@ extern "C" {
 #define OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED 0
 /* 3GPP TS 24.007 Table 11.2.3.1c.1: */
 #define OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED 0
+/* 3GPP TS 24.501 §9.4 + §11.2.3.1: PDU session identity is a 1-octet
+ * value; spec-valid range is 1..255, with 0 reserved as "unassigned".
+ * (TS 29.571 §5.4.4.3 PduSessionId: integer 0..255.) Distinct from the
+ * 4-bit EBI in EPS — do not conflate. */
+#define OGS_NAS_PDU_SESSION_IDENTITY_MAX 255
 
 #define OGS_ACCESS_TYPE_3GPP 1
 #define OGS_ACCESS_TYPE_NON_3GPP 2

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1563,6 +1563,15 @@ smf_sess_t *smf_sess_add_by_sm_context(ogs_sbi_message_t *message)
         return NULL;
     }
 
+    if (SmContextCreateData->pdu_session_id < 1 ||
+            SmContextCreateData->pdu_session_id >
+            OGS_NAS_PDU_SESSION_IDENTITY_MAX) {
+        ogs_error("PDU session identity %d out of valid range [1..%d]",
+                SmContextCreateData->pdu_session_id,
+                OGS_NAS_PDU_SESSION_IDENTITY_MAX);
+        return NULL;
+    }
+
     smf_ue = smf_ue_find_by_supi(SmContextCreateData->supi);
     if (!smf_ue) {
         smf_ue = smf_ue_add_by_supi(SmContextCreateData->supi);
@@ -1613,6 +1622,15 @@ smf_sess_t *smf_sess_add_by_pdu_session(ogs_sbi_message_t *message)
     if (PduSessionCreateData->pdu_session_id ==
             OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
         ogs_error("PDU session identitiy is unassigned");
+        return NULL;
+    }
+
+    if (PduSessionCreateData->pdu_session_id < 1 ||
+            PduSessionCreateData->pdu_session_id >
+            OGS_NAS_PDU_SESSION_IDENTITY_MAX) {
+        ogs_error("PDU session identity %d out of valid range [1..%d]",
+                PduSessionCreateData->pdu_session_id,
+                OGS_NAS_PDU_SESSION_IDENTITY_MAX);
         return NULL;
     }
 


### PR DESCRIPTION
# SMF: validate pduSessionId range on SBI session-create paths

Fixes #4471.

## Summary

Single-commit fix for a remote-DoS in the SMF triggered by an
out-of-range `pduSessionId` field in `Nsmf_PDUSession_CreateSMContext`
or `Nsmf_PDUSession_CreatePDUSession`. The PoC in #4471 sends
`pduSessionId: 256`; that survives the existing UNASSIGNED guard,
wraps to 0 on the implicit cast to `uint8_t` at the
`smf_sess_find_by_psi()` call site (`256 & 0xFF == 0`), and aborts
the SMF process.

The patch adds a spec-derived range check at both SBI ingress points
and a new `OGS_NAS_PDU_SESSION_IDENTITY_MAX` constant alongside the
existing `_UNASSIGNED` constant in `lib/proto/types.h`.

## Root cause

`smf_sess_find_by_psi()` in `src/smf/context.c` is declared as

```c
smf_sess_t *smf_sess_find_by_psi(smf_ue_t *smf_ue, uint8_t psi)
{
    ...
    ogs_assert(smf_ue);
    ogs_assert(psi != OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED);
    ...
}
```

`pduSessionId` arrives via JSON as a full-width `int` (per TS 29.571
§5.4.4.3 the OpenAPI type is `integer` with `minimum: 0, maximum:
255`) and is stored in `OpenAPI_sm_context_create_data_t::pdu_session_id`
and `OpenAPI_pdu_session_create_data_t::pdu_session_id` as `int`. The
existing checks at the two SBI entry functions in
`smf_sess_add_by_sm_context()` and `smf_sess_add_by_pdu_session()`
only reject the literal value 0 (`OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED`):

```c
if (SmContextCreateData->pdu_session_id ==
        OGS_NAS_PDU_SESSION_IDENTITY_UNASSIGNED) {
    ogs_error("PDU session identity is unassigned");
    return NULL;
}
```

So any value with `(value & 0xff) == 0` slips through and crashes
the SMF on the next `smf_sess_find_by_psi()` call. The PoC uses 256;
512, 768, 1024, … all reproduce identically.

## Fix

After the existing UNASSIGNED check in both SBI entry functions, add
an explicit range check against the spec-valid PSI range 1..255:

```c
if (SmContextCreateData->pdu_session_id < 1 ||
        SmContextCreateData->pdu_session_id >
        OGS_NAS_PDU_SESSION_IDENTITY_MAX) {
    ogs_error("PDU session identity %d out of valid range [1..%d]",
            SmContextCreateData->pdu_session_id,
            OGS_NAS_PDU_SESSION_IDENTITY_MAX);
    return NULL;
}
```

The caller (`smf_namf_handle_create_sm_context()` and the HR-roaming
analogue) already treats a `NULL` return from these helpers as an
SBI 400-class error toward the peer NF, so the fix is purely an
ingress-validation extension and does not change the response-flow
contract.

A new constant in `lib/proto/types.h`:

```c
/* 3GPP TS 24.501 §9.4 + §11.2.3.1: PDU session identity is a 1-octet
 * value; spec-valid range is 1..255, with 0 reserved as "unassigned".
 * (TS 29.571 §5.4.4.3 PduSessionId: integer 0..255.) Distinct from the
 * 4-bit EBI in EPS — do not conflate. */
#define OGS_NAS_PDU_SESSION_IDENTITY_MAX 255
```

The `do not conflate` note is deliberate — it is easy (the author
made this exact mistake in a draft of this very patch) to assume PSI
is 4-bit by analogy with the 4G EPS Bearer Identity, but TS 24.501
§11.2.3.1 explicitly defines the PSI octet field, and TS 29.571's
OpenAPI definition allows `0..255`. Capping at 15 would silently
break legitimate 5G UEs that use higher PSI values.

## Testing

Built clean against `upstream/main @ 288f1ca49`:

```
ninja -C build src/smf/open5gs-smfd
[1307/1307] Linking target src/smf/open5gs-smfd
```

Manual replay of the issue #4471 PoC against the patched SMF:

- Pre-patch: SMF aborts with assertion failure
- Post-patch: SMF logs `PDU session identity 256 out of valid range
  [1..255]` at error level, returns SBI 400 toward the peer, and
  stays up. Tested with `pduSessionId` ∈ {0, 1, 15, 16, 100, 255,
  256, 512, -1}; all in-range values pass through unchanged, all
  out-of-range values are rejected cleanly.

## Spec references

- **3GPP TS 24.501 §9.4** + **§11.2.3.1** — PDU session identity is
  a 1-octet value; valid range 1..255, with 0 reserved as
  "unassigned".
- **3GPP TS 29.571 §5.4.4.3** — `PduSessionId` OpenAPI definition,
  `integer 0..255`.
- **3GPP TS 29.502 §6.1.6.2** — `pduSessionId` field in
  `SmContextCreateData` and `PduSessionCreateData`.

## Backward compatibility

- No public API change. `smf_sess_find_by_psi()` keeps its existing
  signature and assertion.
- No change for any spec-conformant peer NF.
- The full spec-valid PSI range 1..255 continues to work; only
  values outside [1, 255] (which a conformant AMF / V-SMF cannot
  send anyway) are rejected.
