### PR TITLE
amf: verify UE Security Capabilities on PathSwitchRequest (TS 33.501 …

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2842,7 +2842,6 @@ void ngap_handle_path_switch_request(
     NGAP_EUTRAintegrityProtectionAlgorithms_t
         *eUTRAintegrityProtectionAlgorithms = NULL;
     uint16_t nr_ea = 0, nr_ia = 0, eutra_ea = 0, eutra_ia = 0;
-    uint8_t nr_ea0 = 0, nr_ia0 = 0, eutra_ea0 = 0, eutra_ia0 = 0;
 
     NGAP_PDUSessionResourceToBeSwitchedDLItem_t *PDUSessionItem = NULL;
     OCTET_STRING_t *transfer = NULL;
@@ -3104,30 +3103,39 @@ void ngap_handle_path_switch_request(
         ogs_assert(r != OGS_ERROR);
         return;
     }
+    /* TS 33.501 §6.7.3.1: verify received UE Security Capabilities
+     * against locally stored values from NAS registration.
+     * On mismatch, retain the stored (authoritative) values and log. */
     memcpy(&nr_ea, nRencryptionAlgorithms->buf, sizeof(nr_ea));
     nr_ea = be16toh(nr_ea);
-    nr_ea0 = amf_ue->ue_security_capability.nr_ea0;
-    amf_ue->ue_security_capability.nr_ea = nr_ea >> 9;
-    amf_ue->ue_security_capability.nr_ea0 = nr_ea0;
-
     memcpy(&nr_ia, nRintegrityProtectionAlgorithms->buf, sizeof(nr_ia));
     nr_ia = be16toh(nr_ia);
-    nr_ia0 = amf_ue->ue_security_capability.nr_ia0;
-    amf_ue->ue_security_capability.nr_ia = nr_ia >> 9;
-    amf_ue->ue_security_capability.nr_ia0 = nr_ia0;
-
     memcpy(&eutra_ea, eUTRAencryptionAlgorithms->buf, sizeof(eutra_ea));
     eutra_ea = be16toh(eutra_ea);
-    eutra_ea0 = amf_ue->ue_security_capability.eutra_ea0;
-    amf_ue->ue_security_capability.eutra_ea = eutra_ea >> 9;
-    amf_ue->ue_security_capability.eutra_ea0 = eutra_ea0;
-
     memcpy(&eutra_ia,
             eUTRAintegrityProtectionAlgorithms->buf, sizeof(eutra_ia));
     eutra_ia = be16toh(eutra_ia);
-    eutra_ia0 = amf_ue->ue_security_capability.eutra_ia0;
-    amf_ue->ue_security_capability.eutra_ia = eutra_ia >> 9;
-    amf_ue->ue_security_capability.eutra_ia0 = eutra_ia0;
+
+    if ((nr_ea >> 9) != (amf_ue->ue_security_capability.nr_ea & 0x7f) ||
+            (nr_ia >> 9) !=
+                (amf_ue->ue_security_capability.nr_ia & 0x7f) ||
+            (eutra_ea >> 9) !=
+                (amf_ue->ue_security_capability.eutra_ea & 0x7f) ||
+            (eutra_ia >> 9) !=
+                (amf_ue->ue_security_capability.eutra_ia & 0x7f)) {
+        ogs_warn("[%s] UE Security Capability mismatch on PathSwitchRequest"
+                " (TS 33.501 clause 6.7.3.1) - retaining stored values",
+                amf_ue->supi ? amf_ue->supi : "unknown");
+        ogs_warn("    Stored NR_EA:0x%x NR_IA:0x%x EUTRA_EA:0x%x"
+                " EUTRA_IA:0x%x",
+                amf_ue->ue_security_capability.nr_ea,
+                amf_ue->ue_security_capability.nr_ia,
+                amf_ue->ue_security_capability.eutra_ea,
+                amf_ue->ue_security_capability.eutra_ia);
+        ogs_warn("    Received NR_EA:0x%x NR_IA:0x%x EUTRA_EA:0x%x"
+                " EUTRA_IA:0x%x",
+                nr_ea >> 9, nr_ia >> 9, eutra_ea >> 9, eutra_ia >> 9);
+    }
 
     /* Update Security Context (NextHop) */
     amf_ue->nhcc++;


### PR DESCRIPTION
Fixes #4393.

### issue

`ngap_handle_path_switch_request` unconditionally overwrites the AMF's stored UE security capabilities with values received from the target gNB. 

This violates TS 33.501 clause 6.7.3.1, ( AMF must  verify received capabilities against locally stored values AND retain its own on mismatch).

 A rogue gNB can exploit this by sending a PathSwitchRequest with null or arbitrary capability fields. The corrupted values propagate to legitimate gNBs via subsequent HandoverRequest messages, causing handover failures ( that persist) until the UE re-registers.

### Fix

Replace the unconditional overwrite with a comparison against the capabilities stored during NAS registration. If there is a  mismatch, the stored values are retained and a warn-level log is emitted with both stored and received values for incident analysis.

### some notes

- The same blind-overwrite pattern exists in `s1ap_handle_path_switch_request` (MME, TS 33.401 equivalent). to be addressed separately.
- TS 33.501 clause6.7.3.1 also calls for including the correct UESecurityCapabilities in the PathSwitchRequestAcknowledge on mismatch
- This may warrant a CVE .
