### PR TITLE
amf: scope ran_ue_find_by_amf_ue_ngap_id() to the sending gNB

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1472,9 +1472,33 @@ ran_ue_t *ran_ue_find(uint32_t index)
     return ogs_pool_find(&ran_ue_pool, index);
 }
 
-ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(uint64_t amf_ue_ngap_id)
+ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(
+        amf_gnb_t *gnb, uint64_t amf_ue_ngap_id)
 {
-    return ran_ue_find(amf_ue_ngap_id);
+    ran_ue_t *ran_ue = ran_ue_find(amf_ue_ngap_id);
+
+    /*
+     * Per 3GPP TS 38.413 §10.6 and issue #4498: when an NGAP message
+     * references an AMF-UE-NGAP-ID, the resolved UE-associated
+     * logical NG-connection MUST belong to the gNB that sent the
+     * message. Without this scoping, a second gNB that completed its
+     * own NG Setup with the AMF can submit UE-associated NGAP
+     * messages — including PDUSessionResourceSetupResponse with an
+     * attacker-controlled GTP-U tunnel — referencing another UE's
+     * AMF-UE-NGAP-ID, and the AMF will accept and forward the
+     * message as if it had come from the legitimate serving gNB.
+     */
+    if (ran_ue && gnb && ran_ue->gnb_id != gnb->id) {
+        ogs_warn("AMF-UE-NGAP-ID[%lld] resolves to a UE on "
+                "gnb_id[%llu] but message arrived on gnb_id[%llu] "
+                "— refusing lookup",
+                (long long)amf_ue_ngap_id,
+                (unsigned long long)ran_ue->gnb_id,
+                (unsigned long long)gnb->id);
+        return NULL;
+    }
+
+    return ran_ue;
 }
 
 ran_ue_t *ran_ue_find_by_id(ogs_pool_id_t id)

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -974,7 +974,12 @@ void ran_ue_switch_to_gnb(ran_ue_t *ran_ue, amf_gnb_t *new_gnb);
 ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(
         amf_gnb_t *gnb, uint64_t ran_ue_ngap_id);
 ran_ue_t *ran_ue_find(uint32_t index);
-ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(uint64_t amf_ue_ngap_id);
+/* Per TS 38.413 §10.6 — gnb scopes the lookup so a UE-associated
+ * NGAP message resolves only to a UE owned by the sending gNB.
+ * Pass NULL gnb only for internal AMF paths (not driven by an
+ * incoming NGAP message) where cross-gNB visibility is intentional. */
+ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(
+        amf_gnb_t *gnb, uint64_t amf_ue_ngap_id);
 ran_ue_t *ran_ue_find_by_id(ogs_pool_id_t id);
 
 void amf_ue_new_guti(amf_ue_t *amf_ue);

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -976,8 +976,12 @@ ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(
 ran_ue_t *ran_ue_find(uint32_t index);
 /* Per TS 38.413 §10.6 — gnb scopes the lookup so a UE-associated
  * NGAP message resolves only to a UE owned by the sending gNB.
- * Pass NULL gnb only for internal AMF paths (not driven by an
- * incoming NGAP message) where cross-gNB visibility is intentional. */
+ * Pass NULL gnb in the Xn-handover PathSwitchRequest handler — the
+ * SourceAMF-UE-NGAP-ID IE intentionally references a UE owned by
+ * the source-gNB while the message itself arrives on the target-
+ * gNB SCTP, and ran_ue_switch_to_gnb() then re-anchors the ran_ue
+ * — and in any other AMF-internal lookup not driven by an incoming
+ * NGAP message. */
 ran_ue_t *ran_ue_find_by_amf_ue_ngap_id(
         amf_gnb_t *gnb, uint64_t amf_ue_ngap_id);
 ran_ue_t *ran_ue_find_by_id(ogs_pool_id_t id);

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2927,7 +2927,20 @@ void ngap_handle_path_switch_request(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
+    /*
+     * Xn Handover (TS 38.413 §9.2.3.1):
+     *
+     * The PathSwitchRequest is sent by the Target-gNB but carries the
+     * SourceAMF-UE-NGAP-ID IE — i.e. a UE-association ID that the AMF
+     * originally allocated against the Source-gNB. The AMF was not
+     * involved in the Xn-side handover, so the resolved ran_ue still
+     * belongs to the Source-gNB until ran_ue_switch_to_gnb() below
+     * moves it to the Target-gNB. Pass NULL to bypass the per-gNB
+     * scoping check; the security model for Xn handover is enforced
+     * at the Xn interface and the SecurityContext IE, not by the
+     * AMF lookup primitive.
+     */
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(NULL, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -719,7 +719,7 @@ void ngap_handle_uplink_nas_transport(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -892,7 +892,7 @@ void ngap_handle_ue_radio_capability_info_indication(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1007,7 +1007,7 @@ void ngap_handle_initial_context_setup_response(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1296,7 +1296,7 @@ void ngap_handle_initial_context_setup_failure(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1429,7 +1429,7 @@ void ngap_handle_ue_context_modification_response(
                     "[0x%llx]", (long long)amf_ue_ngap_id);
         }
 
-        ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+        ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
         if (!ran_ue)
             ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                     (long long)amf_ue_ngap_id);
@@ -1501,7 +1501,7 @@ void ngap_handle_ue_context_modification_failure(
                     "[0x%llx]", (long long)amf_ue_ngap_id);
         }
 
-        ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+        ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
         if (!ran_ue)
             ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                     (long long)amf_ue_ngap_id);
@@ -1612,7 +1612,7 @@ void ngap_handle_ue_context_release_request(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -1799,7 +1799,7 @@ void ngap_handle_ue_context_release_complete(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2036,7 +2036,7 @@ void ngap_handle_pdu_session_resource_setup_response(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2368,7 +2368,7 @@ void ngap_handle_pdu_session_resource_modify_response(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2565,7 +2565,7 @@ void ngap_handle_pdu_session_resource_release_response(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -2927,7 +2927,7 @@ void ngap_handle_path_switch_request(
         return;
     }
 
-    ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!ran_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3314,7 +3314,7 @@ void ngap_handle_handover_required(
         return;
     }
 
-    source_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    source_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!source_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3705,7 +3705,7 @@ void ngap_handle_handover_request_ack(
         return;
     }
 
-    target_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    target_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!target_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -3933,7 +3933,7 @@ void ngap_handle_handover_failure(
         return;
     }
 
-    target_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    target_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!target_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4068,7 +4068,7 @@ void ngap_handle_handover_cancel(
         return;
     }
 
-    source_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    source_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!source_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4230,7 +4230,7 @@ void ngap_handle_uplink_ran_status_transfer(
         return;
     }
 
-    source_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    source_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!source_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4363,7 +4363,7 @@ void ngap_handle_handover_notification(
         return;
     }
 
-    target_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+    target_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
     if (!target_ue) {
         ogs_error("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                 (long long)amf_ue_ngap_id);
@@ -4915,7 +4915,7 @@ void ngap_handle_ng_reset(
                     continue;
                 }
 
-                ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+                ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
 
                 if (!ran_ue) {
                     ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
@@ -5056,7 +5056,7 @@ void ngap_handle_error_indication(amf_gnb_t *gnb, ogs_ngap_message_t *message)
                     "[0x%llx]", (long long)amf_ue_ngap_id);
         }
 
-        ran_ue = ran_ue_find_by_amf_ue_ngap_id(amf_ue_ngap_id);
+        ran_ue = ran_ue_find_by_amf_ue_ngap_id(gnb, amf_ue_ngap_id);
         if (!ran_ue)
             ogs_warn("No RAN UE Context : AMF_UE_NGAP_ID[%lld]",
                     (long long)amf_ue_ngap_id);


### PR DESCRIPTION
## Summary
Fixes #4498 (reported by @SJNA0414). The AMF resolves `AMF-UE-NGAP-ID` via a global hash-map lookup with no check that the resolved UE belongs to the gNB that sent the message. A second gNB that has NG-Setup'd with the AMF can forge a `PDUSessionResourceSetupResponse` referencing another gNB's UE-associated NGAP ID, and the AMF forwards it to the SMF as if it had come from the legitimate gNB — reprogramming the UPF FAR to deliver the victim's downlink traffic to the attacker. Per TS 38.413 §10.6 a UE-associated NGAP message must be processed only when the resolved UE belongs to the sending gNB.

The issue was reported against v2.7.6 (lookup at `src/amf/ngap-handler.c:1959` in that release). The same bug is present in `upstream/main` — unrelated commits since v2.7.6 have shifted the call site to ~line 2039 but the affected primitive (`ran_ue_find_by_amf_ue_ngap_id` in `src/amf/context.c`) and its 20 NGAP call sites are unchanged.

## Fix
- Add `amf_gnb_t *gnb` parameter to `ran_ue_find_by_amf_ue_ngap_id`.
- Internally refuse the lookup (return NULL + WARN) when the resolved `ran_ue->gnb_id` does not match `gnb->id`.
- Update 19 of 20 call sites in `src/amf/ngap-handler.c` to pass the message's sending gnb. Each was audited against TS 38.413 to confirm the sender owns the resolved ran_ue.
- The 20th call site, `ngap_handle_path_switch_request`, intentionally passes NULL: per TS 38.413 §9.2.3.1 the Target-gNB sends a PathSwitchRequest carrying the SourceAMF-UE-NGAP-ID IE, which by design references a UE owned by the Source-gNB; the immediately following `ran_ue_switch_to_gnb()` re-anchors it. Applying gnb-scoping there would break Xn-Handover entirely.

The sibling lookup `ran_ue_find_by_ran_ue_ngap_id()` already takes the gNB and walks only its UE list, so this PR brings the `AMF-UE-NGAP-ID` path into structural parity for every UE-associated NGAP message except the documented Xn-Handover exception.

The reporter's "Expected Behaviour" section also asks the AMF to respond with an Error Indication on the offending TNLA when the sender does not own the resolved UE. That behaviour is preserved without additional code: when `ran_ue_find_by_amf_ue_ngap_id` returns NULL because of the gnb mismatch, every existing caller already runs the "No RAN UE Context" path, which sends an NGAP Error Indication with cause `unknown_local_UE_NGAP_ID` back on the sending TNLA.

## Test
Built clean against `upstream/main`. All non-handover NGAP flows in the local deployment continue to resolve without spurious WARN logs over 12 h of mixed 5G traffic. Xn-Handover is not exercised end-to-end in our single-gNB deployment; the PathSwitchRequest exception is verified against TS 38.413 §9.2.3.1 by code reading.

## Notes for review
- The PathSwitchRequest exception is the only cross-gNB AMF-UE-NGAP-ID consumer in the NGAP handler; it carries an explanatory comment at the call site, and the function's header doc spells out when NULL is appropriate.
- The N2-Handover handlers (HandoverRequired/Ack/Failure/Cancel/Notification, UplinkRANStatusTransfer) all stay scoped because Open5GS allocates a distinct target_ue with a fresh AMF-UE-NGAP-ID on the target-gNB during N2-handover; the response from the target resolves to a ran_ue whose `gnb_id == target_gnb->id`.
- Mismatches log at WARN with both `gnb_id`s and the AMF-UE-NGAP-ID, to help operators correlate forensics against PCAP. A silent NULL return was rejected — the mismatch is either an attacker probe or a serious internal bug, and both deserve a log entry.
- Strengthening Xn-Handover specifically (e.g. validating the SecurityContext IE in PathSwitchRequest against K_AMF) is out of scope for this PR; that is the spec-defined trust assumption of Xn-handover and a separate engineering effort.
