### PR TITLE
mme: add T3396 back-off timer to PDN connectivity reject

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -46,6 +46,8 @@ mme:
   time:
 #    t3402:
 #      value: 720   # 12 minutes * 60 = 720 seconds
+#    t3396:
+#      value: 720   # 12 minutes * 60 = 720 seconds
 #    t3412:
 #      value: 3240  # 54 minutes * 60 = 3240 seconds
 #    t3423:

--- a/src/mme/esm-build.c
+++ b/src/mme/esm-build.c
@@ -24,6 +24,19 @@
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __esm_log_domain
 
+static bool esm_pdn_connectivity_reject_t3396_allowed(
+        ogs_nas_esm_cause_t esm_cause)
+{
+    switch (esm_cause) {
+    case OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN:
+    case OGS_NAS_ESM_CAUSE_SERVICE_OPTION_NOT_SUPPORTED:
+    case OGS_NAS_ESM_CAUSE_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED:
+        return true;
+    default:
+        return false;
+    }
+}
+
 ogs_pkbuf_t *esm_build_pdn_connectivity_reject(
         mme_sess_t *sess, ogs_nas_esm_cause_t esm_cause, int create_action)
 {
@@ -54,6 +67,21 @@ ogs_pkbuf_t *esm_build_pdn_connectivity_reject(
     message.esm.h.message_type = OGS_NAS_EPS_PDN_CONNECTIVITY_REJECT;
 
     pdn_connectivity_reject->esm_cause = esm_cause;
+
+    if (mme_self()->time.t3396.value &&
+        esm_pdn_connectivity_reject_t3396_allowed(esm_cause)) {
+        int rv;
+        ogs_nas_gprs_timer_t gprs_timer;
+
+        rv = ogs_nas_gprs_timer_3_from_sec(
+                &gprs_timer, mme_self()->time.t3396.value);
+        ogs_assert(rv == OGS_OK);
+
+        pdn_connectivity_reject->presencemask |=
+            OGS_NAS_EPS_PDN_CONNECTIVITY_REJECT_BACK_OFF_TIMER_VALUE_PRESENT;
+        pdn_connectivity_reject->back_off_timer_value.length = 1;
+        pdn_connectivity_reject->back_off_timer_value.t = gprs_timer;
+    }
 
     if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST)
         return ogs_nas_eps_plain_encode(&message);

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -215,6 +215,8 @@ static int mme_context_prepare(void)
     self.diam_config->cnf_port = DIAMETER_PORT;
     self.diam_config->cnf_port_tls = DIAMETER_SECURE_PORT;
 
+    /* Set the default T3396 to 12 minutes */
+    self.time.t3396.value = 720;
     /* Set the default T3412 to 9 minutes for backward compatibility. */
     self.time.t3412.value = 540;
 
@@ -297,12 +299,20 @@ static int mme_context_validation(void)
                 ogs_app()->file);
         return OGS_ERROR;
     }
-    if (ogs_nas_gprs_timer_from_sec(&gprs_timer, self.time.t3402.value) !=
+    if (self.time.t3402.value && /* Optional */
+        ogs_nas_gprs_timer_from_sec(&gprs_timer, self.time.t3402.value) !=
         OGS_OK) {
         ogs_error("Not support GPRS Timer [%d]", (int)self.time.t3402.value);
         return OGS_ERROR;
     }
-    if (!self.time.t3412.value) {
+    if (self.time.t3396.value && /* Optional */
+        ogs_nas_gprs_timer_3_from_sec(&gprs_timer, self.time.t3396.value) !=
+        OGS_OK) {
+        ogs_error("Not support GPRS Timer 3 [%d]",
+                (int)self.time.t3396.value);
+        return OGS_ERROR;
+    }
+    if (!self.time.t3412.value) { /* Mandatory */
         ogs_error("No mme.time.t3412.value in '%s'",
                 ogs_app()->file);
         return OGS_ERROR;
@@ -312,7 +322,8 @@ static int mme_context_validation(void)
         ogs_error("Not support GPRS Timer [%d]", (int)self.time.t3412.value);
         return OGS_ERROR;
     }
-    if (ogs_nas_gprs_timer_from_sec(&gprs_timer, self.time.t3423.value) !=
+    if (self.time.t3423.value && /* Optional */
+        ogs_nas_gprs_timer_from_sec(&gprs_timer, self.time.t3423.value) !=
         OGS_OK) {
         ogs_error("Not support GPRS Timer [%d]", (int)self.time.t3423.value);
         return OGS_ERROR;
@@ -2487,6 +2498,22 @@ int mme_context_parse_config(void)
                                         self.time.t3402.value = atoll(v);
                                 } else
                                     ogs_warn("unknown key `%s`", t3402_key);
+                            }
+                        } else if (!strcmp(time_key, "t3396")) {
+                            ogs_yaml_iter_t t3396_iter;
+                            ogs_yaml_iter_recurse(&time_iter, &t3396_iter);
+
+                            while (ogs_yaml_iter_next(&t3396_iter)) {
+                                const char *t3396_key =
+                                    ogs_yaml_iter_key(&t3396_iter);
+                                ogs_assert(t3396_key);
+
+                                if (!strcmp(t3396_key, "value")) {
+                                    const char *v = ogs_yaml_iter_value(&t3396_iter);
+                                    if (v)
+                                        self.time.t3396.value = atoll(v);
+                                } else
+                                    ogs_warn("unknown key `%s`", t3396_key);
                             }
                         } else if (!strcmp(time_key, "t3412")) {
                             ogs_yaml_iter_t t3412_iter;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -163,7 +163,7 @@ typedef struct mme_context_s {
     struct {
         struct {
             ogs_time_t value;       /* Timer Value(Seconds) */
-        } t3402, t3412, t3423;
+        } t3402, t3396, t3412, t3423;
     } time;
 
     struct {


### PR DESCRIPTION
Add T3396 support for selected ESM PDN Connectivity Reject causes.

This change is split out from PR #4483 and keeps only the NAS/ESM back-off timer part.

When the MME rejects a PDN Connectivity Request with one of the ESM causes for which UE back-off behavior is well-defined, include the Back-off timer value IE in the PDN Connectivity Reject message.

The initial supported causes are:

- Missing or unknown APN
- Service option not supported
- Requested service option not subscribed

T3396 defaults to 12 minutes, matching the standard default back-off behavior for these causes, and can be overridden through mme.time.t3396.value.