### PR TITLE
nrf: add TS 28.552 §5.19.1 Prometheus NF management metrics

### DIFF
--- a/src/nrf/init.c
+++ b/src/nrf/init.c
@@ -18,6 +18,7 @@
  */
 
 #include "sbi-path.h"
+#include "metrics.h"
 
 static ogs_thread_t *thread;
 static void nrf_main(void *data);
@@ -31,6 +32,8 @@ int nrf_initialize(void)
     rv = ogs_app_parse_local_conf(APP_NAME);
     if (rv != OGS_OK) return rv;
 
+    nrf_metrics_init();
+
     ogs_sbi_context_init(OpenAPI_nf_type_NRF);
     nrf_context_init();
 
@@ -42,6 +45,9 @@ int nrf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = nrf_context_parse_config();
+    if (rv != OGS_OK) return rv;
+
+    rv = ogs_metrics_context_parse_config(APP_NAME);
     if (rv != OGS_OK) return rv;
 
     rv = nrf_sbi_open();
@@ -86,6 +92,8 @@ void nrf_terminate(void)
 
     nrf_context_final();
     ogs_sbi_context_final();
+
+    nrf_metrics_final();
 }
 
 static void nrf_main(void *data)

--- a/src/nrf/meson.build
+++ b/src/nrf/meson.build
@@ -20,6 +20,8 @@ libnrf_sources = files('''
     event.c
     timer.c
 
+    metrics.c
+
     nnrf-handler.c
     nnrf-build.c
     sbi-path.c
@@ -32,12 +34,12 @@ libnrf_sources = files('''
 
 libnrf = static_library('nrf',
     sources : libnrf_sources,
-    dependencies : libsbi_dep,
+    dependencies : [libsbi_dep, libmetrics_dep],
     install : false)
 
 libnrf_dep = declare_dependency(
     link_with : libnrf,
-    dependencies : libsbi_dep)
+    dependencies : [libsbi_dep, libmetrics_dep])
 
 nrf_sources = files('''
     app.c

--- a/src/nrf/metrics.c
+++ b/src/nrf/metrics.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ogs-app.h"
+
+#include "metrics.h"
+
+typedef struct nrf_metrics_spec_def_s {
+    unsigned int type;
+    const char *name;
+    const char *description;
+    int initial_val;
+    unsigned int num_labels;
+    const char **labels;
+} nrf_metrics_spec_def_t;
+
+/* Helper generic functions */
+static int nrf_metrics_init_inst(ogs_metrics_inst_t **inst,
+        ogs_metrics_spec_t **specs, unsigned int len,
+        unsigned int num_labels, const char **labels)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        inst[i] = ogs_metrics_inst_new(specs[i], num_labels, labels);
+    return OGS_OK;
+}
+
+static int nrf_metrics_init_spec(ogs_metrics_context_t *ctx,
+        ogs_metrics_spec_t **dst, nrf_metrics_spec_def_t *src,
+        unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++) {
+        dst[i] = ogs_metrics_spec_new(ctx, src[i].type,
+                src[i].name, src[i].description,
+                src[i].initial_val, src[i].num_labels, src[i].labels,
+                NULL);
+    }
+    return OGS_OK;
+}
+
+/* GLOBAL */
+static ogs_metrics_spec_t *nrf_metrics_spec_global[_NRF_METR_GLOB_MAX];
+ogs_metrics_inst_t *nrf_metrics_inst_global[_NRF_METR_GLOB_MAX];
+static nrf_metrics_spec_def_t nrf_metrics_spec_def_global[_NRF_METR_GLOB_MAX] = {
+/* Global Gauges: */
+[NRF_METR_GLOB_GAUGE_NF_INSTANCES] = {
+    .type = OGS_METRICS_METRIC_TYPE_GAUGE,
+    .name = "fivegs_nrffunction_nf_nfinstances",
+    .description = "Current number of registered NF instances at the NRF",
+},
+/* Global Counters: */
+[NRF_METR_GLOB_CTR_NF_REGISTER_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfregistrations",
+    .description = "Number of successful NF registrations at the NRF",
+},
+[NRF_METR_GLOB_CTR_NF_REGISTER_FAIL] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfregfailed",
+    .description = "Number of failed NF registrations at the NRF",
+},
+[NRF_METR_GLOB_CTR_NF_HEARTBEAT] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfheartbeats",
+    .description = "Number of NF heartbeat (NF update) requests at the NRF",
+},
+[NRF_METR_GLOB_CTR_NF_DEREGISTER] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfderegistrations",
+    .description = "Number of NF deregistrations at the NRF",
+},
+[NRF_METR_GLOB_CTR_NF_DISCOVER_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfdiscoveryreq",
+    .description = "Number of NF discovery requests received by the NRF",
+},
+[NRF_METR_GLOB_CTR_NF_DISCOVER_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "fivegs_nrffunction_nf_nfdiscoverysucc",
+    .description = "Number of successful NF discoveries at the NRF",
+},
+};
+
+static int nrf_metrics_init_inst_global(void)
+{
+    return nrf_metrics_init_inst(nrf_metrics_inst_global,
+            nrf_metrics_spec_global, _NRF_METR_GLOB_MAX, 0, NULL);
+}
+
+void nrf_metrics_init(void)
+{
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+    ogs_metrics_context_init();
+
+    nrf_metrics_init_spec(ctx, nrf_metrics_spec_global,
+            nrf_metrics_spec_def_global, _NRF_METR_GLOB_MAX);
+
+    nrf_metrics_init_inst_global();
+}
+
+void nrf_metrics_final(void)
+{
+    ogs_metrics_context_final();
+}

--- a/src/nrf/metrics.h
+++ b/src/nrf/metrics.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019-2025 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef NRF_METRICS_H
+#define NRF_METRICS_H
+
+#include "ogs-metrics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * TS 28.552 §5.19.1 — NRF performance measurements.
+ *
+ * Gauge:
+ *   fivegs_nrffunction_nf_nfinstances  — current NF instance count
+ *
+ * Counters:
+ *   fivegs_nrffunction_nf_nfregistrations      — successful NF registrations
+ *   fivegs_nrffunction_nf_nfregfailed          — failed NF registrations
+ *   fivegs_nrffunction_nf_nfheartbeats         — NF heartbeat (NF update) reqs
+ *   fivegs_nrffunction_nf_nfderegistrations    — NF deregistrations
+ *   fivegs_nrffunction_nf_nfdiscoveryreq       — NF discovery requests
+ *   fivegs_nrffunction_nf_nfdiscoverysucc      — successful NF discoveries
+ */
+typedef enum nrf_metric_type_global_s {
+    NRF_METR_GLOB_GAUGE_NF_INSTANCES = 0,
+    NRF_METR_GLOB_CTR_NF_REGISTER_SUCC,
+    NRF_METR_GLOB_CTR_NF_REGISTER_FAIL,
+    NRF_METR_GLOB_CTR_NF_HEARTBEAT,
+    NRF_METR_GLOB_CTR_NF_DEREGISTER,
+    NRF_METR_GLOB_CTR_NF_DISCOVER_REQ,
+    NRF_METR_GLOB_CTR_NF_DISCOVER_SUCC,
+    _NRF_METR_GLOB_MAX,
+} nrf_metric_type_global_t;
+
+extern ogs_metrics_inst_t *nrf_metrics_inst_global[_NRF_METR_GLOB_MAX];
+
+static inline void nrf_metrics_inst_global_set(
+        nrf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_set(nrf_metrics_inst_global[t], val); }
+static inline void nrf_metrics_inst_global_add(
+        nrf_metric_type_global_t t, int val)
+{ ogs_metrics_inst_add(nrf_metrics_inst_global[t], val); }
+static inline void nrf_metrics_inst_global_inc(nrf_metric_type_global_t t)
+{ ogs_metrics_inst_inc(nrf_metrics_inst_global[t]); }
+static inline void nrf_metrics_inst_global_dec(nrf_metric_type_global_t t)
+{ ogs_metrics_inst_dec(nrf_metrics_inst_global[t]); }
+
+void nrf_metrics_init(void);
+void nrf_metrics_final(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRF_METRICS_H */

--- a/src/nrf/nf-sm.c
+++ b/src/nrf/nf-sm.c
@@ -21,6 +21,7 @@
 
 #include "sbi-path.h"
 #include "nnrf-handler.h"
+#include "metrics.h"
 
 void nrf_nf_fsm_init(ogs_sbi_nf_instance_t *nf_instance)
 {
@@ -270,6 +271,10 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
                     ogs_assert(response);
                     ogs_assert(true ==
                             ogs_sbi_server_send_response(stream, response));
+                    nrf_metrics_inst_global_inc(
+                            NRF_METR_GLOB_CTR_NF_DEREGISTER);
+                    nrf_metrics_inst_global_dec(
+                            NRF_METR_GLOB_GAUGE_NF_INSTANCES);
                     OGS_FSM_TRAN(s, nrf_nf_state_de_registered);
                     break;
 

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -19,6 +19,7 @@
 
 #include "nnrf-handler.h"
 #include "sbi-path.h"
+#include "metrics.h"
 
 static int discover_handler(
         int status, ogs_sbi_response_t *response, void *data);
@@ -114,6 +115,7 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
         /* Reject the registration if PLMN-ID is invalid */
         if (!plmn_valid) {
             ogs_error("PLMN-ID in NFProfile is not allowed");
+            nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_REGISTER_FAIL);
             ogs_assert(true == ogs_sbi_server_send_error(
                 stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, recvmsg,
                 "PLMN-ID not allowed", NULL, NULL));
@@ -134,6 +136,7 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
             nf_instance->id,
             OpenAPI_nf_type_ToString(nf_instance->nf_type));
 
+        nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_REGISTER_FAIL);
         ogs_assert(true ==
             ogs_sbi_server_send_error(
                 stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, recvmsg,
@@ -257,6 +260,9 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
 
     ogs_assert(response);
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_REGISTER_SUCC);
+    nrf_metrics_inst_global_inc(NRF_METR_GLOB_GAUGE_NF_INSTANCES);
 
     return true;
 }
@@ -419,6 +425,7 @@ bool nrf_nnrf_handle_nf_update(ogs_sbi_nf_instance_t *nf_instance,
                 recvmsg, OGS_SBI_HTTP_STATUS_NO_CONTENT);
         ogs_assert(response);
         ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+        nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_HEARTBEAT);
         break;
 
     DEFAULT
@@ -997,6 +1004,8 @@ bool nrf_nnrf_handle_nf_discover(
     ogs_assert(stream);
     ogs_assert(recvmsg);
 
+    nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_DISCOVER_REQ);
+
     if (!recvmsg->param.target_nf_type) {
         ogs_error("No target-nf-type [%s]", recvmsg->h.uri);
         ogs_assert(true ==
@@ -1348,6 +1357,7 @@ cleanup:
 
     ogs_free(SearchResult);
 
+    nrf_metrics_inst_global_inc(NRF_METR_GLOB_CTR_NF_DISCOVER_SUCC);
     return true;
 }
 


### PR DESCRIPTION
NRF had no Prometheus metrics despite being the service mesh backbone of the 5G Core. Add seven measurements covering the full NF lifecycle:

  Gauge:
    fivegs_nrffunction_nf_nfinstances      (registered NF instance count)

  Counters:
    fivegs_nrffunction_nf_nfregistrations  (successful NF registrations)
    fivegs_nrffunction_nf_nfregfailed      (rejected NF registrations)
    fivegs_nrffunction_nf_nfheartbeats     (NF heartbeat PATCH requests)
    fivegs_nrffunction_nf_nfderegistrations (NF DELETE events)
    fivegs_nrffunction_nf_nfdiscoveryreq   (discovery requests received)
    fivegs_nrffunction_nf_nfdiscoverysucc  (successful discoveries)

The nfinstances gauge is incremented at the single return-true in nrf_nnrf_handle_nf_register() and decremented on HTTP DELETE in nrf_nf_state_registered, keeping it balanced.

NRF previously depended only on libsbi_dep; libmetrics_dep is now added to both the static_library and declare_dependency in meson.build.

Spec ref: 3GPP TS 28.552 §5.19.1