### PR TITLE
[SMF] Prevent crash on closed stream while preserving FSM transition

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -2442,11 +2442,33 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                                     NGAP_CauseNas_normal_release);
                         ogs_assert(n2smbuf);
 
-                        ogs_assert(stream);
-                        smf_sbi_send_sm_context_updated_data_n1_n2_message(
-                                sess, stream, n1smbuf,
-                                OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,
-                                n2smbuf);
+                        if (stream) {
+                            smf_sbi_send_sm_context_updated_data_n1_n2_message(
+                                    sess, stream, n1smbuf,
+                                    OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,
+                                    n2smbuf);
+                        } else {
+                            /*
+                             * Race window: the SBI stream tied to the
+                             * SM-context-update can be torn down (peer reset,
+                             * timeout, premature client disconnect) before
+                             * this FSM event fires. Without this guard the
+                             * previous ogs_assert(stream) crashes the SMF.
+                             *
+                             * The PDU release path is no longer reachable
+                             * through SBI here, but the local SMF session
+                             * still needs to converge: free the prepared NAS
+                             * and N2 buffers, log, and STILL transition to
+                             * smf_gsm_state_wait_5gc_n1_n2_release so that
+                             * the wait-completion logic and PFCP cleanup run
+                             * to completion. Returning without transitioning
+                             * would leak the smf_sess_t indefinitely.
+                             */
+                            ogs_error("Stream has already been removed; "
+                                    "proceeding with local-only release");
+                            ogs_pkbuf_free(n1smbuf);
+                            ogs_pkbuf_free(n2smbuf);
+                        }
                     }
 
                     OGS_FSM_TRAN(s, smf_gsm_state_wait_5gc_n1_n2_release);


### PR DESCRIPTION
# SMF: NULL-tolerant stream handling in PDU release FSM

Closely related to #4017 — this variant addresses the same crash
report but preserves FSM-transition semantics that the original PR's
`break` statement skipped.

## Summary

Replaces an `ogs_assert(stream)` in
`smf_gsm_state_wait_pfcp_deletion`'s UE-requested PDU release branch
with a NULL-tolerant guard that:

1. Logs and frees the prepared NAS / N2 buffers when the SBI stream
   is gone (otherwise they leak).
2. **Still transitions** the FSM to
   `smf_gsm_state_wait_5gc_n1_n2_release` so that the wait-completion
   logic and PFCP cleanup converge to a final state.

The crash itself is field-observed in production deployments and
matches the report in #4017:

```
smf: FATAL: smf_gsm_state_wait_pfcp_deletion: Assertion `stream'
failed. (../src/smf/gsm-sm.c:1622)
```

## Root cause

`smf_gsm_state_wait_pfcp_deletion` queues an event to itself when
PFCP deletion completes for a UE-requested release. Between event
queueing and event delivery, the SBI stream tied to the original
SM-context-update can be torn down for any of the standard reasons:

- Peer NF ABORT / RST_STREAM.
- HTTP/2 idle-stream timeout.
- Premature client disconnect (UE detach during release race).
- Peer SBI socket close (NF restart, network blip).

When the FSM event then fires, `stream` is `NULL` and the existing
`ogs_assert(stream)` aborts the SMF process.

## Why a tighter variant of #4017

The patch in #4017 (gstaa, 2025-07-23) replaces the assert with:

```c
if (stream) {
    smf_sbi_send_sm_context_updated_data_n1_n2_message(...);
} else {
    ogs_error("Stream has already been removed");
    break;
}
```

That fixes the crash but the `break;` exits the case-block and
**skips the subsequent `OGS_FSM_TRAN(s, smf_gsm_state_wait_5gc_n1_n2_release)`**.
The FSM then sits in `wait_pfcp_deletion` indefinitely; the
`smf_sess_t` and its associated `n1smbuf` / `n2smbuf` (allocated
just before the assert) leak. Crash → memory-leak-and-stuck-FSM is
not a clear improvement.

The variant in this PR keeps the NULL guard but drops the `break`
and adds explicit `ogs_pkbuf_free()` for the prepared buffers, so
the FSM still transitions to `wait_5gc_n1_n2_release` on the
release path. The healthy path (stream still valid) is unchanged.

## Fix

```c
if (stream) {
    smf_sbi_send_sm_context_updated_data_n1_n2_message(
            sess, stream, n1smbuf,
            OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,
            n2smbuf);
} else {
    /* Race window: SBI stream torn down before this FSM event fires.
     * Free the prepared buffers, log, and STILL transition to
     * smf_gsm_state_wait_5gc_n1_n2_release so the wait-completion
     * logic and PFCP cleanup converge. */
    ogs_error("Stream has already been removed; "
            "proceeding with local-only release");
    ogs_pkbuf_free(n1smbuf);
    ogs_pkbuf_free(n2smbuf);
}

OGS_FSM_TRAN(s, smf_gsm_state_wait_5gc_n1_n2_release);
```

## Scope

This patch only touches the one assert at
`src/smf/gsm-sm.c:smf_gsm_state_wait_pfcp_deletion`'s UE-requested
release branch. There is a second `ogs_assert(stream);` in the
NPCF-SMPolicyControl error path (around line 3795 on current main)
which is a different code path — error response toward the SBI
client, not a queued FSM event. That path's race profile is
different and is intentionally left untouched here.

## Spec references

- 3GPP TS 23.502 §4.3.4 — UE-requested PDU Session Release procedure
- 3GPP TS 29.502 §5.2.2.1.4 — Nsmf_PDUSession SBI behavior

## Testing

- Builds clean against current upstream main (commit 288f1ca49):
  `ninja -C build src/smf/open5gs-smfd` succeeds with no warnings.
- Healthy path unchanged — existing release tests in
  `tests/registration/`, `tests/non-3gpp/`, and `tests/vonr/`
  continue to pass (no regression in any test that drives the
  UE-requested release path through this state).
- Crash repro (manual): force the SBI stream to close mid-release
  (peer SMF restart during PDU-release in flight). Without the
  patch the SMF asserts on the next FSM iteration; with the patch
  the FSM logs the missing stream, frees the buffers, and the
  session converges through PFCP deletion to release cleanly.

## Open points for reviewer feedback

1. Treating NULL stream as "log + free + transition" matches the
   semantics of "no peer to notify; proceed with local release."
   An alternative would be to also issue an internal
   `ogs_sbi_server_send_error()` toward a substituted no-op stream,
   but that adds machinery for no observable benefit on the egress
   side. Happy to revisit if the reviewer prefers.
2. Log level is `ogs_error` because the situation indicates an
   abnormal peer behavior (client disconnect during release).
   `ogs_warn` would also be defensible if the reviewer considers
   peer-disconnect-during-release routine; willing to lower.
