### PR TITLE
mme: fall back to subscriber default APN when requested APN is not subscribed

### DIFF
--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -117,15 +117,15 @@ int esm_handle_pdn_connectivity_request(
         } else {
             apn = req->access_point_name.apn;
         }
-        sess->session = mme_session_find_by_apn(mme_ue, apn);
+        sess->session = mme_resolve_session_for_requested_apn(mme_ue, apn);
         if (!sess->session) {
-            /* Invalid APN */
+            /* Invalid APN, no subscriber default APN available. */
             r = nas_eps_send_pdn_connectivity_reject(
                     sess, OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN,
                     create_action);
             ogs_expect(r == OGS_OK);
             ogs_assert(r != OGS_ERROR);
-            ogs_warn("Invalid APN[%s]", apn);
+            ogs_warn("Invalid APN[%s] and no default APN configured", apn);
             return OGS_ERROR;
         }
 
@@ -237,7 +237,7 @@ int esm_handle_information_response(
 
     if (rsp->presencemask &
             OGS_NAS_EPS_ESM_INFORMATION_RESPONSE_ACCESS_POINT_NAME_PRESENT) {
-        sess->session = mme_session_find_by_apn(
+        sess->session = mme_resolve_session_for_requested_apn(
                             mme_ue, rsp->access_point_name.apn);
     }
 

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -5022,6 +5022,42 @@ ogs_session_t *mme_default_session(mme_ue_t *mme_ue)
     return NULL;
 }
 
+ogs_session_t *mme_resolve_session_for_requested_apn(
+        mme_ue_t *mme_ue, const char *requested_apn)
+{
+    ogs_session_t *session = NULL;
+
+    ogs_assert(mme_ue);
+    ogs_assert(requested_apn);
+
+    /* First, try exact match against subscription. */
+    session = mme_session_find_by_apn(mme_ue, requested_apn);
+    if (session)
+        return session;
+
+    /* 3GPP TS 23.401 §5.3.1.1: if the requested APN is not
+     * subscribed, the MME may select a default APN configured for
+     * the subscriber. This handles UEs that are pre-configured for
+     * a different operator's APN (e.g. a customer router whose APN
+     * stays set to a public-PLMN value across SIM swaps) but should
+     * still be admitted to the local PLMN with the subscribed
+     * default APN.
+     *
+     * The fallback is implicitly opt-in per subscriber: it only
+     * fires if the subscription contains a session whose
+     * context_identifier matches the UE-level default — i.e. an
+     * operator that prefers strict reject for a given subscriber
+     * simply does not configure a default-indicator session. */
+    session = mme_default_session(mme_ue);
+    if (session) {
+        ogs_info("Requested APN[%s] not subscribed — substituting "
+                 "default APN[%s] (per TS 23.401 §5.3.1.1)",
+                 requested_apn, session->name);
+    }
+
+    return session;
+}
+
 int mme_find_served_tai(ogs_eps_tai_t *tai)
 {
     int i = 0, j = 0, k = 0;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -1242,6 +1242,8 @@ mme_bearer_t *mme_bearer_find_by_id(ogs_pool_id_t id);
 void mme_session_remove_all(mme_ue_t *mme_ue);
 ogs_session_t *mme_session_find_by_apn(mme_ue_t *mme_ue, const char *apn);
 ogs_session_t *mme_default_session(mme_ue_t *mme_ue);
+ogs_session_t *mme_resolve_session_for_requested_apn(
+        mme_ue_t *mme_ue, const char *requested_apn);
 
 int mme_find_served_tai(ogs_eps_tai_t *tai);
 


### PR DESCRIPTION
## Summary

Per 3GPP TS 23.401 §5.3.1.1, when the UE provides an APN that is not contained in its subscription, the MME may select the subscriber's configured default APN instead of rejecting the request. Open5GS today rejects strictly with ESM cause `MISSING_OR_UNKNOWN_APN` whenever `mme_session_find_by_apn()` misses on the strict name match. The pre-existing default-APN substitution at `esm-handler.c:179-181` only fires when the UE provided **no** APN at all — never when the UE provided a non-matching one.

## Field motivation

Customer-side routers and IoT devices (consumer LTE routers configured for a public-PLMN APN, payment terminals shipped with hard-coded APN, etc.) that need to attach to a private network without their owner re-configuring the device per SIM swap. The strict reject is observed as a sustained ~10s-period attach/reject loop, which both pollutes the MME log and inflates the local cell's E-RAB Setup failure counter.

## Fix

New helper `mme_resolve_session_for_requested_apn()` in `mme-context.c` that:

1. Attempts the exact APN name match against subscribed sessions (existing behaviour).
2. On miss, falls back to the subscriber's default session (the one whose `context_identifier` matches the UE-level default in subscription data).

Both call sites — `esm_handle_pdn_connectivity_request()` and `esm_handle_information_response()` — switch to the helper.

The fallback is **implicitly opt-in per subscriber**: it only fires when the subscription contains a default-indicator session. Operators that prefer strict reject for a given subscriber simply do not configure one. Behaviour is unchanged for subscribers without a default-indicator session, and unchanged for any UE that requests a subscribed APN.

## Test plan

- [x] `ninja -C build` clean against `main @ 93b24ec21`.
- [x] **Subscriber with default APN + UE requests subscribed APN → unchanged (exact match).** Verified in production deployment: see Field validation below.
- [x] **Subscriber with default APN + UE requests non-subscribed APN → fallback fires, attach succeeds against default APN.** This is the field-motivating scenario; verified in production with consumer LTE routers + payment terminals carrying public-PLMN APN configurations.
- [ ] Subscriber **without** default APN + UE requests non-subscribed APN → unchanged reject. Deferred — would require an explicit subscriber config without a default-indicator session for negative-path verification; lab smoke-test invited.
- [x] **UE provides no APN at all → unchanged (pre-existing default-APN path still used).** Verified in production: standard subscriber-attach flow.

## Field validation

Deployed against ep5g-local branch on a production EP5G appliance and a development EP5G appliance since 2026-05-09 10:17 UTC. ~24 hours of continuous operation. Production peaked at ~107 MME UEs (mixed 4G LTE devices: iPad, iPhone, RUTX-routers, payment terminals, consumer LTE-CPE). No regression observed:

- Steady-state attach/detach rate normal.
- No `MISSING_OR_UNKNOWN_APN` reject loops observed in the journal post-deploy (these were observable pre-deploy on customer-router devices).
- Binary fingerprint check: `mme_resolve_session_for_requested_apn` symbol present in deployed `/usr/bin/open5gs-mmed`.

**Live fallback firing** captured in the dev appliance journal at 2026-05-10 03:03:10 UTC — a customer device requested a non-subscribed APN (`payjet`) and was successfully substituted to the subscriber default (`pjt`):

```
[mme] INFO: Requested APN[payjet] not subscribed — substituting
            default APN[pjt] (per TS 23.401 §5.3.1.1)
            (../src/mme/mme-context.c:5173)
```

That single log line is direct evidence of the field-motivating scenario behaving exactly as intended: the UE attached successfully against the substituted default APN, with no reject loop and no manual reconfiguration of the customer device.

## Refs

Companion 5G/AMF patch filed as #4552: same semantics, NGAP analogue per TS 23.501 §5.6.7.
