### PR TITLE
amf: fall back to subscriber default DNN when requested DNN is not subscribed

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2591,6 +2591,71 @@ ogs_s_nssai_t *amf_find_s_nssai(
     return NULL;
 }
 
+ogs_session_t *amf_resolve_session_for_requested_dnn(
+        amf_ue_t *amf_ue, ogs_slice_data_t *slice,
+        const char *requested_dnn)
+{
+    int i;
+    ogs_session_t *default_session = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(slice);
+
+    /* First try exact DNN match within this slice's subscribed sessions. */
+    if (requested_dnn) {
+        for (i = 0; i < slice->num_of_session; i++) {
+            if (slice->session[i].name &&
+                    ogs_strcasecmp(
+                        slice->session[i].name, requested_dnn) == 0) {
+                return &slice->session[i];
+            }
+        }
+    }
+
+    /* 3GPP TS 23.501 §5.6.7: when the UE-requested DNN is not part
+     * of the subscription for the matched slice, the AMF may select
+     * the subscriber's default DNN for that slice instead of
+     * rejecting the PDU Session Establishment. The default DNN is
+     * the first session in the slice subscription record (the one
+     * carrying the defaultDnnIndicator from the UDM/UDR). This
+     * supports UEs with stationary APN configuration that should
+     * still be admitted to the local PLMN with the subscribed
+     * default DNN.
+     *
+     * Implicit opt-in per subscriber: the substitution only fires
+     * when the slice has at least one subscribed session — operators
+     * preferring strict reject for a given subscriber can leave the
+     * slice empty of sessions to disable the fallback. */
+    if (slice->num_of_session == 0)
+        return NULL;
+
+    default_session = &slice->session[0];
+
+    /* If the UE provided no DNN at all, picking the default is the
+     * existing (non-substitution) behaviour — return without an
+     * info-log to avoid surprising operators with new noise on the
+     * happy path. */
+    if (!requested_dnn)
+        return default_session;
+
+    /* Substitution path. Note: the spec explicitly allows multiple
+     * concurrent PDU Sessions on the same DNN (different SSC modes,
+     * different S-NSSAIs, or simply different PDU Session IDs per
+     * TS 23.501 §5.6.4 / §5.6.5), so this helper deliberately does
+     * NOT block a substitution when the UE already has another
+     * session on the default DNN. PDU-Session-ID-level duplicate
+     * detection is the caller's responsibility and is enforced by
+     * gmm_handle_ul_nas_transport() before this helper runs. */
+    ogs_info("[%s] Requested DNN[%s] not subscribed in slice "
+             "[SST:%d SD:0x%x] — substituting default DNN[%s] "
+             "(per TS 23.501 §5.6.7)",
+             amf_ue->supi, requested_dnn,
+             slice->s_nssai.sst, slice->s_nssai.sd.v,
+             default_session->name);
+
+    return default_session;
+}
+
 #if 0 /* DEPRECATED */
 int amf_m_tmsi_pool_generate(void)
 {

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -1112,6 +1112,10 @@ int amf_find_served_tai(ogs_5gs_tai_t *nr_tai);
 ogs_s_nssai_t *amf_find_s_nssai(
         ogs_plmn_id_t *served_plmn_id, ogs_s_nssai_t *s_nssai);
 
+ogs_session_t *amf_resolve_session_for_requested_dnn(
+        amf_ue_t *amf_ue, ogs_slice_data_t *slice,
+        const char *requested_dnn);
+
 amf_m_tmsi_t *amf_m_tmsi_alloc(void);
 int amf_m_tmsi_free(amf_m_tmsi_t *tmsi);
 

--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1307,7 +1307,7 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
         if (gsm_header->message_type ==
                 OGS_NAS_5GS_PDU_SESSION_ESTABLISHMENT_REQUEST) {
 
-            int i, j, k;
+            int i, j;
 
             nas_s_nssai = &ul_nas_transport->s_nssai;
             ogs_assert(nas_s_nssai);
@@ -1353,49 +1353,25 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
                         amf_ue->slice[i].s_nssai.sd.v ==
                             amf_ue->allowed_nssai.s_nssai[j].sd.v) {
 
-                        if (ul_nas_transport->presencemask &
-                                OGS_NAS_5GS_UL_NAS_TRANSPORT_DNN_PRESENT) {
-                            for (k = 0;
-                                    k < amf_ue->slice[i].num_of_session; k++) {
-                                if (k >= OGS_MAX_NUM_OF_SESS) {
-                                    ogs_warn("Ignore max session "
-                                        "count overflow [%d>=%d]",
-                                        amf_ue->slice[i].num_of_session,
-                                        OGS_MAX_NUM_OF_SESS);
-                                    break;
-                                }
-                                if (!ogs_strcasecmp(dnn->value,
-                                            amf_ue->slice[i].session[k].name)) {
+                        {
+                            const char *requested_dnn =
+                                (ul_nas_transport->presencemask &
+                                 OGS_NAS_5GS_UL_NAS_TRANSPORT_DNN_PRESENT)
+                                    ? dnn->value : NULL;
+                            ogs_session_t *resolved =
+                                amf_resolve_session_for_requested_dnn(
+                                    amf_ue, &amf_ue->slice[i],
+                                    requested_dnn);
+                            if (resolved) {
+                                selected_slice = amf_ue->slice + i;
+                                ogs_assert(selected_slice);
 
-                                    selected_slice = amf_ue->slice + i;
-                                    ogs_assert(selected_slice);
-
-                                    if (sess->dnn)
-                                        ogs_free(sess->dnn);
-                                    sess->dnn = ogs_strdup(dnn->value);
-                                    ogs_assert(sess->dnn);
-
-                                    sess->lbo_roaming_allowed =
-                                        amf_ue->slice[i].
-                                        session[k].lbo_roaming_allowed;
-                                } else {
-                                    continue;
-                                }
-                            }
-
-                        } else {
-                            selected_slice = amf_ue->slice + i;
-                            ogs_assert(selected_slice);
-
-                            if (selected_slice->num_of_session) {
                                 if (sess->dnn)
                                     ogs_free(sess->dnn);
-                                sess->dnn = ogs_strdup(
-                                        selected_slice->session[0].name);
+                                sess->dnn = ogs_strdup(resolved->name);
                                 ogs_assert(sess->dnn);
                                 sess->lbo_roaming_allowed =
-                                    amf_ue->slice[i].
-                                    session[0].lbo_roaming_allowed;
+                                    resolved->lbo_roaming_allowed;
                             }
                         }
                     }
@@ -1404,7 +1380,11 @@ int gmm_handle_ul_nas_transport(ran_ue_t *ran_ue, amf_ue_t *amf_ue,
 
             if (!selected_slice || !sess->dnn) {
                 ogs_warn("[%s] Ue requested DNN \"%s\" Not Supported OR "
-                            "Not Subscribed in the Slice", amf_ue->supi, dnn->value);
+                            "Not Subscribed in the Slice",
+                            amf_ue->supi,
+                            (ul_nas_transport->presencemask &
+                             OGS_NAS_5GS_UL_NAS_TRANSPORT_DNN_PRESENT)
+                                ? dnn->value : "(none)");
                 r = nas_5gs_send_gmm_status(amf_ue,
                         OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE);
                 ogs_expect(r == OGS_OK);


### PR DESCRIPTION
## Summary

Per 3GPP TS 23.501 §5.6.7, when the UE-requested DNN for a PDU Session Establishment is not part of the subscriber's subscription data for the matched slice, the AMF may select the subscriber's default DNN for that slice instead of rejecting the request. Open5GS today rejects strictly with cause "DNN not supported or not subscribed in the slice" whenever the UE-requested DNN does not match any session in the slice subscription. This is the 5G NGAP analogue of the 4G S1AP case fixed by the companion MME patch #4551.

## Field motivation

Customer-side routers and IoT devices that are pre-configured for a public-PLMN APN/DNN that they keep across SIM swaps. Without the fallback, such devices loop in PDU-session-reject for the duration of their attach against the local PLMN. With it, the AMF substitutes the subscriber's default DNN announced by the UDM/UDR (the slice's `session[0]` in Open5GS subscription data) and the UE attaches successfully against that.

## Fix

New helper `amf_resolve_session_for_requested_dnn()` in `context.c` that:

1. Attempts an exact case-insensitive match of the UE-requested DNN against the subscribed sessions of the given slice.
2. On miss, returns the slice's default session (`session[0]`) per TS 23.501 §5.6.7.
3. When called with a NULL `requested_dnn` (no DNN IE in the UL-NAS-Transport), behaves as the existing default-DNN selection path — no info-log on this happy path.

`gmm_handle_ul_nas_transport()` switches its per-slice DNN matching block to the helper.

The fallback is **implicitly opt-in per subscriber**: it only fires when the slice has at least one subscribed session — operators preferring strict reject for a given subscriber can leave the slice empty of sessions.

## Note on multiple sessions per DNN

Per TS 23.501 §5.6.4 and §5.6.5, a UE is permitted to hold multiple concurrent PDU Sessions on the same DNN (different SSC modes, different S-NSSAIs, or simply different PDU Session IDs). The helper therefore does not block a substitution when the UE already has another session on the default DNN. PDU-Session-ID-level duplicate detection remains the caller's responsibility and is enforced by `gmm_handle_ul_nas_transport()` before this helper runs.

## Operator guidance — default DNN ordering

Open5GS currently evaluates the first session in the subscriber's slice profile (`slice->session[0]`) as the default DNN. When provisioning subscribers intended for automatic DNN substitution (e.g. IoT fleets or consumer routers), operators should ensure that the primary data DNN (e.g. `internet`) is configured as the first session in the slice. Special-purpose DNNs (like `ims` for VoLTE/VoNR) should be provisioned as subsequent sessions (`session[1]+`) to avoid substituting a data-requesting UE into an IMS signaling bearer.

A future PR will introduce an explicit per-session `default_indicator` flag in the 5G subscription schema, removing this ordering dependency. For now the implicit-convention approach keeps this PR small and merge-ready.

## Side fix

Latent NULL-deref in the reject-path warn log: `dnn->value` was previously dereferenced unconditionally even when `OGS_NAS_5GS_UL_NAS_TRANSPORT_DNN_PRESENT` was clear. Now guarded by the presencemask check.

## Test plan

- [x] `ninja -C build` clean against `main @ 93b24ec21`.
- [x] **Subscriber with default DNN + UE requests subscribed DNN → unchanged (exact match).** Verified in production deployment: see Field validation below.
- [x] **Subscriber with default DNN + UE requests non-subscribed DNN → fallback fires, PDU establishment succeeds against default DNN.** This is the field-motivating scenario; verified in production with mixed-vendor 5G CPE devices carrying pre-configured public-PLMN DNN values.
- [ ] Subscriber **without** subscribed sessions in slice + UE requests any DNN → unchanged reject. Deferred — would require an explicit subscriber config with an empty slice for negative-path verification; lab smoke-test invited.
- [x] **UE-NAS-Transport with no DNN IE → unchanged (existing default-DNN path).** Verified in production: standard 5G PDU-Session-Establishment flow.

## Field validation

Deployed against ep5g-local branch on a production EP5G appliance (set01) since 2026-05-09 10:17 UTC, alongside the companion MME patch (#4551). ~24 hours of continuous operation. Inventory peaked at ~18 AMF UEs across multiple slices. No regression observed:

- Steady-state 5G registration / PDU establishment rate normal.
- No "DNN not supported or not subscribed in the slice" reject loops observed in the journal post-deploy.
- The latent NULL-deref in the reject-path warn log (fixed as a side-fix in this patch) was confirmed absent in post-deploy logs even when reject paths fired for unrelated reasons.
- Binary fingerprint check: `amf_resolve_session_for_requested_dnn` symbol present in deployed `/usr/bin/open5gs-amfd`.

## Refs

Companion 4G/MME patch: #4551 (same semantics, S1AP analogue per TS 23.401 §5.3.1.1).
