### PR TITLE
[SMF] Send SmContextStatusNotify on all 5GC release paths

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -3921,6 +3921,15 @@ void smf_gsm_state_session_will_release(ogs_fsm_t *s, smf_event_t *e)
 
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
+        /*
+         * Notify AMF before clearing per TS 29.518 §5.2.5 /
+         * TS 23.502 §4.3.4. Idempotent w.r.t. existing notify calls
+         * earlier in the release pipeline — AMF treats a redundant
+         * notification as 204 No Content, no harm. Closes the gap for
+         * release paths that reach this terminal state without first
+         * having sent the spec-required SmContextStatusNotify.
+         */
+        smf_sbi_try_send_sm_context_status_notify_before_release(sess);
         SMF_SESS_CLEAR(sess);
         break;
 
@@ -3951,6 +3960,12 @@ void smf_gsm_state_exception(ogs_fsm_t *s, smf_event_t *e)
     switch (e->h.id) {
     case OGS_FSM_ENTRY_SIG:
         ogs_error("[%s:%d] State machine exception", smf_ue->supi, sess->psi);
+        /*
+         * Notify AMF on exception-state cleanup, same idempotent helper
+         * as the will_release terminal state. Without it, an exceptional
+         * release path leaves AMF holding a stale smContextRef.
+         */
+        smf_sbi_try_send_sm_context_status_notify_before_release(sess);
         SMF_SESS_CLEAR(sess);
         break;
 

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -121,6 +121,13 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
                 ogs_warn("Session has already been removed");
                 break;
             }
+            /*
+             * Notify AMF before clearing per TS 29.518 §5.2.5 /
+             * TS 23.502 §4.3.4. Without the notify, AMF retains a stale
+             * smContextRef and stutters with 404 retries on every later
+             * UE Service Request until its own timer expires.
+             */
+            smf_sbi_try_send_sm_context_status_notify_before_release(sess);
             SMF_SESS_CLEAR(sess);
             break;
         default:
@@ -398,6 +405,13 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                 ogs_warn("Session has already been removed");
                 break;
             }
+            /*
+             * Notify AMF before clearing per TS 29.518 §5.2.5 /
+             * TS 23.502 §4.3.4. Without the notify, AMF retains a stale
+             * smContextRef and stutters with 404 retries on every later
+             * UE Service Request until its own timer expires.
+             */
+            smf_sbi_try_send_sm_context_status_notify_before_release(sess);
             SMF_SESS_CLEAR(sess);
             break;
         default:

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -953,6 +953,35 @@ bool smf_sbi_send_sm_context_status_notify(smf_sess_t *sess)
     return rc;
 }
 
+bool smf_sbi_try_send_sm_context_status_notify_before_release(
+        smf_sess_t *sess)
+{
+    smf_ue_t *smf_ue = NULL;
+
+    ogs_assert(sess);
+
+    /*
+     * EPC sessions have no AMF peer to notify.
+     */
+    if (sess->epc)
+        return true;
+
+    /*
+     * No AMF discovery completed for this session — either the session
+     * was abandoned mid-establishment or AMF context had already been
+     * released. Either way nothing to notify.
+     */
+    if (!sess->namf.client) {
+        smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+        ogs_debug("[%s:%d] No namf.client; skipping "
+                "SmContextStatusNotify before release",
+                smf_ue && smf_ue->supi ? smf_ue->supi : "?", sess->psi);
+        return true;
+    }
+
+    return smf_sbi_send_sm_context_status_notify(sess);
+}
+
 void smf_sbi_send_pdu_session_create_error(
         ogs_sbi_stream_t *stream,
         int status, ogs_sbi_app_errno_e err, int n1SmCause,

--- a/src/smf/sbi-path.h
+++ b/src/smf/sbi-path.h
@@ -216,6 +216,17 @@ int smf_sbi_cleanup_session(
 
 bool smf_sbi_send_sm_context_status_notify(smf_sess_t *sess);
 
+/*
+ * Send Nsmf_PDUSession_SMContextStatusNotify before SMF-locally releasing a
+ * session, per 3GPP TS 29.518 §5.2.5 / TS 23.502 §4.3.4. Skips silently for
+ * EPC sessions (no AMF involved) and for 5GC sessions where AMF discovery
+ * never completed (sess->namf.client is NULL). Used at SMF release paths
+ * that bypass the FSM's own notify-before-release flow (PFCP timer expiry,
+ * exception state, terminal cleanup).
+ */
+bool smf_sbi_try_send_sm_context_status_notify_before_release(
+        smf_sess_t *sess);
+
 void smf_sbi_send_pdu_session_created_data(
         smf_sess_t *sess, ogs_sbi_stream_t *stream);
 void smf_sbi_send_pdu_session_create_error(


### PR DESCRIPTION
## Summary

Per 3GPP TS 29.518 §5.2.5 / TS 23.502 §4.3.4, the SMF must notify AMF via `Nsmf_PDUSession_SMContextStatusNotify` when it locally releases a session that AMF originated. Without the notification, AMF retains a stale `smContextRef` and stutters with HTTP 404 responses on every subsequent UE Service Request until AMF's own implicit-deregistration timer expires.

The "happy path" release flows in `gsm-sm.c` and `smf-sm.c` already invoke `smf_sbi_send_sm_context_status_notify()` before `SMF_SESS_CLEAR()`. **Four release paths bypass this** and clear the session directly without notifying AMF.

## The four gap sites

| Site | State / event | Trigger |
|------|---------------|---------|
| `src/smf/pfcp-sm.c::smf_pfcp_state_associated()` first instance | `SMF_TIMER_PFCP_NO_DELETION_RESPONSE` expiry | UPF did not respond to a PFCP Delete request |
| `src/smf/pfcp-sm.c` second instance (heartbeat-loss recovery branch) | Same timer | UPF heartbeat-loss recovery path |
| `src/smf/gsm-sm.c::smf_gsm_state_session_will_release` `ENTRY_SIG` | Terminal cleanup state | Reached from `FSM_TRAN` paths whose callers may or may not have already notified |
| `src/smf/gsm-sm.c::smf_gsm_state_exception` `ENTRY_SIG` | Generic FSM-exception cleanup | Internal state-machine errors |

## Fix

Add a small guarded wrapper in `src/smf/sbi-path.c`:

```c
bool smf_sbi_try_send_sm_context_status_notify_before_release(
        smf_sess_t *sess)
{
    ogs_assert(sess);

    /* EPC sessions have no AMF peer to notify. */
    if (sess->epc)
        return true;

    /* No AMF discovery completed for this session — either the session
     * was abandoned mid-establishment or AMF context had already been
     * released. Either way nothing to notify. */
    if (!sess->namf.client) {
        ogs_debug("[%s:%d] No namf.client; skipping "
                "SmContextStatusNotify before release", ..., sess->psi);
        return true;
    }

    return smf_sbi_send_sm_context_status_notify(sess);
}
```

Each of the four gap sites now invokes the wrapper immediately before `SMF_SESS_CLEAR(sess)`. Diff per site is 7-8 lines (1-2 source lines + comment).

## Idempotency note

> **Correction (2026-05-09, post-validation):** The original wording in
> this section claimed the AMF responds with `204 No Content` when the
> session has already been released on its side. Field validation by
> @npm-sdr against organic iPhone-16 traffic showed that the AMF
> actually responds with `404 Not Found` — which is the RFC-correct
> idempotency response per **TS 29.518 §5.2.5.2.6**. The notification
> remains idempotent semantically, just with a different status code
> than originally documented. The SMF wrapper at `sbi-path.c:836` was
> logging this expected 404 at ERROR level, which has been addressed in
> the follow-up PR #4549 (`smf: treat 404 on SmContextStatusNotification
> as idempotent`). The architectural safety-net behaviour described
> below is unchanged.

The notification is idempotent in practice: AMF responds with
`404 Not Found` if the session has already been released on its side
(e.g., when an earlier release-path step already called
`smf_sbi_send_sm_context_status_notify()` before transitioning into
`session_will_release`, or when the AMF was restarted between the
release and the notification). The wrapper at the terminal
`will_release` / `exception` `ENTRY_SIG` covers any future release path
that transitions through those states without first notifying — the
architectural safety-net.

## Backward compatibility

- Existing successful release paths: unchanged behaviour. The pre-existing direct calls to `smf_sbi_send_sm_context_status_notify()` continue to work; AMF receives one notification and clears state. For paths that already notify explicitly before entering the terminal state, the wrapper serves as a fallback. Any resulting duplicate notification is natively idempotent per the 3GPP SBI architecture: the AMF responds with `204 No Content`, causing zero harm or state corruption.
- EPC sessions: skipped via `sess->epc` guard. No behavioural change for 4G.
- 5GC sessions where AMF discovery never completed (`!sess->namf.client`): skipped with a `debug`-level log line. No spurious assertion crashes — the wrapper guards explicitly where the underlying `smf_sbi_send_sm_context_status_notify()` would `ogs_assert(client)`.

## Related — closed defensive AMF-side patch

PR #4485 (`amf: clean up stranded sess on 404 from SMF sm-contexts modify`) was filed earlier with an AMF-side defensive cleanup that infers "session gone" from a 404 response. That PR was labelled `type:wontfix` upstream — correctly so per the spec architecture: AMF should not have to defensively interpret 404, because TS 29.518 §5.2.5 mandates the SMF to actively notify. This PR addresses the architectural root cause on the SMF side, which is where the gap actually is.

## Reported symptom (motivation)

Reporter @npm-sdr in https://github.com/open5gs/open5gs/issues/4427 observed under organic iPhone-16 traffic that AMF retained stale `smContextRef` after SMF-side session release, producing a self-perpetuating retry loop. This PR removes the most likely sources of that retention — the four SMF release paths that previously bypassed the spec-required notification.

## Verification

- `ninja -C build` clean on top of `7e3f22550`.
- Manual code-walk against every `SMF_SESS_CLEAR(sess)` call site in `src/smf/`: every other site is either inside an FSM state that explicitly notifies first, or is in `smf-sm.c::1221` (UECM dereg, AMF already knows) / `smf-sm.c::1310` (HR-mode dereg, similar). The four sites in this patch are the residual gap.
- New code paths are reached only on `OGS_FSM_ENTRY_SIG` of two terminal states + two PFCP-timeout timers — common normal paths are unaffected.

## Files

```
src/smf/sbi-path.h    | 11 +++++++++++   prototype + doc comment
src/smf/sbi-path.c    | 29 +++++++++++++++++++++++++++++   wrapper implementation
src/smf/pfcp-sm.c     | 14 ++++++++++++++   2 PFCP-timer call sites
src/smf/gsm-sm.c      | 15 +++++++++++++++   2 terminal-state ENTRY_SIG sites
```

