### PR TITLE
mme: verify UE Security Capabilities on S1AP PathSwitchRequest (TS 33…

### DIFF
--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -2714,7 +2714,6 @@ void s1ap_handle_path_switch_request(
     S1AP_EncryptionAlgorithms_t    *encryptionAlgorithms = NULL;
     S1AP_IntegrityProtectionAlgorithms_t *integrityProtectionAlgorithms = NULL;
     uint16_t eea = 0, eia = 0;
-    uint8_t eea0 = 0, eia0 = 0;
 
     enb_ue_t *enb_ue = NULL;
     mme_ue_t *mme_ue = NULL;
@@ -3013,11 +3012,11 @@ void s1ap_handle_path_switch_request(
         ogs_assert(r != OGS_ERROR);
         return;
     }
+    /* TS 33.401 §7.2.4.4: verify received UE Security Capabilities
+     * against locally stored values from NAS Attach/TAU.
+     * On mismatch, retain the stored (authoritative) values and log. */
     memcpy(&eea, encryptionAlgorithms->buf, sizeof(eea));
     eea = be16toh(eea);
-    eea0 = mme_ue->ue_network_capability.eea0;
-    mme_ue->ue_network_capability.eea = eea >> 9;
-    mme_ue->ue_network_capability.eea0 = eea0;
 
     if (integrityProtectionAlgorithms->size != sizeof(eia)) {
         ogs_error("Invalid integrityProtectionAlgorithms->size = %d "
@@ -3034,9 +3033,19 @@ void s1ap_handle_path_switch_request(
     }
     memcpy(&eia, integrityProtectionAlgorithms->buf, sizeof(eia));
     eia = be16toh(eia);
-    eia0 = mme_ue->ue_network_capability.eia0;
-    mme_ue->ue_network_capability.eia = eia >> 9;
-    mme_ue->ue_network_capability.eia0 = eia0;
+
+    if ((eea >> 9) != (mme_ue->ue_network_capability.eea & 0x7f) ||
+            (eia >> 9) !=
+                (mme_ue->ue_network_capability.eia & 0x7f)) {
+        ogs_warn("[%s] UE Security Capability mismatch on PathSwitchRequest"
+                " (TS 33.401 clause 7.2.4.2.2) - retaining stored values",
+                mme_ue->imsi_bcd);
+        ogs_warn("    Stored EEA:0x%x EIA:0x%x",
+                mme_ue->ue_network_capability.eea,
+                mme_ue->ue_network_capability.eia);
+        ogs_warn("    Received EEA:0x%x EIA:0x%x",
+                eea >> 9, eia >> 9);
+    }
 
     /* Update Security Context (NextHop) */
     mme_ue->nhcc++;


### PR DESCRIPTION
Fixes #4519.

LTE/EPC equivalent of the NGAP fix in #4393. `s1ap_handle_path_switch_request` blindly overwrites the MME's stored UE network capabilities with values from the target eNB.

Per TS 33.401 §7.2.4.2.2, the MME must compare received capabilities against locally stored values from NAS Attach/TAU and retain the stored ones on mismatch. This patch replaces the unconditional overwrite with a comparison and warn-level logging on mismatch.

Note: unlike the NGAP PathSwitchRequestAcknowledge (which can optionally carry UESecurityCapabilities), the S1AP PathSwitchRequestAcknowledge structurally does not include this IE (TS 36.413 §9.1.5.9). Log-only is the correct response here in my opinion.