### PR TITLE
mme,amf: Silently discard configuration transfers with unknown targets

### DIFF
--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2855,12 +2855,23 @@ void ngap_handle_uplink_ran_configuration_transfer(
 
         target_gnb = amf_gnb_find_by_gnb_id(target_gnb_id);
         if (!target_gnb) {
-            ogs_error("Uplink RAN configuration transfer : "
-                    "cannot find target gNB-id[0x%x]", target_gnb_id);
-            r = ngap_send_error_indication(gnb, NULL, NULL,
-                    NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
+            /* 3GPP TS 38.413 §8.7.1.2 instructs the AMF to forward
+             * SON Configuration Transfer "if the target gNB is
+             * known" and defines no response for the unknown-target
+             * case. ErrorIndication is technically permitted by
+             * §8.4.1 but in practice it can sustain retransmit
+             * loops on RAN stacks where the X2/Xn-Setup retry
+             * counter is effectively unbounded: each unanswered
+             * Configuration Transfer accumulates state on the
+             * source gNB. Silent discard follows the spec wording
+             * ("if known" → otherwise no action) and breaks the
+             * loop without changing protocol semantics for any
+             * spec-compliant peer. Mirrors the analogous fix in
+             * src/mme/s1ap-handler.c for S1AP §8.7.1. */
+            ogs_warn("Uplink RAN Configuration Transfer: "
+                     "target gNB-id[0x%x] not connected — "
+                     "silently discarding (TS 38.413 §8.7.1.2)",
+                     target_gnb_id);
             return;
         }
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -3253,13 +3253,25 @@ void s1ap_handle_enb_configuration_transfer(
 
         target_enb = mme_enb_find_by_enb_id(target_enb_id);
         if (target_enb == NULL) {
-            ogs_error("eNB configuration transfer : "
-                        "cannot find target eNB-id[0x%x]", target_enb_id);
-            r = s1ap_send_error_indication(enb, NULL, NULL,
-                    S1AP_Cause_PR_radioNetwork,
-                    S1AP_CauseRadioNetwork_unknown_targetID);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
+            /* 3GPP TS 36.413 §8.7.1.2 instructs the MME to
+             * forward SON Configuration Transfer "if the target
+             * eNB is known" and defines no response for the
+             * unknown-target case. ErrorIndication with cause
+             * unknown-targetID is technically permitted by §8.4.1
+             * (procedure cannot be initiated due to unknown
+             * target) but in practice it can sustain retransmit
+             * loops on eNB stacks where the X2-Setup retry
+             * counter is effectively unbounded: each unanswered
+             * Configuration Transfer accumulates state on the
+             * source eNB until an internal watchdog forces a
+             * box reboot. Silent discard follows the spec wording
+             * ("if known" → otherwise no action) and breaks the
+             * loop without changing protocol semantics for any
+             * spec-compliant peer. */
+            ogs_warn("ENB Configuration Transfer: "
+                     "target eNB-id[0x%x] not connected — "
+                     "silently discarding (TS 36.413 §8.7.1.2)",
+                     target_enb_id);
             return;
         }
 


### PR DESCRIPTION
# Patch Proposal: MME + AMF — Silently discard configuration transfers with unknown targets

**Target:** Open5GS upstream `main` (currently `93b24ec21`)
**Branch:** `upstream-pr/mme-amf-config-transfer-silent-discard` (off `upstream/main`)
**Commits (2):**

| # | SHA | Subject |
|---|-----|---------|
| 1 | `49a889de1` | `[MME] Silently discard ENB Configuration Transfer with unknown target` |
| 2 | `4a34eafdb` | `[AMF] Silently discard Uplink RAN Configuration Transfer with unknown target` |

**Suggested PR title:** `mme,amf: Silently discard configuration transfers with unknown targets`
**Diff-Stat:** `2 files changed, 36 insertions(+), 13 deletions(-)`

---

## TL;DR

Per **3GPP TS 36.413 §8.7.1.2 (S1AP)** and **TS 38.413 §8.7.1.2 (NGAP)**:
the MME / AMF forwards `SON Configuration Transfer` to the target node
*"if the target eNB/gNB is known"* — both specs define **no response**
for the unknown-target case.

Open5GS currently returns `ErrorIndication` on both paths (S1AP cause
`unknown-targetID`; NGAP cause `semantic_error`). Both responses are
technically permitted by §8.4.1 but turn into the **trigger** of an
indefinite Configuration-Transfer retransmission loop on RAN stacks
whose X2/Xn-Setup retry counter is effectively unbounded — generating
unnecessary signaling storms on the S1-MME / N2 interface, and on
certain firmware implementations leading to state accumulation on the
source RAN node and eventual watchdog reboots.

The two commits replace each `ErrorIndication` send with a silent
discard plus a single `ogs_warn` for operator visibility. Behaviour
matches the spec wording, and breaks the loop without changing
observable protocol semantics for any spec-compliant peer. The two
commits are kept separate so each subsystem's change can be reviewed
independently, but they are proposed together because S1AP §8.7.1 and
NGAP §8.7.1 have structurally identical procedure semantics — keeping
the two paths in sync prevents asymmetric protocol behaviour between
4G and 5G deployments.

---

## Related Issues / Reports

No matching upstream issue was located. The field narrative below is
suitable to file as an issue first if maintainer prefers.

---

## Problem Statement

### S1AP — `s1ap_handle_enb_configuration_transfer()`

`src/mme/s1ap-handler.c` lines ~3253–3263:

```c
target_enb = mme_enb_find_by_enb_id(target_enb_id);
if (target_enb == NULL) {
    ogs_error("eNB configuration transfer : "
                "cannot find target eNB-id[0x%x]", target_enb_id);
    r = s1ap_send_error_indication(enb, NULL, NULL,
            S1AP_Cause_PR_radioNetwork,
            S1AP_CauseRadioNetwork_unknown_targetID);
    ogs_expect(r == OGS_OK);
    ogs_assert(r != OGS_ERROR);
    return;
}
```

### NGAP — `ngap_handle_uplink_ran_configuration_transfer()`

`src/amf/ngap-handler.c` lines ~2856–2865:

```c
target_gnb = amf_gnb_find_by_gnb_id(target_gnb_id);
if (!target_gnb) {
    ogs_error("Uplink RAN configuration transfer : "
            "cannot find target gNB-id[0x%x]", target_gnb_id);
    r = ngap_send_error_indication(gnb, NULL, NULL,
            NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
    ogs_expect(r == OGS_OK);
    ogs_assert(r != OGS_ERROR);
    return;
}
```

### Loop pattern (both interfaces)

```
   RAN node                         CN node (MME / AMF)
   --- (NG)ENBConfigurationTransfer (target=0xPHANTOM) -->
   <-- ErrorIndication ------------------------------------
   [retransmit timer ~10 s, retry counter ~unbounded]
   --- (NG)ENBConfigurationTransfer (target=0xPHANTOM) -->
   <-- ErrorIndication --------------------------------- ...
```

Each unanswered Configuration Transfer keeps state on the source RAN
node; the loop also produces sustained log noise and avoidable
signaling on the S1-MME / N2 interface for as long as the stale ANR
reference exists.

---

## Root Cause Analysis (Spec-Side)

**TS 36.413 §8.7.1.2 ENB Configuration Transfer — Procedure Operation:**

> "Upon receipt the MME shall, **if the target eNB is known**, forward
> the SON Configuration Transfer IE to the appropriate target eNB
> through the MME CONFIGURATION TRANSFER message."

**TS 38.413 §8.7.1.2 Uplink RAN Configuration Transfer — Procedure Operation:**

> "Upon receipt the AMF shall, **if the target gNB is known**, forward
> the SON Configuration Transfer IE to the appropriate target gNB
> through the Downlink RAN Configuration Transfer message."

Both specs:

1. Are **Class 2 procedures** (no successful response defined).
2. Describe **only the success path** (forward if known) and are silent
   on the unknown-target case. The natural reading is *no action*.

**TS 36.413 / TS 38.413 §8.4.1 Error Indication — Procedure Operation:**

> "When a procedure cannot be initiated due to an erroneous message,
> the MME / AMF shall send the message ERROR INDICATION."

The §8.7.1.2 unknown-target case is **not an erroneous message** — the
incoming Configuration Transfer is syntactically valid and semantically
well-formed; the CN simply lacks state to forward it. Strictly applying
§8.4.1 to "we don't have the target connected right now" stretches the
"erroneous message" wording.

The cause-IE choices in the current code (`unknown-targetID` for S1AP;
`semantic_error` for NGAP) further illustrate the point: neither cause
is spec-narrative for SON Configuration Transfer. `unknown-targetID` is
listed in §10.6 but its narrative usage is in handover-related
procedures. `semantic_error` describes a protocol-level malformation,
which the incoming Configuration Transfer is not.

---

## Field Validation (Symptom Report)

Production deployment, 4-eNB cluster on the S1AP side. Each box was
pre-provisioned with a 5-entry X2 neighbour list. One referenced
eNB-ID had been decommissioned but remained in the neighbour list of
one cluster member, which began to send `ENBConfigurationTransfer` to
the phantom every 8 seconds at boot time. The MME logged:

```
[mme] ERROR: eNB configuration transfer : cannot find target
            eNB-id[0xPHANTOM] (../src/mme/s1ap-handler.c:3256)
[mme] INFO:  ErrorIndication
```

During the 7h 24m window in which the loop persisted, two effects were
observed:

1. **Signaling storm on S1-MME** — sustained 8s-period
   `ENBConfigurationTransfer` / `ErrorIndication` pair, multiplied by
   the source eNB's stack accumulating retry state for the unreachable
   peer. No useful work performed by the CN on these messages.
2. **State accumulation on the source RAN node** — the source eNB was
   running a firmware family (Baicells RTS_3.7.x) whose X2-Setup retry
   counter is configured to a very high value by default. On this
   stack the continuous receipt of `ErrorIndication` leads to gradual
   state accumulation, eventually triggering an internal watchdog
   reboot of the box after ~14 hours of uptime.

Cleaning up the neighbour list on the source eNB (one entry, via the
eNB's own GUI delete button — internally `mibcli deleteobject
FAP.0.LTE_RAN_NEIGH_LIST_LTE_CELL.<idx>`) silenced the loop
immediately, confirming the loop dynamics: **one** stale ANR reference
on **one** eNB drove all observed traffic.

The signaling-storm cost is the broadly relevant impact for any
operator. The watchdog-reboot consequence is firmware-specific but
illustrates that retransmit loops can have non-trivial downstream
effects on RAN stacks that may be assumed harmless from the CN side.

---

## Field Validation (post-deploy, 2026-05-09)

The patch was deployed to the same 4-eNB production deployment on
2026-05-09 03:07 CEST while the phantom-loop was still active. The
deployment-day timeline:

```
T+0    (03:07)  MME+AMF restarted with the patch.
T+0    (03:07)  All 4 eNBs SCTP-reconnect S1, attempt X2 setup again.
T+8min (03:15)  All 4 eNBs sending ENB Configuration Transfer for two
                phantom eNB-IDs (b6 and b9) at 8 s period each.
                Steady-state CN-side rate: ~24 events / minute,
                100% silently discarded, 0 ErrorIndication sent back.
T+90min (~05)   eNB-side X2-Setup retry counters approach exhaustion.
                Without ErrorIndication amplification, the eNB stacks
                give up retrying — observed steady-state rate drops
                to 0 events / 30 min.
T+13.5h (~16:40) First eNB reaches its own pre-patch 14 h watchdog
                threshold (the original failure-mode signature) —
                NO REBOOT, no SCTP "connection refused" event in the
                MME log.
T+14h+ (~17:40) Remaining 3 eNBs cross their respective 14 h marks.
                NONE rebooted. All 4 eNBs continued to serve traffic.
```

End-of-day snapshot (2026-05-09 19:24 CEST):

| eNB | Uptime | Active UEs | E-RAB Setup | Reboots since deploy |
|-----|--------|------------|-------------|----------------------|
|  A  | 16h 05m | 12 | 100 % | 0 |
|  B  | 16h 04m | 11 | 100 % | 0 |
|  C  | 15h 43m | 18 | 100 % | 0 |
|  D  | 16h 41m | 15 | 100 % | 0 |

Conclusions from the field test:

1. **Patch is the actual fix, not a workaround.** The pre-patch
   reboot signature (3 eNBs cycling within 30 min after ~14 h
   uptime) did not recur. The eNBs' internal state pressure that
   was driving the watchdog is gone with the loop broken.
2. **Self-extinguishing loop.** Without `ErrorIndication` feedback,
   the source eNB's X2-Setup retry counter (configurable, 255 by
   default on this firmware) eventually exhausts and the eNB stops
   sending. Steady-state CN log churn drops from sustained to zero.
3. **Operator visibility preserved.** The single `ogs_warn` per
   incoming Configuration Transfer continues to expose stale ANR
   references at a sustainable rate (logs do not get drowned).

### Post-deploy update (T+12h, 2026-05-09 21:38 CEST)

One of the four eNBs (eNB-A) rebooted at ~18 h 21 m uptime due to a
**CEVA-DSP / DDR-controller protection fault** in the Layer-1 PHY
hardware interconnect. Captured by the eNB-side wdog snapshot:

```
[kernel uptime 66044 s]
DDR controller IRQ received. Dumping related registers...
PORT_CMD_ERROR_ID    0x02_0020   (Port ID: 0x02 — CEVA, FFT)
PORT_CMD_ERROR_TYPE  0x04        (Bit[2]: protection error
                                  — address / access / range)
iccserv: no CEVA irqs for 10 ms — switch to iccserv timer
[shmsemadrv]: wait failed
[eNB watchdog] Abnormal process: enodeb (soft=10s / hard=110s)
```

Memory snapshot at crash: `MemFree 17 MB`, `Inactive 158 MB`, `Swap 0 MB`
— no OOM / memory-pressure signature. The fault path lies entirely in
the eNB's Layer-1 PHY hardware interconnect (DSP↔DDR shared-memory),
structurally disjoint from the S1AP code paths this patch addresses.

Remaining three eNBs continued past the 18 h mark without event;
end-of-day snapshot at T+18 h still showed all three serving traffic
with the patched MME log silent for the unknown-target path.

The 14 h reboot-signature elimination claim above stands. The
secondary 18 h reboot is reported here for completeness (the patch
neither caused nor was expected to mitigate a Layer-1 PHY hardware
fault).

### Further update (T+20.5 h, end of deployment window)

A second eNB (eNB-D) rebooted at ~23 h uptime shortly before the
deployment was cleanly shut down at end-of-event. The diagnostic
snapshot from the first reboot (eNB-A) captured the CEVA-DSP /
DDR-controller protection-fault signature; an equivalent snapshot
for eNB-D could not be collected before shutdown. The remaining two
eNBs (eNB-B, eNB-C) reached ~20 h uptime without reboot.

Summary across the four-eNB cluster over the deployment window:

- 4 / 4 eNBs cleared the pre-patch 14 h reboot signature.
- 2 / 4 eNBs exhibited a later reboot in the 18-23 h uptime window;
  on the one box where a snapshot exists, the trigger is the
  Layer-1-hardware fault signature above.
- 2 / 4 eNBs were still up at end-of-event.

The patch's claimed scope (eliminating the S1AP ENB-Configuration-
Transfer feedback loop and its associated state accumulation) is
unaffected by the hardware-fault events at higher uptimes. Further
validation of the longer-uptime patterns is deferred to the next
deployment.

---

## Patches

### Commit 1 — `[MME]` `src/mme/s1ap-handler.c`

```diff
         target_enb = mme_enb_find_by_enb_id(target_enb_id);
         if (target_enb == NULL) {
-            ogs_error("eNB configuration transfer : "
-                        "cannot find target eNB-id[0x%x]", target_enb_id);
-            r = s1ap_send_error_indication(enb, NULL, NULL,
-                    S1AP_Cause_PR_radioNetwork,
-                    S1AP_CauseRadioNetwork_unknown_targetID);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
+            /* 3GPP TS 36.413 §8.7.1.2 instructs the MME to
+             * forward SON Configuration Transfer "if the target
+             * eNB is known" and defines no response for the
+             * unknown-target case. ErrorIndication with cause
+             * unknown-targetID is technically permitted by §8.4.1
+             * (procedure cannot be initiated due to unknown
+             * target) but in practice it can sustain retransmit
+             * loops on eNB stacks where the X2-Setup retry
+             * counter is effectively unbounded: each unanswered
+             * Configuration Transfer accumulates state on the
+             * source eNB until an internal watchdog forces a
+             * box reboot. Silent discard follows the spec wording
+             * ("if known" → otherwise no action) and breaks the
+             * loop without changing protocol semantics for any
+             * spec-compliant peer. */
+            ogs_warn("ENB Configuration Transfer: "
+                     "target eNB-id[0x%x] not connected — "
+                     "silently discarding (TS 36.413 §8.7.1.2)",
+                     target_enb_id);
             return;
         }
```

### Commit 2 — `[AMF]` `src/amf/ngap-handler.c`

```diff
         target_gnb = amf_gnb_find_by_gnb_id(target_gnb_id);
         if (!target_gnb) {
-            ogs_error("Uplink RAN configuration transfer : "
-                    "cannot find target gNB-id[0x%x]", target_gnb_id);
-            r = ngap_send_error_indication(gnb, NULL, NULL,
-                    NGAP_Cause_PR_protocol, NGAP_CauseProtocol_semantic_error);
-            ogs_expect(r == OGS_OK);
-            ogs_assert(r != OGS_ERROR);
+            /* 3GPP TS 38.413 §8.7.1.2 instructs the AMF to forward
+             * SON Configuration Transfer "if the target gNB is
+             * known" and defines no response for the unknown-target
+             * case. ErrorIndication is technically permitted by
+             * §8.4.1 but in practice it can sustain retransmit
+             * loops on RAN stacks where the X2/Xn-Setup retry
+             * counter is effectively unbounded: each unanswered
+             * Configuration Transfer accumulates state on the
+             * source gNB. Silent discard follows the spec wording
+             * ("if known" → otherwise no action) and breaks the
+             * loop without changing protocol semantics for any
+             * spec-compliant peer. Mirrors the analogous fix in
+             * src/mme/s1ap-handler.c for S1AP §8.7.1. */
+            ogs_warn("Uplink RAN Configuration Transfer: "
+                     "target gNB-id[0x%x] not connected — "
+                     "silently discarding (TS 38.413 §8.7.1.2)",
+                     target_gnb_id);
             return;
         }
```

---

## What is NOT changed

Several other ErrorIndication call sites are present in the same two
functions and are intentionally **left untouched**:

**S1AP `s1ap_handle_enb_configuration_transfer()`**:

- `if (sourceeNB_ID->selected_TAI.tAC.size != sizeof(source_tac))`
- `if (targeteNB_ID->selected_TAI.tAC.size != sizeof(target_tac))`

These validate the wire-encoded length of a TAI octet string. A wrong
length is a syntactic protocol error — exactly the §8.4.1 scenario
("an erroneous message"). ErrorIndication is correct here.

**NGAP `ngap_handle_uplink_ran_configuration_transfer()`**:

- `if (targetGlobalRANNodeID->present != ...PR_globalGNB_ID)`
- `if (!targetGlobalGNB_ID)`
- `if (sourceGlobalRANNodeID->present != ...PR_globalGNB_ID)`
- `if (!sourceGlobalGNB_ID)`

Same reasoning: present-type and pointer-presence checks describe wire
malformation, not unknown-target. Unchanged.

The structurally similar block in S1AP
`s1ap_handle_handover_required_intralte()` (calls
`s1ap_send_handover_preparation_failure()` — the spec-defined Class-1
failure response for §8.4.2) is also **left untouched**.

---

## Risk Assessment

| Aspect | Assessment |
|--------|------------|
| Backward compatibility | None broken. Both procedures are Class 2 with no expected response on the success path. The previous ErrorIndication was supplementary, not a successful procedure response. |
| Operator visibility | Maintained. `ogs_warn` (instead of `ogs_error`) clearly logs the unknown-target with the offending eNB/gNB-ID; existing log-scrapers searching for "configuration transfer" still find these events. |
| Test surface | Both changes are on non-UE-context, non-handover code paths. No state machines or memory ownership change. |
| 4G/5G symmetry | Restored. Without the AMF commit, an operator running NGAP-only deployments would still suffer the signaling storm at scale despite the S1AP-side fix. |
| Downside if not merged | Open5GS deployments with stale ANR references on connected RAN nodes continue to produce sustained `ogs_error` storms on whichever interface (S1AP or NGAP) is in use. |

---

## Test Plan (additional, beyond field validation above)

1. **Existing tests** — both changes are additions of `ogs_warn` and
   removal of an SCTP-send branch on a non-UE-context, non-handover
   code path. No existing test exercises this specific branch.
   Existing test suite should remain green.
2. **Regression sanity** — with target eNB / gNB **present** (the
   success path), both patches are no-ops; the conditional branch is
   not entered and `s1ap_send_mme_configuration_transfer()` /
   `ngap_send_downlink_ran_configuration_transfer()` is reached as
   before.
3. **S1AP field re-trigger** — re-add a phantom eNB-ID to a connected
   eNB's X2-NEIGH_LIST via its OAM. Observe MME log:
   - **Before patch**: `ogs_error` + ErrorIndication every 8 s for
     the phantom — sustained indefinitely.
   - **After patch**: single `ogs_warn` per Configuration Transfer
     received; no SCTP send back; loop on eNB side either attenuates
     over its retry-counter or persists at the eNB's timer rate
     without amplifying CN log volume / S1-MME signaling.
4. **NGAP field re-trigger** — analogous to (3) on the AMF side once
   a gNB stack capable of producing the equivalent NGAP traffic is
   available.
5. **Memory / RAN-side stability** — monitor the source RAN node
   free-RAM trend across a 24h window with the phantom in place.
   Expect: stable, no creep, no firmware-watchdog reboot at the prior
   threshold.

---

## Open Questions / Anticipated Maintainer Feedback

1. **Should the `ErrorIndication` be preserved as a configurable
   knob?** Argument against: configurable spec-compliance levels add
   complexity and, in this case, the configurable "off" mode would
   always be the correct one for production. Argument for: some
   operators may prefer the loud ErrorIndication for diagnosability —
   covered by the new `ogs_warn` log line on each call.
2. **Should the same change be applied to MME / Downlink RAN
   Configuration Transfer handling (the reverse direction)?** TS
   36.413 §8.7.2 / TS 38.413 §8.7.2 are structurally similar. Open5GS
   does not currently send these to itself; no symmetric receiver
   path exists in the CN. Out of scope for this PR.
3. **Should the two commits be split into separate PRs?** They share
   a single failure mode and are deliberately framed as a single
   protocol-symmetry fix. Splitting would lose the symmetry argument
   and create review-ordering concerns. Happy to split if maintainer
   prefers.

---

## Cross-References

- 3GPP TS 36.413 §8.7.1 (ENB Configuration Transfer), §8.4.1 (Error
  Indication), §10.6 (S1AP Cause-IE values)
- 3GPP TS 38.413 §8.7.1 (Uplink RAN Configuration Transfer), §8.4.1
  (Error Indication), §9.3.1.2 (NGAP Cause-IE values)
- Source paths: `src/mme/s1ap-handler.c` lines 3157–3271 (S1AP);
  `src/amf/ngap-handler.c` lines 2745–2873 (NGAP)
- Field-event documentation: `docs/nova_x2_phantom_neighbor_review.md`
