### PR TITLE
[SMF] Pre-validate Modification Request QoS rules before mutation

### DIFF
--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -237,6 +237,73 @@ int gsm_handle_pdu_session_modification_qos_rules(
         return OGS_ERROR;
     }
 
+    /*
+     * Pass 1 — pre-validation.
+     *
+     * Pass 2 below mutates qos_flow state (smf_pf_remove_all,
+     * smf_pf_add, ipfw_rule writes via reconfigure_packet_filter)
+     * inside the per-rule loop. A malformed rule encountered
+     * mid-loop after one or more valid rules had already been
+     * applied would otherwise leave the SMF with PF-list updates
+     * committed locally while the UE rejects the entire
+     * Modification Request — a state drift between core and UE
+     * that only detach + re-attach can resolve.
+     *
+     * Validates per rule:
+     *  - code is one of the spec-defined values (TS 24.501
+     *    §9.11.4.13: DELETE / CREATE_NEW / MODIFY_AND_ADD /
+     *    MODIFY_AND_REPLACE).
+     *  - for non-DELETE rules with packet filters, each packet
+     *    filter is dispatchable through reconfigure_packet_filter
+     *    when called with the inner index `j` (the filter's
+     *    actual position within the rule). Uses a stack-local
+     *    scratch_pf so this is read-only with respect to
+     *    qos_flow state.
+     */
+    for (i = 0; i < num_of_rule; i++) {
+        switch (qos_rule[i].code) {
+        case OGS_NAS_QOS_CODE_DELETE_EXISTING_QOS_RULE:
+            /* No packet filter content to validate. */
+            break;
+        case OGS_NAS_QOS_CODE_CREATE_NEW_QOS_RULE:
+        case OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_AND_ADD_PACKET_FILTERS:
+        case OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_AND_REPLACE_ALL_PACKET_FILTERS:
+            for (j = 0; j < qos_rule[i].num_of_packet_filter &&
+                        j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
+                smf_pf_t scratch_pf = { 0 };
+
+                if (reconfigure_packet_filter(
+                            &scratch_pf, &qos_rule[i], j) <= 0) {
+                    ogs_error("[%s:%d] Invalid packet filter at "
+                            "rule[%d] pf[%d] (rule_id[%d] pf_id[%d])",
+                            smf_ue->supi, sess->psi, i, j,
+                            qos_rule[i].identifier,
+                            qos_rule[i].pf[j].identifier);
+                    return OGS_ERROR;
+                }
+            }
+            break;
+        default:
+            ogs_error("[%s:%d] Unknown QoS rule code [%d] at rule[%d]",
+                    smf_ue->supi, sess->psi, qos_rule[i].code, i);
+            return OGS_ERROR;
+        }
+    }
+
+    /*
+     * Pass 2 — apply the validated rules.
+     *
+     * Pass 1 has already proven that every reachable code is
+     * spec-defined and every packet filter would dispatch
+     * cleanly through reconfigure_packet_filter() at index j.
+     * The reconfigure_packet_filter() call below therefore
+     * carries the corrected index `j` (was: outer rule index
+     * `i`, a copy-paste typo that triggered an OOB read on
+     * multi-rule shapes — issues #4429 and #4512). The
+     * trailing ogs_assert(... > 0) is preserved as an
+     * engineering guard-rail; with Pass 1 in place it should
+     * never fire from peer input.
+     */
     for (i = 0; i < num_of_rule; i++) {
         smf_pf_t *pf = NULL;
         smf_bearer_t *qos_flow =
@@ -272,7 +339,7 @@ int gsm_handle_pdu_session_modification_qos_rules(
                 ogs_assert(pf);
 
                 ogs_assert(
-                    reconfigure_packet_filter(pf, &qos_rule[i], i) > 0);
+                    reconfigure_packet_filter(pf, &qos_rule[i], j) > 0);
 /*
  * Refer to lib/ipfw/ogs-ipfw.h
  * Issue #338


### PR DESCRIPTION
# SMF: pre-validate Modification Request QoS rules before mutation

Closes #4429.
Closes #4512.

Both reported by @Vechicken with two distinct NAS PDU Session
Modification Request shapes that exercise the same root cause:
a copy-paste loop-index typo passed to a helper, leading to an
out-of-bounds read and an SMF process abort.

## Summary

Two structural changes in
`gsm_handle_pdu_session_modification_qos_rules()`:

1. The actual root-cause fix: pass the inner loop's
   packet-filter index `j` (not the outer rule index `i`) to
   `reconfigure_packet_filter()`.
2. A Pass-1 pre-validation walk that checks every rule code and
   dry-runs `reconfigure_packet_filter()` against a stack-local
   scratch_pf before any `qos_flow` state mutation happens in
   Pass 2.

Single file (`src/smf/gsm-handler.c`), +68/-1.

## Root cause

`reconfigure_packet_filter()` is declared

```c
static int reconfigure_packet_filter(
        smf_pf_t *pf, ogs_nas_qos_rule_t *qos_rule, int i)
```

and uses its third parameter as the **packet filter index** within
the rule:

```c
pf->direction = qos_rule->pf[i].direction;
for (j = 0; j < qos_rule->pf[i].content.num_of_component; j++) { ... }
return j;
```

The caller walks the QoS rules with `i` and the per-rule packet
filters with `j`, but passes the outer rule index `i`:

```c
for (i = 0; i < num_of_rule; i++) {
    ...
    for (j = 0; j < qos_rule[i].num_of_packet_filter; j++) {
        pf = smf_pf_add(qos_flow);
        ogs_assert(pf);

        ogs_assert(
            reconfigure_packet_filter(pf, &qos_rule[i], i) > 0);
                                                       /* should be j */
    }
}
```

In the common single-rule case `i == j == 0` and the bug is
hidden. Multi-rule shapes drive `i ≥ rule->num_of_packet_filter`,
the helper reads past the meaningful packet-filter array into a
zero-initialised slot, returns `0`, and the caller's
`ogs_assert(... > 0)` aborts the SMF.

## Reporter reproducers

Both shapes drive `i ≥ rule's num_of_packet_filter`:

### #4429 (2026-04-20): two CREATE rules with the same Rule Identifier

```
rule[0]: id=1, code=CREATE_NEW, direction=downlink, QFI=1
rule[1]: id=1, code=CREATE_NEW, direction=downlink, QFI=1
```

When `i==1` for `rule[1]`, the helper tries `qos_rule[1].pf[1]`
— but rule[1] carries one packet filter (`pf[0]`), so `pf[1]`
is the zero-initialised slot.

### #4512 (2026-05-02): DELETE + CREATE on the same Rule Identifier

```
rule[0]: id=1, op=DELETE
rule[1]: id=1, op=CREATE, packet_filter[0]: ipv4 192.168.1.1/24
```

Same dynamics: when the loop reaches `rule[1]` (`i==1`) the
helper is called with the wrong index and trips the OOB read.

## Why pre-validate (not validate-during-mutation)

The Pass-2 mutation loop calls `smf_pf_remove_all()` (DELETE
branch and reset-on-CREATE branch) and `smf_pf_add()` +
`reconfigure_packet_filter()`'s `ipfw_rule` writes (CREATE-class
branches) inline. Returning `OGS_ERROR` mid-loop after one or
more valid rules had already been applied would commit those
PF-list updates to SMF state while the UE rejects the entire
Modification Request — a state drift between core and UE that
only detach + re-attach can resolve. Pre-validation is read-only
and decides up-front whether the request is fully processable.

Rollback-on-error in C is a fragile alternative: the mutations
include `smf_pf_remove_all()` (irreversible without saving prior
state), `smf_pf_add()` (must be paired with explicit
`smf_pf_remove()`), and `ipfw_rule` writes inside
`reconfigure_packet_filter()`. The two-pass approach avoids
introducing that machinery.

## Fix

```c
/* Pass 1 — pre-validation. Read-only. */
for (i = 0; i < num_of_rule; i++) {
    switch (qos_rule[i].code) {
    case OGS_NAS_QOS_CODE_DELETE_EXISTING_QOS_RULE:
        break;
    case OGS_NAS_QOS_CODE_CREATE_NEW_QOS_RULE:
    case OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_AND_ADD_PACKET_FILTERS:
    case OGS_NAS_QOS_CODE_MODIFY_EXISTING_QOS_RULE_AND_REPLACE_ALL_PACKET_FILTERS:
        for (j = 0; j < qos_rule[i].num_of_packet_filter &&
                    j < OGS_MAX_NUM_OF_FLOW_IN_NAS; j++) {
            smf_pf_t scratch_pf = { 0 };

            if (reconfigure_packet_filter(
                        &scratch_pf, &qos_rule[i], j) <= 0) {
                ogs_error(...);
                return OGS_ERROR;
            }
        }
        break;
    default:
        ogs_error(...);
        return OGS_ERROR;
    }
}

/* Pass 2 — apply. The reconfigure_packet_filter() call below
 * now passes `j` (was: `i`, copy-paste typo). */
for (i = 0; i < num_of_rule; i++) {
    ...
    for (j = 0; j < qos_rule[i].num_of_packet_filter && ...; j++) {
        pf = smf_pf_add(qos_flow);
        ogs_assert(pf);

        ogs_assert(
            reconfigure_packet_filter(pf, &qos_rule[i], j) > 0);
                                                       /* ↑ was: i */
    }
}
```

The Pass-2 `ogs_assert(... > 0)` is preserved as an engineering
guard-rail; with Pass 1 in place it should never fire from peer
input.

## Why dry-run with `smf_pf_t scratch_pf = { 0 }`

`reconfigure_packet_filter()` writes to `pf->direction` and
`pf->ipfw_rule` only, after a `memset(&pf->ipfw_rule, 0, ...)`
on entry. Passing a stack-local scratch makes Pass 1's call
read-only with respect to session state — no `qos_flow` is
touched, no allocation happens — while still exercising the same
dispatch the helper performs in Pass 2.

## Spec references

- 3GPP TS 24.501 §9.11.4.13 — Authorized QoS Rules / packet
  filter list semantics

## Testing

- Builds clean against current upstream main (commit `288f1ca49`):
  `ninja -C build src/smf/open5gs-smfd` succeeds with no
  warnings.
- Behaviour for valid input is identical: in the single-rule
  case (`i==j==0`) the helper sees the same array slot before
  and after the patch; Pass 1 is read-only.
- Both reporter reproducers (#4429 + #4512) now reject cleanly
  with a single `ogs_error` log line and `OGS_ERROR` return —
  the SMF process and other PDU sessions stay up.

## Scope note

`reconfigure_packet_filter()`'s third parameter `i` shadows the
caller's outer-loop convention by name; renaming it (`pf_index`
or similar) and/or hoisting the `qos_rule->pf[index]` access
into a single point inside the helper would prevent this class
of bug from recurring. Out of scope here — happy to file a
separate cleanup PR if @acetcom prefers.
