### PR TITLE
amf: store gNB ID length with UE NR-CGI

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1328,14 +1328,20 @@ amf_gnb_t *amf_gnb_find_by_gnb_id(uint32_t gnb_id)
     return (amf_gnb_t *)ogs_hash_get(self.gnb_id_hash, &gnb_id, sizeof(gnb_id));
 }
 
-int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id)
+int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id, uint8_t gnb_id_length)
 {
     ogs_assert(gnb);
+
+    if (gnb_id_length < 22 || gnb_id_length > 32) {
+        ogs_error("Invalid gNB-ID length[%d]", gnb_id_length);
+        return OGS_ERROR;
+    }
 
     if (gnb->gnb_id_presence == true)
         ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), NULL);
 
     gnb->gnb_id = gnb_id;
+    gnb->gnb_id_length = gnb_id_length;
     ogs_hash_set(self.gnb_id_hash, &gnb->gnb_id, sizeof(gnb->gnb_id), gnb);
 
     gnb->gnb_id_presence = true;
@@ -1676,6 +1682,11 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
     ogs_list_init(&amf_ue->sess_list);
 
     /* Initialization */
+    amf_ue->gnb_ostream_id = ran_ue->gnb_ostream_id;
+    memcpy(&amf_ue->nr_tai, &ran_ue->saved.nr_tai, sizeof(ogs_5gs_tai_t));
+    memcpy(&amf_ue->nr_cgi, &ran_ue->saved.nr_cgi, sizeof(ogs_nr_cgi_t));
+    amf_ue->nr_cgi_gnb_id_length = ran_ue->saved.nr_cgi_gnb_id_length;
+
     amf_ue->guami = &amf_self()->served_guami[0];
     amf_ue->nas.access_type = OGS_ACCESS_TYPE_3GPP;
     amf_ue->nas.amf.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -141,6 +141,7 @@ typedef struct amf_gnb_s {
 
     bool            gnb_id_presence;
     uint32_t        gnb_id;     /* gNB_ID received from gNB */
+    uint8_t         gnb_id_length; /* gNB-ID BIT STRING length(22..32) */
     ogs_plmn_id_t   plmn_id;    /* gNB PLMN-ID received from gNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */
 
@@ -205,6 +206,7 @@ struct ran_ue_s {
     struct {
         ogs_5gs_tai_t   nr_tai;
         ogs_nr_cgi_t    nr_cgi;
+        uint8_t         nr_cgi_gnb_id_length;
     } saved;
 
     /* NG Holding timer for removing this context */
@@ -363,6 +365,7 @@ struct amf_ue_s {
     uint16_t        gnb_ostream_id;
     ogs_5gs_tai_t   nr_tai;
     ogs_nr_cgi_t    nr_cgi;
+    uint8_t         nr_cgi_gnb_id_length;
     ogs_time_t      ue_location_timestamp;
     ogs_plmn_id_t   last_visited_plmn_id;
     ogs_nas_ue_usage_setting_t ue_usage_setting;
@@ -964,7 +967,7 @@ void amf_gnb_remove(amf_gnb_t *gnb);
 void amf_gnb_remove_all(void);
 amf_gnb_t *amf_gnb_find_by_addr(ogs_sockaddr_t *addr);
 amf_gnb_t *amf_gnb_find_by_gnb_id(uint32_t gnb_id);
-int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id);
+int amf_gnb_set_gnb_id(amf_gnb_t *gnb, uint32_t gnb_id, uint8_t gnb_id_length);
 int amf_gnb_sock_type(ogs_sock_t *sock);
 amf_gnb_t *amf_gnb_find_by_id(ogs_pool_id_t id);
 

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -115,6 +115,51 @@ static bool s_nssai_is_found(amf_gnb_t *gnb)
     return false;
 }
 
+static bool gnb_id_length_from_global_gnb_id(
+        NGAP_GlobalGNB_ID_t *globalGNB_ID, uint8_t *gnb_id_length)
+{
+    BIT_STRING_t *bit_string = NULL;
+    size_t length;
+
+    ogs_assert(globalGNB_ID);
+    ogs_assert(gnb_id_length);
+
+    if (globalGNB_ID->gNB_ID.present != NGAP_GNB_ID_PR_gNB_ID) {
+        ogs_error("Unsupported GNB_ID present[%d]",
+                globalGNB_ID->gNB_ID.present);
+        return false;
+    }
+
+    bit_string = &globalGNB_ID->gNB_ID.choice.gNB_ID;
+    if (!bit_string->buf || bit_string->size == 0) {
+        ogs_error("Invalid GNB_ID BIT STRING");
+        return false;
+    }
+
+    if (bit_string->bits_unused < 0 || bit_string->bits_unused > 7) {
+        ogs_error("Invalid GNB_ID bits_unused[%d]",
+                bit_string->bits_unused);
+        return false;
+    }
+
+    length = bit_string->size * 8;
+    if ((size_t)bit_string->bits_unused > length) {
+        ogs_error("Invalid GNB_ID length[size:%d,bits_unused:%d]",
+                (int)bit_string->size, bit_string->bits_unused);
+        return false;
+    }
+
+    length -= bit_string->bits_unused;
+    if (length < 22 || length > 32) {
+        ogs_error("Invalid GNB_ID length[%d]", (int)length);
+        return false;
+    }
+
+    *gnb_id_length = (uint8_t)length;
+
+    return true;
+}
+
 void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
 {
     char buf[OGS_ADDRSTRLEN];
@@ -133,6 +178,7 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     long cause = 0;
 
     uint32_t gnb_id;
+    uint8_t gnb_id_length = 0;
 
     ogs_assert(gnb);
     ogs_assert(gnb->sctp.sock);
@@ -205,8 +251,18 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
         return;
     }
 
+    if (!gnb_id_length_from_global_gnb_id(globalGNB_ID, &gnb_id_length)) {
+        group = NGAP_Cause_PR_protocol;
+        cause = NGAP_CauseProtocol_semantic_error;
+        r = ngap_send_ng_setup_failure(gnb, group, cause);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return;
+    }
+
     ogs_ngap_GNB_ID_to_uint32(&globalGNB_ID->gNB_ID, &gnb_id);
-    ogs_debug("    IP[%s] GNB_ID[0x%x]", OGS_ADDR(gnb->sctp.addr, buf), gnb_id);
+    ogs_debug("    IP[%s] GNB_ID[0x%x] GNB_ID_LENGTH[%d]",
+            OGS_ADDR(gnb->sctp.addr, buf), gnb_id, gnb_id_length);
 
     memcpy(&gnb->plmn_id,
             globalGNB_ID->pLMNIdentity.buf, sizeof(gnb->plmn_id));
@@ -423,7 +479,7 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
         return;
     }
 
-    amf_gnb_set_gnb_id(gnb, gnb_id);
+    ogs_assert(OGS_OK == amf_gnb_set_gnb_id(gnb, gnb_id, gnb_id_length));
 
     gnb->state.ng_setup_success = true;
     r = ngap_send_ng_setup_response(gnb);
@@ -616,6 +672,7 @@ void ngap_handle_initial_ue_message(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     ogs_assert(UserLocationInformationNR);
     ogs_ngap_ASN_to_nr_cgi(
             &UserLocationInformationNR->nR_CGI, &ran_ue->saved.nr_cgi);
+    ran_ue->saved.nr_cgi_gnb_id_length = gnb->gnb_id_length;
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &ran_ue->saved.nr_tai);
 
@@ -796,6 +853,7 @@ void ngap_handle_uplink_nas_transport(
 
     ogs_ngap_ASN_to_nr_cgi(
             &UserLocationInformationNR->nR_CGI, &ran_ue->saved.nr_cgi);
+    ran_ue->saved.nr_cgi_gnb_id_length = gnb->gnb_id_length;
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &ran_ue->saved.nr_tai);
 
@@ -807,6 +865,7 @@ void ngap_handle_uplink_nas_transport(
     /* Copy NR-TAI/NR-CGI from ran_ue */
     memcpy(&amf_ue->nr_tai, &ran_ue->saved.nr_tai, sizeof(ogs_5gs_tai_t));
     memcpy(&amf_ue->nr_cgi, &ran_ue->saved.nr_cgi, sizeof(ogs_nr_cgi_t));
+    amf_ue->nr_cgi_gnb_id_length = ran_ue->saved.nr_cgi_gnb_id_length;
 
     ogs_expect(OGS_OK == ngap_send_to_nas(
                 ran_ue, NGAP_ProcedureCode_id_UplinkNASTransport, NAS_PDU));
@@ -3035,6 +3094,7 @@ void ngap_handle_path_switch_request(
 
     ogs_ngap_ASN_to_nr_cgi(
             &UserLocationInformationNR->nR_CGI, &ran_ue->saved.nr_cgi);
+    ran_ue->saved.nr_cgi_gnb_id_length = gnb->gnb_id_length;
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &ran_ue->saved.nr_tai);
 
@@ -3042,6 +3102,7 @@ void ngap_handle_path_switch_request(
     amf_ue->gnb_ostream_id = ran_ue->gnb_ostream_id;
     memcpy(&amf_ue->nr_tai, &ran_ue->saved.nr_tai, sizeof(ogs_5gs_tai_t));
     memcpy(&amf_ue->nr_cgi, &ran_ue->saved.nr_cgi, sizeof(ogs_nr_cgi_t));
+    amf_ue->nr_cgi_gnb_id_length = ran_ue->saved.nr_cgi_gnb_id_length;
 
     ogs_info("    [NEW] TAC[%d] CellID[0x%llx]",
         amf_ue->nr_tai.tac.v, (long long)amf_ue->nr_cgi.cell_id);
@@ -4428,6 +4489,7 @@ void ngap_handle_handover_notification(
     ogs_assert(UserLocationInformationNR);
     ogs_ngap_ASN_to_nr_cgi(
             &UserLocationInformationNR->nR_CGI, &target_ue->saved.nr_cgi);
+    target_ue->saved.nr_cgi_gnb_id_length = gnb->gnb_id_length;
     ogs_ngap_ASN_to_5gs_tai(
             &UserLocationInformationNR->tAI, &target_ue->saved.nr_tai);
 
@@ -4448,6 +4510,7 @@ void ngap_handle_handover_notification(
     amf_ue->gnb_ostream_id = target_ue->gnb_ostream_id;
     memcpy(&amf_ue->nr_tai, &target_ue->saved.nr_tai, sizeof(ogs_5gs_tai_t));
     memcpy(&amf_ue->nr_cgi, &target_ue->saved.nr_cgi, sizeof(ogs_nr_cgi_t));
+    amf_ue->nr_cgi_gnb_id_length = target_ue->saved.nr_cgi_gnb_id_length;
 
     r = ngap_send_ran_ue_context_release_command(source_ue,
             NGAP_Cause_PR_radioNetwork,
@@ -4511,6 +4574,7 @@ void ngap_handle_ran_configuration_update(
     long cause = 0;
 
     uint32_t gnb_id;
+    uint8_t gnb_id_length = 0;
 
     ogs_assert(gnb);
     ogs_assert(gnb->sctp.sock);
@@ -4552,11 +4616,20 @@ void ngap_handle_ran_configuration_update(
             return;
         }
 
-        ogs_ngap_GNB_ID_to_uint32(&globalGNB_ID->gNB_ID, &gnb_id);
-        ogs_debug("    IP[%s] GNB_ID[0x%x]",
-                OGS_ADDR(gnb->sctp.addr, buf), gnb_id);
+        if (!gnb_id_length_from_global_gnb_id(globalGNB_ID, &gnb_id_length)) {
+            group = NGAP_Cause_PR_protocol;
+            cause = NGAP_CauseProtocol_semantic_error;
+            r = ngap_send_ran_configuration_update_failure(gnb, group, cause);
+            ogs_expect(r == OGS_OK);
+            ogs_assert(r != OGS_ERROR);
+            return;
+        }
 
-        amf_gnb_set_gnb_id(gnb, gnb_id);
+        ogs_ngap_GNB_ID_to_uint32(&globalGNB_ID->gNB_ID, &gnb_id);
+        ogs_debug("    IP[%s] GNB_ID[0x%x] GNB_ID_LENGTH[%d]",
+                OGS_ADDR(gnb->sctp.addr, buf), gnb_id, gnb_id_length);
+
+        ogs_assert(OGS_OK == amf_gnb_set_gnb_id(gnb, gnb_id, gnb_id_length));
     }
 
     if (SupportedTAList) {

--- a/src/amf/ue-info.c
+++ b/src/amf/ue-info.c
@@ -131,6 +131,26 @@ static inline uint32_t u24_to_u32(ogs_uint24_t v)
     return (x & 0xFFFFFFu);
 }
 
+static void split_nr_cgi(
+        uint64_t nci, uint8_t gnb_id_length,
+        uint32_t *gnb_id, uint32_t *cell_id)
+{
+    int cell_id_bits;
+
+    ogs_assert(gnb_id);
+    ogs_assert(cell_id);
+
+    nci &= 0xFFFFFFFFFULL; /* NR Cell Identity is 36 bits */
+
+    if (gnb_id_length < 22 || gnb_id_length > 32)
+        gnb_id_length = 22;
+
+    cell_id_bits = 36 - gnb_id_length;
+
+    *gnb_id = (uint32_t)(nci >> cell_id_bits);
+    *cell_id = (uint32_t)(nci & ((1ULL << cell_id_bits) - 1));
+}
+
 /* AM policy feature labels */
 static const char *am_policy_feature_names[64] = {
     /*0*/ "AM Policy Association",
@@ -222,9 +242,11 @@ static int add_gnb(cJSON *parent, const amf_ue_t *ue)
 
     ran_ue_t *ran = ran_ue_find_by_id(ue->ran_ue_id);
     if (ran) {
-        uint64_t nci = ue->nr_cgi.cell_id & 0xFFFFFFFFFULL; /* 36-bit */
-        uint32_t gnb_id  = (uint32_t)((nci >> 14) & 0x3FFFFF);
-        uint32_t cell_id = (uint32_t)(nci & 0x3FFF);
+        uint64_t nci = ue->nr_cgi.cell_id;
+        uint32_t gnb_id = 0;
+        uint32_t cell_id = 0;
+
+        split_nr_cgi(nci, ue->nr_cgi_gnb_id_length, &gnb_id, &cell_id);
 
         cJSON *a = cJSON_CreateNumber((double)ran->amf_ue_ngap_id);
         cJSON *r = cJSON_CreateNumber((double)ran->ran_ue_ngap_id);
@@ -294,9 +316,11 @@ static int add_location(cJSON *parent, const amf_ue_t *ue)
         if (!p) { cJSON_Delete(cgi); cJSON_Delete(loc); return -1; }
         cJSON_AddItemToObjectCS(cgi, "plmn", p);
 
-        uint64_t nci     = ue->nr_cgi.cell_id & 0xFFFFFFFFFULL; /* 36-bit */
-        uint32_t gnb_id  = (uint32_t)((nci >> 14) & 0x3FFFFF);
-        uint32_t cell_id = (uint32_t)(nci & 0x3FFF);
+        uint64_t nci = ue->nr_cgi.cell_id;
+        uint32_t gnb_id = 0;
+        uint32_t cell_id = 0;
+
+        split_nr_cgi(nci, ue->nr_cgi_gnb_id_length, &gnb_id, &cell_id);
 
         cJSON *n = cJSON_CreateNumber((double)nci);
         cJSON *g = cJSON_CreateNumber((double)gnb_id);


### PR DESCRIPTION
The /ue-info endpoint decodes the stored NR Cell Identity into gNB ID and Cell ID. However, the gNB-ID length is not always the legacy 22-bit split, and using only the current live gNB context to decode ue->nr_cgi can produce incorrect results.

ue->nr_cgi is stored independently in the AMF UE context and can outlive or lag the current RAN association, for example after NG release or after a later GlobalRANNodeID change. Therefore the gNB-ID length must be stored together with the UE's saved NR-CGI location.

This patch stores the parsed gNB-ID length in amf_gnb_t, snapshots it into ran_ue->saved together with nr_cgi, copies it into amf_ue_t, and uses the UE-local nr_cgi_gnb_id_length when rendering /ue-info.

The legacy 22-bit gNB ID / 14-bit Cell ID split is kept as a fallback when no valid gNB-ID length is available.

Related PR: #4424