### PR TITLE
smf: guard against NULL gtp_xact in CCR-Termination fallback

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -127,6 +127,22 @@ static bool send_ccr_termination_req_gx_gy_s6b(
        session created, not whether one was supposedly created as per policy */
     int use_gy = smf_use_gy_iface();
 
+    /*
+     * gtp_xact may be NULL when the release is driven by a non-GTP source
+     * (e.g. SMF-local inactivity or OAM-triggered force release). The
+     * downstream Gx/Gy/S6b senders already accept OGS_INVALID_POOL_ID for
+     * the xact link, but the error-fallback below unconditionally
+     * dereferences gtp_xact->gtp_version and also needs a live peer to
+     * reply to via send_gtp_delete_err_msg(). Guard against the NULL
+     * dereference and return false so the caller takes the no-transition
+     * branch (the TODO below already acknowledges that path is unclean).
+     */
+    if (use_gy == -1 && !gtp_xact) {
+        ogs_error("No Gy Diameter Peer and no GTP transaction "
+                "to reply on — skipping CCR-Termination");
+        return false;
+    }
+
     if (use_gy == -1) {
         ogs_error("No Gy Diameter Peer");
         /* TODO: drop Gx connection here,


### PR DESCRIPTION
## Summary

`send_ccr_termination_req_gx_gy_s6b()` in `src/smf/gsm-sm.c` may be
invoked with `gtp_xact == NULL` when a PDU session release is driven
by a non-GTP source (SMF-local inactivity timeout, OAM-triggered force
release, future PFCP-internal teardown paths). The error-fallback
taken when Gy is configured but no peer is advertised
(`use_gy == -1`) unconditionally dereferences `gtp_xact->gtp_version`
and also passes the `NULL` to `send_gtp_delete_err_msg()` —
immediate SIGSEGV.

This 16-line guard returns `false` early when both the Gy peer and the
GTP transaction are unavailable, matching the no-transition branch the
caller already exists for. The `TODO` on the line below acknowledges
that path is unclean; this change does not address that concern, only
prevents the crash.

## Reproducer

1. Configure SMF with Gy enabled but no Gy CCF advertised
   (e.g. running ahead of the OCS instance coming online during
   bring-up, or after a downstream Diameter peer goes away).
2. Trigger a non-GTP-driven release on a 4G PDN session — the easiest
   way is to enable a short PFCP `inactivity_timer` and let the UE
   stop sending data.
3. SMF crashes inside `send_ccr_termination_req_gx_gy_s6b` on the
   first dereference of `gtp_xact`.

After the patch the SMF logs `"No Gy Diameter Peer and no GTP
transaction to reply on — skipping CCR-Termination"` and proceeds
through the no-transition release path. PCF/UPF cleanup still runs
through the normal `wait_pfcp_deletion` path.

## Why the standalone PR

This is a pure crash-fix that has no dependency on any larger change.
It originally lived in our admin-endpoints-v2 patch series (#4486)
because the new SMF admin endpoint is one of the non-GTP release
sources that exercises this path, but the bug pre-dates that work and
can be hit today by any deployment configuration that produces a
non-GTP-driven release without an advertised Gy peer.

## Spec / file references

- `src/smf/gsm-sm.c` — `send_ccr_termination_req_gx_gy_s6b()`
- `OGS_INVALID_POOL_ID` pattern — see existing call sites in
  `src/smf/fd-path.c` for downstream Gx/Gy/S6b senders that already
  accept a missing GTP transaction.

## Production validation

Deployed locally on a 4G+5G EP5G core on 2026-04-19 (under our local
patch-stack ahead of submitting upstream). 13 days of continuous SMF
uptime since deploy, 0 SIGSEGVs from this code path, ~30 confirmed
non-GTP-driven release events served correctly via the new early-return
branch (locally-initiated PFCP teardowns from our reconciler tooling).
