### PR TITLE
smf: unify IMSI and SUPI UE indexes

### DIFF
--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -365,6 +365,97 @@ cleanup:
     return ueid;
 }
 
+
+/*
+ * ogs_bcd_to_buffer() only converts bytes.  It does not validate that
+ * the input is a bounded decimal IMSI string, so check it first.
+ */
+bool ogs_imsi_bcd_is_valid(const char *imsi_bcd)
+{
+    int i, len;
+
+    ogs_assert(imsi_bcd);
+
+    len = strlen(imsi_bcd);
+    if (len == 0 || len > OGS_MAX_IMSI_BCD_LEN) {
+        ogs_error("Invalid IMSI BCD length [%d:%s]",
+                len, imsi_bcd);
+        return false;
+    }
+
+    for (i = 0; i < len; i++) {
+        if (imsi_bcd[i] < '0' || imsi_bcd[i] > '9') {
+            ogs_error("Invalid IMSI BCD digit [%d:%c:%s]",
+                    i, imsi_bcd[i], imsi_bcd);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*
+ * Return the decimal IMSI string only for IMSI-type SUPI.  Other SUPI
+ * types cannot be used as EPC IMSI keys and remain SUPI-only.
+ *
+ * Return OGS_ERROR only when the SUPI claims to be IMSI-type but the
+ * IMSI payload is malformed.  That must not fall back to SUPI-only.
+ */
+int ogs_supi_to_imsi_bcd(
+        const char *supi, char *imsi_bcd, bool *imsi_supi)
+{
+    int rv = OGS_ERROR;
+    char *type = NULL;
+    char *value = NULL;
+
+    ogs_assert(supi);
+    ogs_assert(imsi_bcd);
+    ogs_assert(imsi_supi);
+
+    *imsi_supi = false;
+
+    type = ogs_id_get_type(supi);
+    if (!type) {
+        ogs_error("ogs_id_get_type() failed [%s]", supi);
+        goto cleanup;
+    }
+
+    /* Non-IMSI SUPI is valid, but has no EPC IMSI alias. */
+    if (strcmp(type, OGS_ID_SUPI_TYPE_IMSI) != 0) {
+        rv = OGS_OK;
+        goto cleanup;
+    }
+
+    value = ogs_id_get_value(supi);
+    if (!value) {
+        ogs_error("No IMSI in SUPI [%s]", supi);
+        goto cleanup;
+    }
+
+    /* Reject extra '-' components that ogs_id_get_value() ignores. */
+    if (strlen(supi) != strlen(type) + 1 + strlen(value)) {
+        ogs_error("Invalid IMSI SUPI [%s]", supi);
+        goto cleanup;
+    }
+
+    if (ogs_imsi_bcd_is_valid(value) == false) {
+        ogs_error("Invalid IMSI SUPI [%s]", supi);
+        goto cleanup;
+    }
+
+    ogs_cpystrn(imsi_bcd, value, OGS_MAX_IMSI_BCD_LEN+1);
+    *imsi_supi = true;
+    rv = OGS_OK;
+
+cleanup:
+    if (type)
+        ogs_free(type);
+    if (value)
+        ogs_free(value);
+
+    return rv;
+}
+
 char *ogs_s_nssai_sd_to_string(const ogs_uint24_t sd)
 {
     char *string = NULL;

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -308,6 +308,9 @@ ogs_amf_id_t *ogs_amf_id_build(ogs_amf_id_t *amf_id,
 #define OGS_ID_5G_GUTI_TYPE "5g-guti"
 char *ogs_id_get_type(const char *str);
 char *ogs_id_get_value(const char *str);
+bool ogs_imsi_bcd_is_valid(const char *imsi_bcd);
+int ogs_supi_to_imsi_bcd(
+        const char *supi, char *imsi_bcd, bool *imsi_supi);
 
 /************************************
  * TAI Structure                    */

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1071,40 +1071,239 @@ static smf_ue_t *smf_ue_add(void)
     return smf_ue;
 }
 
-smf_ue_t *smf_ue_add_by_supi(char *supi)
+/*
+ * Set and index SUPI in one place.  Callers decide which smf_ue_t to
+ * use; this helper prevents a hash entry owned by another UE from being
+ * overwritten by ogs_hash_set().
+ */
+static int smf_ue_set_supi(smf_ue_t *smf_ue, const char *supi)
 {
-    smf_ue_t *smf_ue;
+    smf_ue_t *indexed_smf_ue = NULL;
 
+    ogs_assert(smf_ue);
     ogs_assert(supi);
 
-    if ((smf_ue = smf_ue_add()) == NULL) {
-        ogs_error("smf_ue_add_by_supi() failed");
-        return NULL;
+    if (smf_ue->supi) {
+        if (strcmp(smf_ue->supi, supi) != 0) {
+            ogs_fatal("SUPI mismatch [%s:%s]", smf_ue->supi, supi);
+            ogs_assert_if_reached();
+            return OGS_ERROR;
+        }
+        return OGS_OK;
+    }
+
+    indexed_smf_ue = smf_ue_find_by_supi((char *)supi);
+    if (indexed_smf_ue && indexed_smf_ue != smf_ue) {
+        ogs_fatal("SUPI[%s] already indexed", supi);
+        ogs_assert_if_reached();
+        return OGS_ERROR;
     }
 
     smf_ue->supi = ogs_strdup(supi);
     ogs_assert(smf_ue->supi);
-    ogs_hash_set(self.supi_hash, smf_ue->supi, strlen(smf_ue->supi), smf_ue);
+
+    ogs_hash_set(self.supi_hash,
+            smf_ue->supi, strlen(smf_ue->supi), smf_ue);
+
+    return OGS_OK;
+}
+
+/*
+ * Set and index IMSI in one place.  Convert first to a temporary buffer
+ * so an existing hash key is not modified before mismatch detection.
+ */
+static int smf_ue_set_imsi_bcd(smf_ue_t *smf_ue, const char *imsi_bcd)
+{
+    smf_ue_t *indexed_smf_ue = NULL;
+    uint8_t imsi[OGS_MAX_IMSI_LEN];
+    int imsi_len = 0;
+
+    ogs_assert(smf_ue);
+    ogs_assert(imsi_bcd);
+
+    if (ogs_imsi_bcd_is_valid(imsi_bcd) == false) {
+        ogs_error("ogs_imsi_bcd_is_valid() failed [%s]", imsi_bcd);
+        return OGS_ERROR;
+    }
+
+    memset(imsi, 0, sizeof(imsi));
+    ogs_bcd_to_buffer(imsi_bcd, imsi, &imsi_len);
+    ogs_assert(imsi_len > 0);
+    ogs_assert(imsi_len <= OGS_MAX_IMSI_LEN);
+
+    if (smf_ue->imsi_len) {
+        if (smf_ue->imsi_len != imsi_len ||
+            memcmp(smf_ue->imsi, imsi, imsi_len) != 0) {
+            ogs_fatal("IMSI mismatch [%s:%s]",
+                    smf_ue->imsi_bcd, imsi_bcd);
+            ogs_assert_if_reached();
+            return OGS_ERROR;
+        }
+        return OGS_OK;
+    }
+
+    indexed_smf_ue = smf_ue_find_by_imsi(imsi, imsi_len);
+    if (indexed_smf_ue && indexed_smf_ue != smf_ue) {
+        ogs_fatal("IMSI[%s] already indexed", imsi_bcd);
+        ogs_assert_if_reached();
+        return OGS_ERROR;
+    }
+
+    smf_ue->imsi_len = imsi_len;
+    memcpy(smf_ue->imsi, imsi, smf_ue->imsi_len);
+    ogs_cpystrn(smf_ue->imsi_bcd, imsi_bcd, OGS_MAX_IMSI_BCD_LEN+1);
+
+    ogs_hash_set(self.imsi_hash,
+            smf_ue->imsi, smf_ue->imsi_len, smf_ue);
+
+    return OGS_OK;
+}
+
+/*
+ * The EPC path receives raw BCD bytes.  Convert them to the canonical
+ * decimal IMSI string used by the SUPI path.
+ */
+static int smf_ue_set_imsi(smf_ue_t *smf_ue, uint8_t *imsi, int imsi_len)
+{
+    char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
+
+    ogs_assert(smf_ue);
+    ogs_assert(imsi);
+    ogs_assert(imsi_len);
+
+    if (imsi_len > OGS_MAX_IMSI_LEN) {
+        ogs_error("Invalid IMSI length [%d]", imsi_len);
+        return OGS_ERROR;
+    }
+
+    memset(imsi_bcd, 0, sizeof(imsi_bcd));
+    ogs_buffer_to_bcd(imsi, imsi_len, imsi_bcd);
+
+    if (smf_ue_set_imsi_bcd(smf_ue, imsi_bcd) != OGS_OK) {
+        ogs_error("smf_ue_set_imsi_bcd() failed [%s]", imsi_bcd);
+        return OGS_ERROR;
+    }
+
+    return OGS_OK;
+}
+
+smf_ue_t *smf_ue_add_by_supi(char *supi)
+{
+    smf_ue_t *smf_ue = NULL;
+    char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
+    uint8_t imsi[OGS_MAX_IMSI_LEN];
+    int imsi_len = 0;
+    bool created = false;
+    bool imsi_supi = false;
+
+    ogs_assert(supi);
+
+    memset(imsi_bcd, 0, sizeof(imsi_bcd));
+    memset(imsi, 0, sizeof(imsi));
+
+    if (ogs_supi_to_imsi_bcd(supi, imsi_bcd, &imsi_supi) != OGS_OK) {
+        ogs_error("ogs_supi_to_imsi_bcd() failed [%s]", supi);
+        return NULL;
+    }
+
+    /* First use the native SBI key. */
+    smf_ue = smf_ue_find_by_supi(supi);
+
+    /* If this is an IMSI SUPI, try the EPC IMSI key as an alias. */
+    if (!smf_ue && imsi_supi == true) {
+        ogs_bcd_to_buffer(imsi_bcd, imsi, &imsi_len);
+        smf_ue = smf_ue_find_by_imsi(imsi, imsi_len);
+    }
+
+    if (!smf_ue) {
+        smf_ue = smf_ue_add();
+        if (!smf_ue) {
+            ogs_error("smf_ue_add_by_supi() failed");
+            return NULL;
+        }
+        created = true;
+    }
+
+    if (smf_ue_set_supi(smf_ue, supi) != OGS_OK) {
+        ogs_error("smf_ue_set_supi() failed [%s]", supi);
+        goto error;
+    }
+
+    if (imsi_supi == true &&
+        smf_ue_set_imsi_bcd(smf_ue, imsi_bcd) != OGS_OK) {
+        ogs_error("smf_ue_set_imsi_bcd() failed [%s:%s]",
+                supi, imsi_bcd);
+        goto error;
+    }
 
     return smf_ue;
+
+error:
+    if (created == true)
+        smf_ue_remove(smf_ue);
+    return NULL;
 }
 
 smf_ue_t *smf_ue_add_by_imsi(uint8_t *imsi, int imsi_len)
 {
-    smf_ue_t *smf_ue;
+    smf_ue_t *smf_ue = NULL;
+    char imsi_bcd[OGS_MAX_IMSI_BCD_LEN+1];
+    char *supi = NULL;
+    bool created = false;
 
     ogs_assert(imsi);
     ogs_assert(imsi_len);
 
-    if ((smf_ue = smf_ue_add()) == NULL)
-        return NULL;;
+    if (imsi_len > OGS_MAX_IMSI_LEN) {
+        ogs_error("Invalid IMSI length [%d]", imsi_len);
+        return NULL;
+    }
 
-    smf_ue->imsi_len = ogs_min(imsi_len, OGS_MAX_IMSI_LEN);
-    memcpy(smf_ue->imsi, imsi, smf_ue->imsi_len);
-    ogs_buffer_to_bcd(smf_ue->imsi, smf_ue->imsi_len, smf_ue->imsi_bcd);
-    ogs_hash_set(self.imsi_hash, smf_ue->imsi, smf_ue->imsi_len, smf_ue);
+    memset(imsi_bcd, 0, sizeof(imsi_bcd));
+    ogs_buffer_to_bcd(imsi, imsi_len, imsi_bcd);
+    if (ogs_imsi_bcd_is_valid(imsi_bcd) == false) {
+        ogs_error("ogs_imsi_bcd_is_valid() failed [%s]", imsi_bcd);
+        return NULL;
+    }
 
+    supi = ogs_msprintf("%s-%s", OGS_ID_SUPI_TYPE_IMSI, imsi_bcd);
+    ogs_assert(supi);
+
+    /* First use the native EPC key. */
+    smf_ue = smf_ue_find_by_imsi(imsi, imsi_len);
+
+    /* Then try the canonical IMSI SUPI used by the SBI path. */
+    if (!smf_ue)
+        smf_ue = smf_ue_find_by_supi(supi);
+
+    if (!smf_ue) {
+        smf_ue = smf_ue_add();
+        if (!smf_ue) {
+            ogs_error("smf_ue_add() failed");
+            goto error;
+        }
+        created = true;
+    }
+
+    if (smf_ue_set_imsi(smf_ue, imsi, imsi_len) != OGS_OK) {
+        ogs_error("smf_ue_set_imsi() failed [%s]", imsi_bcd);
+        goto error;
+    }
+
+    if (smf_ue_set_supi(smf_ue, supi) != OGS_OK) {
+        ogs_error("smf_ue_set_supi() failed [%s]", supi);
+        goto error;
+    }
+
+    ogs_free(supi);
     return smf_ue;
+
+error:
+    if (supi)
+        ogs_free(supi);
+    if (created == true)
+        smf_ue_remove(smf_ue);
+    return NULL;
 }
 
 void smf_ue_remove(smf_ue_t *smf_ue)

--- a/src/smf/nsmf-handler.c
+++ b/src/smf/nsmf-handler.c
@@ -223,24 +223,10 @@ bool smf_nsmf_handle_create_sm_context(
         return false;
     }
 
-    if (SmContextCreateData->supi) {
-        type = ogs_id_get_type(SmContextCreateData->supi);
-        if (type) {
-            if (strncmp(type, OGS_ID_SUPI_TYPE_IMSI,
-                        strlen(OGS_ID_SUPI_TYPE_IMSI)) == 0) {
-                char *imsi_bcd = ogs_id_get_value(SmContextCreateData->supi);
-
-                ogs_cpystrn(smf_ue->imsi_bcd, imsi_bcd,
-                        ogs_min(strlen(imsi_bcd), OGS_MAX_IMSI_BCD_LEN)+1);
-                ogs_bcd_to_buffer(smf_ue->imsi_bcd,
-                        smf_ue->imsi, &smf_ue->imsi_len);
-
-                ogs_free(imsi_bcd);
-            }
-            ogs_free(type);
-        }
-    }
-
+    /*
+     * SUPI/IMSI identity is canonicalized in smf_ue_add_by_supi().
+     * Do not rewrite smf_ue->imsi here; it may already be a hash key.
+     */
     if (SmContextCreateData->pei) {
         type = ogs_id_get_type(SmContextCreateData->pei);
         if (type) {
@@ -1568,24 +1554,10 @@ bool smf_nsmf_handle_create_data_in_hsmf(
     ogs_freeaddrinfo(addr);
     ogs_freeaddrinfo(addr6);
 
-    if (PduSessionCreateData->supi) {
-        type = ogs_id_get_type(PduSessionCreateData->supi);
-        if (type) {
-            if (strncmp(type, OGS_ID_SUPI_TYPE_IMSI,
-                        strlen(OGS_ID_SUPI_TYPE_IMSI)) == 0) {
-                char *imsi_bcd = ogs_id_get_value(PduSessionCreateData->supi);
-
-                ogs_cpystrn(smf_ue->imsi_bcd, imsi_bcd,
-                        ogs_min(strlen(imsi_bcd), OGS_MAX_IMSI_BCD_LEN)+1);
-                ogs_bcd_to_buffer(smf_ue->imsi_bcd,
-                        smf_ue->imsi, &smf_ue->imsi_len);
-
-                ogs_free(imsi_bcd);
-            }
-            ogs_free(type);
-        }
-    }
-
+    /*
+     * SUPI/IMSI identity is canonicalized in smf_ue_add_by_supi().
+     * Do not rewrite smf_ue->imsi here; it may already be a hash key.
+     */
     if (PduSessionCreateData->pei) {
         type = ogs_id_get_type(PduSessionCreateData->pei);
         if (type) {


### PR DESCRIPTION
This is a revised implementation based on the original PR #4482.

When a UE attaches through EPC, the SMF indexes the UE by raw IMSI bytes. When the same subscriber later attaches through 5GC, the SMF indexes the UE by SUPI string. Since the two add paths only populated their native index, the same physical subscriber could end up with two different smf_ue_t objects and separate session lists.

Fix this by keeping IMSI and SUPI as two canonical representations of the same subscriber identity. For IMSI-based SUPIs, both add paths now converge on the same smf_ue_t:

- smf_ue_add_by_supi() derives the IMSI alias from "imsi-..." SUPI and registers the UE in imsi_hash.
- smf_ue_add_by_imsi() derives the "imsi-..." SUPI alias from raw IMSI bytes and registers the UE in supi_hash.
- identity setters own both field assignment and hash registration.
- identity ownership violations are treated as fatal invariants.
- malformed IMSI SUPIs are rejected instead of being accepted as SUPI-only UE contexts.

Move common IMSI/SUPI parsing helpers to lib/proto so the validation is not SMF-specific and can be reused by other components.

Also remove the later IMSI re-population from nsmf-handler.c. Once the UE identity is canonicalized at add time, rewriting smf_ue->imsi from the SBI request body would risk mutating memory already used as an imsi_hash key.

This prevents split SMF UE contexts across 4G and 5G attach paths and lets existing per-UE session cleanup and uniqueness checks operate on the complete session list.