### PR TITLE
smf: treat 404 on SmContextStatusNotification as idempotent

### DIFF
--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -833,9 +833,23 @@ static int client_notify_cb(
         return OGS_ERROR;
     }
 
-    if (message.res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)
+    if (message.res_status == OGS_SBI_HTTP_STATUS_NOT_FOUND) {
+        /*
+         * The AMF has already cleared its sm-context state for this
+         * session (e.g. after a 404 on sm-contexts/{ref}/modify, or
+         * post-AMF-restart, or after the AMF-side defensive cleanup
+         * fired ahead of our notification). Per TS 29.518 §5.2.5.2.6
+         * the response is intentionally idempotent — 404 here means
+         * "already gone", which is a successful steady-state outcome
+         * for the SMF, not an error. Downgrade to debug to keep the
+         * log signal clean during release-cascade events.
+         */
+        ogs_debug("SmContextStatusNotification idempotent: AMF "
+                "already cleared session [404]");
+    } else if (message.res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT) {
         ogs_error("SmContextStatusNotification failed [%d]",
                 message.res_status);
+    }
 
     ogs_sbi_message_free(&message);
     ogs_sbi_response_free(response);


### PR DESCRIPTION
## Summary

When the SMF notifies the AMF of a session status change via `Nsmf_PDUSession_SMContextStatusNotify`, RFC-correct AMF behaviour per **TS 29.518 §5.2.5.2.6** is to return `404 Not Found` if the AMF has already released its local sm-context state. The current SMF wrapper at `src/smf/sbi-path.c:836` logs every non-`204` response — including this expected 404 — at ERROR level.

Field-observed during release-cascade events while @npm-sdr was validating the PR #4528 + #4485 + #4540 stack on issue #4427. The SMF emitted

```
ERROR: SmContextStatusNotification failed [404]   (sbi-path.c:837)
```

once per ~16 s during a 16-round retry cycle, even though every release in the cascade was correctly self-cleaning and zero IPs leaked. This is log noise, not a real error condition.

## Fix

Split the 404 case explicitly:

- `404` → debug-level log, treat as successful idempotent outcome.
- Every other non-2xx (5xx, transport-side failures, parse failures) remains ERROR exactly as before.

No risk of swallowing real errors:

- Network-level failures already short-circuit upstream in the `status != OGS_DONE` branch of `client_notify_cb()` and return `OGS_ERROR` before reaching this block.
- Parse failures are caught by the `ogs_sbi_parse_response()` check immediately above this site.

## Test plan

- [x] `ninja -C build` clean against `main @ 93b24ec21`.
- [ ] No functional behaviour change — only log level for the specific 404-on-status-notify case.
- [ ] @npm-sdr's reproducer would emit the same release flow but without the recurring ERROR line in the journal.
