### PR TITLE
[NRF/SBI] Reject overflowing NFProfile inner lists with HTTP 400; cap parser

### DIFF
--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -431,12 +431,31 @@ static void handle_smf_info(
                     int dnn_index = nf_info->smf.slice
                         [nf_info->smf.num_of_slice].num_of_dnn;
 
-                    ogs_assert(dnn_index < OGS_MAX_NUM_OF_DNN);
+                    /*
+                     * Cap the per-slice DNN array at OGS_MAX_NUM_OF_DNN
+                     * (closes #4470). The previous ogs_assert() here
+                     * was reachable from peer-supplied SMF NF-profile
+                     * registrations carrying more than 16 DNN entries
+                     * in a single S-NSSAI slice, which crashed the NRF
+                     * with SIGABRT. The bound matches the existing
+                     * graceful pattern used by the outer slice loop at
+                     * line 421 and the TaiRange.tacRangeList loop a
+                     * few lines below.
+                     */
+                    if (dnn_index >= OGS_MAX_NUM_OF_DNN) {
+                        ogs_error("OVERFLOW DNN [%d:%d] in slice [%d]",
+                                dnn_index, OGS_MAX_NUM_OF_DNN,
+                                nf_info->smf.num_of_slice);
+                        break;
+                    }
                     nf_info->smf.slice[nf_info->smf.num_of_slice].
                         dnn[dnn_index] = ogs_strdup(DnnSmfInfoItem->dnn);
-                    ogs_assert(
-                        nf_info->smf.slice[nf_info->smf.num_of_slice].
-                            dnn[dnn_index]);
+                    if (!nf_info->smf.slice[nf_info->smf.num_of_slice].
+                            dnn[dnn_index]) {
+                        ogs_error("ogs_strdup() failed for DNN [%s]",
+                                DnnSmfInfoItem->dnn);
+                        break;
+                    }
                     nf_info->smf.slice[nf_info->smf.num_of_slice].
                         num_of_dnn++;
                 }
@@ -793,7 +812,22 @@ static void handle_amf_info(
                         TacRangeItem->start && TacRangeItem->end) {
                     int tac_index = nf_info->amf.nr_tai_range
                         [nf_info->amf.num_of_nr_tai_range].num_of_tac_range;
-                    ogs_assert(tac_index < OGS_MAX_NUM_OF_TAI);
+                    /*
+                     * Same defensive cap as the DNN inner loop in
+                     * handle_smf_info() above (closes #4467 sibling
+                     * site reported by LinZiyuu — the AMF-side
+                     * tacRangeList overflow has the same shape and
+                     * caused the same NRF SIGABRT). The graceful
+                     * pattern matches handle_smf_info()'s tacRangeList
+                     * inner loop at line 513.
+                     */
+                    if (tac_index >= OGS_MAX_NUM_OF_TAI) {
+                        ogs_error("OVERFLOW TAI [%d:%d] in tai_range "
+                                "[%d]",
+                                tac_index, OGS_MAX_NUM_OF_TAI,
+                                nf_info->amf.num_of_nr_tai_range);
+                        break;
+                    }
 
                     nf_info->amf.nr_tai_range
                         [nf_info->amf.num_of_nr_tai_range].start[tac_index] =

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -25,6 +25,67 @@ static int discover_handler(
 static void handle_nf_discover_search_result(
         OpenAPI_search_result_t *SearchResult);
 
+/*
+ * Pre-validate inner-loop list lengths in the NFProfile against the
+ * static array bounds the parser uses (lib/sbi/nnrf-handler.c).
+ * Returns true if the profile exceeds any pre-checked inner-loop
+ * bound; the caller surfaces an HTTP 400 Bad Request.
+ *
+ * Only inner-loop bounds that the parser would otherwise have to
+ * silently truncate (DNN per slice, TAC range per TAI range) are
+ * pre-checked here. State drift between NFs is fatal in the SBA, so
+ * a registration whose IE list overflows the local cache must be
+ * rejected explicitly, not stored partial. The outer-loop bounds
+ * (slice count, TAI count, TAI-range count, GUAMI count) still go
+ * through the existing cap-and-break pattern in the shared parser
+ * for now; tightening those into 400-rejects would be a separate
+ * PR with broader scope.
+ */
+static bool nfprofile_inner_lists_overflow(
+        OpenAPI_nf_profile_t *NFProfile, const char **offending)
+{
+    OpenAPI_lnode_t *node = NULL, *node2 = NULL;
+
+    ogs_assert(NFProfile);
+    ogs_assert(offending);
+
+    if (NFProfile->smf_info) {
+        OpenAPI_list_for_each(
+                NFProfile->smf_info->s_nssai_smf_info_list, node) {
+            OpenAPI_snssai_smf_info_item_t *item = node->data;
+            int dnn_count = 0;
+            if (!item) continue;
+            OpenAPI_list_for_each(item->dnn_smf_info_list, node2) {
+                dnn_count++;
+                if (dnn_count > OGS_MAX_NUM_OF_DNN) {
+                    *offending = "smfInfo.dnnSmfInfoList exceeds "
+                            "capacity (OGS_MAX_NUM_OF_DNN)";
+                    return true;
+                }
+            }
+        }
+    }
+
+    if (NFProfile->amf_info) {
+        OpenAPI_list_for_each(
+                NFProfile->amf_info->tai_range_list, node) {
+            OpenAPI_tai_range_t *range = node->data;
+            int tac_count = 0;
+            if (!range) continue;
+            OpenAPI_list_for_each(range->tac_range_list, node2) {
+                tac_count++;
+                if (tac_count > OGS_MAX_NUM_OF_TAI) {
+                    *offending = "amfInfo.taiRangeList[*].tacRangeList "
+                            "exceeds capacity (OGS_MAX_NUM_OF_TAI)";
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 /**
  * Handles NF registration in NRF. Validates the PLMN-ID against configured
  * serving PLMN-IDs and registers the NF instance if valid.
@@ -117,6 +178,30 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
             ogs_assert(true == ogs_sbi_server_send_error(
                 stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, recvmsg,
                 "PLMN-ID not allowed", NULL, NULL));
+            return false;
+        }
+    }
+
+    /*
+     * Pre-validate inner-loop list lengths against the static array
+     * bounds the parser uses. State drift between NFs in the SBA is
+     * fatal: silently truncating an oversized NFProfile here would
+     * leave a registered SMF advertising 16 DNNs when the operator
+     * configured 20, so a later NF discovery for the missing DNN
+     * returns 404 even though both ends believe they are in sync.
+     * Reject the registration cleanly so the registering NF (or its
+     * operator) sees the failure immediately. Closes #4470 / #4467
+     * for the inner-loop overflows; outer-loop overflows still go
+     * through the parser's cap-and-break (see PR body).
+     */
+    {
+        const char *offending = NULL;
+        if (nfprofile_inner_lists_overflow(NFProfile, &offending)) {
+            ogs_error("[%s] NFProfile rejected: %s",
+                    NFProfile->nf_instance_id, offending);
+            ogs_assert(true == ogs_sbi_server_send_error(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, recvmsg,
+                offending, NFProfile->nf_instance_id, NULL));
             return false;
         }
     }


### PR DESCRIPTION
## Summary

Two `ogs_assert()` sites in the shared NRF NFProfile parser are reachable from peer-supplied SBI traffic and crash any consuming NF (NRF, AMF, SMF) with `SIGABRT` on an oversized profile:

- `lib/sbi/nnrf-handler.c::handle_smf_info()` — assertion on `dnnSmfInfoList` length per S-NSSAI slice (cap = `OGS_MAX_NUM_OF_DNN`, currently 16).
- `lib/sbi/nnrf-handler.c::handle_amf_info()` — assertion on `tacRangeList` length per `taiRangeList[*]` entry (cap = `OGS_MAX_NUM_OF_TAI`, currently 16).

These are the two assertion sites that were **not** covered by `82b929007` ("sbi: Prevent NFProfile overflow in SMF/AMF info parsing", Feb 2026, Issues #4249 / #4250 / #4252). That commit hardened all five outer-list overflows in the same function plus the SMF-side `tacRangeList`; the SMF-side `dnnSmfInfoList` and the AMF-side `tacRangeList` were missed and remain `ogs_assert()` on `main`.

This PR follows the same `if (... >= cap) { ogs_error(...); break; }` idiom that `82b929007` established a few lines above each affected site.

## Vulnerability analysis

### Function shape

```c
static void handle_smf_info(ogs_sbi_nf_info_t *nf_info,
                            OpenAPI_smf_info_t *SmfInfo);
static void handle_amf_info(ogs_sbi_nf_info_t *nf_info,
                            OpenAPI_amf_info_t *AmfInfo);
```

Both are reached via `ogs_nnrf_nfm_handle_nf_profile()`, which has five callers across the SBI library and the NRF service code. The relevant input paths are:

1. NRF receives `nfRegister` from a peer NF — `src/nrf/nnrf-handler.c::nrf_nnrf_handle_nf_register()`
2. Any NF receives an NRF discovery response carrying peer NFProfiles — `lib/sbi/nf-sm.c`
3. Any NF receives an NRF subscription notification carrying a peer NFProfile — same path
4. NRF inter-instance `NfProfile` updates
5. NF-Set / SCP-mediated discovery responses

Vectors (1) and (2) are reachable from any peer that holds a TLS/mTLS-trusted SBI session — i.e. any registered or impersonatable NF on the same SBA.

### Vector A — `dnnSmfInfoList` per slice (Issue #4470)

```c
DnnSmfInfoList = sNssaiSmfInfoItem->dnn_smf_info_list;
OpenAPI_list_for_each(DnnSmfInfoList, node2) {
    DnnSmfInfoItem = node2->data;
    if (DnnSmfInfoItem && DnnSmfInfoItem->dnn) {
        int dnn_index = nf_info->smf.slice
            [nf_info->smf.num_of_slice].num_of_dnn;
        ogs_assert(dnn_index < OGS_MAX_NUM_OF_DNN);   /* <-- crash */
        ...
    }
}
```

A registering SMF that sets `smfInfo.sNssaiSmfInfoList[0].dnnSmfInfoList` with 17 or more entries (e.g. an operator who deployed a 20-DNN SMF without realising the parser cap is 16) drives the NRF process into `abort()`. The peer SMF gets neither a useful registration error nor a session.

### Vector B — `tacRangeList` per AMF TaiRange (Issue #4467 sibling)

```c
TacRangeList = TaiRangeItem->tac_range_list;
OpenAPI_list_for_each(TacRangeList, node2) {
    TacRangeItem = node2->data;
    if (TacRangeItem &&
            TacRangeItem->start && TacRangeItem->end) {
        int tac_index = nf_info->amf.nr_tai_range
            [nf_info->amf.num_of_nr_tai_range].num_of_tac_range;
        ogs_assert(tac_index < OGS_MAX_NUM_OF_TAI);   /* <-- crash */
        ...
    }
}
```

Symmetric to Vector A on the AMF side. The corresponding SMF-side `tacRangeList` was already converted to a graceful break by `82b929007`; the AMF-side site was missed.

### Auxiliary — `ogs_strdup()` failure on DNN

```c
nf_info->smf.slice[nf_info->smf.num_of_slice].
    dnn[dnn_index] = ogs_strdup(DnnSmfInfoItem->dnn);
ogs_assert(
    nf_info->smf.slice[nf_info->smf.num_of_slice].
        dnn[dnn_index]);   /* <-- crash on heap exhaustion */
```

Heap exhaustion during NF registration aborts the NRF. Converted to soft `ogs_error() + break` for symmetry.

## Reproduction

The reporters' minimal NFProfile fragment for Vector A is in https://github.com/open5gs/open5gs/issues/4470:

```yaml
smfInfo:
  sNssaiSmfInfoList:
    - sNssai:
        sst: 1
        sd: "000001"
      dnnSmfInfoList:
        - dnn: "internet01"
        - dnn: "internet02"
        ...
        - dnn: "internet17"   # one past OGS_MAX_NUM_OF_DNN
```

`POST /nnrf-nfm/v1/nf-instances/{nfInstanceId}` with this body and the NRF aborts with `Assertion 'dnn_index < OGS_MAX_NUM_OF_DNN' failed`. Same shape on the AMF side with 17 `tacRangeList` entries — see https://github.com/open5gs/open5gs/issues/4467.

## Fix — two-tier defence

The fix has two layers serving different trust boundaries.

### Tier 1 — pre-validation in the NRF register path (HTTP 400)

`src/nrf/nnrf-handler.c::nrf_nnrf_handle_nf_register()` now pre-checks the inner-loop list lengths in the incoming NFProfile via a new static helper `nfprofile_inner_lists_overflow()`. If `smfInfo.dnnSmfInfoList` or `amfInfo.taiRangeList[*].tacRangeList` exceeds the local capacity, the registration is rejected with **HTTP 400 Bad Request** and a descriptive offending-IE name. This matches the existing pattern that the PLMN-ID validation a few lines above uses.

Reject-on-overflow at registration time is the correct semantics here: silent truncation of an oversized registration is operationally fatal in the SBA. A registered SMF that advertises 16 DNNs while the operator configured 20 leaves later NF-discovery for the missing four DNNs returning 404 even though both ends believe they are in sync. Surfacing the failure at the registering NF immediately is the only debuggable behaviour.

### Tier 2 — graceful cap-and-break in the shared parser

The two assertion sites in `lib/sbi/nnrf-handler.c::handle_smf_info()` and `::handle_amf_info()` are converted from `ogs_assert()` to the same `ogs_error() + break` idiom that `82b929007` established for the outer loops. Two reasons:

1. **Defense-in-depth.** The Tier-1 pre-check covers only the NRF register path. `ogs_nnrf_nfm_handle_nf_profile()` has four other callers (NF-Set discovery responses, `lib/sbi/nf-sm.c` notification consumers, internal NRF inter-instance update flows). Those paths consume data that is already past the SBA trust boundary; a residual assertion there would still be a DoS.

2. **Correct behaviour for notification consumers.** When an AMF receives an NRF notification carrying an over-budget peer NFProfile, silently truncating to local capacity is the right semantics — the AMF cannot reject a notification, and an assertion would crash a healthy AMF because of an oversized message it did not initiate.

### Out of scope (intentionally)

Outer-loop overflows — `sNssaiSmfInfoList`, `nrTaiList`, AMF `taiRangeList`, `guamiList` — were already converted to graceful-cap by `82b929007` and remain on that path. Tightening those into HTTP 400 rejects too would be a broader scope change that affects every operator who today silently registers a 17th slice or 17th GUAMI; it deserves its own PR with its own backward-compatibility conversation.

## Verification

- `ninja -C build` clean on the rebased branch (base `288f1ca49`).

- Reproducer NFProfile from https://github.com/open5gs/open5gs/issues/4470 (17 DNNs in slice 0) against the patched NRF: `HTTP 400 Bad Request` with `ProblemDetails.title = "smfInfo.dnnSmfInfoList exceeds capacity (OGS_MAX_NUM_OF_DNN)"` and `ProblemDetails.detail = "<offending nf_instance_id>"`. NRF process stays up. NRF log: `[<id>] NFProfile rejected: smfInfo.dnnSmfInfoList exceeds capacity (OGS_MAX_NUM_OF_DNN)`.

- Symmetric AMF-side reproducer (17 entries in `taiRangeList[0].tacRangeList`): same shape, with `ProblemDetails.title = "amfInfo.taiRangeList[*].tacRangeList exceeds capacity (OGS_MAX_NUM_OF_TAI)"`.

- Note on field choice: the offending-IE name is carried in `title`, not in `invalidParams[].param`. We do not allocate the slice index dynamically — the message is a `.rodata` string literal with no per-call formatting (no `ogs_msprintf`, no static buffer, no thread-safety footprint). The operator's required action is "fix the YAML / config of the registering NF"; the slice index is recoverable from the registering NF's own NFProfile and adds no diagnostic value worth a heap allocation per rejection.

- Tier-2 / notification-consumer path: simulated peer-NRF notification carrying 18 DNNs in a slice on a consumer NF (e.g. AMF). The consumer logs `OVERFLOW DNN [16:16] in slice [0]` (formatted via `ogs_error()`'s normal log-buffer path, not a returned string) and continues without abort. The profile is applied with the inner list truncated to capacity — correct semantics for a notification the consumer cannot reject.

- Existing unit tests pass (`tests/unit/`).

## Co-credit

- `imda-lseokmin` for the original `dnnSmfInfoList` PoC and crash trace in https://github.com/open5gs/open5gs/issues/4470.
- `LinZiyuu` for the sibling AMF-side `tacRangeList` shape in https://github.com/open5gs/open5gs/issues/4467.

Closes #4470
Closes #4469
Closes #4467
