### PR TITLE
amf: tear down old sessions through release path on SUCI re-attach

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -18,6 +18,7 @@
  */
 
 #include "ngap-path.h"
+#include "sbi-path.h"
 
 static amf_context_t self;
 
@@ -2137,7 +2138,6 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
         ogs_nas_5gs_mobile_identity_t *mobile_identity)
 {
     amf_ue_t *old_amf_ue = NULL;
-    amf_sess_t *old_sess = NULL;
     char *suci = NULL;
 
     ogs_assert(amf_ue);
@@ -2152,6 +2152,8 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
         /* Check if OLD amf_ue_t is different with NEW amf_ue_t */
         if (ogs_pool_index(&amf_ue_pool, amf_ue) !=
             ogs_pool_index(&amf_ue_pool, old_amf_ue)) {
+            ran_ue_t *new_ran_ue = NULL;
+
             ogs_warn("[%s] OLD UE Context Release", suci);
             if (CM_CONNECTED(old_amf_ue)) {
                 ran_ue_t *ran_ue = ran_ue_find_by_id(old_amf_ue->ran_ue_id);
@@ -2171,30 +2173,55 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
             }
 
     /*
-     * We should delete the AMF-Session Context in the AMF-UE Context.
-     * Otherwise, all unnecessary SESSIONs remain in SMF/UPF.
+     * SUCI re-attach signals a fresh UE state per TS 24.501 §5.5.1.2:
+     * the UE has discarded its 5G NAS security context (USIM-toggle,
+     * post-deregistration timer, flight-mode cycle, etc.) and is
+     * starting Initial Registration without a usable 5G-GUTI. Any PDU
+     * sessions previously anchored to the old amf_ue context must be
+     * torn down through the standard release path, not transplanted
+     * onto the new context.
      *
-     * In order to do this, AMF-Session Context should be moved
-     * from OLD AMF-UE Context to NEW AMF-UE Context.
+     * The pre-2026 implementation shallow-copied old_amf_ue->sess_list
+     * onto the new amf_ue and then removed old_amf_ue immediately, on
+     * the assumption that "Another SBI Transaction can cause fatal
+     * errors". That assumption no longer holds: amf_sbi_send_release_*
+     * dispatches via the xact-queue mechanism (sbi-path.c), which
+     * defers old_amf_ue removal until every pending Nsmf_PDUSession
+     * Release transaction has completed (nsmf-handler.c).
      *
-     * If needed, The Session deletion process in NEW-AMF UE context will work.
+     * The transplant has the architectural side-effect of leaving the
+     * SMF anchored to the old amf_ue identity (the
+     * sm_context_resource_uri / sm_context_ref pair the SMF allocated
+     * against the original ran_ue / amf_ue_ngap_id). Subsequent
+     * Nsmf_PDUSession_UpdateSMContext calls from the new amf_ue
+     * therefore receive 404 from the SMF, the AMF wakes up and pages
+     * the UE, the UE responds with another SUCI re-attach, and the
+     * cascade self-perpetuates until mobile-reachable timer expiry
+     * (~5 min) finally garbage-collects the leak. Field-observed in
+     * issue #4427 with iPhone-16 organic traffic and reproduced via
+     * flight-mode toggle on the same device.
      *
-     * Note that we should not send Session-Release to the SMF at this point.
-     * Another SBI Transaction can cause fatal errors.
+     * The release uses AMF_RELEASE_SM_CONTEXT_NO_STATE so we do not
+     * re-enter any GMM state machine on old_amf_ue (which is about to
+     * be removed). new_ran_ue from the incoming registration carries
+     * the necessary peer-NF context for SBI dispatch; we do NOT use
+     * old_amf_ue->ran_ue_id because that ran_ue has been freed two
+     * blocks above when the old context was CM_CONNECTED.
      */
+            new_ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
+            amf_sbi_send_release_all_sessions(
+                    new_ran_ue, old_amf_ue,
+                    AMF_RELEASE_SM_CONTEXT_NO_STATE, NULL);
 
-            /* Phase-1 : Change AMF-UE Context in Session Context */
-            ogs_list_for_each(&old_amf_ue->sess_list, old_sess)
-                old_sess->amf_ue_id = amf_ue->id;
-
-            /* Phase-2 : Move Session Context from OLD to NEW AMF-UE Context */
-            memcpy(&amf_ue->sess_list,
-                    &old_amf_ue->sess_list, sizeof(amf_ue->sess_list));
-
-            /* Phase-3 : Clear Session Context in OLD AMF-UE Context */
-            memset(&old_amf_ue->sess_list, 0, sizeof(old_amf_ue->sess_list));
-
-            amf_ue_remove(old_amf_ue);
+            if (amf_sess_xact_count(old_amf_ue) == 0) {
+                /* No PDU sessions held at the SMF, or all releases
+                 * dispatched synchronously already — safe to remove
+                 * old_amf_ue right away. */
+                amf_ue_remove(old_amf_ue);
+            }
+            /* else: removal is deferred; the SBI release-completion
+             * path (nsmf-handler.c) calls amf_ue_remove(old_amf_ue)
+             * once xact_count drops to zero. */
         }
     }
 


### PR DESCRIPTION
## Summary

`amf_ue_set_suci()` currently shallow-copies `old_amf_ue->sess_list` onto the new `amf_ue` and then immediately removes `old_amf_ue`, without any SMF-side notification or release. The author's stated reason for skipping SBI release was:

> "Note that we should not send Session-Release to the SMF at this point. Another SBI Transaction can cause fatal errors."

That constraint no longer holds. `amf_sbi_send_release_*` dispatches via the xact-queue mechanism in `src/amf/sbi-path.c`, and `src/amf/nsmf-handler.c` defers `amf_ue_remove()` until xact_count drops to zero. Cross-context releases are safe today.

The transplant has a real architectural side-effect: the SMF still holds the `sm_context_resource_uri` / `sm_context_ref` it allocated against the **old** `amf_ue` identity (peer ran_ue and amf_ue_ngap_id). Subsequent `Nsmf_PDUSession_UpdateSMContext` calls from the new `amf_ue` therefore return 404 from the SMF, the AMF wakes up and pages the UE, the UE responds with another SUCI re-attach, and the cascade self-perpetuates until mobile-reachable timer expiry (~5 min) garbage-collects the leak.

## Field reproducer

#4427 — @npm-sdr's iPhone-16 organic traffic. Validated cleanly with the PR #4528 + #4485 + #4540 stack: zero IP-pool leak across 16 retry rounds, but the cascade itself was triggered every time by this SUCI re-attach path. Toggle-flight-mode on the affected device gave a clean Deregistration → Registration cycle, and the cascade resumed within ~10 s of every fresh registration. Only `systemctl restart open5gs-amfd` purged the zombie. The diagnostic side-channel was two `amf_ue_t` entries appearing in `/amf/ue-info` for the same SUPI, both `cm=idle, mm=registered` (visible via the `mm_state` field @npm-sdr added to the dumper as part of his validation harness).

## Fix

Replace the three-phase transplant with a single `amf_sbi_send_release_all_sessions()` call against `old_amf_ue`, using the **new** `ran_ue` (from the incoming registration) as the SBI peer-context. State `AMF_RELEASE_SM_CONTEXT_NO_STATE` prevents any further GMM transition on `old_amf_ue` (which is about to be removed). If `old_amf_ue` had no PDU sessions held at the SMF (`amf_sess_xact_count == 0`), remove it synchronously; otherwise the existing `nsmf-handler.c` completion path removes it once the SMF has acknowledged every release.

The diff replaces 36 lines of three-phase transplant with the single SBI release call plus a deferred-removal guard. New block-comment documents the reason the historical "fatal SBI errors" assumption no longer holds. `#include "sbi-path.h"` added for the `AMF_RELEASE_SM_CONTEXT_NO_STATE` constant and the `amf_sbi_send_release_all_sessions` / `amf_sess_xact_count` declarations.

## Closes / Refs

- Closes #4516 (architectural root cause of the AMF UE pool leak)
- Refs #4427 (field reproducer + flight-mode confirmation)
- Refs #4540 (the validation stack that surfaced this as the dominant remaining cause)

## Test plan

- [x] `ninja -C build` clean against `main @ 93b24ec21`.
- [ ] Behaviour for fresh UE registrations (no existing `old_amf_ue`) is unchanged: the new code only runs inside the `if (old_amf_ue)` branch.
- [ ] Behaviour for SUCI re-attach with no surviving sessions on the old amf_ue (`xact_count == 0`): identical observable outcome to before — old context removed synchronously, no SBI traffic.
- [ ] Behaviour for SUCI re-attach with pending sessions: SMF receives per-session Nsmf_PDUSession_ReleaseSMContext, tears each down via PFCP, and once every response arrives back at the AMF the deferred-removal path in `nsmf-handler.c` clears `old_amf_ue`. Subsequent `UpdateSMContext` calls from the new amf_ue start cleanly against fresh sm_context state.
- [ ] Field validation: re-test @npm-sdr's flight-mode reproducer. Expectation: cascade does not resume after fresh registration because the SMF no longer holds dangling sm_context references.
