### PR TITLE
mme/smf: expose UE location timestamp in info dumps

### DIFF
--- a/src/mme/ue-info.c
+++ b/src/mme/ue-info.c
@@ -44,7 +44,8 @@
  *           "plmn": "99970",
  *           "tac_hex": "0001",
  *           "tac": 1
- *         }
+ *         },
+ *         "timestamp": 1778223227627488
  *       },
  *       "ambr": {
  *         "downlink": 1000000000,
@@ -176,6 +177,17 @@ static cJSON *build_location(const mme_ue_t *ue)
     if (!cJSON_AddNumberToObject(tai, "tac", (double)ue->tai.tac)) { cJSON_Delete(tai); goto end; }
 
     cJSON_AddItemToObjectCS(loc, "tai", tai);
+
+    /* Last location update timestamp (epoch microseconds, ogs_time_t).
+     * A value of 0 means the location has not yet been updated (i.e.
+     * the UE has not completed Initial Attach / TAU / Handover /
+     * Service Request response since the context was created).
+     * Updated on Initial Attach, TAU, Handover and Service Request responses;
+     * bounded by Periodic TAU (T3412). Keep the field name aligned with
+     * AMF /ue-info, which exposes this value as location.timestamp. */
+    if (!cJSON_AddNumberToObject(loc, "timestamp",
+                (double)ue->ue_location_timestamp)) goto end;
+
     return loc;
 
 end:

--- a/src/smf/pdu-info.c
+++ b/src/smf/pdu-info.c
@@ -57,7 +57,8 @@
  *               "pdr_id": 2
  *             }
  *           },
- *           "pdu_state": "inactive"
+ *           "pdu_state": "inactive",
+ *           "ue_location_timestamp": 1778223227627488
  *         }
  *       ],
  *       "ue_activity": "idle"
@@ -603,6 +604,20 @@ static cJSON *build_single_pdu_object(const smf_sess_t *sess, int *any_active, i
 
         if (any_active && !strcmp(state, "active")) *any_active = 1;
         else if (any_unknown && !strcmp(state, "unknown")) *any_unknown = 1;
+    }
+
+    /* Last location update timestamp (epoch microseconds, ogs_time_t).
+     * A value of 0 means the location has not yet been updated by the
+     * peer NF for this session.
+     * Inherited from the UE context at each N1/N2 location-bearing event
+     * (Initial Registration, TAU/Registration Update, Handover, Service
+     * Request response). Exposed for external reconciliation tools that
+     * need to age PDU sessions — e.g. distinguish a truly stale session
+     * from one that is legitimately idle-parked for later Resume. */
+    {
+        cJSON *ts = cJSON_CreateNumber((double)sess->ue_location_timestamp);
+        if (!ts) { cJSON_Delete(pdu); return NULL; }
+        cJSON_AddItemToObjectCS(pdu, "ue_location_timestamp", ts);
     }
 
     return pdu;


### PR DESCRIPTION
Expose the last UE location update timestamp in the operator-facing JSON info dumps.

For MME /ue-info, add the timestamp under the existing location object as location.timestamp, matching the AMF /ue-info schema.

For SMF /pdu-info, add ue_location_timestamp to each PDU session entry, since the value is exposed directly in the PDU session object.

The timestamp is stored as epoch microseconds in ogs_time_t. A value of 0 means the location has not yet been updated for the corresponding UE or session.

This helps external OAM and reconciliation tools distinguish stale UE or PDU session state from legitimately idle state.

This change is based on the original proposal in PR #4484, with the MME field name adjusted to align with the existing AMF /ue-info schema.