### PR TITLE
sbi: prevent NF crash on callback URI without path component

### DIFF
--- a/lib/sbi/client.c
+++ b/lib/sbi/client.c
@@ -834,6 +834,11 @@ bool ogs_sbi_client_send_via_scp_or_sepp(
         ogs_assert(apiroot);
 
         rc = ogs_sbi_getpath_from_uri(&path, request->h.uri);
+        if (rc == false) {
+            ogs_error("Cannot extract path from URI [%s]", request->h.uri);
+            ogs_free(apiroot);
+            return false;
+        }
         ogs_assert(path);
 
         request->h.uri = ogs_msprintf("%s/%s", apiroot, path);


### PR DESCRIPTION
Fixes #4489.

`ogs_sbi_client_send_via_scp_or_sepp()` in `lib/sbi/client.c` calls
`ogs_sbi_getpath_from_uri()` but does not check the return value before
asserting on `path`. When a caller supplies a URI without a path
component (e.g. an NRF subscription with
`nfStatusNotificationUri = http://host:port`),
`ogs_sbi_getpath_from_uri()` returns `false` with `path = NULL`, and the
subsequent `ogs_assert(path)` aborts the process — usable as a remote
DoS against any SBI-based NF.

Previously:

```c
rc = ogs_sbi_getpath_from_uri(&path, request->h.uri);
ogs_assert(path);
```

This patch checks the return value, logs the malformed URI, frees the
locally-allocated `apiroot`, and returns `false`. The function already
returns `bool` and all existing call sites in `lib/sbi/path.c` and
`src/sepp/sbi-path.c` check the return value, so no caller changes are
needed.

Affected versions per the issue: v2.7.5, v2.7.6, v2.7.7.

Verified locally with a clean `meson setup build && ninja -C build` on
Ubuntu 22.04.