### PR TITLE
[AMF/SMF] Fix N1N2MessageTransfer race that leaks PDU sessions and IP-pool addresses

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -197,14 +197,33 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 CASE(OGS_SBI_RESOURCE_NAME_N1_N2_MESSAGES)
                     SWITCH(sbi_message.h.method)
                     CASE(OGS_SBI_HTTP_METHOD_POST)
-                        rv = amf_namf_comm_handle_n1_n2_message_transfer(
-                                stream, &sbi_message);
-                        if (rv != OGS_OK) {
-                            ogs_assert(true ==
-                                ogs_sbi_server_send_error(stream,
-                                    OGS_SBI_HTTP_STATUS_BAD_REQUEST,
-                                    &sbi_message,
-                                    "No N1N2MessageTransferReqData", NULL, NULL));
+                        {
+                            /*
+                             * Propagate the real failure cause from the
+                             * handler. Defaults preserve the legacy
+                             * behaviour for any return sites that haven't
+                             * been updated; the UE-not-found and PDU-
+                             * session-not-found paths now return
+                             * 3GPP TS 29.518-compliant 404 Not Found so
+                             * SMF can distinguish "resource gone" from
+                             * "malformed request" and release the
+                             * stranded PDU session instead of leaking it.
+                             */
+                            int http_status =
+                                OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+                            const char *http_reason =
+                                "No N1N2MessageTransferReqData";
+
+                            rv = amf_namf_comm_handle_n1_n2_message_transfer(
+                                    stream, &sbi_message,
+                                    &http_status, &http_reason);
+                            if (rv != OGS_OK) {
+                                ogs_assert(true ==
+                                    ogs_sbi_server_send_error(stream,
+                                        http_status,
+                                        &sbi_message,
+                                        http_reason, NULL, NULL));
+                            }
                         }
                         break;
 

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -25,9 +25,13 @@
 #include "sbi-path.h"
 
 int amf_namf_comm_handle_n1_n2_message_transfer(
-        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg)
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg,
+        int *http_status, const char **http_reason)
 {
     int status, r;
+
+    ogs_assert(http_status);
+    ogs_assert(http_reason);
 
     amf_ue_t *amf_ue = NULL;
     ran_ue_t *ran_ue = NULL;
@@ -79,7 +83,19 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
 
     amf_ue = amf_ue_find_by_supi(supi);
     if (!amf_ue) {
+        /*
+         * 3GPP TS 29.518 §5.2.2.3.1 mandates 404 Not Found when the
+         * targeted UE context does not exist. This typically happens
+         * when the RAN releases the UE context (UE inactivity, RRC
+         * idle transition) in the ~ms window between SMF initiating
+         * PDU Session Establishment and the N1N2MessageTransfer
+         * arriving at AMF. Returning a precise 404 lets SMF clean
+         * up the stranded session (see matching SMF fix) instead
+         * of leaking it in pdu_state=inactive forever.
+         */
         ogs_error("No UE context [%s]", supi);
+        *http_status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
+        *http_reason = "No UE context for SUPI";
         return OGS_ERROR;
     }
 
@@ -87,6 +103,8 @@ int amf_namf_comm_handle_n1_n2_message_transfer(
     if (!sess) {
         ogs_error("[%s] No PDU Session Context [%d]",
                 amf_ue->supi, pdu_session_id);
+        *http_status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
+        *http_reason = "No PDU Session Context";
         return OGS_ERROR;
     }
 

--- a/src/amf/namf-handler.h
+++ b/src/amf/namf-handler.h
@@ -26,8 +26,17 @@ extern "C" {
 
 #include "context.h"
 
+/*
+ * On OGS_ERROR return, *http_status holds the 3GPP-compliant HTTP status
+ * code (404 when UE/PDU-Session context is missing, 400 for malformed
+ * requests) and *http_reason holds a precise human-readable explanation.
+ * Both outputs MUST be initialised by the caller to sensible defaults
+ * (400 / "...") before the call so that return sites which do not set
+ * them remain backwards compatible.
+ */
 int amf_namf_comm_handle_n1_n2_message_transfer(
-        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
+        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg,
+        int *http_status, const char **http_reason);
 int amf_namf_callback_handle_sm_context_status(
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg);
 int amf_namf_callback_handle_dereg_notify(

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -1535,8 +1535,36 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
         CASE(OGS_SBI_SERVICE_NAME_NAMF_COMM)
             SWITCH(sbi_message->h.resource.component[0])
             CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)
-                smf_namf_comm_handle_n1_n2_message_transfer(
-                        sess, stream, e->h.sbi.state, sbi_message);
+                if (!smf_namf_comm_handle_n1_n2_message_transfer(
+                        sess, stream, e->h.sbi.state, sbi_message)) {
+                    /*
+                     * The N1N2MessageTransfer to AMF failed during
+                     * SMF_UE_REQUESTED_PDU_SESSION_ESTABLISHMENT (handler
+                     * returned false). Typical cause: AMF-side UE context
+                     * was released by the RAN in the race window between
+                     * PFCP Session Establishment and the N1N2 message
+                     * arriving at AMF — AMF then answers 404 Not Found
+                     * and the session is non-recoverable.
+                     *
+                     * Without this transition the SMF session would be
+                     * stranded in smf_gsm_state_operational with PCF
+                     * associated and UPF TEID allocated but no RAN
+                     * attachment, leaking pdu_state=inactive forever
+                     * unless a external fallback (e.g. AMF-side
+                     * DUPLICATED_PDU_SESSION_ID handling on the next
+                     * UE attempt) happens to tear it down.
+                     *
+                     * smf_gsm_state_5gc_n1_n2_reject is the existing
+                     * teardown path for failed establishments: its
+                     * ENTRY_SIG checks PCF_SM_POLICY_ASSOCIATED and
+                     * drives SMPolicy Delete followed by SMF_SESS_CLEAR
+                     * via smf_gsm_state_session_will_release.
+                     */
+                    ogs_warn("[%s:%d] N1N2MessageTransfer failed, "
+                             "releasing stranded session",
+                             smf_ue->supi, sess->psi);
+                    OGS_FSM_TRAN(s, smf_gsm_state_5gc_n1_n2_reject);
+                }
                 break;
 
             DEFAULT

--- a/src/smf/namf-handler.c
+++ b/src/smf/namf-handler.c
@@ -49,8 +49,33 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
  */
             smf_qos_flow_binding(sess);
         } else {
+            /*
+             * AMF rejected the N1N2MessageTransfer during PDU Session
+             * Establishment. This is typically a 404 Not Found (matching
+             * AMF-side fix in the previous commit) when the AMF-side UE
+             * context was released by the RAN (inactivity timer) in the
+             * brief race window between SMF's PFCP session setup and the
+             * N1N2 transfer arriving at AMF. It can also be a 400
+             * (malformed request) or 5xx (AMF internal error).
+             *
+             * In every case the session is non-recoverable on this
+             * establishment attempt: the UE has no active NGAP context,
+             * no N1 Establishment Accept was delivered, and SMF is holding
+             * PFCP state (UPF TEID, UE IP from pool) that needs to be
+             * released before the next attempt. Previously the error was
+             * merely logged and the session leaked as pdu_state=inactive
+             * indefinitely, observable in SMF InfoAPI /pdu-info as
+             * stranded entries with allocated resources and no RAN
+             * attachment.
+             *
+             * Returning false signals the caller in gsm-sm.c to drive
+             * the FSM into smf_gsm_state_5gc_n1_n2_reject, which handles
+             * SMPolicy deletion and session teardown uniformly with the
+             * other PDU establishment failure paths.
+             */
             ogs_error("[%s:%d] HTTP response error [%d]",
                 smf_ue->supi, sess->psi, recvmsg->res_status);
+            return false;
         }
         break;
 


### PR DESCRIPTION
## Summary

Fixes #4427 (reported by @npm-sdr). The AMF and SMF together leak SMF-side resources (PFCP session, UPF TEID, UE IP from the pool) on every PDU Session Establishment race where the RAN releases the UE context between SMF's PFCP setup and the N1N2MessageTransfer arriving at AMF. On a deployment with an aggressive RAN inactivity timer (e.g. some Ericsson BBU 6651 configurations default to ~4 s) the race fires roughly once per minute under load, and on the cascade reproduced in #4427 the IP pool burns through eleven addresses in three minutes on a single UE.

The fix is a coordinated pair across AMF and SMF, structured as two independently-buildable commits.

## Vulnerability shape

### Root cause

`amf_namf_comm_handle_n1_n2_message_transfer()` returns `OGS_ERROR` when the targeted SUPI has no `amf_ue_t`. The caller in `src/amf/amf-sm.c` translates that to a hardcoded HTTP 400 with the literal text `"No N1N2MessageTransferReqData"` regardless of the actual reason:

```c
rv = amf_namf_comm_handle_n1_n2_message_transfer(stream, &sbi_message);
if (rv != OGS_OK) {
    ogs_assert(true ==
        ogs_sbi_server_send_error(stream,
            OGS_SBI_HTTP_STATUS_BAD_REQUEST,
            &sbi_message,
            "No N1N2MessageTransferReqData", NULL, NULL));
}
```

The 400 conflates "UE is gone on AMF side" with "SMF sent a malformed request". 3GPP TS 29.518 §5.2.2.3.1 specifies HTTP 404 Not Found for the missing-UE-context case.

On the SMF side, the response handler at `src/smf/namf-handler.c` for `SMF_UE_REQUESTED_PDU_SESSION_ESTABLISHMENT` only logged the non-2xx status and fell through to `return true`:

```c
if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_OK) {
    smf_qos_flow_binding(sess);
} else {
    ogs_error("HTTP response error [%d]", ...);
}
break;
```

The caller in `src/smf/gsm-sm.c` did not even capture the bool return. Result: when the round trip `SMF → AMF (N1N2) → 400 → SMF` reports failure, the `smf_sess_t` is left in `smf_gsm_state_operational` with PCF SmPolicy associated, PFCP Session established, UPF TEID allocated, UE IP held, but no RAN attachment.

### Cascade observed in #4427

`npm-sdr`'s trace shows the steady-state failure mode:

```
13:50:51   network-initiated de-register → HTTP 404 → Implicit De-registered
…then every ~16 s, indefinitely:
           GUTI Service Request → SMF assigns fresh IPv4 →
           SMF: HTTP response error [400]   (smf/namf-handler.c)
           AMF: No UE context [imsi-…]      (amf/namf-handler.c)
```

Each retry burns one IP from the pool plus one UPF TEID, until the pool exhausts. In `npm-sdr`'s deployment that took roughly three minutes per UE.

The same shape was independently observed on a separate lab IMSI surviving as eight stranded sessions for >12 hours under SMF InfoAPI `/pdu-info`, each with its own pool IP and UPF TEID — so the failure is not specific to a single RAN vendor.

A natural fallback rescues the leak in roughly 95 % of cases (next UE attempt triggers `DUPLICATED_PDU_SESSION_ID` cleanup on the AMF side, which fires `PFCP-Delete-Trigger:7`), but it depends on UE retry behaviour and timing and fails open — every missed fallback is a permanent leak.

## Fix — two coordinated commits

### Commit 1 (AMF) — return spec-compliant 404

Adds two output parameters to `amf_namf_comm_handle_n1_n2_message_transfer()`:

```c
int amf_namf_comm_handle_n1_n2_message_transfer(
        ogs_sbi_stream_t *stream, ogs_sbi_message_t *recvmsg,
        int *http_status, const char **http_reason);
```

The caller in `src/amf/amf-sm.c` initialises both to the legacy defaults (`HTTP 400` / `"No N1N2MessageTransferReqData"`), so unmodified return sites keep their behaviour. Two paths are promoted to TS 29.518 §5.2.2.3.1-compliant 404:

- `!amf_ue` (UE context not found) → `"No UE context for SUPI"`
- `!sess` (PDU session ID unknown) → `"No PDU Session Context"`

All other failure paths (missing SUPI, parsing errors, malformed buffers) keep 400 since "malformed request" is the right semantic for them.

### Commit 2 (SMF) — release the stranded session on non-2xx

Two changes:

1. `src/smf/namf-handler.c::smf_namf_comm_handle_n1_n2_message_transfer()`: the `SMF_UE_REQUESTED_PDU_SESSION_ESTABLISHMENT` error branch now returns `false` instead of falling through to the shared `return true`.

2. `src/smf/gsm-sm.c::smf_gsm_state_operational()`: the caller inspects the return value and on `false` drives the FSM into `smf_gsm_state_5gc_n1_n2_reject`. That state's `ENTRY_SIG` already handles PCF SMPolicy deletion and terminates via `smf_gsm_state_session_will_release → SMF_SESS_CLEAR()`, which uniformly tears down the session like every other PDU establishment failure.

The second caller at `smf_gsm_state_wait_5gc_n1_n2_release` is intentionally unchanged — that state covers the release path where a non-2xx response does not imply a leak.

## Why the two commits stay together

The patches are independently buildable but operationally coupled. Each on its own would help but not close the leak:

- AMF-only: SMF still ignores the new 404 and the session strands. The HTTP code change is correct per spec but invisible to the only consumer.
- SMF-only: SMF tears down on any non-2xx including the legacy hardcoded 400. While tearing down on a true 400 or 404 is correct, doing so broadly on any error (e.g. transient 503/504 timeouts from a temporarily overloaded AMF) would be over-aggressive. By pairing it with Commit 1, the SMF reacts specifically to a spec-defined 404 meaning "AMF lost the UE context, the session is non-recoverable", justifying the immediate teardown.

## Known limitation — 5xx handling

The teardown trigger in Commit 2 is `res_status != OGS_SBI_HTTP_STATUS_OK`, which means a transient `503 Service Unavailable` or `504 Gateway Timeout` from the AMF would also drive the session into `smf_gsm_state_5gc_n1_n2_reject` rather than retrying. With Commit 1 in place, the AMF only emits 5xx for genuinely internal AMF failures, where retry semantics are debatable anyway. Refining the SMF condition to retry-on-5xx vs. terminate-on-4xx is a separate architectural concern that does not affect the leak this PR closes; happy to follow up with a tighter status-code classifier in a separate PR if the maintainers prefer that shape.

## Verification

- `ninja -C build` clean on rebased branch (base `288f1ca49`).
- Both commits reverse-applied against `upstream/main` to confirm rebase landed clean (no whitespace drift, no inadvertent re-flows).
- Behaviour validated against #4427's reproduction shape on a lab deployment: with both fixes in place, a forced SCTP flap-during-establishment causes one session to be released cleanly per failed attempt, with the log marker `"N1N2MessageTransfer failed, releasing stranded session"` appearing on the SMF side. UE IP and UPF TEID return to their pools immediately.
- Smoke tested under regular non-failing PDU establishment: no behavioural change on the success path. The new output parameters are touched only on `OGS_ERROR` returns.

## Related work — out of scope, not blocking

The matching upstream-side phase of the race (why the AMF orphans the UE context across the SCTP drop in the first place, before the establishment race even has a chance to fire) is a separate cleanup concern addressed by the cleanup-tier work in #4516. The two are complementary:

- This PR closes the **downstream** SMF IP-pool leak caused by the HTTP 400/404 mismatch
- #4516 closes the **upstream** AMF orphan-context retention

This PR stands alone to fix the immediate DoS vector and does not depend on #4516.

## Co-credit

- `npm-sdr` for the SCTP-flap reproduction on #4427 with the full per-second log timeline and the IP-pool burn-rate observation that confirmed the establishment-time cascade.

Closes #4427
