### PR TITLE
ausf: add TS 28.552 §5.21.3 Prometheus authentication metrics

### DIFF
--- a/src/ausf/init.c
+++ b/src/ausf/init.c
@@ -18,6 +18,7 @@
  */
 
 #include "sbi-path.h"
+#include "metrics.h"
 
 static ogs_thread_t *thread;
 static void ausf_main(void *data);
@@ -31,6 +32,8 @@ int ausf_initialize(void)
     rv = ogs_app_parse_local_conf(APP_NAME);
     if (rv != OGS_OK) return rv;
 
+    ausf_metrics_init();
+
     ogs_sbi_context_init(OpenAPI_nf_type_AUSF);
     ausf_context_init();
 
@@ -39,6 +42,9 @@ int ausf_initialize(void)
     if (rv != OGS_OK) return rv;
 
     rv = ogs_sbi_context_parse_config(APP_NAME, "nrf", "scp");
+    if (rv != OGS_OK) return rv;
+
+    rv = ogs_metrics_context_parse_config(APP_NAME);
     if (rv != OGS_OK) return rv;
 
     rv = ausf_context_parse_config();
@@ -92,6 +98,8 @@ void ausf_terminate(void)
 
     ausf_context_final();
     ogs_sbi_context_final();
+
+    ausf_metrics_final();
 }
 
 static void ausf_main(void *data)

--- a/src/ausf/meson.build
+++ b/src/ausf/meson.build
@@ -29,18 +29,22 @@ libausf_sources = files('''
     sbi-path.c
     ausf-sm.c
 
+    metrics.c
+
     init.c
 '''.split())
 
 libausf = static_library('ausf',
     sources : libausf_sources,
-    dependencies : [libcrypt_dep,
+    dependencies : [libmetrics_dep,
+                    libcrypt_dep,
                     libsbi_dep],
     install : false)
 
 libausf_dep = declare_dependency(
     link_with : libausf,
-    dependencies : [libcrypt_dep,
+    dependencies : [libmetrics_dep,
+                    libcrypt_dep,
                     libsbi_dep])
 
 ausf_sources = files('''

--- a/src/ausf/metrics.c
+++ b/src/ausf/metrics.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * 3GPP TS 28.552 Section 5.21.3
+ * Performance measurements for Authentication Server Function (AUSF):
+ *   - fivegs_ausffunction_auth_authreq   (initiated authentication requests)
+ *   - fivegs_ausffunction_auth_authsucc  (successful authentications)
+ *   - fivegs_ausffunction_auth_authfail  (failed authentications)
+ */
+
+#include "ogs-app.h"
+#include "context.h"
+
+#include "metrics.h"
+
+typedef struct ausf_metrics_spec_def_s {
+    unsigned int    type;
+    const char     *name;
+    const char     *description;
+    int             initial_val;
+    unsigned int    num_labels;
+    const char    **labels;
+} ausf_metrics_spec_def_t;
+
+/* Generic helpers (mirror of AMF pattern) */
+static int ausf_metrics_init_inst(
+        ogs_metrics_inst_t **inst, ogs_metrics_spec_t **specs,
+        unsigned int len,
+        unsigned int num_labels, const char **labels)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        inst[i] = ogs_metrics_inst_new(specs[i], num_labels, labels);
+    return OGS_OK;
+}
+
+static int ausf_metrics_free_inst(
+        ogs_metrics_inst_t **inst, unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++)
+        ogs_metrics_inst_free(inst[i]);
+    memset(inst, 0, sizeof(inst[0]) * len);
+    return OGS_OK;
+}
+
+static int ausf_metrics_init_spec(
+        ogs_metrics_context_t *ctx,
+        ogs_metrics_spec_t **dst,
+        ausf_metrics_spec_def_t *src, unsigned int len)
+{
+    unsigned int i;
+    for (i = 0; i < len; i++) {
+        dst[i] = ogs_metrics_spec_new(ctx, src[i].type,
+                src[i].name, src[i].description,
+                src[i].initial_val,
+                src[i].num_labels, src[i].labels,
+                NULL);
+    }
+    return OGS_OK;
+}
+
+/* GLOBAL */
+ogs_metrics_spec_t *ausf_metrics_spec_global[_AUSF_METR_GLOB_MAX];
+ogs_metrics_inst_t *ausf_metrics_inst_global[_AUSF_METR_GLOB_MAX];
+
+/*
+ * TS 28.552 §5.21.3 Table 5.21.3-1
+ * Authentication-related performance counters for AUSF.
+ */
+ausf_metrics_spec_def_t ausf_metrics_spec_def_global[_AUSF_METR_GLOB_MAX] = {
+
+[AUSF_METR_GLOB_CTR_AUTH_REQ] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    /* TS 28.552 §5.21.3 — 5GS.Auth.AuthenticationsInitiated */
+    .name = "fivegs_ausffunction_auth_authreq",
+    .description =
+        "Number of authentication requests received by the AUSF",
+},
+
+[AUSF_METR_GLOB_CTR_AUTH_SUCC] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    /* TS 28.552 §5.21.3 — 5GS.Auth.AuthenticationsSucceeded */
+    .name = "fivegs_ausffunction_auth_authsucc",
+    .description =
+        "Number of successful authentication confirmations at the AUSF",
+},
+
+[AUSF_METR_GLOB_CTR_AUTH_FAIL] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    /* TS 28.552 §5.21.3 — 5GS.Auth.AuthenticationsFailed */
+    .name = "fivegs_ausffunction_auth_authfail",
+    .description =
+        "Number of failed authentication confirmations at the AUSF",
+},
+
+}; /* ausf_metrics_spec_def_global */
+
+int ausf_metrics_init_inst_global(void)
+{
+    return ausf_metrics_init_inst(
+            ausf_metrics_inst_global,
+            ausf_metrics_spec_global,
+            _AUSF_METR_GLOB_MAX, 0, NULL);
+}
+
+int ausf_metrics_free_inst_global(void)
+{
+    return ausf_metrics_free_inst(
+            ausf_metrics_inst_global, _AUSF_METR_GLOB_MAX);
+}
+
+void ausf_metrics_init(void)
+{
+    ogs_metrics_context_t *ctx = ogs_metrics_self();
+    ogs_metrics_context_init();
+
+    ausf_metrics_init_spec(ctx,
+            ausf_metrics_spec_global,
+            ausf_metrics_spec_def_global,
+            _AUSF_METR_GLOB_MAX);
+
+    ausf_metrics_init_inst_global();
+}
+
+void ausf_metrics_final(void)
+{
+    ogs_metrics_context_final();
+}

--- a/src/ausf/metrics.h
+++ b/src/ausf/metrics.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019-2024 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * 3GPP TS 28.552 Section 5.21.3
+ * Performance measurements for Authentication Server Function (AUSF)
+ *
+ * Metrics implemented:
+ *   fivegs_ausffunction_auth_authreq   — initiated auth requests
+ *   fivegs_ausffunction_auth_authsucc  — successful authentications
+ *   fivegs_ausffunction_auth_authfail  — failed authentications
+ */
+
+#ifndef AUSF_METRICS_H
+#define AUSF_METRICS_H
+
+#include "ogs-metrics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TS 28.552 §5.21.3 — global AUSF counters */
+typedef enum ausf_metric_type_global_s {
+    AUSF_METR_GLOB_CTR_AUTH_REQ = 0,  /* auth requests initiated   */
+    AUSF_METR_GLOB_CTR_AUTH_SUCC,     /* auth confirmations passed */
+    AUSF_METR_GLOB_CTR_AUTH_FAIL,     /* auth confirmations failed */
+    _AUSF_METR_GLOB_MAX,
+} ausf_metric_type_global_t;
+
+extern ogs_metrics_inst_t *ausf_metrics_inst_global[_AUSF_METR_GLOB_MAX];
+
+int ausf_metrics_init_inst_global(void);
+int ausf_metrics_free_inst_global(void);
+
+static inline void ausf_metrics_inst_global_inc(
+        ausf_metric_type_global_t t)
+{
+    ogs_metrics_inst_inc(ausf_metrics_inst_global[t]);
+}
+
+void ausf_metrics_init(void);
+void ausf_metrics_final(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AUSF_METRICS_H */

--- a/src/ausf/nausf-handler.c
+++ b/src/ausf/nausf-handler.c
@@ -20,6 +20,7 @@
 #include "sbi-path.h"
 #include "nnrf-handler.h"
 #include "nausf-handler.h"
+#include "metrics.h"
 
 bool ausf_nausf_auth_handle_authenticate(ausf_ue_t *ausf_ue,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
@@ -31,6 +32,9 @@ bool ausf_nausf_auth_handle_authenticate(ausf_ue_t *ausf_ue,
     ogs_assert(ausf_ue);
     ogs_assert(stream);
     ogs_assert(recvmsg);
+
+    /* TS 28.552 §5.21.3 — count each authentication request received */
+    ausf_metrics_inst_global_inc(AUSF_METR_GLOB_CTR_AUTH_REQ);
 
     AuthenticationInfo = recvmsg->AuthenticationInfo;
     if (!AuthenticationInfo) {
@@ -103,8 +107,12 @@ bool ausf_nausf_auth_handle_authenticate_confirmation(ausf_ue_t *ausf_ue,
         ogs_log_hexdump(OGS_LOG_WARN, ausf_ue->xres_star, OGS_MAX_RES_LEN);
 
         ausf_ue->auth_result = OpenAPI_auth_result_AUTHENTICATION_FAILURE;
+        /* TS 28.552 §5.21.3 — RES* mismatch: authentication failed */
+        ausf_metrics_inst_global_inc(AUSF_METR_GLOB_CTR_AUTH_FAIL);
     } else {
         ausf_ue->auth_result = OpenAPI_auth_result_AUTHENTICATION_SUCCESS;
+        /* TS 28.552 §5.21.3 — RES* match: authentication succeeded */
+        ausf_metrics_inst_global_inc(AUSF_METR_GLOB_CTR_AUTH_SUCC);
     }
 
     r = ausf_sbi_discover_and_send(


### PR DESCRIPTION
Add three 3GPP-mandated performance counters to the AUSF:
  - fivegs_ausffunction_auth_authreq   (initiated auth requests)
  - fivegs_ausffunction_auth_authsucc  (successful authentications)
  - fivegs_ausffunction_auth_authfail  (RES* mismatch failures)

Counters follow the existing AMF metrics pattern (metrics.h / metrics.c pair, libmetrics_dep in meson.build). ausf_metrics_init() is called before ogs_sbi_context_init() in ausf_initialize(), consistent with how amf_metrics_init() is wired in amf/init.c.

Spec ref: 3GPP TS 28.552 Table 5.21.3-1