### PR TITLE
[SBI] Refuse new HTTP/2 stream gracefully on stream-pool exhaustion

### DIFF
--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -1626,7 +1626,11 @@ static int on_begin_headers(nghttp2_session *session,
     }
 
     stream = stream_add(sbi_sess, frame->hd.stream_id);
-    ogs_assert(stream);
+    if (!stream) {
+        ogs_error("stream_add() failed (pool exhausted), "
+                "refusing stream %d", frame->hd.stream_id);
+        return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+    }
     ogs_debug("STREAM added [%d]", frame->hd.stream_id);
 
     nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, stream);


### PR DESCRIPTION
# SBI: refuse new HTTP/2 stream gracefully on stream-pool exhaustion

Fixes (the crash component of) #4474.

## Summary

Single-line behaviour change in `lib/sbi/nghttp2-server.c::on_begin_headers()`
that converts a process-aborting assertion failure into a per-stream
RST_STREAM rejection when the shared SBI stream pool is exhausted.

The crash is reachable from any HTTP/2 client that opens enough
concurrent streams to exhaust the per-process pool — in the issue's
reproduction, 32 connections × 1024 stream-headers-then-no-body
exhausted the default 16 384-slot pool on every tested SBI NF (NRF,
UDM, UDR, NSSF, BSF, PCF, AMF, AUSF, SMF) and aborted each with the
same `on_begin_headers: Assertion 'stream' failed` line.

## Root cause

`stream_add()` is the allocator that sources slots from the global
`stream_pool`. It is defensively written: on `ogs_pool_id_calloc()`
returning NULL, it logs `ogs_pool_id_calloc() failed` and returns
NULL itself.

The sole caller in `on_begin_headers()` ignores that contract:

```c
stream = stream_add(sbi_sess, frame->hd.stream_id);
ogs_assert(stream);  // ← SIGABRT on pool exhaustion
```

So the well-mannered NULL return becomes a process abort. Every
peer's in-flight requests on the same NF die with it.

The pool is sized centrally as `pool.stream = max.ue * 16` (default
1024 × 16 = 16 384 slots) and is process-global, so a single peer can
exhaust the whole NF's stream capacity by churning incomplete streams.

## Fix

Replace the assertion with a NULL check that returns
`NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE`. Per the nghttp2 documentation
that return code from `on_begin_headers` instructs the library to send
RST_STREAM with error code REFUSED_STREAM to the peer for that
specific stream, while leaving the underlying SCTP/TCP connection and
already-accepted streams intact.

```c
stream = stream_add(sbi_sess, frame->hd.stream_id);
if (!stream) {
    ogs_error("stream_add() failed (pool exhausted), "
            "refusing stream %d", frame->hd.stream_id);
    return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
}
```

The `NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE` return is the established
pattern for stream-level rejection in this same file — already used
in five other places (header overflow, request body overflow,
session-state mismatches).

## What this fix does NOT address

Important to call out: this patch removes the *crash* component of
issue #4474 but it does not by itself prevent the underlying DoS
shape. A single malicious client can still keep the global pool fully
occupied by churning short-lived incomplete streams, starving
legitimate peer NFs.

True defense-in-depth would also need:

- Per-connection `NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS` set
  significantly below the global `pool.stream` value (the current code
  advertises the *global* pool size to every peer, which is what
  invites the exhaustion)
- An idle-stream RST timer that REFUSES streams whose headers were
  accepted but whose request body never finished within N seconds
- Per-peer connection rate limiting at the listener layer

Those are larger, separate changes worth their own PR(s). The
minimal patch here removes the assertion-abort, lets the NF stay up,
and gives operators a fighting chance to react (logs, metrics, peer
rate-limit at the network layer) instead of being thrown back into a
restart loop.

## Spec / library references

- **nghttp2 API documentation** for `on_begin_headers_callback`:
  returning `NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE` triggers
  RST_STREAM with REFUSED_STREAM toward the peer for the offending
  stream only.
- **RFC 7540 §6.4** — RST_STREAM frame (`REFUSED_STREAM` = 7,
  defined as "The endpoint refuses the stream prior to performing
  any application processing").
- **RFC 9113 §5.1.2** — Stream concurrency: this PR brings the SBI
  server's behaviour into spec-conformance with how an HTTP/2 server
  should react when it cannot accept additional streams.

## Testing

Built clean against `upstream/main @ 288f1ca49`:

```
ninja -C build
[71/71] Linking target tests/transfer/transfer-error
```

Manual replay of the issue #4474 PoC pattern (`H2_CONNECTIONS=32
H2_STREAMS_PER_CONNECTION=1024` with held-open headers) against the
patched SMF:

- Pre-patch: SMF aborts with `on_begin_headers: Assertion 'stream'
  failed` after pool exhaustion, container exits with code 134.
- Post-patch: overflow streams receive RST_STREAM(REFUSED_STREAM),
  client sees a stream-level error, the SMF process stays up and
  continues serving every other peer normally. The
  `ogs_pool_id_calloc() failed` ERROR log appears in journalctl as
  expected, but `on_begin_headers` no longer asserts.

Same change applies identically to every SBI NF since they share the
helper.

## Backward compatibility

- No public API change.
- No protocol change visible to spec-conformant clients (a
  conformant peer will not exhaust the pool in the first place; if
  they do receive a REFUSED_STREAM under load, they retry per
  HTTP/2 conventions).
- No behaviour change on the success path.
