### PR TITLE
sbi: refuse HTTP/2 stream on allocation failure

### DIFF
--- a/lib/sbi/nghttp2-server.c
+++ b/lib/sbi/nghttp2-server.c
@@ -1615,6 +1615,7 @@ static int on_begin_headers(nghttp2_session *session,
 {
     ogs_sbi_session_t *sbi_sess = user_data;
     ogs_sbi_stream_t *stream = NULL;
+    int rv;
 
     ogs_assert(sbi_sess);
     ogs_assert(session);
@@ -1626,7 +1627,20 @@ static int on_begin_headers(nghttp2_session *session,
     }
 
     stream = stream_add(sbi_sess, frame->hd.stream_id);
-    ogs_assert(stream);
+    if (!stream) {
+        ogs_error("stream_add() failed for stream [%d]",
+                frame->hd.stream_id);
+
+        rv = nghttp2_submit_rst_stream(
+                session, NGHTTP2_FLAG_NONE,
+                frame->hd.stream_id, NGHTTP2_REFUSED_STREAM);
+        if (rv != 0)
+            ogs_error("nghttp2_submit_rst_stream() failed (%d:%s)",
+                    rv, nghttp2_strerror(rv));
+
+        return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+    }
+
     ogs_debug("STREAM added [%d]", frame->hd.stream_id);
 
     nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, stream);


### PR DESCRIPTION
This change is based on the issue addressed in original PR #4488.

When stream_add() fails in on_begin_headers(), the SBI server currently hits ogs_assert(stream), which can abort the whole NF process.

Handle the failure as a stream-level refusal instead of a process-level abort.  Explicitly submit RST_STREAM with NGHTTP2_REFUSED_STREAM before returning NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE.

According to nghttp2, returning NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE alone closes the stream with NGHTTP2_INTERNAL_ERROR.  If a different HTTP/2 error code is desired, the application must first submit RST_STREAM with the desired code and then return
NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE.

NGHTTP2_REFUSED_STREAM is the better semantic match here because the request has not been processed yet.  This lets the peer treat the failure as a temporary stream refusal rather than a generic internal server error, which is more appropriate when the stream pool is exhausted.