### PR TITLE
[AMF] Prevent slice->session[] overflow via bounds check at OGS_MAX_NUM_OF_SESS

### DIFF
--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -214,6 +214,41 @@ int amf_nudm_sdm_handle_provisioned(
                             DnnInfoList = SubscribedSnssaiInfo->dnn_infos;
                             if (DnnInfoList) {
                                 OpenAPI_list_for_each(DnnInfoList, node2) {
+                                    /*
+                                     * slice->session[] is sized by
+                                     * OGS_MAX_NUM_OF_SESS (max active PDU
+                                     * sessions per UE), but a UDM-provisioned
+                                     * S-NSSAI may carry up to OGS_MAX_NUM_OF_DNN
+                                     * subscribed DNNs. Subscribers configured
+                                     * with more DNNs than max-sessions would
+                                     * overflow the array, leak ogs_strdup'ed
+                                     * session names, and ultimately trip
+                                     *   amf_clear_subscribed_info: Assertion
+                                     *   `slice[i].num_of_session <=
+                                     *    OGS_MAX_NUM_OF_SESS' failed.
+                                     * on UE re-registration or AMF restart.
+                                     *
+                                     * Bound the cache at OGS_MAX_NUM_OF_SESS
+                                     * (preserving the array's intended
+                                     * semantics) and emit a warning so the
+                                     * operator notices subscribers that
+                                     * exceed the per-UE session budget. If
+                                     * more DNNs per UE are needed, raise
+                                     * OGS_MAX_NUM_OF_SESS at build time
+                                     * rather than letting the cache overflow.
+                                     */
+                                    if (slice->num_of_session >=
+                                            OGS_MAX_NUM_OF_SESS) {
+                                        ogs_warn("[%s] subscriber has more "
+                                                "provisioned DNNs than "
+                                                "OGS_MAX_NUM_OF_SESS=%d; "
+                                                "truncating at S-NSSAI "
+                                                "[SST:%d SD:0x%x]",
+                                                amf_ue->supi,
+                                                OGS_MAX_NUM_OF_SESS,
+                                                s_nssai.sst, s_nssai.sd.v);
+                                        break;
+                                    }
                                     DnnInfo = node2->data;
                                     if (DnnInfo) {
                                         ogs_session_t *session =


### PR DESCRIPTION
# AMF: bound provisioned-DNN cache to prevent slice->session[] overflow

Closely related to #4030 — this variant addresses the same crash
report but does so without changing struct layout / ABI / per-UE
memory footprint.

## Summary

`amf_nudm_sdm_handle_provisioned()` iterates over UDM-provisioned
DnnInfoList entries for each subscribed S-NSSAI and writes them
into `slice->session[]`. The destination array is sized
`OGS_MAX_NUM_OF_SESS` (default 4 — max active PDU sessions per UE)
but the source list may carry up to `OGS_MAX_NUM_OF_DNN` entries
(default 16 — max provisioned DNNs).

When a subscriber is configured with more provisioned DNNs in one
S-NSSAI than `OGS_MAX_NUM_OF_SESS`, the loop overflows the
`slice->session[]` array, leaks the `ogs_strdup()`'d session names,
and trips the next-cycle assertion:

```
[amf] FATAL: amf_clear_subscribed_info: Assertion
  `amf_ue->slice[i].num_of_session <= OGS_MAX_NUM_OF_SESS' failed.
  (../src/amf/context.c:3022)
```

The fix in this PR adds a bounds check at the head of the inner
loop. When the cache is full, log a warning identifying the
subscriber and the affected S-NSSAI, and break out of the inner
loop. The outer iteration continues normally for other S-NSSAIs.

## Why a different variant from #4030

The patch in #4030 (gstaa, 2025-07-31) addresses the same crash by
**widening** the destination array:

```c
-    ogs_session_t session[OGS_MAX_NUM_OF_SESS];
+    ogs_session_t session[OGS_MAX_NUM_OF_DNN];
```

That works but has three operational downsides:

1. **Conflates two concepts** that the codebase otherwise keeps
   separate: max active PDU sessions per UE
   (`OGS_MAX_NUM_OF_SESS = 4`) vs max provisioned DNNs
   (`OGS_MAX_NUM_OF_DNN = 16`). The PR body in #4030 itself notes
   "slice->num_of_session corresponds to the number of subscribed
   DNNs, not the number of sessions." Once the array is widened
   the semantic confusion becomes permanent.
2. **Per-UE memory inflation:** `ogs_slice_data_t` is referenced by
   `amf_ue_t::slice[OGS_MAX_NUM_OF_SLICE = 8]`, so the fix
   multiplies the per-UE slice-cache footprint by 4×. For an AMF
   holding 100k UEs the impact is non-trivial.
3. **Cross-NF struct + ABI change:** `lib/proto/types.h` is shared
   across all NFs that link against `libogsproto.so`, so changing
   the layout requires a coordinated `.so` redeploy — exactly the
   foot-gun documented in the project notes for #4474 / PR-8.

This variant keeps `OGS_MAX_NUM_OF_SESS` semantics intact and
preserves the existing struct layout.

## Fix

```c
OpenAPI_list_for_each(DnnInfoList, node2) {
    if (slice->num_of_session >= OGS_MAX_NUM_OF_SESS) {
        ogs_warn("[%s] subscriber has more provisioned DNNs than "
                "OGS_MAX_NUM_OF_SESS=%d; truncating at S-NSSAI "
                "[SST:%d SD:0x%x]",
                amf_ue->supi, OGS_MAX_NUM_OF_SESS,
                s_nssai.sst, s_nssai.sd.v);
        break;
    }
    DnnInfo = node2->data;
    if (DnnInfo) {
        /* unchanged: insert into slice->session[slice->num_of_session++] */
    }
}
```

Total: +35 / -0 in `src/amf/nudm-handler.c` (most of which is the
multi-line warn message + the explanatory comment block; the
functional delta is ~5 lines).

## Behavior

- **Subscribers with ≤4 DNNs per S-NSSAI:** unchanged. All DNNs are
  cached as before.
- **Subscribers with >4 DNNs per S-NSSAI:** the first 4 DNNs are
  cached; the remainder is dropped silently from the cache but
  logged via `ogs_warn` so the operator knows. The UE can still
  request any of the cached DNNs at session-establishment; it
  cannot request the dropped DNNs (they're not in the AMF cache,
  so the AMF's S-NSSAI / DNN cross-check rejects them at
  PDU-session-establishment).
- **Operators who genuinely need >4 DNNs per UE:** raise
  `OGS_MAX_NUM_OF_SESS` at build time. The constant lives at
  `lib/proto/types.h:31` for that purpose. This patch does not
  prevent that path — it just refuses to silently overflow a
  4-slot cache when a 16-slot subscription is provisioned.

## Spec references

- 3GPP TS 29.503 §6.1.6.2.18 — Nudm_SDM SmfSelectionData /
  SubscribedSnssaiInfo / DnnInfo
- 3GPP TS 23.501 §5.15 — Network Slicing (per-UE max sessions per
  S-NSSAI is implementation-defined; the AMF imposes
  `OGS_MAX_NUM_OF_SESS` as the local policy ceiling)

## Testing

- Builds clean against current upstream main (commit 288f1ca49):
  `ninja -C build src/amf/open5gs-amfd` succeeds with no warnings.
- Reproducer: provision a single subscriber's MongoDB document
  with 5+ DNNs in one S-NSSAI; trigger UE registration. Without
  the patch, the AMF aborts the next time
  `amf_clear_subscribed_info()` runs (re-registration or restart);
  with the patch, the cache stays bounded and the operator sees:

  ```
  [amf] WARN: [imsi-001010000000001] subscriber has more
  provisioned DNNs than OGS_MAX_NUM_OF_SESS=4; truncating at
  S-NSSAI [SST:1 SD:0xabc012]
  ```

## Open points for reviewer feedback

1. The warn-and-truncate behavior is asymmetric vs. the AMF's
   handling of other "subscription exceeds local capacity" cases
   (some return errors all the way to UDM, some truncate
   silently). The choice here matches the AMF's behavior for
   slice-overflow elsewhere in `gmm_handle_ul_nas_transport()`
   (which logs and continues). Happy to align with whichever
   convention the reviewer prefers.
2. An alternative would be to add a separate
   `slice->num_of_dnn` + `slice->dnn[OGS_MAX_NUM_OF_DNN]` field
   pair so the AMF cache can reflect the full subscription. That
   is the right architectural answer but is a much bigger patch
   touching every call site that consumes `slice->session[]`. If
   the reviewer prefers that direction, willing to pursue it as a
   follow-up; this PR is the minimum-invasive crash-fix.
