### PR TITLE
[AMF] Honor no-SD S-NSSAI as Default-Slice per TS 23.501 §5.15.2.1

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2848,10 +2848,25 @@ static bool gnb_ta_is_supported(
             for (k = 0;
                     k < gnb->supported_ta_list[i].bplmn_list[j].num_of_s_nssai;
                     k++) {
-                if (gnb->supported_ta_list[i].bplmn_list[j].s_nssai[k].sst ==
-                        s_nssai->sst &&
-                    gnb->supported_ta_list[i].bplmn_list[j].s_nssai[k].sd.v ==
-                        s_nssai->sd.v)
+                ogs_s_nssai_t *gnb_snssai = &gnb->supported_ta_list[i].
+                        bplmn_list[j].s_nssai[k];
+
+                /* SST must always match exactly */
+                if (gnb_snssai->sst != s_nssai->sst)
+                    continue;
+
+                /* 3GPP TS 23.501 §5.15.2.1 / TS 23.003 §28.4.2:
+                 * S-NSSAI without SD (encoded as 0xFFFFFF) is the
+                 * "default slice" for that SST and matches any SD
+                 * within the same SST. Required to support gNBs
+                 * that broadcast SST-only S-NSSAI in SIB1.
+                 */
+                if (gnb_snssai->sd.v == OGS_S_NSSAI_NO_SD_VALUE ||
+                    s_nssai->sd.v == OGS_S_NSSAI_NO_SD_VALUE)
+                    return true;
+
+                /* Both sides have explicit SD — require strict equality */
+                if (gnb_snssai->sd.v == s_nssai->sd.v)
                     return true;
             }
         }
@@ -2979,10 +2994,41 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
                     &amf_ue->rejected_nssai.
                         s_nssai[amf_ue->rejected_nssai.num_of_s_nssai];
             bool ta_supported = false;
+            ogs_s_nssai_t requested_resolved;
+
+            /* Working copy — may be substituted below for no-SD case */
+            requested_resolved.sst = requested->sst;
+            requested_resolved.sd.v = requested->sd.v;
+
+            /* 3GPP TS 23.501 §5.15.2.1 / §5.15.5.2.1:
+             * If the requested S-NSSAI has SD absent (encoded 0xFFFFFF,
+             * "Default Slice for SST"), substitute it with the subscriber's
+             * defaultSingleNssai for that SST before strict-matching.
+             * This honors the spec-defined Default-Slice semantics without
+             * touching shared utility libraries (lib/proto/types.c).
+             */
+            if (requested_resolved.sd.v == OGS_S_NSSAI_NO_SD_VALUE) {
+                int s;
+                for (s = 0; s < amf_ue->num_of_slice; s++) {
+                    if (amf_ue->slice[s].s_nssai.sst ==
+                            requested_resolved.sst &&
+                        amf_ue->slice[s].default_indicator == true) {
+                        ogs_debug("[%s] Substituting no-SD requested "
+                                "S-NSSAI[SST:%d] with subscriber default "
+                                "SD:0x%06x (TS 23.501 §5.15.5.2.1)",
+                                amf_ue->supi,
+                                requested_resolved.sst,
+                                amf_ue->slice[s].s_nssai.sd.v);
+                        requested_resolved.sd.v =
+                                amf_ue->slice[s].s_nssai.sd.v;
+                        break;
+                    }
+                }
+            }
 
             slice = ogs_slice_find_by_s_nssai(
                     amf_ue->slice, amf_ue->num_of_slice,
-                    (ogs_s_nssai_t *)requested);
+                    &requested_resolved);
             if (slice)
                 ta_supported = gnb_ta_is_supported(gnb,
                         &amf_ue->nr_tai.plmn_id, amf_ue->nr_tai.tac,
@@ -2990,8 +3036,14 @@ bool amf_update_allowed_nssai(amf_ue_t *amf_ue)
 
             if (ta_supported == true) {
 
-                allowed->sst = requested->sst;
-                allowed->sd.v = requested->sd.v;
+                /* Allowed-NSSAI returned to UE uses the resolved SD so
+                 * that subsequent procedures (PDU session, NSSF selection,
+                 * plmn_support strict checks via memcmp in
+                 * amf_ue_save_to_release_session_list) see a concrete
+                 * SD value, not 0xFFFFFF.
+                 */
+                allowed->sst = requested_resolved.sst;
+                allowed->sd.v = requested_resolved.sd.v;
                 allowed->mapped_hplmn_sst_presence =
                         requested->mapped_hplmn_sst_presence;
                 allowed->mapped_hplmn_sst = requested->mapped_hplmn_sst;


### PR DESCRIPTION
## Summary

Per 3GPP TS 23.501 §5.15.2.1, an S-NSSAI with SD absent (encoded as `0xFFFFFF`) represents the **"Default Slice for that SST"**. Open5GS AMF currently enforces strict `SST+SD` equality, which breaks UE registration in two distinct real-world scenarios.

## Scenario 1 — UE-side no-SD (the Android 5G slicing issue) — closes #1651

Android 5G UEs **hardcode their requested Default-NSSAI to `SD=0xFFFFFF`**. The value is not configurable by the operator (per the [Android 5G slicing source documentation](https://source.android.com/devices/tech/connect/5g-slicing)). On a deployment that uses explicit `SD` values for actual network slicing, the AMF rejects every Android UE with **5GMM cause #62 ("no network slices available")**.

The historical workaround — discussed at length in #1651 and elsewhere — is to remap the entire core and gNB environment to `SD=0xFFFFFF`. That defeats the purpose of network slicing entirely: every UE collapses into a single slot, and the operator loses the ability to differentiate subscribers across slices.

**Change 2** in this PR substitutes the UE's `0xFFFFFF` request with the subscriber's actual `defaultSingleNssai` SD before strict-matching. The Allowed-NSSAI returned to the UE carries the concrete SD, so the UE attaches to the slice the operator actually intends — true slicing alongside default Android UEs becomes possible.

## Scenario 2 — gNB-side no-SD (small-cell SIB1 broadcast)

Some gNBs broadcast SST-only S-NSSAI in SIB1, regardless of how the AMF and subscriber data are configured. We have observed this on Baicells Stellar 227 directly, and #1651 references analogous behaviour on certain Nokia BS configurations.

Even when the subscriber's `defaultSingleNssai` carries an explicit SD that matches the operator's slicing intent, `gnb_ta_is_supported()` previously rejected the TA on strict SD comparison: `gnb_sd.v == 0xFFFFFF != subscriber_sd.v == 0x010203` failed even though spec says they should match.

**Change 1** in this PR treats `0xFFFFFF` on either side of the comparison as a wildcard for that SST, exactly per TS 23.501 §5.15.2.1.

## Code changes

Two surgical changes in `src/amf/context.c`. **No shared library is touched** — `lib/proto/types.c` is unchanged, so SMF / NSSF / PCF behaviour is identical to upstream.

### Change 1 — `gnb_ta_is_supported()` honours no-SD as wildcard

```c
/* SST must always match exactly */
if (gnb_snssai->sst != s_nssai->sst)
    continue;

/* 3GPP TS 23.501 §5.15.2.1 / TS 23.003 §28.4.2:
 * S-NSSAI without SD (encoded as 0xFFFFFF) is the
 * "default slice" for that SST and matches any SD
 * within the same SST. Required to support gNBs
 * that broadcast SST-only S-NSSAI in SIB1.
 */
if (gnb_snssai->sd.v == OGS_S_NSSAI_NO_SD_VALUE ||
    s_nssai->sd.v == OGS_S_NSSAI_NO_SD_VALUE)
    return true;

/* Both sides have explicit SD — require strict equality */
if (gnb_snssai->sd.v == s_nssai->sd.v)
    return true;
```

### Change 2 — `amf_update_allowed_nssai()` substitutes no-SD with subscriber default

```c
ogs_s_nssai_t requested_resolved;
requested_resolved.sst = requested->sst;
requested_resolved.sd.v = requested->sd.v;

/* 3GPP TS 23.501 §5.15.2.1 / §5.15.5.2.1:
 * If the requested S-NSSAI has SD absent (encoded 0xFFFFFF,
 * "Default Slice for SST"), substitute it with the subscriber's
 * defaultSingleNssai for that SST before strict-matching.
 */
if (requested_resolved.sd.v == OGS_S_NSSAI_NO_SD_VALUE) {
    int s;
    for (s = 0; s < amf_ue->num_of_slice; s++) {
        if (amf_ue->slice[s].s_nssai.sst == requested_resolved.sst &&
            amf_ue->slice[s].default_indicator == true) {
            ogs_debug("[%s] Substituting no-SD requested "
                    "S-NSSAI[SST:%d] with subscriber default "
                    "SD:0x%06x (TS 23.501 §5.15.5.2.1)", ...);
            requested_resolved.sd.v = amf_ue->slice[s].s_nssai.sd.v;
            break;
        }
    }
}
```

## Backward compatibility

- **Strict-match deployments** (both gNB and subscriber have explicit SD): no behavioural change. The new code paths are only reached when at least one side has `sd.v == OGS_S_NSSAI_NO_SD_VALUE` (= `0xFFFFFF`).
- **Subscriber without `defaultSingleNssai` for the requested SST**: the no-SD requested S-NSSAI falls through to the existing strict-match path with `sd.v=0xFFFFFF`, which still fails — same as today. The new code is strictly additive, never more restrictive.
- **`Allowed-NSSAI` returned to UE**: carries the resolved (concrete) SD when substitution fires, so subsequent procedures see a deterministic value rather than `0xFFFFFF`.

## Verification

- `ninja -C build` clean on the rebased branch (base `288f1ca49`).
- Live-deployed on a small lab cluster running a Baicells Stellar 227 gNB (Scenario 2) and a mix of Android 5G UEs (Scenario 1) since 2026-05-04, three days. Pre-patch: Stellar-227 attached UEs failed with `5GS_SERVICES_NOT_ALLOWED`; Android UEs attached only when the cluster was reconfigured to `SD=0xFFFFFF` everywhere. Post-patch: both attach cleanly without flattening the slice configuration.
- Parallel test cluster with explicit-SD broadcast on every gNB and explicit-SD on every subscriber: registrations unchanged, new code paths confirmed not reached (verified via `ogs_debug` log).

## Related

- **#1651** (the issue this closes) — open since 2022-07-08, 15 comments, no maintainer counter-proposal in the thread, original reporter ended their project without resolution. The community-suggested workaround ("adapt your environment to `0xFFFFFF`") was understood at the time to defeat slicing.
- #2528, #859, #1064 (all closed) — same root family, recurring as different operators hit the same spec mismatch on different gNB / UE combinations.

The fix in this PR is the spec-correct resolution that those reports asked for at different times — and crucially, it does *not* require operators to choose between "support Android UEs" and "use real network slicing".

Closes #1651
