### PR TITLE
[MME] S-NAPTR DNS PGW Discovery

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -160,6 +160,52 @@ mme:
 #          default_route: true
 #
 ################################################################################
+# S5/S8 Interface — PGW Discovery via S-NAPTR DNS (3GPP TS 29.303)
+################################################################################
+#  When mme.s5s8.dns is configured the MME performs a live NAPTR→SRV→A
+#  DNS lookup at session-setup time to discover PGW candidates dynamically.
+#  Results are cached in-process per APN-FQDN.  The effective cache TTL is
+#  min(NAPTR TTL, SRV TTL, A TTL), clamped to [30 s, 86400 s].  The floor
+#  prevents cache thrashing from broken zones returning TTL 0; the ceiling
+#  caps the cache lifetime at one day so that long-lived processes always
+#  refresh the PGW pool at least once every 24 hours.  Up to 64 distinct
+#  APN-FQDNs are cached simultaneously.
+#
+#  On each Create Session Request the MME selects one candidate at random
+#  and retries with the next candidate on any transient GTP failure
+#  (causes: 100, 73, 68, 72, 120, 110, 122) per TS 23.401 §5.3.2.1.
+#
+#  IPv4 only.  Only A records are resolved; AAAA is not supported yet.
+#  Falls back to the static pgw address in mme.yaml when dns is absent.
+#
+#  o Minimal — primary DNS server only
+#  s5s8:
+#    dns:
+#      - 192.168.1.53
+#
+#  o Recommended — primary + secondary for DNS failover
+#  s5s8:
+#    dns:
+#      - 192.168.1.53     # primary EPC DNS  (IPv4 only)
+#      - 192.168.1.54     # secondary EPC DNS (optional, IPv4 only)
+#
+#  o Lab / test network using dnsmasq on loopback
+#  s5s8:
+#    dns:
+#      - 127.0.0.1
+#
+#  DNS zone example (bind9 / dnsmasq) for APN "internet", MCC=234, MNC=01:
+#
+#  internet.apn.epc.mnc01.mcc234.3gppnetwork.org.  IN NAPTR 10 10 "S" \
+#      "x-3gpp-pgw:x-gtp-v2" "" _gtp-v2._udp.pgw.epc.example.com.
+#
+#  _gtp-v2._udp.pgw.epc.example.com.  IN SRV 10 10 2123 pgw1.epc.example.com.
+#  _gtp-v2._udp.pgw.epc.example.com.  IN SRV 10 10 2123 pgw2.epc.example.com.
+#
+#  pgw1.epc.example.com.  IN A  10.0.1.1
+#  pgw2.epc.example.com.  IN A  10.0.1.2
+#
+################################################################################
 # SGaAP Server
 ################################################################################
 #  o MSC/VLR

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -45,6 +45,8 @@ libmme_sources = files('''
     mme-path.h
     metrics.h
 
+    mme-s-naptr.h
+    mme-s-naptr.c
     mme-init.c
     mme-event.c
     mme-timer.c
@@ -84,15 +86,26 @@ libmme_sources = files('''
     ../../lib/metrics/prometheus/json_pager.c
 '''.split())
 
+libresolv = cc.find_library('resolv', required : true)
+
+# nameser_compat.h is present on glibc but absent on musl (Alpine Linux).
+# mme-s-naptr.c guards the include with this macro so it builds on both.
+mme_c_args = []
+if cc.has_header('arpa/nameser_compat.h')
+    mme_c_args += ['-DHAVE_ARPA_NAMESER_COMPAT_H']
+endif
+
 libmme = static_library('mme',
     sources : libmme_sources,
+    c_args : mme_c_args,
     dependencies : [libmetrics_dep,
                     libsctp_dep,
                     libs1ap_dep,
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libgtp_dep,
-                    libsbi_dep],
+                    libsbi_dep,
+                    libresolv],
     install : false)
 
 libmme_dep = declare_dependency(
@@ -103,7 +116,8 @@ libmme_dep = declare_dependency(
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libsbi_dep,
-                    libgtp_dep])
+                    libgtp_dep,
+                    libresolv])
 
 mme_sources = files('''
     app-init.c

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -27,6 +27,7 @@
 #include "s1ap-handler.h"
 #include "mme-sm.h"
 #include "mme-gtp-path.h"
+#include "mme-s-naptr.h"
 
 #define MAX_CELL_PER_ENB            8
 
@@ -152,6 +153,9 @@ void mme_context_init(void)
 void mme_context_final(void)
 {
     ogs_assert(context_initialized == 1);
+
+    /* Release the S-NAPTR DNS cache before tearing down the rest of context */
+    mme_s_naptr_cache_flush();
 
     mme_enb_remove_all();
     mme_ue_remove_all();
@@ -583,6 +587,54 @@ int mme_context_parse_config(void)
                             } else
                                 ogs_warn("unknown key `%s`", fd_key);
                         }
+                    }
+                } else if (!strcmp(mme_key, "s5s8")) {
+                    ogs_yaml_iter_t s5s8_iter;
+                    ogs_yaml_iter_recurse(&mme_iter, &s5s8_iter);
+                    while (ogs_yaml_iter_next(&s5s8_iter)) {
+                        const char *s5s8_key = ogs_yaml_iter_key(&s5s8_iter);
+                        ogs_assert(s5s8_key);
+                        if (!strcmp(s5s8_key, "dns")) {
+                            ogs_yaml_iter_t dns_iter;
+                            ogs_yaml_iter_recurse(&s5s8_iter, &dns_iter);
+                            ogs_assert(ogs_yaml_iter_type(&dns_iter) !=
+                                YAML_MAPPING_NODE);
+                            do {
+                                const char *v = NULL;
+
+                                if (ogs_yaml_iter_type(&dns_iter) ==
+                                        YAML_SEQUENCE_NODE) {
+                                    if (!ogs_yaml_iter_next(&dns_iter))
+                                        break;
+                                }
+
+                                v = ogs_yaml_iter_value(&dns_iter);
+                                if (v && strlen(v)) {
+                                    ogs_ipsubnet_t ipsub;
+                                    rv = ogs_ipsubnet(&ipsub, v, NULL);
+                                    if (rv != OGS_OK) {
+                                        ogs_warn("s5s8.dns: invalid address "
+                                                 "'%s', ignoring", v);
+                                        continue;
+                                    }
+
+                                    if (ipsub.family != AF_INET) {
+                                        ogs_warn("s5s8.dns only supports "
+                                            "IPv4, ignoring: %s", v);
+                                        continue; /* do not store IPv6 addr */
+                                    } else if (self.s5s8_dns[0] &&
+                                               self.s5s8_dns[1]) {
+                                        ogs_warn("Ignore s5s8 DNS : %s", v);
+                                    } else if (self.s5s8_dns[0]) {
+                                        self.s5s8_dns[1] = v;
+                                    } else {
+                                        self.s5s8_dns[0] = v;
+                                    }
+                                }
+                            } while (ogs_yaml_iter_type(&dns_iter) ==
+                                        YAML_SEQUENCE_NODE);
+                        } else
+                            ogs_warn("unknown key `%s`", s5s8_key);
                     }
                 } else if (!strcmp(mme_key, "relative_capacity")) {
                     const char *v = ogs_yaml_iter_value(&mme_iter);
@@ -4476,6 +4528,14 @@ void mme_sess_remove(mme_sess_t *sess)
     OGS_NAS_CLEAR_DATA(&sess->ue_epco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_pco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_epco);
+
+    /* Free DNS-resolved PGW candidates (allocated by mme_s_naptr_resolve_candidates()) */
+    if (sess->pgw_candidates.list) {
+        ogs_free(sess->pgw_candidates.list);
+        sess->pgw_candidates.list  = NULL;
+        sess->pgw_candidates.count = 0;
+        sess->pgw_candidates.index = 0;
+    }
 
     ogs_pool_id_free(&mme_sess_pool, sess);
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -169,6 +169,11 @@ typedef struct mme_context_s {
     struct {
         const char *dnn;            /* Emergency APN */
     } emergency;
+
+    /* S5/S8 DNS servers for S-NAPTR PGW discovery (TS 29.303, IPv4 only).
+     * Points directly into the YAML document heap (ogs_app_context lifetime).
+     * Do NOT ogs_free() these pointers. */
+    const char *s5s8_dns[2];        /* [0]=primary, [1]=secondary */
 } mme_context_t;
 
 typedef struct mme_sgsn_route_s {
@@ -926,6 +931,24 @@ typedef struct mme_sess_s {
 
     /* Save Extended Protocol Configuration Options from PGW */
     ogs_tlv_octet_t pgw_epco;
+
+    /*
+     * DNS-resolved PGW candidates for TS 23.401 §5.3.2.1 retry.
+     *
+     * Populated on the first Create Session Request when S-NAPTR DNS
+     * discovery is configured (mme.s5s8.dns in mme.yaml).  index 0 is the
+     * initially-preferred candidate (chosen at random); subsequent entries
+     * are tried in order on each transient failure.
+     *
+     * Memory: list is heap-allocated by mme_s_naptr_resolve_candidates() and
+     * freed in mme_sess_remove().  list == NULL means DNS was not used or has
+     * not yet been resolved for this session.
+     */
+    struct {
+        ogs_sockaddr_t *list;   /* heap array of candidates, or NULL */
+        int             count;  /* total entries in list[]            */
+        int             index;  /* current candidate index (0-based)  */
+    } pgw_candidates;
 } mme_sess_t;
 
 #define MME_HAVE_ENB_S1U_PATH(__bEARER) \

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -188,6 +188,52 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
             ogs_warn("No S1 Context");
         }
         break;
+    case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+        /*
+         * 3GPP TS 23.401 §5.3.2.1: if the Create Session Request times out,
+         * retry with the next DNS-resolved PGW candidate before rejecting the
+         * UE.  The candidate array was populated by mme_s_naptr_resolve_candidates()
+         * in mme-s11-build.c on the first attempt.
+         *
+         * If no more candidates are available (static config path, or all DNS
+         * candidates exhausted), fall through to release the UE context.
+         */
+        /* Skip retry when the session is already anchored to a specific PGW
+         * (PATH_SWITCH/TAU after a successful initial CSR).  The CSR builder
+         * would re-use sess->pgw_s5c_ip and produce an identical request. */
+        if (sess->pgw_candidates.list &&
+            sess->pgw_candidates.index + 1 < sess->pgw_candidates.count &&
+            !(sess->pgw_s5c_ip.ipv4 && sess->pgw_s5c_ip.addr != 0)) {
+            sess->pgw_candidates.index++;
+            ogs_warn("[%s] CSR timeout — retrying with PGW candidate [%d/%d]",
+                     mme_ue->imsi_bcd,
+                     sess->pgw_candidates.index + 1,
+                     sess->pgw_candidates.count);
+            r = mme_gtp_send_create_session_request(
+                    enb_ue, sess, xact->create_action);
+            if (r == OGS_OK) {
+                ogs_warn("GTP Timeout (retry) : IMSI[%s] Message-Type[%d]",
+                        mme_ue->imsi_bcd, type);
+                return;  /* retry in flight — await next CSR response */
+            }
+            /*
+             * The resend failed (e.g. no GTP transaction slot, socket error).
+             * ogs_expect() would only log and the unconditional return would
+             * leave the UE with no release path even though no retry is in
+             * flight.  Fall through to the release block below.
+             */
+            ogs_error("[%s] mme_gtp_send_create_session_request() failed on "
+                      "timeout retry candidate [%d/%d]; releasing UE",
+                      mme_ue->imsi_bcd,
+                      sess->pgw_candidates.index + 1,
+                      sess->pgw_candidates.count);
+        }
+        /* No more candidates, or resend failed — release UE context */
+        if (enb_ue)
+            mme_send_delete_session_or_mme_ue_context_release(enb_ue, mme_ue);
+        else
+            ogs_error("No S1 Context");
+        break;
     case OGS_GTP2_BEARER_RESOURCE_COMMAND_TYPE:
         /* Nothing to do */
         break;

--- a/src/mme/mme-s-naptr.c
+++ b/src/mme/mme-s-naptr.c
@@ -1,0 +1,1274 @@
+/*
+ * Copyright (C) 2026 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <resolv.h>
+#include <arpa/nameser.h>
+/* nameser_compat.h provides legacy T_xxx / C_IN macros; absent on musl libc.
+ * Fall back to the portable ns_* enum values when the header is missing. */
+#ifdef HAVE_ARPA_NAMESER_COMPAT_H
+#  include <arpa/nameser_compat.h>
+#else
+#  ifndef T_NAPTR
+#    define T_NAPTR  ns_t_naptr
+#  endif
+#  ifndef T_SRV
+#    define T_SRV    ns_t_srv
+#  endif
+#  ifndef T_A
+#    define T_A      ns_t_a
+#  endif
+#  ifndef C_IN
+#    define C_IN     ns_c_in
+#  endif
+#endif
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <time.h>
+
+#include "mme-context.h"
+#include "mme-s-naptr.h"
+
+#undef OGS_LOG_DOMAIN
+#define OGS_LOG_DOMAIN __mme_log_domain
+
+/* -------------------------------------------------------------------------
+ * Constants
+ * ---------------------------------------------------------------------- */
+
+/* 3GPP TS 29.303 §5.2: S-NAPTR service tag for PGW over GTPv2 (S5/S8) */
+#define S_NAPTR_SERVICE_PGW_GTP  "x-3gpp-pgw:x-gtp-v2"
+
+/*
+ * DNS response buffer.  4096 bytes is the maximum DNS UDP payload size
+ * (RFC 6891 §6.2.5 hard cap) and is sufficient for any well-formed response.
+ */
+#define DNS_BUF_LEN  4096
+
+/*
+ * Maximum candidate records collected at each resolution stage.
+ * Records beyond this limit are skipped with a warning.
+ */
+#define MAX_NAPTR_CANDIDATES  16
+#define MAX_SRV_CANDIDATES    16
+#define MAX_A_CANDIDATES      16
+
+/* -------------------------------------------------------------------------
+ * DNS candidate cache
+ *
+ * Caches the PGW candidate list keyed by APN-FQDN so that repeated
+ * Create Session Requests for the same APN avoid a full DNS
+ * NAPTR→SRV→A round-trip on every call.
+ *
+ * Cache lifetime is governed by the minimum TTL across the full DNS chain:
+ * min(NAPTR TTL, SRV TTL, A TTL).  This ensures that changes at any level
+ * of the NAPTR→SRV→A hierarchy are honoured promptly.  A floor
+ * (S_NAPTR_CACHE_MIN_TTL_S) prevents pathologically short TTLs from broken
+ * resolvers from hammering DNS.
+ *
+ * The cache is keyed on the full APN-FQDN which already encodes the
+ * APN name, MCC, and MNC per TS 23.003 §19.4.2, so no separate PLMN
+ * field is needed in the key.
+ *
+ * Thread safety: the open5gs MME is single-threaded (event-driven), so no
+ * locking is required.
+ *
+ * Load balancing: on every cache hit, mme_s_naptr_resolve_candidates()
+ * returns a freshly rotated copy of the cached list so that successive
+ * sessions for the same APN still receive a random initial PGW selection.
+ * ---------------------------------------------------------------------- */
+
+/* Maximum distinct APN-FQDNs in cache; oldest entry evicted when full */
+#define S_NAPTR_CACHE_MAX_ENTRIES    64
+
+/*
+ * Minimum effective cache TTL (seconds).  If the DNS TTL is shorter than this
+ * floor, the actual cache lifetime is raised to S_NAPTR_CACHE_MIN_TTL_S to
+ * avoid hammering the DNS server on every session setup.
+ * Set to 0 to honour the DNS TTL exactly (no floor).
+ */
+#define S_NAPTR_CACHE_MIN_TTL_S      30
+
+/* Maximum effective cache TTL (seconds).  DNS TTLs longer than this are
+ * clamped down so that the cached PGW pool is never used for more than one
+ * day without a fresh DNS lookup.  Set to 0 to honour the DNS TTL exactly. */
+#define S_NAPTR_CACHE_DEFAULT_TTL_S  86400
+
+/*
+ * Per-SRV-target descriptor stored inside the cache entry for tier0 targets.
+ *
+ * Each tier0 SRV target contributes one or more A records to list[].  This
+ * struct records WHERE in list[] those IPs live (start..start+count-1) and
+ * what SRV weight was advertised for the target.
+ *
+ * build_rotated_candidates() uses these descriptors to apply RFC 2782 §3
+ * weight-proportional selection at the SRV-TARGET level: a target with
+ * weight=99 is selected 99× more often than one with weight=1, regardless
+ * of how many A records each target has.  Weight 0 is treated as 1 per
+ * RFC 2782 ("a very small chance of being selected").
+ */
+typedef struct {
+    uint16_t weight;   /* SRV weight; 0 treated as 1 per RFC 2782 §3 */
+    int      start;    /* index into list[] of this target's first IP  */
+    int      count;    /* number of A records resolved for this target */
+} tier0_target_t;
+
+typedef struct {
+    ogs_lnode_t     lnode;
+    char            fqdn[NS_MAXDNAME];   /* lookup key (APN-FQDN)              */
+    ogs_sockaddr_t *list;                /* heap copy of candidate array       */
+    int             count;              /* total entries in list[]            */
+    int             tier0_count;        /* IPs from the lowest SRV priority   *
+                                         * tier (list[0..tier0_count-1]).      *
+                                         * build_rotated_candidates() applies  *
+                                         * RFC 2782 weight selection here;     *
+                                         * backup tiers are appended after so  *
+                                         * RFC 2782 priority ordering holds.   */
+    tier0_target_t  tier0_targets[MAX_SRV_CANDIDATES]; /* per-target weight+range */
+    int             tier0_target_count; /* valid entries in tier0_targets[]   */
+    time_t          expires_at;         /* time(NULL) value at expiry         */
+} s_naptr_cache_entry_t;
+
+/* Entries are appended at the tail; oldest is at the head (FIFO eviction) */
+static OGS_LIST(s_naptr_cache);
+static int s_naptr_cache_entries = 0;
+
+/* Release one cache entry and update the occupancy counter */
+static void cache_entry_free(s_naptr_cache_entry_t *e)
+{
+    ogs_assert(e);
+    ogs_list_remove(&s_naptr_cache, e);
+    s_naptr_cache_entries--;
+    ogs_free(e->list);
+    ogs_free(e);
+}
+
+/*
+ * cache_lookup() - find a live (non-expired) entry by FQDN.
+ *
+ * Expired entries encountered during the scan are collected and freed after
+ * the iteration completes.  This avoids calling cache_entry_free() (which
+ * calls ogs_list_remove()) from inside ogs_list_for_each_safe, making the
+ * removal explicit and easy to reason about.
+ *
+ * Returns the entry on cache hit, NULL on miss or expiry.
+ */
+static s_naptr_cache_entry_t *cache_lookup(const char *fqdn)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+    s_naptr_cache_entry_t *found = NULL, *expired = NULL;
+    time_t now = time(NULL);
+
+    ogs_list_for_each_safe(&s_naptr_cache, next, e) {
+        if (strcmp(e->fqdn, fqdn) != 0)
+            continue;
+
+        if (now >= e->expires_at) {
+            ogs_debug("S-NAPTR cache: expired entry for '%s'", fqdn);
+            expired = e;   /* free after loop exits */
+        } else {
+            ogs_debug("S-NAPTR cache: HIT '%s' (%d candidates, %lds remaining)",
+                      fqdn, e->count, (long)(e->expires_at - now));
+            found = e;
+        }
+        break;  /* FQDN is unique in the cache — stop scanning */
+    }
+
+    if (expired)
+        cache_entry_free(expired);  /* safe: loop already finished */
+
+    return found;
+}
+
+/*
+ * cache_store() - insert or refresh a cache entry for fqdn.
+ *
+ * Makes a deep copy of list[0..count-1].  The effective TTL is clamped to
+ * [S_NAPTR_CACHE_MIN_TTL_S, S_NAPTR_CACHE_DEFAULT_TTL_S].  When the cache is
+ * full the oldest entry (head of the list) is evicted before the new one is
+ * appended.  If an entry for fqdn already exists it is updated in-place
+ * (moved to the tail to maintain recency ordering for eviction).
+ *
+ * target_count == 0 is accepted: it represents a backup-only pool where every
+ * primary SRV target had no A records.  build_rotated_candidates() handles
+ * this with a uniform random rotation fast-path (t0_count <= 0 branch).
+ */
+static void cache_store(const char *fqdn,
+        const ogs_sockaddr_t *list, int count,
+        int tier0_count,
+        const tier0_target_t *targets, int target_count,
+        uint32_t ttl_s)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+    uint32_t effective_ttl;
+
+    /* Programmer-error guards: invalid inputs from the caller. */
+    ogs_assert(fqdn && list && count > 0);
+    /*
+     * target_count == 0 is legal: backup-only pool — all primary SRV targets
+     * had no A records and backup IPs were promoted.  Guard against obviously
+     * corrupt values only.
+     */
+    ogs_assert(target_count >= 0 && target_count <= MAX_SRV_CANDIDATES);
+    /* tier0_count must be in (0, count].
+     * Use a soft error instead of abort() so an unusual DNS topology or a
+     * future bookkeeping regression doesn't crash the live MME process.
+     * NOTE: the result is NOT cached — the next session for this APN will
+     * re-query DNS.  This is intentional and safe; log at ERROR so operators
+     * can see that caching was skipped. */
+    if (tier0_count <= 0 || tier0_count > count) {
+        ogs_error("S-NAPTR cache_store: invalid tier0_count=%d (count=%d) "
+                  "for '%s' — result NOT cached; next session will re-query",
+                  tier0_count, count, fqdn);
+        return;
+    }
+
+    /*
+     * Clamp the effective TTL to the range [S_NAPTR_CACHE_MIN_TTL_S,
+     * S_NAPTR_CACHE_DEFAULT_TTL_S] (i.e. [30s, 86400s]).
+     *
+     *   Floor (30 s): prevents cache thrashing from misconfigured zones that
+     *     return TTL 0 or a pathologically short value.
+     *   Ceiling (86400 s): honours whatever TTL the DNS zone publishes up to
+     *     a maximum of one day.  After that the cached PGW pool is always
+     *     refreshed, ensuring long-lived processes do not retain arbitrarily
+     *     stale topology indefinitely.
+     */
+    effective_ttl = ttl_s;
+    if (effective_ttl < S_NAPTR_CACHE_MIN_TTL_S)
+        effective_ttl = S_NAPTR_CACHE_MIN_TTL_S;
+    if (effective_ttl > S_NAPTR_CACHE_DEFAULT_TTL_S)
+        effective_ttl = S_NAPTR_CACHE_DEFAULT_TTL_S;
+
+    /* Check if this FQDN is already cached — update in-place */
+    ogs_list_for_each_safe(&s_naptr_cache, next, e) {
+        if (strcmp(e->fqdn, fqdn) == 0) {
+            /* Remove from current position; re-insert at tail below.
+             * Zero the lnode after removal so ogs_list_add() starts with
+             * clean prev/next pointers (defensive; OGS list_add overwrites
+             * them anyway, but avoids any latent confusion). */
+            ogs_list_remove(&s_naptr_cache, e);
+            s_naptr_cache_entries--;
+            ogs_free(e->list);
+            e->list = NULL;
+            memset(&e->lnode, 0, sizeof(e->lnode));
+            goto fill;
+        }
+    }
+
+    /* New entry — evict the oldest (head) if the cache is full */
+    if (s_naptr_cache_entries >= S_NAPTR_CACHE_MAX_ENTRIES) {
+        e = ogs_list_first(&s_naptr_cache);
+        ogs_assert(e);
+        ogs_debug("S-NAPTR cache: evicting oldest entry '%s'", e->fqdn);
+        ogs_list_remove(&s_naptr_cache, e);
+        s_naptr_cache_entries--;
+        ogs_free(e->list);
+        memset(e, 0, sizeof(*e));   /* reuse the allocation */
+    } else {
+        e = ogs_calloc(1, sizeof(s_naptr_cache_entry_t));
+        ogs_assert(e);
+    }
+
+fill:
+    ogs_cpystrn(e->fqdn, fqdn, sizeof(e->fqdn));
+    e->count              = count;
+    e->tier0_count        = tier0_count;
+    e->tier0_target_count = target_count;
+    if (target_count > 0)   /* 0 = backup-only pool; no target descriptors to copy */
+        memcpy(e->tier0_targets, targets, target_count * sizeof(tier0_target_t));
+    e->list               = ogs_calloc(count, sizeof(ogs_sockaddr_t));
+    ogs_assert(e->list);
+    memcpy(e->list, list, count * sizeof(ogs_sockaddr_t));
+    e->expires_at         = time(NULL) + (time_t)effective_ttl;
+
+    ogs_list_add(&s_naptr_cache, e);  /* newest entries at tail */
+    s_naptr_cache_entries++;
+
+    ogs_info("S-NAPTR cache: stored '%s' (%d candidates: %d primary across "
+             "%d SRV target(s) / %d backup, TTL %us)",
+             fqdn, count, tier0_count, target_count,
+             count - tier0_count, effective_ttl);
+}
+
+/*
+ * mme_s_naptr_cache_flush() - release all cached entries.
+ *
+ * Called from mme_context_final() on shutdown to prevent leak reports from
+ * tools like valgrind.  Not required for correctness; the OS reclaims all
+ * memory on process exit regardless.
+ */
+void mme_s_naptr_cache_flush(void)
+{
+    s_naptr_cache_entry_t *e = NULL, *next = NULL;
+
+    ogs_list_for_each_safe(&s_naptr_cache, next, e)
+        cache_entry_free(e);
+
+    ogs_assert(s_naptr_cache_entries == 0);
+    ogs_debug("S-NAPTR cache: flushed");
+}
+
+/* -------------------------------------------------------------------------
+ * Internal helpers
+ * ---------------------------------------------------------------------- */
+
+/*
+ * build_apn_fqdn() - construct the APN FQDN per 3GPP TS 23.003 §19.4.2.
+ *
+ * Format: <apn-ni>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ *
+ * MNC is zero-padded to 2 or 3 digits; MCC is always 3 digits.
+ * Returns the number of characters written (excluding NUL), or -1 if the
+ * buffer is too small.
+ */
+static int build_apn_fqdn(
+        char *buf, size_t buflen,
+        const char *apn, const ogs_plmn_id_t *plmn_id)
+{
+    int n;
+    uint16_t mcc     = ogs_plmn_id_mcc(plmn_id);
+    uint16_t mnc     = ogs_plmn_id_mnc(plmn_id);
+    uint16_t mnc_len = ogs_plmn_id_mnc_len(plmn_id);
+
+    ogs_assert(buf && buflen > 0 && apn && plmn_id);
+
+    if (mnc_len == 2)
+        n = ogs_snprintf(buf, buflen,
+                "%s.apn.epc.mnc%02d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+    else
+        n = ogs_snprintf(buf, buflen,
+                "%s.apn.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+
+    if (n < 0 || (size_t)n >= buflen) {
+        ogs_error("APN FQDN too long for APN[%s]", apn);
+        return -1;
+    }
+    return n;
+}
+
+/*
+ * init_resolver() - initialise a res_state pointing at the configured
+ * s5s8_dns servers, bypassing /etc/resolv.conf.
+ *
+ * Ownership / cleanup contract:
+ *   - Returns 0 on success.  Caller MUST call res_nclose() when done.
+ *   - Returns -1 on failure.  res_nclose() must NOT be called.
+ */
+static int init_resolver(struct __res_state *res)
+{
+    int i;
+    const char *dns[2];
+
+    ogs_assert(res);
+
+    dns[0] = mme_self()->s5s8_dns[0];
+    dns[1] = mme_self()->s5s8_dns[1];
+
+    if (!dns[0]) {
+        ogs_debug("S-NAPTR: s5s8.dns not configured, skipping DNS discovery");
+        return -1;
+    }
+
+    if (res_ninit(res) != 0) {
+        ogs_error("res_ninit() failed");
+        return -1;
+    }
+
+    res->nscount = 0;
+    for (i = 0; i < 2 && dns[i]; i++) {
+        struct in_addr addr;
+        if (inet_pton(AF_INET, dns[i], &addr) != 1) {
+            ogs_warn("Invalid s5s8.dns[%d] address '%s', skipping", i, dns[i]);
+            continue;
+        }
+        memset(&res->nsaddr_list[res->nscount], 0,
+                sizeof(res->nsaddr_list[res->nscount]));
+        res->nsaddr_list[res->nscount].sin_family = AF_INET;
+        res->nsaddr_list[res->nscount].sin_port   = htons(NS_DEFAULTPORT);
+        res->nsaddr_list[res->nscount].sin_addr   = addr;
+        res->nscount++;
+    }
+
+    if (res->nscount == 0) {
+        ogs_error("No valid s5s8.dns addresses available");
+        res_nclose(res);
+        return -1;
+    }
+
+    /*
+     * Fast failover to the secondary DNS server.
+     * retrans=1: 1 s per-server timeout.
+     * retry=2:   2 attempts per server before trying the next.
+     * Worst-case total (both servers down): 2 × 2 = 4 s.
+     */
+    res->retrans = 1;
+    res->retry   = 2;
+
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * NAPTR record parsing and selection
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    uint16_t order;
+    uint16_t pref;
+    char     flags[8];
+    char     service[64];
+    char     replacement[NS_MAXDNAME];
+} naptr_rec_t;
+
+/*
+ * parse_naptr_rdata() - decode a NAPTR RDATA field into naptr_rec_t.
+ * Wire format per RFC 3403 §4.
+ * Returns 0 on success, -1 on malformed input.
+ */
+static int parse_naptr_rdata(
+        const unsigned char *msg, int msglen,
+        const unsigned char *rdata, int rdlen,
+        naptr_rec_t *out)
+{
+    const unsigned char *p   = rdata;
+    const unsigned char *end = rdata + rdlen;
+    int slen;
+
+    if (p + 4 > end) return -1;
+    out->order = ns_get16(p);  p += 2;
+    out->pref  = ns_get16(p);  p += 2;
+
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end || (size_t)slen >= sizeof(out->flags)) return -1;
+    memcpy(out->flags, p, slen);
+    out->flags[slen] = '\0';
+    p += slen;
+
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end || (size_t)slen >= sizeof(out->service)) return -1;
+    memcpy(out->service, p, slen);
+    out->service[slen] = '\0';
+    p += slen;
+
+    /* REGEXP — skip (not used for S-NAPTR per RFC 3958 §6.5) */
+    if (p >= end) return -1;
+    slen = *p++;
+    if (p + slen > end) return -1;
+    p += slen;
+
+    if (ns_name_uncompress(msg, msg + msglen, p,
+                out->replacement, NS_MAXDNAME) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*
+ * query_naptr_all() - query NAPTR records and return ALL candidates at the
+ * lowest ORDER value, sorted by preference ascending (most preferred first).
+ *
+ * Algorithm (TS 29.303 §5.2 / RFC 3958 §6.5):
+ *   1. Filter records: service "x-3gpp-pgw:x-gtp-v2", flag "S".
+ *   2. Keep only records at the lowest ORDER value.
+ *   3. Sort the survivors by PREF ascending (lower pref = more preferred).
+ *
+ * Returns the count (≥ 1) and fills srv_names[0..count-1] on success.
+ * Returns -1 on failure.
+ *
+ * Returning the full ordered list (rather than a single randomly-selected
+ * entry) lets the caller fall back to the next candidate when a chosen
+ * replacement has no usable SRV or A records, without re-querying DNS.
+ */
+static int query_naptr_all(
+        struct __res_state *res,
+        const char *fqdn,
+        char srv_names[][NS_MAXDNAME],
+        int max_count,
+        int *count_out,
+        uint32_t *min_ttl_out)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, j, count = 0;
+    uint16_t best_order = 0;
+    uint32_t min_ttl = UINT32_MAX;
+    ns_msg handle;
+    ns_rr rr;
+    naptr_rec_t candidates[MAX_NAPTR_CANDIDATES];
+    naptr_rec_t cur, key;
+
+    ogs_assert(count_out && min_ttl_out);
+    *count_out   = 0;
+    *min_ttl_out = 0;
+
+    ogs_debug("S-NAPTR: NAPTR query for '%s'", fqdn);
+
+    len = res_nquery(res, fqdn, C_IN, T_NAPTR, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: NAPTR query failed for '%s'", fqdn);
+        return -1;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse failed for '%s'", fqdn);
+        return -1;
+    }
+
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_NAPTR)
+            continue;
+        if (parse_naptr_rdata(buf, len,
+                ns_rr_rdata(rr), ns_rr_rdlen(rr), &cur) < 0)
+            continue;
+
+        ogs_debug("S-NAPTR: NAPTR[%d] order=%u pref=%u flags='%s' "
+                  "service='%s' replacement='%s'",
+                  i, cur.order, cur.pref, cur.flags,
+                  cur.service, cur.replacement);
+
+        if (strcasecmp(cur.service, S_NAPTR_SERVICE_PGW_GTP) != 0)
+            continue;
+        if (strcasecmp(cur.flags, "s") != 0)
+            continue;
+
+        /* Track TTL across all qualifying records — the shortest drives expiry */
+        if (ns_rr_ttl(rr) < min_ttl)
+            min_ttl = ns_rr_ttl(rr);
+
+        if (count == 0 || cur.order < best_order) {
+            best_order    = cur.order;
+            candidates[0] = cur;
+            count         = 1;
+        } else if (cur.order == best_order) {
+            if (count < MAX_NAPTR_CANDIDATES) {
+                candidates[count++] = cur;
+            } else {
+                ogs_warn("S-NAPTR: NAPTR candidate limit (%d) reached for "
+                         "'%s'; extra records at order=%u skipped",
+                         MAX_NAPTR_CANDIDATES, fqdn, best_order);
+            }
+        }
+    }
+
+    if (count == 0) {
+        ogs_warn("S-NAPTR: no matching NAPTR record for '%s' "
+                 "(service=" S_NAPTR_SERVICE_PGW_GTP ", flag=S)", fqdn);
+        return -1;
+    }
+
+    /*
+     * Sort candidates by PREF ascending so the most-preferred SRV target
+     * is tried first.  Falls back to the next entry when the chosen
+     * replacement has no usable SRV/A data (handled in the caller).
+     *
+     * Insertion sort is O(n²) but n ≤ MAX_NAPTR_CANDIDATES (16).
+     */
+    for (i = 1; i < count; i++) {
+        key = candidates[i];
+        j   = i - 1;
+        while (j >= 0 && candidates[j].pref > key.pref) {
+            candidates[j + 1] = candidates[j];
+            j--;
+        }
+        candidates[j + 1] = key;
+    }
+
+    /* Copy up to max_count sorted replacement strings to the output array */
+    *count_out = (count < max_count) ? count : max_count;
+    for (i = 0; i < *count_out; i++) {
+        ogs_cpystrn(srv_names[i], candidates[i].replacement, NS_MAXDNAME);
+        ogs_debug("S-NAPTR: NAPTR candidate[%d/%d] order=%u pref=%u → '%s'",
+                  i + 1, *count_out,
+                  candidates[i].order, candidates[i].pref, srv_names[i]);
+    }
+
+    *min_ttl_out = (min_ttl == UINT32_MAX) ? 0 : min_ttl;
+    ogs_debug("S-NAPTR: %d NAPTR candidate(s) for '%s'; min TTL %us",
+              *count_out, fqdn, *min_ttl_out);
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * SRV record querying and selection
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    uint16_t priority;
+    uint16_t weight;
+    uint16_t port;
+    char     target[NS_MAXDNAME];
+} srv_rec_t;
+
+/*
+ * query_srv_all() - query SRV records and return ALL targets across ALL
+ * priority tiers, sorted by priority ascending then weight descending.
+ *
+ * RFC 2782 §3 mandates:
+ *   1. Always try the lowest numeric priority value first.
+ *   2. Within a priority tier use weight-proportional random selection.
+ *   3. Only proceed to the next priority tier when every target in the
+ *      current tier has been tried and failed.
+ *
+ * To honour rule (3) without discarding any backup targets this function:
+ *   - Collects EVERY SRV record from the response, across all priorities.
+ *   - Sorts them: primary sort by priority ASC (lower = preferred), secondary
+ *     sort by weight DESC (higher weight = earlier within a tier).
+ *   - Returns the total count and sets *tier0_count_out to the number of
+ *     records at the lowest (most-preferred) priority value.
+ *
+ * The caller resolves A records for each target in order, so the resulting
+ * IP array has all primary-tier IPs first and backup-tier IPs after them.
+ * build_rotated_candidates() then applies random rotation only within the
+ * primary-tier prefix, preserving the priority ordering for retries.
+ *
+ * Returns the total number of SRV records stored in out[] (≥1), or 0 on
+ * failure.  *tier0_count_out is set to 0 on failure.
+ */
+static int query_srv_all(
+        struct __res_state *res,
+        const char *srv_name,
+        srv_rec_t *out, int max_count,
+        int *tier0_count_out,
+        uint32_t *min_ttl_out)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, j, count = 0;
+    uint32_t min_ttl = UINT32_MAX;
+    ns_msg handle;
+    ns_rr rr;
+    const unsigned char *rdata;
+    srv_rec_t cur, key;
+    uint16_t min_priority;
+
+    ogs_assert(tier0_count_out);
+    ogs_assert(min_ttl_out);
+    *tier0_count_out = 0;
+    *min_ttl_out     = 0;
+
+    ogs_debug("S-NAPTR: SRV query (all tiers) for '%s'", srv_name);
+
+    len = res_nquery(res, srv_name, C_IN, T_SRV, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: SRV query failed for '%s'", srv_name);
+        return 0;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse (SRV) failed for '%s'", srv_name);
+        return 0;
+    }
+
+    /* Pass 1: collect every SRV record regardless of priority */
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_SRV)
+            continue;
+
+        rdata = ns_rr_rdata(rr);
+        if (ns_rr_rdlen(rr) < 6)
+            continue;
+
+        cur.priority = ns_get16(rdata);  rdata += 2;
+        cur.weight   = ns_get16(rdata);  rdata += 2;
+        cur.port     = ns_get16(rdata);  rdata += 2;
+
+        if (ns_name_uncompress(buf, buf + len, rdata,
+                cur.target, NS_MAXDNAME) < 0)
+            continue;
+
+        ogs_debug("S-NAPTR: SRV[%d] priority=%u weight=%u port=%u target='%s' "
+                  "(TTL %us)",
+                  i, cur.priority, cur.weight, cur.port, cur.target,
+                  ns_rr_ttl(rr));
+
+        /* Track minimum SRV TTL across ALL tiers — any SRV record expiring
+         * early should shorten the cache lifetime for the whole pool. */
+        if (ns_rr_ttl(rr) < min_ttl)
+            min_ttl = ns_rr_ttl(rr);
+
+        if (count < max_count) {
+            out[count++] = cur;
+        } else {
+            ogs_warn("S-NAPTR: SRV record limit (%d) reached for '%s'; "
+                     "extra records skipped", max_count, srv_name);
+            break;
+        }
+    }
+
+    if (count == 0) {
+        ogs_warn("S-NAPTR: no SRV records found for '%s'", srv_name);
+        return 0;
+    }
+
+    /*
+     * Pass 2: insertion-sort by priority ASC, weight DESC.
+     *
+     * Insertion sort is O(n²) but n ≤ MAX_SRV_CANDIDATES (16) so it is
+     * faster in practice than qsort() due to zero overhead and cache
+     * friendliness on small arrays.
+     *
+     * Within the same priority, higher-weight targets sort earlier.  This
+     * gives weight-influenced ordering within a tier while still exposing
+     * every target to the retry mechanism.
+     */
+    for (i = 1; i < count; i++) {
+        key = out[i];
+        j   = i - 1;
+        while (j >= 0 && (out[j].priority > key.priority ||
+               (out[j].priority == key.priority &&
+                out[j].weight   <  key.weight))) {
+            out[j + 1] = out[j];
+            j--;
+        }
+        out[j + 1] = key;
+    }
+
+    /* Pass 3: count tier0 (records at the lowest priority value) */
+    min_priority = out[0].priority;
+    for (i = 0; i < count; i++) {
+        if (out[i].priority != min_priority)
+            break;
+        (*tier0_count_out)++;
+    }
+
+    *min_ttl_out = (min_ttl == UINT32_MAX) ? 0 : min_ttl;
+
+    ogs_debug("S-NAPTR: %d SRV target(s) total; %d primary (priority=%u) "
+              "+ %d backup for '%s'; SRV min TTL %us",
+              count, *tier0_count_out, min_priority,
+              count - *tier0_count_out, srv_name, *min_ttl_out);
+    return count;
+}
+
+/* -------------------------------------------------------------------------
+ * A record resolution — all addresses for retry support
+ * ---------------------------------------------------------------------- */
+
+/*
+ * query_a_all() - resolve hostname to ALL IPv4 addresses.
+ *
+ * Fills out[0..max_count-1] with all A records found, each with the given
+ * port.  *min_ttl_out receives the minimum TTL across all A records; this
+ * drives the DNS cache expiry.  Returns the count stored, or 0 on failure.
+ */
+static int query_a_all(
+        struct __res_state *res,
+        const char *hostname, uint16_t port,
+        ogs_sockaddr_t *out, int max_count,
+        uint32_t *min_ttl_out)
+{
+    unsigned char buf[DNS_BUF_LEN];
+    int len, i, count = 0;
+    uint32_t min_ttl = UINT32_MAX;
+    ns_msg handle;
+    ns_rr rr;
+
+    ogs_assert(res && hostname && out && max_count > 0 && min_ttl_out);
+
+    ogs_debug("S-NAPTR: A query for '%s'", hostname);
+
+    len = res_nquery(res, hostname, C_IN, T_A, buf, sizeof(buf));
+    if (len < 0) {
+        ogs_warn("S-NAPTR: A query failed for '%s'", hostname);
+        *min_ttl_out = 0;
+        return 0;
+    }
+
+    if (ns_initparse(buf, len, &handle) < 0) {
+        ogs_error("S-NAPTR: ns_initparse (A) failed for '%s'", hostname);
+        *min_ttl_out = 0;
+        return 0;
+    }
+
+    for (i = 0; i < ns_msg_count(handle, ns_s_an); i++) {
+        if (ns_parserr(&handle, ns_s_an, i, &rr) < 0)
+            continue;
+        if (ns_rr_type(rr) != T_A)
+            continue;
+        if (ns_rr_rdlen(rr) != NS_INADDRSZ)
+            continue;
+
+        if (count >= max_count) {
+            ogs_warn("S-NAPTR: A record limit (%d) reached for '%s'; "
+                     "extra records skipped", max_count, hostname);
+            break;
+        }
+
+        memset(&out[count], 0, sizeof(ogs_sockaddr_t));
+        out[count].sin.sin_family = AF_INET;
+        out[count].sin.sin_port   = htons(port);
+        memcpy(&out[count].sin.sin_addr, ns_rr_rdata(rr), NS_INADDRSZ);
+
+        /* Track minimum TTL for cache expiry calculation */
+        if (ns_rr_ttl(rr) < min_ttl)
+            min_ttl = ns_rr_ttl(rr);
+
+        {
+            char _addr[INET_ADDRSTRLEN];
+            ogs_debug("S-NAPTR: A[%d] %s:%u (TTL %us)",
+                      count,
+                      inet_ntop(AF_INET, &out[count].sin.sin_addr,
+                                _addr, sizeof(_addr)),
+                      port, ns_rr_ttl(rr));
+        }
+        count++;
+    }
+
+    *min_ttl_out = (min_ttl == UINT32_MAX) ? 0 : min_ttl;
+
+    if (count == 0)
+        ogs_warn("S-NAPTR: no A records found for '%s'", hostname);
+
+    return count;
+}
+
+/* -------------------------------------------------------------------------
+ * Internal: build a rotated candidate array
+ * ---------------------------------------------------------------------- */
+
+/*
+ * build_rotated_candidates() - RFC 2782-compliant weighted candidate array.
+ *
+ * INPUT LAYOUT
+ *   addrs[0 .. tier0_total-1]  Primary-tier IPs, grouped by SRV target.
+ *                               targets[i] describes each group:
+ *                                 .start   = first index of this group
+ *                                 .count   = IPs in this group
+ *                                 .weight  = SRV weight (0 → 1 per RFC 2782)
+ *   addrs[tier0_total .. n-1]  Backup-tier IPs (SRV priority > min), unchanged.
+ *
+ * SELECTION ALGORITHM (RFC 2782 §3 at the SRV-target level)
+ *   1. Compute total_weight = Σ effective_weight[i]  (0 → 1).
+ *   2. Pick r = ogs_random32() % total_weight  → select SRV target group.
+ *      A target with weight=99 is selected 99× more often than weight=1.
+ *   3. Within the selected group, pick a random starting IP uniformly.
+ *
+ * OUTPUT LAYOUT
+ *   result[0]                  Random IP from the weight-selected target.
+ *   result[1 .. sel_count-1]   Remaining IPs of the selected target.
+ *   result[sel_count ..]       IPs of OTHER primary targets in weight-DESC
+ *                               order (they are already weight-sorted in
+ *                               addrs[] by query_srv_all()).
+ *   result[tier0_total ..]     Backup-tier IPs (unchanged order).
+ *
+ * This ensures:
+ *   - Load balancing: high-weight PGWs receive proportionally more new
+ *     sessions (DNS weight=99:1 → ~99% vs ~1% initial selection).
+ *   - Failover within tier: after the preferred PGW's IPs are exhausted,
+ *     retry advances to the next-highest-weight primary PGW.
+ *   - Priority failover: backup tier is only reached after all primary
+ *     IPs are exhausted (RFC 2782 priority semantics).
+ *
+ * Edge cases:
+ *   t0_count == 0  → no target descriptors; uniform rotation of all IPs.
+ *   n == 1         → single candidate; copy directly, no selection needed.
+ *
+ * The caller owns the returned array and must ogs_free() it.
+ */
+static ogs_sockaddr_t *build_rotated_candidates(
+        const ogs_sockaddr_t *addrs, int n,
+        const tier0_target_t *targets, int t0_count,
+        int *count_out)
+{
+    ogs_sockaddr_t *result = NULL;
+    int out = 0, sel = 0, start_ip = 0, tier0_total = 0, i, j;
+    uint32_t total_weight = 0, pick, cum;
+
+    ogs_assert(addrs && n > 0 && count_out);
+
+    result = ogs_calloc(n, sizeof(ogs_sockaddr_t));
+    ogs_assert(result);
+
+    /* ------------------------------------------------------------------
+     * Fast path: no target descriptors (should not normally occur, but
+     * handles the edge case gracefully with uniform rotation).
+     * ------------------------------------------------------------------ */
+    if (t0_count <= 0) {
+        int preferred = (n > 1) ? (int)(ogs_random32() % (uint32_t)n) : 0;
+        for (i = 0; i < n; i++)
+            result[i] = addrs[(preferred + i) % n];
+        *count_out = n;
+        return result;
+    }
+
+    /* Compute total primary-tier IP count from target descriptors */
+    for (i = 0; i < t0_count; i++)
+        tier0_total += targets[i].count;
+
+    /* ------------------------------------------------------------------
+     * Step 1: RFC 2782 §3 weighted random selection of the SRV target.
+     *
+     * Weight is applied at the SRV-target (hostname) level, not the IP
+     * level.  A target with weight=99 is 99× more likely to be selected
+     * as the preferred starting group than one with weight=1, regardless
+     * of how many A records each target resolved to.
+     * ------------------------------------------------------------------ */
+    for (i = 0; i < t0_count; i++)
+        total_weight += targets[i].weight ? (uint32_t)targets[i].weight : 1u;
+
+    pick = ogs_random32() % total_weight;
+    sel  = t0_count - 1;   /* safe default: last target */
+    cum  = 0;
+    for (i = 0; i < t0_count; i++) {
+        cum += targets[i].weight ? (uint32_t)targets[i].weight : 1u;
+        if (pick < cum) { sel = i; break; }
+    }
+
+    /* ------------------------------------------------------------------
+     * Step 2: random start within the selected target's IP group.
+     * ------------------------------------------------------------------ */
+    start_ip = (targets[sel].count > 1)
+                   ? (int)(ogs_random32() % (uint32_t)targets[sel].count)
+                   : 0;
+
+    for (j = 0; j < targets[sel].count; j++)
+        result[out++] = addrs[targets[sel].start +
+                               (start_ip + j) % targets[sel].count];
+
+    /* ------------------------------------------------------------------
+     * Step 3: append other primary-tier targets in their original order
+     * (weight-DESC as produced by query_srv_all()'s insertion sort).
+     * ------------------------------------------------------------------ */
+    for (i = 0; i < t0_count; i++) {
+        if (i == sel)
+            continue;
+        for (j = 0; j < targets[i].count; j++)
+            result[out++] = addrs[targets[i].start + j];
+    }
+
+    /* ------------------------------------------------------------------
+     * Step 4: append backup-tier IPs unchanged.
+     * ------------------------------------------------------------------ */
+    for (i = tier0_total; i < n; i++)
+        result[out++] = addrs[i];
+
+    /* Sanity: every IP must have been placed exactly once.  Use a soft error
+     * rather than abort() so a bookkeeping inconsistency doesn't crash the
+     * live MME during a session setup. */
+    if (out != n) {
+        ogs_error("S-NAPTR build_rotated: placement error (out=%d n=%d); "
+                  "dropping result to avoid partial candidate array", out, n);
+        ogs_free(result);
+        *count_out = 0;
+        return NULL;
+    }
+
+    ogs_debug("S-NAPTR: weighted selection: target[%d/%d] weight=%u "
+              "(total_weight=%u) start_ip=%d",
+              sel + 1, t0_count,
+              targets[sel].weight ? targets[sel].weight : 1,
+              total_weight, start_ip);
+
+    *count_out = n;
+    return result;
+}
+
+/* -------------------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------------- */
+
+/*
+ * mme_s_naptr_resolve_candidates() - S-NAPTR PGW discovery with caching.
+ *
+ * On cache miss, runs the full NAPTR→SRV→A DNS chain and stores the result.
+ * On cache hit, returns a freshly rotated copy of the cached candidates.
+ *
+ * The cache key is the APN-FQDN derived from apn + plmn_id per TS 23.003
+ * §19.4.2.  Cache lifetime = min(NAPTR TTL, SRV TTL, A TTL) seconds,
+ *             clamped to [S_NAPTR_CACHE_MIN_TTL_S, S_NAPTR_CACHE_DEFAULT_TTL_S]
+ *             i.e. [30 s, 86400 s].
+ *
+ * Returns a heap-allocated array (caller ogs_free()s in mme_sess_remove())
+ * and sets *count.  Returns NULL / *count=0 on failure.
+ *
+ * All returned addresses carry port OGS_GTPV2_C_UDP_PORT (2123).
+ */
+ogs_sockaddr_t *mme_s_naptr_resolve_candidates(
+        const char *apn, const ogs_plmn_id_t *plmn_id, int *count)
+{
+    char fqdn[NS_MAXDNAME];
+    char naptr_srvs[MAX_NAPTR_CANDIDATES][NS_MAXDNAME]; /* ordered SRV names from NAPTR */
+    int  naptr_count = 0, ni = 0;
+    struct __res_state res;
+    ogs_sockaddr_t tmp[MAX_A_CANDIDATES];
+    ogs_sockaddr_t *result = NULL;
+    srv_rec_t srvs[MAX_SRV_CANDIDATES];
+    uint32_t min_ttl = UINT32_MAX;       /* minimum A-record TTL across all targets */
+    uint32_t naptr_ttl = UINT32_MAX;     /* minimum NAPTR TTL from the NAPTR response */
+    /* TTL of the SRV response for the successful NAPTR candidate.
+     * Reset to UINT32_MAX at the start of each NAPTR loop iteration and
+     * overwritten by query_srv_all() when SRV records are found.  The NAPTR
+     * loop breaks on the first candidate that yields A records, so only that
+     * candidate's SRV TTL contributes to the effective cache TTL. */
+    uint32_t chosen_srv_ttl = UINT32_MAX;
+    uint32_t a_ttl = 0;    /* per-SRV-target A-record TTL from query_a_all() */
+    int n = 0, srv_count = 0, tier0_srv_count = 0, tier0_ip_count = 0;
+    int s = 0, got = 0;
+    tier0_target_t tier0_targets[MAX_SRV_CANDIDATES];
+    int tier0_target_count = 0;
+    s_naptr_cache_entry_t *cached = NULL;
+
+    ogs_assert(apn);
+    ogs_assert(plmn_id);
+    ogs_assert(count);
+
+    *count = 0;
+
+    /* Step 1: build APN-FQDN — serves as both the DNS query name and cache key */
+    if (build_apn_fqdn(fqdn, sizeof(fqdn), apn, plmn_id) < 0)
+        return NULL;
+
+    /* ------------------------------------------------------------------
+     * Cache lookup — skip the DNS round-trip when we have a fresh result.
+     *
+     * The cache stores the FULL candidate pool sorted by SRV priority:
+     *   list[0 .. tier0_count-1]   primary-tier IPs  (SRV priority == min)
+     *   list[tier0_count .. count-1] backup-tier IPs  (SRV priority >  min)
+     *
+     * build_rotated_candidates() applies random rotation only within the
+     * primary prefix so load is distributed across primary PGWs while
+     * backup PGWs remain at the tail for RFC 2782 priority-ordered failover.
+     * ------------------------------------------------------------------ */
+    cached = cache_lookup(fqdn);
+    if (cached) {
+        result = build_rotated_candidates(cached->list, cached->count,
+                                          cached->tier0_targets,
+                                          cached->tier0_target_count, count);
+        if (result && *count > 0) {
+            char _addr[INET_ADDRSTRLEN];
+            ogs_info("S-NAPTR: [CACHE HIT] APN[%s] → %d PGW candidate(s) "
+                     "(%d primary / %d backup); preferred %s",
+                     apn, *count, cached->tier0_count,
+                     cached->count - cached->tier0_count,
+                     inet_ntop(AF_INET, &result[0].sin.sin_addr,
+                               _addr, sizeof(_addr)));
+        } else {
+            /* build_rotated_candidates() hit a placement-error guard and
+             * returned NULL.  The session will fall back to static PGW config.
+             * Log so the operator knows the cache entry is effectively unusable. */
+            ogs_warn("S-NAPTR: [CACHE HIT] candidate rotation failed for "
+                     "APN[%s]; falling back to static PGW config", apn);
+        }
+        return result;
+    }
+
+    /* ------------------------------------------------------------------
+     * Cache MISS — full DNS resolution: NAPTR → SRV (all tiers) → A.
+     *
+     * srvs[] is sorted by priority ASC so processing in order naturally
+     * produces a priority-partitioned tmp[]:
+     *   tmp[0 .. tier0_ip_count-1]  primary-tier IPs
+     *   tmp[tier0_ip_count .. n-1]  backup-tier IPs
+     * ------------------------------------------------------------------ */
+    ogs_debug("S-NAPTR: [CACHE MISS] APN[%s] FQDN[%s]", apn, fqdn);
+
+    if (init_resolver(&res) != 0)
+        return NULL;
+
+    /*
+     * Step 1: get all lowest-ORDER NAPTR candidates sorted by pref ASC.
+     * Returns an ordered array — most-preferred SRV name first.
+     */
+    if (query_naptr_all(&res, fqdn, naptr_srvs, MAX_NAPTR_CANDIDATES,
+                        &naptr_count, &naptr_ttl) != 0)
+        goto out;
+
+    /*
+     * Step 2: try each NAPTR candidate in preference order until one yields
+     * usable A records.  A broken DNS zone on the first replacement no longer
+     * makes discovery fail when another valid lowest-order NAPTR answer was
+     * returned in the same response.
+     *
+     * For each candidate:
+     *   a. Query all SRV targets across all priority tiers.
+     *   b. Resolve A records for each SRV target (primary tier first).
+     *   c. If at least one A record is found, commit and break.
+     *   d. Otherwise warn and advance to the next NAPTR candidate.
+     *
+     * The priority-partitioned layout of tmp[] is the same as before:
+     *   tmp[0 .. tier0_ip_count-1]  primary-tier IPs  (SRV priority == min)
+     *   tmp[tier0_ip_count .. n-1]  backup-tier IPs   (SRV priority >  min)
+     */
+    for (ni = 0; ni < naptr_count; ni++) {
+        /* Reset per-candidate accumulators before each attempt */
+        n                 = 0;
+        tier0_ip_count    = 0;
+        tier0_target_count = 0;
+        srv_count         = 0;
+        tier0_srv_count   = 0;
+        chosen_srv_ttl    = UINT32_MAX;   /* reset: set by query_srv_all()
+                                           * on success; must not carry over
+                                           * from a previous failed candidate */
+
+        srv_count = query_srv_all(&res, naptr_srvs[ni], srvs,
+                                  MAX_SRV_CANDIDATES,
+                                  &tier0_srv_count, &chosen_srv_ttl);
+        if (srv_count == 0) {
+            ogs_warn("S-NAPTR: NAPTR[%d/%d] '%s' → no SRV records; "
+                     "trying next candidate",
+                     ni + 1, naptr_count, naptr_srvs[ni]);
+            continue;
+        }
+
+        /*
+         * Primary tier: srvs[0 .. tier0_srv_count-1], weight DESC.
+         * Record tier0_target_t descriptors for build_rotated_candidates().
+         */
+        for (s = 0; s < tier0_srv_count && n < MAX_A_CANDIDATES; s++) {
+            int before = n;
+            got = query_a_all(&res, srvs[s].target, srvs[s].port,
+                              tmp + n, MAX_A_CANDIDATES - n, &a_ttl);
+            if (got > 0) {
+                ogs_debug("S-NAPTR: primary SRV '%s:%u' weight=%u → %d addr(s)",
+                          srvs[s].target, srvs[s].port, srvs[s].weight, got);
+                tier0_targets[tier0_target_count].weight = srvs[s].weight;
+                tier0_targets[tier0_target_count].start  = before;
+                tier0_targets[tier0_target_count].count  = got;
+                tier0_target_count++;
+                n += got;
+                if (a_ttl < min_ttl)
+                    min_ttl = a_ttl;
+            } else {
+                ogs_warn("S-NAPTR: primary SRV target '%s' has no A records "
+                         "— skipped", srvs[s].target);
+            }
+        }
+        tier0_ip_count = n;  /* boundary: tmp[0..tier0_ip_count-1] are primary */
+
+        /* Backup tiers: srvs[tier0_srv_count .. srv_count-1] */
+        for (s = tier0_srv_count; s < srv_count && n < MAX_A_CANDIDATES; s++) {
+            got = query_a_all(&res, srvs[s].target, srvs[s].port,
+                              tmp + n, MAX_A_CANDIDATES - n, &a_ttl);
+            if (got > 0) {
+                ogs_debug("S-NAPTR: backup SRV '%s:%u' (priority=%u) → %d addr(s)",
+                          srvs[s].target, srvs[s].port, srvs[s].priority, got);
+                n += got;
+                if (a_ttl < min_ttl)
+                    min_ttl = a_ttl;
+            } else {
+                ogs_warn("S-NAPTR: backup SRV target '%s' has no A records "
+                         "— skipped", srvs[s].target);
+            }
+        }
+
+        if (n > 0) {
+            if (ni > 0)
+                ogs_warn("S-NAPTR: NAPTR[%d/%d] '%s' succeeded after "
+                         "%d broken candidate(s)",
+                         ni + 1, naptr_count, naptr_srvs[ni], ni);
+            break;   /* found usable addresses — done */
+        }
+        ogs_warn("S-NAPTR: NAPTR[%d/%d] '%s' → SRV records present but "
+                 "no A records resolved; trying next candidate",
+                 ni + 1, naptr_count, naptr_srvs[ni]);
+    }
+
+    if (n == 0)
+        goto out;
+
+    /*
+     * If all primary SRV targets had no A records, promote backup-tier IPs
+     * to the primary tier so the session has candidates to try.
+     */
+    if (tier0_ip_count == 0 || tier0_target_count == 0) {
+        tier0_ip_count     = n;
+        tier0_target_count = 0;  /* signal fast-path in build_rotated_candidates */
+    }
+
+    /*
+     * Effective cache lifetime = min(NAPTR TTL, SRV TTL, A TTL).
+     *
+     * Each DNS level in the NAPTR→SRV→A chain has its own TTL:
+     *   - naptr_ttl     : how long the APN→SRV-name mapping is valid
+     *   - chosen_srv_ttl : how long any SRV target mapping is valid
+     *   - min_ttl       : the shortest A-record TTL across all targets
+     *
+     * If an operator reduces the NAPTR TTL to trigger rapid re-discovery
+     * (e.g. during a PGW migration) we must honour that.  Using only the
+     * A-record TTL would keep a stale PGW pool until the A records expire.
+     *
+     * Take the minimum across all three layers.  If a layer returned 0
+     * (nothing captured), skip it — the cache_store() floor will apply.
+     */
+    {
+        /* Snapshot the A-record minimum before folding in NAPTR/SRV values
+         * so we can log all three contributions separately. */
+        uint32_t a_chain_ttl = (min_ttl == UINT32_MAX) ? 0 : min_ttl;
+
+        if (naptr_ttl != UINT32_MAX && naptr_ttl < min_ttl)
+            min_ttl = naptr_ttl;
+        if (chosen_srv_ttl != UINT32_MAX && chosen_srv_ttl < min_ttl)
+            min_ttl = chosen_srv_ttl;
+        if (min_ttl == UINT32_MAX)
+            min_ttl = 0;   /* nothing captured at any level — use cache_store() floor */
+
+        ogs_debug("S-NAPTR: effective cache TTL for APN[%s]: "
+                  "NAPTR=%us SRV=%us A=%us → min=%us",
+                  apn,
+                  naptr_ttl     == UINT32_MAX ? 0 : naptr_ttl,
+                  chosen_srv_ttl == UINT32_MAX ? 0 : chosen_srv_ttl,
+                  a_chain_ttl,
+                  min_ttl);
+    }
+
+    /*
+     * Store the full priority-partitioned pool in cache together with the
+     * per-target weight descriptors so cache hits reproduce the same
+     * RFC 2782-weighted selection without re-querying DNS.
+     */
+    cache_store(fqdn, tmp, n,
+                tier0_ip_count, tier0_targets, tier0_target_count,
+                min_ttl);
+
+    /* Build the caller's rotated copy using weighted target selection */
+    result = build_rotated_candidates(tmp, n,
+                                      tier0_targets, tier0_target_count,
+                                      count);
+
+    if (result && *count > 0) {
+        char _addr[INET_ADDRSTRLEN];
+        ogs_info("S-NAPTR: [DNS] resolved APN[%s] → %d PGW candidate(s) "
+                 "(%d primary across %d SRV target(s) / %d backup); "
+                 "preferred %s (DNS TTL %us, now cached)",
+                 apn, *count, tier0_ip_count, tier0_target_count,
+                 n - tier0_ip_count,
+                 inet_ntop(AF_INET, &result[0].sin.sin_addr,
+                           _addr, sizeof(_addr)),
+                 min_ttl);
+    }
+
+out:
+    res_nclose(&res);
+
+    if (*count == 0 && result) {
+        ogs_free(result);
+        result = NULL;
+    }
+
+    if (!result)
+        ogs_warn("S-NAPTR: DNS discovery failed for APN[%s]; "
+                 "will fall back to static PGW config", apn);
+
+    return result;
+}

--- a/src/mme/mme-s-naptr.h
+++ b/src/mme/mme-s-naptr.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * PGW/SMF discovery via S-NAPTR DNS procedure with in-process caching.
+ *
+ * Standards:
+ *   3GPP TS 29.303  - Domain Name System Procedures (Stage 3)
+ *   3GPP TS 23.003  - Numbering, addressing and identification
+ *   3GPP TS 23.401  §5.3.2.1 - PGW selection and retry
+ *   RFC 3958        - Domain-Based Application Service Location Using SRV RRs
+ *                     and the Dynamic Delegation Discovery Service (DDDS)
+ *
+ * Resolution order per Create Session Request:
+ *   1. Build APN-FQDN per TS 23.003 §19.4.2
+ *   2. Check in-process DNS cache (keyed on APN-FQDN)
+ *      → HIT:  return rotated copy of cached candidates (no DNS I/O)
+ *      → MISS: proceed with steps 3-6
+ *   3. DNS NAPTR query → find record with service "x-3gpp-pgw:x-gtp-v2"
+ *   4. DNS SRV  query → resolve target hostname + port (weighted random)
+ *   5. DNS A    query → resolve ALL IPv4 addresses; read TTL for cache expiry
+ *   6. Store result in cache; return candidate array for this session
+ *
+ * The candidate array is stored in sess->pgw_candidates for per-session retry
+ * per TS 23.401 §5.3.2.1.
+ */
+
+#ifndef MME_S_NAPTR_H
+#define MME_S_NAPTR_H
+
+#include "ogs-gtp.h"
+#include "mme-context.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * mme_s_naptr_resolve_candidates() - resolve ALL PGW IPv4 candidates via
+ * S-NAPTR for a given APN and home PLMN ID, with in-process DNS caching.
+ *
+ * Uses the DNS servers configured under mme.s5s8.dns in mme.yaml.
+ *
+ * On the first call for a given APN+PLMN the function runs the full DNS
+ * NAPTR→SRV→A chain and caches the result keyed by APN-FQDN.  Subsequent
+ * calls within the DNS TTL window return a freshly rotated copy of the
+ * cached list, avoiding repeated DNS round-trips for the same APN.
+ *
+ * Returns a heap-allocated array of ogs_sockaddr_t (caller must ogs_free()
+ * the array — typically in mme_sess_remove()).  Sets *count to the number
+ * of entries.  Index 0 is the randomly-selected preferred candidate per
+ * TS 23.401 §5.3.2.1; subsequent entries are ordered retry candidates.
+ *
+ * Returns NULL and sets *count = 0 on any failure.
+ * The sin_port field in each returned address is set to the value from the
+ * DNS SRV record (typically 2123).  Callers MUST use OGS_GTPV2_C_UDP_PORT
+ * for actual GTP-C socket connections — the GTPv2 F-TEID IE does not carry
+ * a port number, so the port field here is informational only.
+ */
+ogs_sockaddr_t *mme_s_naptr_resolve_candidates(
+        const char *apn, const ogs_plmn_id_t *plmn_id, int *count);
+
+/*
+ * mme_s_naptr_cache_flush() - release all in-process DNS cache entries.
+ *
+ * Must be called from mme_context_final() on shutdown to free the cache and
+ * prevent memory-leak reports from analysis tools such as valgrind.
+ */
+void mme_s_naptr_cache_flush(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MME_S_NAPTR_H */

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -17,7 +17,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <arpa/inet.h>
+
 #include "mme-context.h"
+#include "mme-s-naptr.h"
 
 #include "mme-s11-build.h"
 
@@ -141,25 +144,204 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
         req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
         req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
             &pgw_s5c_teid;
-    } else {
-        ogs_sockaddr_t *pgw_addr = NULL;
-        ogs_sockaddr_t *pgw_addr6 = NULL;
-
-        pgw_addr = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET, sess);
-        pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET6, sess);
-        if (!pgw_addr && !pgw_addr6) {
-            pgw_addr = mme_self()->pgw_addr;
-            pgw_addr6 = mme_self()->pgw_addr6;
-        }
-
-        rv = ogs_gtp2_sockaddr_to_f_teid(
-                pgw_addr, pgw_addr6, &pgw_s5c_teid, &len);
-        ogs_assert(rv == OGS_OK);
+    } else if ((create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST ||
+                create_action == OGS_GTP_CREATE_IN_TRACKING_AREA_UPDATE) &&
+               sess->pgw_s5c_ip.ipv4 && sess->pgw_s5c_ip.addr != 0) {
+        /*
+         * Handover / TAU re-attach: the session is already established.
+         * Use the PGW IP that accepted the original Create Session Request
+         * (stored in sess->pgw_s5c_ip after the first CSR response).
+         * Do NOT re-run DNS discovery — the SGW must anchor the S5/S8
+         * tunnel to the same PGW that holds the subscriber context.
+         *
+         * Guard: require addr != 0 in addition to the ipv4 flag, so a
+         * non-compliant PGW that sets ipv4=1 but returns 0.0.0.0 falls
+         * through to the warning + DNS/static path below rather than
+         * sending a CSR with a null destination address.
+         */
+        pgw_s5c_teid.ipv4 = 1;
+        pgw_s5c_teid.addr = sess->pgw_s5c_ip.addr;
         req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
         req->pgw_s5_s8_address_for_control_plane_or_pmip.data = &pgw_s5c_teid;
-        req->pgw_s5_s8_address_for_control_plane_or_pmip.len = len;
+        req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
+            OGS_GTP2_F_TEID_IPV4_LEN;
+    } else {
+        /*
+         * PGW/SMF address not provisioned by HSS.
+         *
+         * Resolution order:
+         *   1. S-NAPTR DNS (3GPP TS 29.303) — only when mme.s5s8.dns is
+         *      configured in mme.yaml.  Completely optional: if omitted, or
+         *      if DNS resolution fails for any reason, the MME falls through
+         *      transparently to the static configuration below.
+         *   2. Static PGW list from mme.yaml matched by APN / Cell-ID / TAC.
+         *   3. First PGW in the static list (last-resort).
+         */
+
+        /*
+         * PATH_SWITCH / TAU with no established PGW IP.
+         *
+         * Normally the PGW IP is recorded in sess->pgw_s5c_ip when the
+         * Create Session Response is processed.  If we reach here during a
+         * handover or TAU it means that field was never set — either the PGW
+         * omitted the F-TEID from its response (non-compliant) or the session
+         * was never fully established.  Fall through to DNS/static discovery
+         * and warn the operator so the misconfiguration is visible in logs.
+         */
+        if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST ||
+            create_action == OGS_GTP_CREATE_IN_TRACKING_AREA_UPDATE) {
+            ogs_warn("S-NAPTR: PATH_SWITCH/TAU but pgw_s5c_ip not set for "
+                     "session — PGW may not have returned F-TEID in CSR "
+                     "response; falling back to DNS/static discovery");
+        }
+
+        ogs_sockaddr_t *pgw_addr  = NULL;
+        ogs_sockaddr_t *pgw_addr6 = NULL;
+        bool dns_used = false;
+
+        /*
+         * --- Path 1: S-NAPTR DNS (optional, TS 29.303) ---
+         *
+         * On the FIRST Create Session Request for this session, resolve ALL
+         * PGW candidates via DNS and store them in sess->pgw_candidates.
+         * On RETRY attempts (pgw_candidates.list already set), just advance
+         * to the next candidate — do not re-query DNS.
+         *
+         * This implements TS 23.401 §5.3.2.1: the MME shall try the next
+         * DNS-resolved candidate before rejecting the UE.
+         */
+        if (mme_self()->s5s8_dns[0] && session->name) {
+            /* mme_ue is already looked up and asserted non-NULL at the top of
+             * this function; no second lookup needed. */
+            if (!sess->pgw_candidates.list) {
+                /*
+                 * First attempt: resolve the subscriber's home PLMN, then
+                 * run S-NAPTR DNS to discover PGW candidates.
+                 *
+                 * Home PLMN source priority:
+                 *
+                 *   1. hssmap (mme.yaml hssmap_map) — explicit operator
+                 *      config mapping IMSI prefix → home PLMN + HSS realm.
+                 *      Most precise; required for roaming UEs whose home
+                 *      PLMN differs from every served GUMMEI.
+                 *
+                 *   2. IMSI-prefix match against served GUMMEIs — derives
+                 *      home PLMN from the leading MCC+MNC digits of the
+                 *      IMSI, checked against every PLMN in the configured
+                 *      gummei list.  Covers non-roaming and simple single-
+                 *      PLMN deployments without requiring hssmap config.
+                 *
+                 * Do NOT use tai.plmn_id: TAI is the VISITED PLMN.  For
+                 * roaming UEs, visited ≠ home, and using it would build
+                 * the APN-FQDN in the wrong DNS zone (TS 23.003 §19.4.2).
+                 *
+                 * If neither source yields a PLMN, fall through to static
+                 * PGW config (dns_used stays false, no error logged here).
+                 */
+                const ogs_plmn_id_t *home_plmn = NULL;
+                /* derived_plmn is used only if hssmap is absent.
+                 * home_plmn may point into it; both are used only within
+                 * this block before mme_s_naptr_resolve_candidates(), which
+                 * copies the struct by value — no dangling-pointer risk. */
+                ogs_plmn_id_t derived_plmn;
+
+                if (mme_ue->hssmap) {
+                    /* Source 1: explicit hssmap — exact home PLMN */
+                    home_plmn = &mme_ue->hssmap->plmn_id;
+                } else {
+                    /* Source 2: derive from IMSI prefix vs served GUMMEIs */
+                    int g, p;
+                    for (g = 0; g < mme_self()->num_of_served_gummei
+                                && !home_plmn; g++) {
+                        for (p = 0;
+                             p < mme_self()->served_gummei[g].num_of_plmn_id
+                             && !home_plmn; p++) {
+                            char plmn_str[OGS_PLMNIDSTRLEN];
+                            ogs_plmn_id_to_string(
+                                &mme_self()->served_gummei[g].plmn_id[p],
+                                plmn_str);
+                            if (strncmp(plmn_str, mme_ue->imsi_bcd,
+                                        strlen(plmn_str)) == 0) {
+                                derived_plmn =
+                                    mme_self()->served_gummei[g].plmn_id[p];
+                                home_plmn = &derived_plmn;
+                            }
+                        }
+                    }
+                    if (!home_plmn)
+                        ogs_debug("S-NAPTR: cannot derive home PLMN for "
+                                  "[%s] APN[%s] — no GUMMEI PLMN matches "
+                                  "IMSI prefix; using static PGW config",
+                                  mme_ue->imsi_bcd,
+                                  session->name ? session->name : "(null)");
+                }
+
+                if (home_plmn) {
+                    sess->pgw_candidates.list =
+                        mme_s_naptr_resolve_candidates(
+                                session->name,
+                                home_plmn,
+                                &sess->pgw_candidates.count);
+                    sess->pgw_candidates.index = 0;
+                }
+            }
+
+            if (sess->pgw_candidates.list &&
+                sess->pgw_candidates.index < sess->pgw_candidates.count) {
+                dns_used = true;
+            }
+        }
+
+        if (dns_used) {
+            /*
+             * DNS discovery succeeded — use the current candidate.
+             * index 0 on first attempt; incremented by retry machinery
+             * in mme-gtp-path.c (timeout) and mme-s11-handler.c (fail:).
+             */
+            ogs_sockaddr_t *cand =
+                &sess->pgw_candidates.list[sess->pgw_candidates.index];
+
+            char _cand_addr[INET_ADDRSTRLEN];
+            ogs_debug("S-NAPTR: using PGW candidate [%d/%d] %s:%u",
+                      sess->pgw_candidates.index + 1,
+                      sess->pgw_candidates.count,
+                      inet_ntop(AF_INET, &cand->sin.sin_addr,
+                                _cand_addr, sizeof(_cand_addr)),
+                      OGS_GTPV2_C_UDP_PORT);
+
+            pgw_s5c_teid.ipv4 = 1;
+            pgw_s5c_teid.addr = cand->sin.sin_addr.s_addr;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
+                &pgw_s5c_teid;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.len =
+                OGS_GTP2_F_TEID_IPV4_LEN;
+        } else {
+            /*
+             * --- Path 2 & 3: static config ---
+             * Reached when:
+             *   (a) s5s8.dns is not configured — DNS never invoked, OR
+             *   (b) DNS resolution returned NULL — already warned internally
+             *       by mme_s_naptr_resolve_candidates().
+             * Either way this is normal operation; no additional warning needed.
+             */
+            pgw_addr = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET, sess);
+            pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET6, sess);
+            if (!pgw_addr && !pgw_addr6) {
+                pgw_addr  = mme_self()->pgw_addr;
+                pgw_addr6 = mme_self()->pgw_addr6;
+            }
+
+            rv = ogs_gtp2_sockaddr_to_f_teid(
+                    pgw_addr, pgw_addr6, &pgw_s5c_teid, &len);
+            ogs_assert(rv == OGS_OK);
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.presence = 1;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.data =
+                &pgw_s5c_teid;
+            req->pgw_s5_s8_address_for_control_plane_or_pmip.len = len;
+        }
     }
 
     req->access_point_name.presence = 1;

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -173,6 +173,32 @@ void mme_s11_handle_echo_response(
     /* Not Implemented */
 }
 
+/*
+ * is_transient_gtp_cause() - classify a GTPv2 cause code as transient.
+ *
+ * A transient cause indicates a temporary PGW/SMF unavailability that may be
+ * resolved by retrying with a different PGW candidate per 3GPP TS 23.401
+ * §5.3.2.1.  Permanent causes (e.g. APN not supported, subscriber barred) are
+ * not retried — they would fail identically on any other PGW.
+ *
+ * Returns true for causes that warrant a retry with the next candidate.
+ */
+static bool is_transient_gtp_cause(uint8_t cause)
+{
+    switch (cause) {
+    case OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING:                   /* 100 */
+    case OGS_GTP2_CAUSE_NO_RESOURCES_AVAILABLE:                       /*  73 */
+    case OGS_GTP2_CAUSE_SERVICE_NOT_SUPPORTED:                        /*  68 */
+    case OGS_GTP2_CAUSE_SYSTEM_FAILURE:                               /*  72 */
+    case OGS_GTP2_CAUSE_GTP_C_ENTITY_CONGESTION:                      /* 120 */
+    case OGS_GTP2_CAUSE_TEMPORARILY_REJECTED_DUE_TO_HANDOVER_IN_PROGRESS: /* 110 */
+    case OGS_GTP2_CAUSE_TIMED_OUT_REQUEST:                            /* 122 */
+        return true;
+    default:
+        return false;
+    }
+}
+
 static void mme_s11_create_session_fail(
         enb_ue_t *enb_ue, mme_ue_t *mme_ue,
         int create_action, uint8_t fail_cause,
@@ -216,6 +242,18 @@ void mme_s11_handle_create_session_response(
     uint8_t fail_cause = OGS_GTP2_CAUSE_REQUEST_REJECTED_REASON_NOT_SPECIFIED;
     uint8_t session_cause = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
     uint8_t bearer_cause = OGS_GTP2_CAUSE_UNDEFINED_VALUE;
+    /*
+     * local_failure: set to true when a goto-fail is triggered by an MME-side
+     * error AFTER the PGW has already responded with REQUEST_ACCEPTED (i.e. the
+     * PGW session already exists).  The retry gate MUST NOT fire in this case —
+     * sending a Create Session Request to the next candidate would create a
+     * duplicate PGW session instead of reporting the local error.
+     *
+     * Contrast with fail_cause values that come directly from the PGW's
+     * response (bearer_cause / session_cause): those indicate the PGW rejected
+     * our request, so no session was created and retrying is safe.
+     */
+    bool local_failure = false;
     ogs_gtp2_f_teid_t *sgw_s11_teid = NULL;
     ogs_gtp2_f_teid_t *pgw_s5c_teid = NULL;
     ogs_gtp2_f_teid_t *sgw_s1u_teid = NULL;
@@ -271,6 +309,9 @@ void mme_s11_handle_create_session_response(
 
     source_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
     if (!source_ue) {
+        /* MME-local context gap — not a PGW failure.  Mark local_failure so
+         * the retry gate does not send CSR to the next DNS candidate. */
+        local_failure = true;
         fail_reason = "No SGW UE Context";
         fail_cause = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         goto fail;
@@ -279,6 +320,8 @@ void mme_s11_handle_create_session_response(
     if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST) {
         target_ue = sgw_ue_find_by_id(source_ue->target_ue_id);
         if (!target_ue) {
+            /* MME-local context gap — not a PGW failure. */
+            local_failure = true;
             fail_reason = "No target SGW UE Context";
             fail_cause = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
             goto fail;
@@ -312,6 +355,8 @@ void mme_s11_handle_create_session_response(
     if (!mme_ue_from_teid) {
         ogs_error("[%s] No Context in TEID [Cause:%d]",
                 mme_ue->imsi_bcd, session_cause);
+        /* MME-local TEID lookup failure — not a PGW availability problem. */
+        local_failure = true;
         fail_cause = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         fail_reason = "No Context in TEID";
         goto fail;
@@ -403,8 +448,17 @@ void mme_s11_handle_create_session_response(
      ********************/
     session = sess->session;
     if (!session) {
+        /*
+         * The PGW responded REQUEST_ACCEPTED but the MME has no subscriber
+         * session record for this APN.  This is a local data-model
+         * inconsistency, not a PGW availability problem.  Mark as a local
+         * failure so the retry gate does not send CSR to the next candidate
+         * (which would open a second PGW session while the first one, already
+         * accepted, remains orphaned).
+         */
+        local_failure = true;
         fail_cause = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
-        fail_reason = "No Session";
+        fail_reason = "No Session context (local MME failure)";
         goto fail;
     }
 
@@ -573,8 +627,18 @@ void mme_s11_handle_create_session_response(
             if (OGS_OK != sgsap_send_location_update_request(mme_ue)) {
                 ogs_error("[%s] sgsap_send_location_update_request() failed",
                         mme_ue->imsi_bcd);
+                /*
+                 * The PGW session is fully established at this point — we are
+                 * past all GTP response validation and are about to send Attach
+                 * Accept to the UE.  The SGs/VLR path failure is an MME↔MSC
+                 * signalling issue completely unrelated to PGW availability.
+                 * Mark as a local failure to suppress the retry gate: retrying
+                 * CSR with the next DNS candidate would open a duplicate PGW
+                 * session without fixing the SGs problem.
+                 */
+                local_failure = true;
                 fail_cause = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
-                fail_reason = "SGs location update failed";
+                fail_reason = "SGs location update failed (local MME failure)";
                 goto fail;
             }
         }
@@ -608,6 +672,60 @@ void mme_s11_handle_create_session_response(
     return;
 
 fail:
+    /*
+     * 3GPP TS 23.401 §5.3.2.1: on a transient failure, retry the Create
+     * Session Request with the next DNS-resolved PGW candidate before
+     * rejecting the UE.
+     *
+     * Retry conditions (ALL must be true):
+     *   1. fail_cause is a transient PGW cause (temporary unavailability).
+     *   2. !local_failure — the cause was set by the PGW's response, NOT by
+     *      a local MME error that fired after the PGW already accepted the
+     *      request.  Local failures (e.g. missing session context, SGs path
+     *      error) must not trigger retry: the PGW session already exists and
+     *      sending CSR to the next candidate would create a duplicate session.
+     *   3. Candidates remain (index + 1 < count).
+     *
+     * Permanent causes (APN not supported, subscriber barred, etc.) are not
+     * retried because they would fail identically on any other PGW.
+     */
+    /*
+     * Skip retry when an S5/S8 tunnel is already anchored to a specific PGW
+     * (PATH_SWITCH/TAU after a successful initial CSR).  In that case the
+     * CSR builder takes the handover branch and unconditionally re-uses
+     * sess->pgw_s5c_ip — incrementing pgw_candidates.index would just produce
+     * an identical request to the same PGW, wasting GTP transaction slots.
+     */
+    if (sess && is_transient_gtp_cause(fail_cause) &&
+        !local_failure &&
+        sess->pgw_candidates.list &&
+        sess->pgw_candidates.index + 1 < sess->pgw_candidates.count &&
+        !(sess->pgw_s5c_ip.ipv4 && sess->pgw_s5c_ip.addr != 0)) {
+        int r;
+        sess->pgw_candidates.index++;
+        ogs_warn("[%s] CSR rejected cause[%d] — retrying with PGW "
+                 "candidate [%d/%d]",
+                 mme_ue ? mme_ue->imsi_bcd : "?", fail_cause,
+                 sess->pgw_candidates.index + 1,
+                 sess->pgw_candidates.count);
+        r = mme_gtp_send_create_session_request(enb_ue, sess, create_action);
+        if (r == OGS_OK)
+            return;   /* retry in flight; response will re-enter this handler */
+
+        /*
+         * The resend itself failed (e.g. no GTP transaction slot, socket
+         * error).  ogs_expect() would only log and return, leaving the UE
+         * without a reject or release path.  Fall through to
+         * mme_s11_create_session_fail() so the UE is torn down cleanly.
+         */
+        ogs_error("[%s] mme_gtp_send_create_session_request() failed on "
+                  "retry candidate [%d/%d]; releasing UE (cause %d)",
+                  mme_ue ? mme_ue->imsi_bcd : "?",
+                  sess->pgw_candidates.index + 1,
+                  sess->pgw_candidates.count,
+                  fail_cause);
+    }
+
     mme_s11_create_session_fail(enb_ue, mme_ue,
             create_action, fail_cause, fail_reason);
     return;

--- a/tests/unit/abts-main.c
+++ b/tests/unit/abts-main.c
@@ -38,6 +38,7 @@ abts_suite *test_sbi_message(abts_suite *suite);
 abts_suite *test_security(abts_suite *suite);
 abts_suite *test_nrf_discovery(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
+abts_suite *test_s_naptr(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -51,6 +52,7 @@ const struct testlist {
     {test_security},
     {test_nrf_discovery},
     {test_crash},
+    {test_s_naptr},
     {NULL},
 };
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -26,6 +26,7 @@ testunit_unit_sources = files('''
     security-test.c
     nrf-discovery-test.c
     crash-test.c
+    s-naptr-test.c
 '''.split())
 
 testunit_unit_exe = executable('unit',

--- a/tests/unit/s-naptr-test.c
+++ b/tests/unit/s-naptr-test.c
@@ -1,0 +1,466 @@
+/*
+ * Copyright (C) 2026 by Rami Mohamed <ramrode@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Unit tests for the S-NAPTR DNS-based PGW discovery module (mme-s-naptr.c).
+ *
+ * Tests cover:
+ *   1. APN-FQDN construction per 3GPP TS 23.003 ss.19.4.2
+ *   2. SRV weighted target selection per RFC 2782 s.3 --
+ *        mirrors the target-selection step of build_rotated_candidates()
+ *        using test_tier0_target_t, the test equivalent of tier0_target_t.
+ *        MUST be kept in sync with the production function.
+ *   3. NAPTR preference-ascending sort per 3GPP TS 29.303 ss.5.2 --
+ *        mirrors the insertion-sort step of query_naptr_all().
+ *        The old inverse-preference weighted-random algorithm was replaced
+ *        in B12; tests 13-16 were updated accordingly.
+ *        MUST be kept in sync with the production function.
+ *
+ * All tests are self-contained (no DNS server or MME context required) and
+ * mirror the algorithms implemented in mme-s-naptr.c.
+ */
+
+#include "ogs-core.h"
+#include "core/abts.h"
+
+/* ==========================================================================
+ * APN-FQDN construction helpers
+ *
+ * Mirrors build_apn_fqdn() from mme-s-naptr.c.
+ * 3GPP TS 23.003 ss.19.4.2 format:
+ *   <apn-ni>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ * MNC zero-padded to 2 digits (mnc_len==2) or 3 digits (mnc_len==3).
+ * MCC always zero-padded to 3 digits.
+ * ========================================================================== */
+
+static int build_apn_fqdn_test(char *buf, size_t buflen,
+        const char *apn, uint16_t mcc, uint16_t mnc, int mnc_len)
+{
+    int n;
+
+    if (mnc_len == 2)
+        n = snprintf(buf, buflen,
+                "%s.apn.epc.mnc%02d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+    else
+        n = snprintf(buf, buflen,
+                "%s.apn.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+                apn, mnc, mcc);
+
+    return (n < 0 || (size_t)n >= buflen) ? -1 : n;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 1: 2-digit MNC -- France Orange (MCC=208 MNC=93)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_2digit_mnc(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "internet", 208, 93, 2);
+
+    ABTS_TRUE(tc, rc > 0);
+    ABTS_STR_EQUAL(tc,
+            "internet.apn.epc.mnc93.mcc208.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 2: 3-digit MNC -- test network (MCC=001 MNC=001)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_3digit_mnc(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "ims", 1, 1, 3);
+
+    ABTS_TRUE(tc, rc > 0);
+    ABTS_STR_EQUAL(tc,
+            "ims.apn.epc.mnc001.mcc001.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 3: T-Mobile US (MCC=310 MNC=260, 3-digit MNC)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_tmobile_us(abts_case *tc, void *data)
+{
+    char buf[256];
+    int rc = build_apn_fqdn_test(buf, sizeof(buf),
+            "fast.t-mobile.com", 310, 260, 3);
+
+    ABTS_TRUE(tc, rc > 0);
+    ABTS_STR_EQUAL(tc,
+            "fast.t-mobile.com.apn.epc.mnc260.mcc310.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 4: Buffer too small -- must return -1 (no overflow)
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_buf_too_small(abts_case *tc, void *data)
+{
+    char buf[10]; /* intentionally smaller than any valid FQDN */
+    int rc = build_apn_fqdn_test(buf, sizeof(buf), "internet", 208, 93, 2);
+
+    ABTS_INT_EQUAL(tc, -1, rc);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 5: 2-digit MNC with 2-digit value -- zero-padding check (MNC=10 -> "10")
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mnc_two_digits_no_extra_pad(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "apn", 234, 10, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "apn.apn.epc.mnc10.mcc234.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 6: 2-digit MNC, single-digit value -- zero-padded to 2 (MNC=1 -> "01")
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mnc_single_digit_padded(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "apn", 234, 1, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "apn.apn.epc.mnc01.mcc234.3gppnetwork.org", buf);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 7: MCC zero-padding -- MCC=1 must appear as "001"
+ * -------------------------------------------------------------------------- */
+static void test_fqdn_mcc_zero_padded(abts_case *tc, void *data)
+{
+    char buf[256];
+    build_apn_fqdn_test(buf, sizeof(buf), "internet", 1, 1, 2);
+
+    ABTS_STR_EQUAL(tc,
+            "internet.apn.epc.mnc01.mcc001.3gppnetwork.org", buf);
+}
+
+/* ==========================================================================
+ * SRV weighted target selection -- RFC 2782 s.3
+ *
+ * Mirrors the target-selection step of build_rotated_candidates() from
+ * mme-s-naptr.c.  The production function works at the SRV-target level
+ * using tier0_target_t descriptors {weight, start, count}; this helper
+ * replicates that exact algorithm so regressions in the production code
+ * are caught here.
+ *
+ * IMPORTANT: if the selection logic in build_rotated_candidates() changes,
+ * this helper MUST be updated to match.
+ *
+ * Weight-0 entries are promoted to a nominal weight of 1 per RFC 2782 s.3.
+ * Uses a deterministic sweep over [0, total_weight) to verify distribution
+ * without relying on rand().
+ * ========================================================================== */
+
+typedef struct {
+    uint16_t weight;
+    int      start;   /* first index in the IP array for this target */
+    int      count;   /* number of IPs for this target */
+} test_tier0_target_t;
+
+/*
+ * build_rotated_select_target() - mirrors Step 1 of build_rotated_candidates().
+ *
+ * Given an array of SRV targets and a deterministic 'pick' value in
+ * [0, total_weight), returns the index of the selected target.
+ * Callers sweep 'pick' over [0, total_weight) to verify proportions.
+ */
+static int build_rotated_select_target(
+        const test_tier0_target_t *targets, int t0_count, uint32_t pick)
+{
+    uint32_t total_weight = 0;
+    uint32_t cum = 0;
+    int i;
+
+    for (i = 0; i < t0_count; i++)
+        total_weight += targets[i].weight ? (uint32_t)targets[i].weight : 1u;
+
+    pick %= total_weight;
+    for (i = 0; i < t0_count; i++) {
+        cum += targets[i].weight ? (uint32_t)targets[i].weight : 1u;
+        if (pick < cum) return i;
+    }
+    return t0_count - 1;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 8: Uniform SRV target weights -- each target receives equal share.
+ *   3 targets, weight 10 each -> 1/3 each over 30 000 deterministic picks.
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_uniform(abts_case *tc, void *data)
+{
+    test_tier0_target_t t[] = {
+        {10, 0, 1}, {10, 1, 1}, {10, 2, 1}
+    };
+    int counts[3] = {0, 0, 0};
+    int i, s;
+
+    /* Total weight = 30; sweep 30 000 picks (1000 full cycles). */
+    for (i = 0; i < 30000; i++) {
+        s = build_rotated_select_target(t, 3, (uint32_t)i);
+        if (s >= 0 && s < 3)
+            counts[s]++;
+    }
+
+    /* Each target: exactly 10 000 / 30 000 */
+    for (i = 0; i < 3; i++)
+        ABTS_INT_EQUAL(tc, 10000, counts[i]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 9: Skewed SRV target weights 10:20:70 -- proportional distribution.
+ *   Total weight = 100; sweep 100 000 picks (1000 full cycles).
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_skewed(abts_case *tc, void *data)
+{
+    test_tier0_target_t t[] = {
+        {10, 0, 2}, {20, 2, 1}, {70, 3, 3}
+    };
+    int counts[3] = {0, 0, 0};
+    int i, s;
+
+    for (i = 0; i < 100000; i++) {
+        s = build_rotated_select_target(t, 3, (uint32_t)i);
+        if (s >= 0 && s < 3)
+            counts[s]++;
+    }
+
+    /* Exact proportions over 100 000 picks */
+    ABTS_INT_EQUAL(tc, 10000, counts[0]);
+    ABTS_INT_EQUAL(tc, 20000, counts[1]);
+    ABTS_INT_EQUAL(tc, 70000, counts[2]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 10: Both SRV targets have weight 0.
+ *   Promoted to 1 each -> 50% / 50% over 20 000 picks.
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_zero_records(abts_case *tc, void *data)
+{
+    test_tier0_target_t t[] = {
+        {0, 0, 1}, {0, 1, 2}
+    };
+    int counts[2] = {0, 0};
+    int i, s;
+
+    /* Total effective weight = 1+1 = 2; sweep 20 000 picks. */
+    for (i = 0; i < 20000; i++) {
+        s = build_rotated_select_target(t, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    ABTS_INT_EQUAL(tc, 10000, counts[0]);
+    ABTS_INT_EQUAL(tc, 10000, counts[1]);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 11: Single SRV target -- always returns index 0 regardless of weight.
+ * -------------------------------------------------------------------------- */
+static void test_srv_single_entry(abts_case *tc, void *data)
+{
+    test_tier0_target_t t[] = {{42, 0, 3}};
+    int i;
+
+    for (i = 0; i < 100; i++)
+        ABTS_INT_EQUAL(tc, 0, build_rotated_select_target(t, 1, (uint32_t)i));
+}
+
+/* --------------------------------------------------------------------------
+ * Test 12: Weight 1:99 -- low-weight target receives ~1% of selections.
+ *   Total weight = 100; 10 000 picks -> target[0] selected exactly 100 times.
+ * -------------------------------------------------------------------------- */
+static void test_srv_weight_mixed_zero(abts_case *tc, void *data)
+{
+    /* weight-0 promoted to 1; weight 99 stays 99 -> total 100 */
+    test_tier0_target_t t[] = {
+        {0, 0, 1}, {99, 1, 4}
+    };
+    int counts[2] = {0, 0};
+    int i, s;
+
+    for (i = 0; i < 10000; i++) {
+        s = build_rotated_select_target(t, 2, (uint32_t)i);
+        if (s >= 0 && s < 2)
+            counts[s]++;
+    }
+
+    /* 1% for target 0 (weight-0 -> 1), 99% for target 1 */
+    ABTS_INT_EQUAL(tc, 100,  counts[0]);
+    ABTS_INT_EQUAL(tc, 9900, counts[1]);
+}
+
+/* ==========================================================================
+ * NAPTR preference ordering -- 3GPP TS 29.303 ss.5.2
+ *
+ * Mirrors the insertion-sort step of query_naptr_all() in mme-s-naptr.c.
+ *
+ * query_naptr_all() (B12 replacement for the old query_naptr()) returns ALL
+ * lowest-ORDER NAPTR candidates sorted by PREF ascending so the most-preferred
+ * (lowest numeric pref) entry is tried first.  The caller iterates in order
+ * and advances to the next entry only when the current replacement has no
+ * usable SRV or A records.
+ *
+ * IMPORTANT: if the sort logic in query_naptr_all() changes, this helper
+ * MUST be updated to match.
+ *
+ * Note: tests 13-16 previously exercised an inverse-preference weighted-
+ * random algorithm (naptr_select()) that no longer exists in production code.
+ * They have been replaced with deterministic sort-order checks that mirror the
+ * actual behavior of query_naptr_all().
+ * ========================================================================== */
+
+typedef struct {
+    uint16_t pref;
+    int      original_idx; /* input position -- used to verify record identity */
+} test_naptr_rec_t;
+
+/*
+ * naptr_pref_sort() - mirrors the insertion sort in query_naptr_all().
+ * Sorts recs[0..count-1] by pref ascending (lower value = more preferred,
+ * tried first).  Equal prefs preserve relative input order (stable sort).
+ */
+static void naptr_pref_sort(test_naptr_rec_t *recs, int count)
+{
+    int i, j;
+    test_naptr_rec_t key;
+
+    for (i = 1; i < count; i++) {
+        key = recs[i];
+        j   = i - 1;
+        while (j >= 0 && recs[j].pref > key.pref) {
+            recs[j + 1] = recs[j];
+            j--;
+        }
+        recs[j + 1] = key;
+    }
+}
+
+/* --------------------------------------------------------------------------
+ * Test 13: Three records at distinct prefs -- sorted pref-ascending.
+ *   Input:  [pref=30, pref=10, pref=20]
+ *   Output: [pref=10, pref=20, pref=30]
+ *   Most-preferred (lowest pref) ends up at index 0 and is tried first.
+ * -------------------------------------------------------------------------- */
+static void test_naptr_sort_ascending(abts_case *tc, void *data)
+{
+    test_naptr_rec_t recs[] = {
+        {30, 0}, {10, 1}, {20, 2}
+    };
+
+    naptr_pref_sort(recs, 3);
+
+    ABTS_INT_EQUAL(tc, 10, (int)recs[0].pref);
+    ABTS_INT_EQUAL(tc, 20, (int)recs[1].pref);
+    ABTS_INT_EQUAL(tc, 30, (int)recs[2].pref);
+    /* Verify original_idx to confirm record identity, not just pref values */
+    ABTS_INT_EQUAL(tc, 1,  recs[0].original_idx);
+    ABTS_INT_EQUAL(tc, 2,  recs[1].original_idx);
+    ABTS_INT_EQUAL(tc, 0,  recs[2].original_idx);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 14: All equal prefs -- input order preserved (sort is stable).
+ *   Three records all pref=50; insertion sort preserves relative order.
+ * -------------------------------------------------------------------------- */
+static void test_naptr_sort_equal_pref(abts_case *tc, void *data)
+{
+    test_naptr_rec_t recs[] = {
+        {50, 0}, {50, 1}, {50, 2}
+    };
+
+    naptr_pref_sort(recs, 3);
+
+    ABTS_INT_EQUAL(tc, 50, (int)recs[0].pref);
+    ABTS_INT_EQUAL(tc, 50, (int)recs[1].pref);
+    ABTS_INT_EQUAL(tc, 50, (int)recs[2].pref);
+    /* Relative order must be preserved for equal keys */
+    ABTS_INT_EQUAL(tc, 0,  recs[0].original_idx);
+    ABTS_INT_EQUAL(tc, 1,  recs[1].original_idx);
+    ABTS_INT_EQUAL(tc, 2,  recs[2].original_idx);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 15: Single NAPTR record -- sort is a no-op; record unchanged.
+ * -------------------------------------------------------------------------- */
+static void test_naptr_sort_single(abts_case *tc, void *data)
+{
+    test_naptr_rec_t recs[] = {{100, 0}};
+
+    naptr_pref_sort(recs, 1);
+
+    ABTS_INT_EQUAL(tc, 100, (int)recs[0].pref);
+    ABTS_INT_EQUAL(tc, 0,   recs[0].original_idx);
+}
+
+/* --------------------------------------------------------------------------
+ * Test 16: pref=0 (lowest possible) sorts to index 0.
+ *   Input:  [pref=100, pref=0]
+ *   Output: [pref=0, pref=100]
+ *   pref=0 record must be the first candidate tried per TS 29.303 ss.5.2.
+ * -------------------------------------------------------------------------- */
+static void test_naptr_lowest_pref_first(abts_case *tc, void *data)
+{
+    test_naptr_rec_t recs[] = {
+        {100, 0}, {0, 1}
+    };
+
+    naptr_pref_sort(recs, 2);
+
+    ABTS_INT_EQUAL(tc, 0,   (int)recs[0].pref);
+    ABTS_INT_EQUAL(tc, 100, (int)recs[1].pref);
+    /* pref=0 was at input[1] -- verify it moved to front */
+    ABTS_INT_EQUAL(tc, 1,   recs[0].original_idx);
+    ABTS_INT_EQUAL(tc, 0,   recs[1].original_idx);
+}
+
+/* ==========================================================================
+ * Suite entry point
+ * ========================================================================== */
+
+abts_suite *test_s_naptr(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite);
+
+    /* APN-FQDN construction (3GPP TS 23.003 ss.19.4.2) */
+    abts_run_test(suite, test_fqdn_2digit_mnc,                 NULL);
+    abts_run_test(suite, test_fqdn_3digit_mnc,                 NULL);
+    abts_run_test(suite, test_fqdn_tmobile_us,                 NULL);
+    abts_run_test(suite, test_fqdn_buf_too_small,              NULL);
+    abts_run_test(suite, test_fqdn_mnc_two_digits_no_extra_pad, NULL);
+    abts_run_test(suite, test_fqdn_mnc_single_digit_padded,    NULL);
+    abts_run_test(suite, test_fqdn_mcc_zero_padded,            NULL);
+
+    /* SRV weighted random selection (RFC 2782 s.3) */
+    abts_run_test(suite, test_srv_weight_uniform,              NULL);
+    abts_run_test(suite, test_srv_weight_skewed,               NULL);
+    abts_run_test(suite, test_srv_weight_zero_records,         NULL);
+    abts_run_test(suite, test_srv_single_entry,                NULL);
+    abts_run_test(suite, test_srv_weight_mixed_zero,           NULL);
+
+    /* NAPTR preference-ascending sort (3GPP TS 29.303 ss.5.2) */
+    abts_run_test(suite, test_naptr_sort_ascending,            NULL);
+    abts_run_test(suite, test_naptr_sort_equal_pref,           NULL);
+    abts_run_test(suite, test_naptr_sort_single,               NULL);
+    abts_run_test(suite, test_naptr_lowest_pref_first,         NULL);
+
+    return suite;
+}


### PR DESCRIPTION
Standards: TS 29.303 · TS 23.003 · TS 23.401 §5.3.2.1 · RFC 2782 · RFC 3958

1 — PGW Address Resolution Order
The CSR builder evaluates the following order on every Create Session Request:

- Priority 0 — HSS-provisioned: if session->smf_ip is set from S6a ULA, use it directly (no DNS, no config lookup).
- Priority 1 — PATH_SWITCH / TAU anchor: during handover or TAU, if pgw_s5c_ip.ipv4 && addr != 0, re-use the original PGW that accepted the first CSR (mandatory: the S5/S8 tunnel must stay anchored to the same PGW).
- Priority 2 — S-NAPTR DNS [NEW]: when mme.s5s8.dns is configured and the session has an APN, derive the home PLMN, build the APN-FQDN, run NAPTR → SRV → A, store the result in cache, and return a rotated candidate array.
- Priority 3 — Static config: match APN / Cell-ID / TAC against mme.yaml PGW list.
- Priority 4 — First static PGW: last-resort fallback.
- Home PLMN is derived from hssmap->plmn_id (roaming) or by matching the IMSI prefix against served GUMMEI PLMNs (local). Any DNS failure transparently falls through to static — sessions never drop because of DNS.

2 — Known Limitations and Assumptions

- IPv4 only — only A records are resolved; AAAA / IPv6 PGWs require static config or HSS provisioning.
- No DNSSEC, no DNS-over-TLS, no DNS-over-HTTPS — plain libresolv. Use a validating upstream resolver in untrusted networks.
- DNS server failover is sequential (libresolv): primary tried with retries before secondary; ≈4 seconds worst case if both servers dead.
- Per-APN record caps: 16 NAPTR, 16 SRV, 16 A. Excess entries silently truncated.
- Cache is per-process — for MME Pools, each maintain their own cache.
- SRV port is informational only — GTPv2 control-plane sockets always use port 2123 per spec.
- True inbound roaming (HPLMN ≠ any served GUMMEI) requires hssmap_map: in mme.yaml.
- The mme.s5s8.dns resolver must serve the epc.mnc*.mcc*.3gppnetwork.org zone.

3 — Caching Mechanism
The cache is keyed on the full APN-FQDN (which already encodes APN + MCC + MNC per TS 23.003 §19.4.2). Each entry stores the flat list of resolved IPs, a per-SRV-target descriptor array carrying {weight, start, count}, the primary-tier IP boundary, and the absolute expiry timestamp.

The effective TTL is min(NAPTR TTL, chosen SRV TTL, min A TTL), clamped to [30 s, 86400 s]. The floor prevents thrashing from broken zones publishing TTL 0; the ceiling ensures stale topology cannot be retained for more than one day.

On every cache hit, build_rotated_candidates() produces a fresh independent copy for that session using RFC 2782 weighted-random selection — the cache itself is never mutated. Two concurrent sessions for the same APN independently draw their own first-choice PGW. The cache is FIFO with a maximum of 64 entries; expired entries are lazily freed on lookup. mme_s_naptr_cache_flush() runs first in mme_context_final() for clean shutdown.

4 — Fail and Retry Logic
DNS-server failover is handled by libresolv: each query times out after 1 second, retries once, then switches to the secondary, retries once more, and finally fails (≈4 seconds total worst case). On total DNS failure the function returns NULL and the CSR builder falls through to static config — the UE never sees the failure.

Within a single resolution, the NAPTR loop walks all candidates in preference order and breaks on the first one that yields A records. If every NAPTR candidate has no usable A records, the resolver gives up and returns NULL.

Session-level retry implements TS 23.401 §5.3.2.1. On transient GTPv2 causes (100, 73, 68, 72, 120, 110, 122) the retry gate increments pgw_candidates.index and retransmits the CSR to the next candidate. The gate is suppressed when local_failure=true (MME-local error after PGW already accepted the session) or when the session is already anchored to a specific PGW (pgw_s5c_ip.ipv4 && addr != 0, e.g. during PATH_SWITCH/TAU). The same logic guards the GTP-timeout path. When all candidates are exhausted the session is cleanly torn down; mme_sess_remove() always frees pgw_candidates.list under a NULL guard.

5 — Scalability in Multi-PGW Architectures
Adding a PGW is purely a DNS operation — adding an A record propagates to every MME after the cache TTL expires; no MME restart is required. Load distribution uses RFC 2782 weighted random at the SRV-target level: weights of 70:20:10 produce roughly 70%/20%/10% of first-attempt sessions, regardless of how many A records each target carries. SRV priority partitions candidates into a primary pool (lowest priority value) and backup pool; backup PGWs receive traffic only after every primary candidate has failed.

Each session owns its own independent candidate-array copy returned from build_rotated_candidates(). There is no cross-session shared counter, no global lock, and no synchronisation cost beyond the brief mutex window during the cache lookup. Cache amortisation means the DNS layer pays one round-trip per APN per TTL window regardless of attach rate. Weight=0 is promoted to 1 per RFC 2782, ensuring no PGW is ever permanently excluded. Each session has up to 16 retry slots, sufficient for all realistic deployments.

6 — Dynamic Traffic Engineering
All traffic-engineering levers are DNS-driven and take effect after the cache TTL expires — no MME restart. Operators can rebalance load by adjusting SRV weight values; promote or demote a PGW by changing its SRV priority; gracefully drain a PGW by lowering its weight to 0 or removing its A record (existing sessions are unaffected because each holds its own candidate list). Canary rollouts work by adding a new PGW with weight=1 alongside existing weight=99 entries and ramping gradually. Emergency failover is a simple removal of the SRV or A record — the next cache miss omits the dead PGW entirely. Different APNs can be served by completely separate DNS zones with no cross-APN interference. The speed of a topology change is governed by the published TTL: lower it before the change, raise it afterwards for stability. The minimum effective response time is 30 seconds (the cache TTL floor); the cache is pull-based — there is no push-invalidation channel.

7 — DNS Lookup in Roaming Cases
The APN-FQDN must be built from the Home PLMN, never the visited PLMN; using TAI's PLMN would query the wrong DNS zone and find the wrong PGWs. The home PLMN is resolved from two ordered sources: first mme_ue->hssmap->plmn_id if hssmap_map: is configured (mandatory for true inbound roaming where HPLMN differs from every served GUMMEI), otherwise by matching the IMSI prefix against the MME's served GUMMEI PLMNs (sufficient for non-roaming and single-PLMN deployments).

For home subscribers in a single-PLMN deployment, the GUMMEI fallback derives the correct HPLMN automatically — no extra config needed. For multi-PLMN MMEs, the GUMMEI fallback still works as long as the IMSI prefix uniquely matches one served PLMN. Inbound roamers whose HPLMN happens to be a served GUMMEI are also handled by the fallback. Only true inbound roamers — where the home PLMN is not served by the visited MME — require hssmap_map: to point the FQDN at the correct home zone. If neither source yields a PLMN, the MME logs a debug message and falls through to static PGW config (the session is not dropped).

NAPTR / SRV / A records live in the home operator's DNS zone; the visited MME simply queries them. The home operator therefore retains full control over PGW selection for its roamers, and TTL-driven cache expiry propagates topology changes to all visiting MMEs automatically — no bilateral coordination beyond standard DNS delegation is needed. hssmap_map: is roaming-only configuration; local deployments never need it.