### PR TITLE
[SMF] Pre-validate Modification Request QoS Flow parameters before mutation

### DIFF
--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -401,6 +401,71 @@ int gsm_handle_pdu_session_modification_qos_flow_descriptions(
         return OGS_ERROR;
     }
 
+    /*
+     * Pass 1 — pre-validation.
+     *
+     * Every QoS-flow parameter the inner switch dispatches on
+     * (identifier + bitrate unit) must be checked BEFORE any
+     * mutation of qos_flow state in Pass 2. A malformed
+     * description encountered mid-loop after one or more valid
+     * descriptions had already been applied would otherwise
+     * leave the SMF with bitrate updates committed locally while
+     * the UE rejects the entire Modification Request — a state
+     * drift that can only be unwound by detach/re-attach.
+     *
+     * Validates:
+     *  - parameter identifier is one of the spec-defined values
+     *    (TS 24.501 §9.11.4.12: 5QI, GFBR uplink/downlink,
+     *    MFBR uplink/downlink). Closes #4430.
+     *  - bitrate unit is in the spec-defined range
+     *    OGS_NAS_BR_UNIT_1K..OGS_NAS_BR_UNIT_256P
+     *    (TS 24.501 §9.11.4.13). Closes #4511.
+     */
+    for (i = 0; i < num_of_description; i++) {
+        for (j = 0; j < qos_flow_description[i].num_of_parameter; j++) {
+            ogs_nas_bitrate_t *br =
+                &qos_flow_description[i].param[j].br;
+
+            switch(qos_flow_description[i].param[j].identifier) {
+            case OGS_NAX_QOS_FLOW_PARAMETER_ID_5QI:
+                /* No bitrate field; nothing to validate. */
+                break;
+            case OGS_NAX_QOS_FLOW_PARAMETER_ID_GFBR_UPLINK:
+            case OGS_NAX_QOS_FLOW_PARAMETER_ID_GFBR_DOWNLINK:
+            case OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_UPLINK:
+            case OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_DOWNLINK:
+                if (br->unit < OGS_NAS_BR_UNIT_1K ||
+                    br->unit > OGS_NAS_BR_UNIT_256P) {
+                    ogs_error("[%s:%d] Invalid bitrate unit [%d] in "
+                            "qos_flow parameter [%d] at "
+                            "description[%d] index[%d]",
+                            smf_ue->supi, sess->psi, br->unit,
+                            qos_flow_description[i].param[j].identifier,
+                            i, j);
+                    return OGS_ERROR;
+                }
+                break;
+            default:
+                ogs_error("[%s:%d] Unknown qos_flow parameter "
+                        "identifier [%d] at description[%d] index[%d]",
+                        smf_ue->supi, sess->psi,
+                        qos_flow_description[i].param[j].identifier,
+                        i, j);
+                return OGS_ERROR;
+            }
+        }
+    }
+
+    /*
+     * Pass 2 — apply the validated descriptions.
+     *
+     * Pass 1 has already proven that every parameter identifier
+     * is in the dispatch set and every bitrate unit is in the
+     * spec range. The default branch below is therefore an
+     * engineering invariant, not reachable from peer input;
+     * keep ogs_assert_if_reached() as a guard-rail in case a
+     * future Pass 1 extension forgets a case.
+     */
     for (i = 0; i < num_of_description; i++) {
         smf_bearer_t *qos_flow =
             smf_qos_flow_find_by_qfi(
@@ -433,7 +498,7 @@ int gsm_handle_pdu_session_modification_qos_flow_descriptions(
                 break;
             default:
                 ogs_fatal("Unknown qos_flow parameter identifier [%d]",
-                        qos_flow_description[i].param[i].identifier);
+                        qos_flow_description[i].param[j].identifier);
                 ogs_assert_if_reached();
             }
         }


### PR DESCRIPTION
# SMF: pre-validate Modification Request QoS Flow parameters before mutation

Closes #4511 (bitrate unit out of spec range).
Closes #4430 (unknown qos_flow parameter identifier).

Both reported by @Vechicken. Both are SMF-side abort vectors
triggered by malformed UE NAS PDU Session Modification Request
input, both rooted in the same handler:
`gsm_handle_pdu_session_modification_qos_flow_descriptions()`.

## Summary

Adds a Pass-1 pre-validation walk that checks every parameter
identifier and every bitrate unit before any mutation of
`qos_flow` state in Pass 2. On failure, returns `OGS_ERROR` with
SMF state unchanged.

Single file (`src/smf/gsm-handler.c`), +66/-1.

## Why pre-validate, and not change the helper

A natural-looking alternative would be to make
`ogs_nas_bitrate_to_uint64()` return `0` instead of asserting on
unknown units. That helper lives in `lib/nas/common/types.c` and
is used by SMF, AMF, MME and other NFs; silently changing its
contract would risk producing zero-bitrate flows (which in many
NAS contexts means "blocked" or "best-effort" rather than
"error") in NFs whose validation discipline differs from the
SMF's. The library function is left untouched here; its
`ogs_assert_if_reached()` continues to act as a caller-contract
guard-rail. Validation lives in the caller, where the malformed
UE input actually arrives.

The same reasoning applies to the in-handler `default:` branch
in Pass 2: post-validation it is an engineering invariant rather
than a peer-input handler, so its `ogs_assert_if_reached()` is
preserved (a future Pass-1 extension that forgets a case will
now trip on the engineering side, not in production traffic).

## Why two passes, not validate-during-mutation

The Pass-2 dispatch writes `qos_flow->qos.{gbr,mbr}.{uplink,downlink}`
inline as it visits each parameter. Returning `OGS_ERROR`
mid-loop after one or more valid descriptions had already been
applied would commit those bitrate updates to SMF state while
the UE rejects the entire Modification Request — a state drift
between core and UE that only detach + re-attach can resolve.
Pre-validation is read-only and decides up-front whether the
Modification Request is fully processable; only then does
Pass 2 commit any state.

## Bug 1 — #4511: bitrate unit out of spec range

Reporter steps: complete normal registration + PDU session
establishment, then send a Modification Request with a QoS Flow
Description carrying GFBR / MFBR with `unit = 0` (or any value
> `0x19`). SMF aborts with

```
[nas] FATAL: Unknown unit [0] (../lib/nas/common/types.c:502)
[nas] FATAL: ogs_nas_bitrate_to_uint64: should not be reached.
```

`ogs_nas_bitrate_to_uint64()` ends with
`ogs_fatal(...) + ogs_assert_if_reached()`. Per TS 24.501
§9.11.4.13 only `0x01..0x19` are spec-defined; UE-supplied input
outside that range is malformed and reaches the assert.

## Bug 2 — #4430: unknown qos_flow parameter identifier

Reporter steps: send a Modification Request with malformed QoS
Flow Descriptions:

```
[QFI=1, code=CREATE, E=1, num_params=9]
    header + 8×[5QI, len=1, val=9] + [0,0,0]
```

`num_params=9` is declared but only 8 actual params are present;
the 9th iteration in this handler reads a zero-initialised entry
whose `identifier` field falls into the `default:` branch's
`ogs_assert_if_reached()` and the SMF aborts.

## Fix

Add Pass 1 before the existing mutation loop:

```c
for (i = 0; i < num_of_description; i++) {
    for (j = 0; j < qos_flow_description[i].num_of_parameter; j++) {
        ogs_nas_bitrate_t *br = &qos_flow_description[i].param[j].br;

        switch(qos_flow_description[i].param[j].identifier) {
        case OGS_NAX_QOS_FLOW_PARAMETER_ID_5QI:
            /* No bitrate field; nothing to validate. */
            break;
        case OGS_NAX_QOS_FLOW_PARAMETER_ID_GFBR_UPLINK:
        case OGS_NAX_QOS_FLOW_PARAMETER_ID_GFBR_DOWNLINK:
        case OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_UPLINK:
        case OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_DOWNLINK:
            if (br->unit < OGS_NAS_BR_UNIT_1K ||
                br->unit > OGS_NAS_BR_UNIT_256P) {
                ogs_error(...);
                return OGS_ERROR;
            }
            break;
        default:
            ogs_error(...);
            return OGS_ERROR;
        }
    }
}

/* Pass 2: original mutation loop, unchanged structure. */
```

Pass 2 is the original `for (i = 0; i < num_of_description; i++)`
loop, kept as-is — its dispatch is now reached only with
pre-validated input.

## Pre-existing copy-paste typo

While moving past the `default:` log line in Pass 2 we noticed a
stale typo from prior code: `param[i].identifier` (using the
outer rule index) where `param[j].identifier` was meant.
Corrected on the line we touched. Cosmetic — the line is now
unreachable from peer input post-validation.

## Spec references

- 3GPP TS 24.501 §9.11.4.12 — Authorized QoS Flow Descriptions,
  parameter identifiers (5QI=0x01, GFBR uplink=0x02, GFBR
  downlink=0x03, MFBR uplink=0x04, MFBR downlink=0x05)
- 3GPP TS 24.501 §9.11.4.13 — Session-AMBR / GFBR / MFBR
  encoding, unit values `0x01..0x19`

## Testing

- Builds clean against current upstream main (commit `288f1ca49`):
  `ninja -C build src/smf/open5gs-smfd` succeeds, no library
  changes (`lib/nas/common/types.c` is untouched).
- Behaviour for valid Modification Requests is identical: Pass 1
  is read-only and lets all spec-defined input through; Pass 2 is
  the original mutation loop unchanged.
- Both reporter reproducers produce a single `ogs_error` log
  line and an `OGS_ERROR` return — the SMF rejects the
  Modification Request toward the UE and continues serving
  other UEs without state corruption.

## Scope note

The hidden sibling case in
`gsm_handle_pdu_session_modification_qos_rules()` (state-drift
risk on multi-rule Modification Requests where one rule is
malformed) is structurally similar. Addressed in a separate PR
because it has its own root cause (a one-character index typo)
and its own reporter context (#4429 / #4512).
