### PR TITLE
[SBI] Replace nf_service_pool assert with graceful cap-and-break

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1477,7 +1477,11 @@ ogs_sbi_nf_service_t *ogs_sbi_nf_service_add(
     ogs_assert(name);
 
     ogs_pool_alloc(&nf_service_pool, &nf_service);
-    ogs_assert(nf_service);
+    if (!nf_service) {
+        ogs_error("nf_service_pool exhausted (capacity %d)",
+                (int)ogs_app()->pool.nf_service);
+        return NULL;
+    }
     memset(nf_service, 0, sizeof(ogs_sbi_nf_service_t));
 
     nf_service->id = ogs_strdup(id);

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -251,7 +251,18 @@ void ogs_nnrf_nfm_handle_nf_profile(
                             nf_instance,
                             NFService->service_instance_id,
                             NFService->service_name, NFService->scheme);
-            ogs_assert(nf_service);
+            if (!nf_service) {
+                /*
+                 * nf_service_pool exhausted. Cap-and-break matches the
+                 * existing pattern for outer-list overflows in this file
+                 * (e.g. handle_smf_info() slice list, handle_amf_info()
+                 * GUAMI list): truncate gracefully and keep the entries
+                 * already parsed instead of aborting the process.
+                 */
+                ogs_error("Truncating NFProfile.nfServices on "
+                        "nf_service_pool exhaustion");
+                break;
+            }
         }
 
         ogs_sbi_nf_service_clear(nf_service);
@@ -294,7 +305,14 @@ void ogs_nnrf_nfm_handle_nf_profile(
                                 nf_instance,
                                 NFService->service_instance_id,
                                 NFService->service_name, NFService->scheme);
-                ogs_assert(nf_service);
+                if (!nf_service) {
+                    /* Same cap-and-break as the nf_services loop above —
+                     * NFProfile.nfServiceList is the legacy MAP-shaped
+                     * format with the same per-pool exhaustion shape. */
+                    ogs_error("Truncating NFProfile.nfServiceList on "
+                            "nf_service_pool exhaustion");
+                    break;
+                }
             }
 
             ogs_sbi_nf_service_clear(nf_service);


### PR DESCRIPTION
## Summary

Fixes #4466 (reported by @LinZiyuu). `ogs_sbi_nf_service_add()` aborts via `ogs_assert(nf_service)` when `nf_service_pool` is exhausted. The pool is sized at `ogs_app()->pool.nf * 16` (default 1024 entries), and any peer that can submit an NFProfile carrying more than that many `nfServices` entries crashes the receiving process. The same shared parser is used by every NF that consumes NFProfile data — directly via `PUT /nnrf-nfm/v1/nf-instances/{id}` on the NRF, and indirectly by every NF that processes an NRF discovery response — so the bug surfaces across the SBA.

## Vulnerability shape

`lib/sbi/context.c:1479-1480`:

```c
ogs_pool_alloc(&nf_service_pool, &nf_service);
ogs_assert(nf_service);
```

The reporter's reproducer in #4466:

```
PUT /nnrf-nfm/v1/nf-instances/{id}
Content-Type: application/json

{
    "nfInstanceId": "...",
    "nfType": "AMF",
    "nfStatus": "REGISTERED",
    "nfServices": [<1100 entries>]
}
```

With the default 1024-slot pool, the 1024th `nfServices` entry triggers the assertion abort. The targeted NF terminates and every other ongoing SBI session for every legitimate peer is killed alongside.

The same crash is reachable indirectly when any NF consumes an oversized `SearchResult.nfInstances[*].nfServices` payload from a peer NRF — the parser is the same.

## Fix

Two coordinated changes follow the same cap-and-break idiom that `acetcom` established in `82b929007` ("sbi: Prevent NFProfile overflow in SMF/AMF info parsing", Feb 2026) for outer-list bounds, and that we extended to the inner-list bounds in PR #4527.

### Change 1 — `lib/sbi/context.c::ogs_sbi_nf_service_add()`

Convert the assertion to a NULL-return with an error log naming the exhausted pool and its configured capacity:

```c
ogs_pool_alloc(&nf_service_pool, &nf_service);
if (!nf_service) {
    ogs_error("nf_service_pool exhausted (capacity %d)",
            (int)ogs_app()->pool.nf_service);
    return NULL;
}
```

The function's existing return type is already nullable, so this is a non-breaking change for any caller that happens to handle NULL correctly today.

### Change 2 — `lib/sbi/nnrf-handler.c::ogs_nnrf_nfm_handle_nf_profile()`

Handle the new NULL return at both call sites (modern `nf_services` list and legacy `nf_service_list` MAP form):

```c
nf_service = ogs_sbi_nf_service_add(...);
if (!nf_service) {
    /* nf_service_pool exhausted. Cap-and-break matches the existing
     * pattern for outer-list overflows in this file (e.g. handle_smf_info()
     * slice list, handle_amf_info() GUAMI list): truncate gracefully and
     * keep the entries already parsed instead of aborting the process. */
    ogs_error("Truncating NFProfile.nfServices on nf_service_pool exhaustion");
    break;
}
```

On exhaustion, the loop is terminated cleanly. Entries already parsed remain in the consuming NF's context; the registering NF is told the registration succeeded but with the truncated service list. This matches the existing semantics for outer-list overflows in the same file.

### Note on state drift vs. crash mitigation

While returning an HTTP 400 (Bad Request) on overflow would be architecturally purer for the NRF registration path — to avoid state drift between the registering NF and the NRF, as we did in PR #4527 for inner-list bounds — `nf_service_pool` exhaustion is a **global, dynamic resource limit**, not a static per-profile struct bound. The immediate priority of this PR is mitigating the SIGABRT DoS vector across all consuming NFs (both NRF on register and AMF/SMF/etc. on discovery-response notification consumption) using the least invasive change. Cap-and-break achieves this and mirrors the existing outer-list logic that `82b929007` established.

Upgrading specific register paths to HTTP 400 / 503 on pool exhaustion — to surface the truncation explicitly to the registering NF and prevent the silent SBA-state-drift symptom — is left for future hardening, in the same shape as PR #4527's Tier-1 reject. The two patterns are layered and complementary: this PR ensures no NF crashes; a follow-up can ensure the registering NF learns about the truncation immediately rather than discovering it later via missing service-name lookups.

## Out of scope

- The third caller of `ogs_sbi_nf_service_add()` at `lib/sbi/context.c:1943` is inside `ogs_sbi_nf_service_build_default()`, which is invoked only at NF startup with a fixed, controlled set of services. Pool exhaustion at that point reflects a configuration error or a memory shortage, not an attacker-reachable shape. The existing assertion is appropriate as a startup invariant and is left unchanged.
- The matching `nf_instance_pool` (#4456) and `subscription_data_pool` (#4465) follow the identical anti-pattern in the same file. The same fix extends naturally to them, but is filed as separate follow-up commits to keep this PR's scope auditable.

## Verification

- `ninja -C build` clean on top of `7e3f22550`.
- Reproducer from #4466 (1100-entry `nfServices` array) on the patched NRF: no abort. The NRF logs `nf_service_pool exhausted (capacity 1024)` once at the boundary, then `Truncating NFProfile.nfServices on nf_service_pool exhaustion` once per affected NFProfile, and continues to serve every other legitimate peer.
- Existing non-overflow path: identical behaviour. The new code paths are reached only when `pool_alloc` returns `NULL`, which only happens at exhaustion.

## Related

- This PR completes one of the outer-list-style bounds that `82b929007` left for follow-up.
- Companion to PR #4527, which converted the inner-list (`dnnSmfInfoList`, `tacRangeList`) bounds in the same parser using the identical idiom.
- Two further pools in the same family (`nf_instance_pool` for #4456, `subscription_data_pool` for #4465) are out of scope here but are the obvious next-step PRs.

Closes #4466
