### PR TITLE
smf: reject unhandled HsmfUpdateData with HTTP 400 instead of FATAL

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -1245,11 +1245,17 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                                             OGS_PFCP_MODIFY_UE_REQUESTED|
                                             sess->nsmf_param.pfcp_flags, 0));
                             } else {
-                                ogs_fatal("Invalid [upCnxState:%d]"
-                                        "[pfcp_flags:0x%llx]",
+                                ogs_error("Invalid HsmfUpdateData "
+                                        "[upCnxState:%d][pfcp_flags:0x%llx]",
                                         sess->nsmf_param.up_cnx_state,
                                         (long long)sess->nsmf_param.pfcp_flags);
-                                ogs_assert_if_reached();
+                                ogs_assert(true ==
+                                    ogs_sbi_server_send_error(stream,
+                                        OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                        sbi_message,
+                                        "Invalid HsmfUpdateData",
+                                        "Unhandled upCnxState/pfcp_flags "
+                                        "combination", NULL));
                             }
                             break;
                         case OpenAPI_request_indication_UE_REQ_PDU_SES_REL:


### PR DESCRIPTION
## Summary
Fixes #4490 (reported by @0wln3d). The SMF aborts when a peer SMF sends `HsmfUpdateData` with a `(upCnxState, pfcpFlags)` combination outside the four documented branches of the `UE_REQ_PDU_SES_MOD` handler. The reporter's PoC uses `upCnxState=SUSPENDED` (enum value 4) with `pfcpFlags=0`, falls through to the `else` arm at `src/smf/gsm-sm.c:1247`, and crashes the entire SMF process via `ogs_fatal()` + `ogs_assert_if_reached()`.

This satisfies the reporter's stated expectation: "SMF should return a controlled HTTP error (4xx) for invalid state transitions and must not abort the process for schema-valid JSON that is inconsistent with internal session state."

## Fix
Replace the FATAL with the same pattern used by the surrounding handlers in this file: log the unexpected input, return HTTP 400 BAD_REQUEST to the peer via `ogs_sbi_server_send_error()`, and stay in the current FSM state so the local session is not destroyed by a peer protocol violation.

## Test
Manually verified the build. The legitimate DEACTIVATED / ACTIVATING / ACTIVATED branches are unchanged. The PoC from #4490 now produces an error log line and a 400 response on the offending request without disturbing other sessions or the SMF process itself.

## Notes for review
- No FSM transition to `smf_gsm_state_exception` — the surrounding success branches (DEACTIVATED/ACTIVATING/ACTIVATED) also stay in the current state. A peer protocol violation should not destroy local session state.
- Other `ogs_fatal`/`ogs_assert_if_reached` sites in this file guard internal FSM invariants (post-PFCP-deletion etc.) not reachable from raw SBI input; deliberately not touched in this PR.
