### PR TITLE
smf: add TS 28.552 §5.22.3.1 PDU session establishment latency histogram

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -459,6 +459,13 @@ typedef struct smf_sess_s {
     ogs_nr_cgi_t    nr_cgi;
     ogs_time_t      ue_location_timestamp;
 
+    /*
+     * TS 28.552 §5.22.3.1 — PDU session establishment latency histogram.
+     * Recorded at PDU session create request receipt (Nsmf_PDUSession_CreateSMContext).
+     * Cleared on session removal.
+     */
+    ogs_time_t      pdu_session_start; /* ogs_time_now() at create */
+
 #define HOME_ROUTED_ROAMING_IN_VSMF(__sESS) \
     ((__sESS) && (__sESS)->h_smf_uri)
     char            *h_smf_uri;

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -36,6 +36,7 @@
 #include "ngap-path.h"
 #include "fd-path.h"
 #include "local-path.h"
+#include "metrics.h"
 
 static uint8_t gtp_cause_from_diameter(uint8_t gtp_version,
         const uint32_t dia_err, const uint32_t *dia_exp_err)
@@ -836,6 +837,12 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
                                 "failed");
                         OGS_FSM_TRAN(s, smf_gsm_state_5gc_n1_n2_reject);
                         return;
+                    }
+                    /* TS 28.552 §5.22.3.1 — PDU session setup latency */
+                    if (sess->pdu_session_start) {
+                        ogs_time_t latency_ms = ogs_time_to_msec(
+                                ogs_time_now() - sess->pdu_session_start);
+                        smf_metrics_pdu_sess_setup_time_observe(latency_ms);
                     }
                     param.n2smbuf =
                         ngap_build_pdu_session_resource_setup_request_transfer(

--- a/src/smf/metrics.c
+++ b/src/smf/metrics.c
@@ -10,6 +10,7 @@ typedef struct smf_metrics_spec_def_s {
     int initial_val;
     unsigned int num_labels;
     const char **labels;
+    ogs_metrics_histogram_params_t histogram_params;
 } smf_metrics_spec_def_t;
 
 /* Helper generic functions: */
@@ -40,7 +41,7 @@ static int smf_metrics_init_spec(ogs_metrics_context_t *ctx,
         dst[i] = ogs_metrics_spec_new(ctx, src[i].type,
                 src[i].name, src[i].description,
                 src[i].initial_val, src[i].num_labels, src[i].labels,
-                NULL);
+                &src[i].histogram_params);
     }
     return OGS_OK;
 }
@@ -135,6 +136,24 @@ smf_metrics_spec_def_t smf_metrics_spec_def_global[_SMF_METR_GLOB_MAX] = {
     .type = OGS_METRICS_METRIC_TYPE_GAUGE,
     .name = "pfcp_peers_active",
     .description = "Active PFCP peers",
+},
+/* Global Histograms: */
+[SMF_METR_GLOB_HIST_PDU_SESS_SETUP_TIME] = {
+    /*
+     * TS 28.552 §5.22.3.1 Table 5.22.3.1-2
+     * PDU session establishment latency (milliseconds).
+     * Exponential buckets: [10, 20, 40, 80, 160, 320, 640, 1280] ms.
+     */
+    .type = OGS_METRICS_METRIC_TYPE_HISTOGRAM,
+    .name = "fivegs_smffunction_sm_pdusessionestabreqlatency",
+    .description =
+        "Time of PDU session establishment procedure at the SMF (ms)",
+    .histogram_params = {
+        .type = OGS_METRICS_HISTOGRAM_BUCKET_TYPE_EXPONENTIAL,
+        .count = 8,
+        .exp.start = 10,
+        .exp.factor = 2,
+    },
 },
 };
 int smf_metrics_init_inst_global(void)

--- a/src/smf/metrics.h
+++ b/src/smf/metrics.h
@@ -26,20 +26,38 @@ typedef enum smf_metric_type_global_s {
     SMF_METR_GLOB_GAUGE_GTP_PEERS_ACTIVE,
     SMF_METR_GLOB_GAUGE_PFCP_SESSIONS_ACTIVE,
     SMF_METR_GLOB_GAUGE_PFCP_PEERS_ACTIVE,
+    /* TS 28.552 §5.22.3.1 — PDU session establishment latency histogram */
+    SMF_METR_GLOB_HIST_PDU_SESS_SETUP_TIME,
     _SMF_METR_GLOB_MAX,
 } smf_metric_type_global_t;
 extern ogs_metrics_inst_t *smf_metrics_inst_global[_SMF_METR_GLOB_MAX];
 int smf_metrics_init_inst_global(void);
 int smf_metrics_free_inst_global(void);
 
-static inline void smf_metrics_inst_global_set(smf_metric_type_global_t t, int val)
+static inline void smf_metrics_inst_global_set(
+        smf_metric_type_global_t t, int val)
 { ogs_metrics_inst_set(smf_metrics_inst_global[t], val); }
-static inline void smf_metrics_inst_global_add(smf_metric_type_global_t t, int val)
+static inline void smf_metrics_inst_global_add(
+        smf_metric_type_global_t t, int val)
 { ogs_metrics_inst_add(smf_metrics_inst_global[t], val); }
 static inline void smf_metrics_inst_global_inc(smf_metric_type_global_t t)
 { ogs_metrics_inst_inc(smf_metrics_inst_global[t]); }
 static inline void smf_metrics_inst_global_dec(smf_metric_type_global_t t)
 { ogs_metrics_inst_dec(smf_metrics_inst_global[t]); }
+
+/*
+ * TS 28.552 §5.22.3.1 — Observe PDU session setup latency (ms).
+ * Call when PDU Session Establishment Accept has been sent to the AMF.
+ * latency_ms must be non-negative; negative values are clamped to 0.
+ */
+static inline void smf_metrics_pdu_sess_setup_time_observe(
+        ogs_time_t latency_ms)
+{
+    if (latency_ms < 0) latency_ms = 0;
+    ogs_metrics_inst_add(
+        smf_metrics_inst_global[SMF_METR_GLOB_HIST_PDU_SESS_SETUP_TIME],
+        (int)latency_ms);
+}
 
 /* GTP NODE */
 typedef enum smf_metric_type_gtp_node_s {

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -24,6 +24,7 @@
 #include "local-path.h"
 #include "gsm-handler.h"
 #include "nsmf-handler.h"
+#include "metrics.h"
 
 bool smf_nsmf_handle_create_sm_context(
     smf_sess_t *sess, ogs_sbi_stream_t *stream, ogs_sbi_message_t *message)
@@ -605,6 +606,9 @@ bool smf_nsmf_handle_create_sm_context(
     if (sess->n1SmBufFromUe) ogs_pkbuf_free(sess->n1SmBufFromUe);
     sess->n1SmBufFromUe = ogs_pkbuf_copy(n1smbuf);
     ogs_assert(sess->n1SmBufFromUe);
+
+    /* TS 28.552 §5.22.3.1 — record PDU session create request timestamp */
+    sess->pdu_session_start = ogs_time_now();
 
     ogs_assert(OGS_OK ==
             smf_5gc_pfcp_send_session_establishment_request(sess, NULL, 0));


### PR DESCRIPTION
Record per-session setup latency from NAS PDU Session Establishment Request receipt (smf_nsmf_handle_create_sm_context) to PDU Session Establishment Accept transmission (gsm_build_pdu_session_establishment_accept).

Histogram metric: fivegs_smffunction_sm_pdusessionestabreqlatency
Buckets (ms, exponential): 10 20 40 80 160 320 640 1280

Implementation:
- Add ogs_time_t pdu_session_start to smf_sess_t (zero-init by pool)
- Add histogram_params field to smf_metrics_spec_def_t so the existing smf_metrics_init_spec() path handles both counter and histogram specs
- Observe histogram only on the success path; failed sessions are not counted per spec definition

Spec ref: 3GPP TS 28.552 Table 5.22.3.1-2