### PR TITLE
[SMF] wait_pfcp_deletion: route NULL-stream case to local-only release

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -2430,6 +2430,39 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
 
                     } else {
 
+                        if (!stream) {
+                            /*
+                             * SBI stream was torn down before this
+                             * PFCP-deletion-completion event fired (peer
+                             * RST_STREAM, idle-stream timeout, premature
+                             * client disconnect). The N1/N2 release
+                             * messages cannot reach the AMF, so the build
+                             * is skipped entirely. Transitioning to
+                             * smf_gsm_state_wait_5gc_n1_n2_release would
+                             * deadlock the FSM waiting for completion of a
+                             * release procedure that was never started.
+                             *
+                             * Take the local-only cleanup path:
+                             *   - PCF SmPolicy associated → run delete via
+                             *     smf_gsm_state_5gc_session_will_deregister
+                             *     which converges to session_will_release.
+                             *   - No PCF policy → straight to
+                             *     session_will_release (terminal teardown).
+                             */
+                            ogs_error("[%s:%d] Stream removed before PFCP "
+                                    "deletion completion; proceeding with "
+                                    "local-only release",
+                                    smf_ue->supi, sess->psi);
+
+                            if (PCF_SM_POLICY_ASSOCIATED(sess))
+                                OGS_FSM_TRAN(s,
+                                    smf_gsm_state_5gc_session_will_deregister);
+                            else
+                                OGS_FSM_TRAN(s,
+                                    smf_gsm_state_session_will_release);
+                            break;
+                        }
+
                         n1smbuf = gsm_build_pdu_session_release_command(
                                 sess, OGS_5GSM_CAUSE_REGULAR_DEACTIVATION);
                         ogs_assert(n1smbuf);
@@ -2442,7 +2475,6 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                                     NGAP_CauseNas_normal_release);
                         ogs_assert(n2smbuf);
 
-                        ogs_assert(stream);
                         smf_sbi_send_sm_context_updated_data_n1_n2_message(
                                 sess, stream, n1smbuf,
                                 OpenAPI_n2_sm_info_type_PDU_RES_REL_CMD,


### PR DESCRIPTION
## Summary

Field-observed crash report (originally https://github.com/open5gs/open5gs/issues/4017, duplicate report `ogs_assert(stream)` failure at `src/smf/gsm-sm.c:1622`) in the UE-requested PDU Session release path of `smf_gsm_state_wait_pfcp_deletion`. The SBI stream tied to the SM-context-update can be torn down between PFCP-deletion-completion event queueing and event delivery (peer RST_STREAM, HTTP/2 idle-stream timeout, premature client disconnect, peer SBI socket close).

Following up on closed PR #4493 with the revised design per [@acetcom's review feedback](https://github.com/open5gs/open5gs/pull/4493#issuecomment-4406175550): the NULL-stream case is now handled **before** allocating the N1/N2 release buffers (no useless build-then-free), and the FSM routes to a local-only cleanup path instead of transitioning to `smf_gsm_state_wait_5gc_n1_n2_release` for a release procedure that was never started.

## Fix

In `src/smf/gsm-sm.c::smf_gsm_state_wait_pfcp_deletion()`, before the N1/N2 buffer allocation in the UE-requested release branch:

```c
if (!stream) {
    ogs_error("[%s:%d] Stream removed before PFCP deletion completion; "
            "proceeding with local-only release", smf_ue->supi, sess->psi);

    if (PCF_SM_POLICY_ASSOCIATED(sess))
        OGS_FSM_TRAN(s, smf_gsm_state_5gc_session_will_deregister);
    else
        OGS_FSM_TRAN(s, smf_gsm_state_session_will_release);
    break;
}
```

Plus removal of the `ogs_assert(stream)` further down (now guaranteed non-NULL by the new guard).

## Why this target state

- **`smf_gsm_state_5gc_session_will_deregister`** when PCF SmPolicy is associated: runs the PCF SmPolicy delete via the existing `smf_sbi_cleanup_session()` flow, then converges to `session_will_release`. The PCF-side state is freed cleanly.
- **`smf_gsm_state_session_will_release`** otherwise: direct terminal teardown via `SMF_SESS_CLEAR(sess)` without spurious SBI traffic.

`smf_gsm_state_wait_5gc_n1_n2_release` is wrong for this case because no N1/N2 release was actually started — the FSM would deadlock waiting for completion of a procedure that does not exist, and the `smf_sess_t` would leak.

## Field-observed crash signature

```
smf: FATAL: smf_gsm_state_wait_pfcp_deletion: Assertion `stream' failed.
(../src/smf/gsm-sm.c:1622)
```

## Verification

- `ninja -C build` clean on `7e3f22550`.
- Healthy path (stream still valid when PFCP-deletion-completion event fires) is unchanged: same buffer build, same SBI message send, same trailing transition to `wait_5gc_n1_n2_release`. The new code is reachable only when `stream` is `NULL`.
- The two target FSM states (`smf_gsm_state_5gc_session_will_deregister` and `smf_gsm_state_session_will_release`) are existing, well-exercised cleanup paths; no new state introduced.

## Related

- Closed PR #4493 — original variant, wontfix'd with the architectural feedback this PR implements verbatim.
- Closed https://github.com/open5gs/open5gs/issues/4017 (gstaa, 2025-07-23) — earlier crash report and an initial `if (stream) { ... } else { break; }` proposal that was also not merged.

Closes #4017
