### PR TITLE
mme: fix TAU BCS presence mask check

### DIFF
--- a/src/mme/emm-sm.c
+++ b/src/mme/emm-sm.c
@@ -743,7 +743,7 @@ static void common_register_state(ogs_fsm_t *s, mme_event_t *e,
 
                 /* check BCS regardless of active_flag */
                 if (mme_ue->tracking_area_update_request_presencemask &
-                    OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_TYPE) {
+                    OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_PRESENT) {
                     ogs_info("[%s] TAU accept(active_flag=%d, BCS check)",
                         mme_ue->imsi_bcd,
                         mme_ue->nas_eps.update.active_flag);

--- a/src/mme/sgsap-handler.c
+++ b/src/mme/sgsap-handler.c
@@ -152,7 +152,7 @@ void sgsap_handle_location_update_accept(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
 
         /* check BCS regardless of active_flag */
         if (mme_ue->tracking_area_update_request_presencemask &
-            OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_TYPE) {
+            OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_PRESENT) {
             ogs_info("[%s] LU accept + TAU accept(active_flag=%d, BCS)",
                 mme_ue->imsi_bcd,
                 mme_ue->nas_eps.update.active_flag);
@@ -317,7 +317,7 @@ void sgsap_handle_location_update_reject(mme_vlr_t *vlr, ogs_pkbuf_t *pkbuf)
 
         /* check BCS regardless of active_flag */
         if (mme_ue->tracking_area_update_request_presencemask &
-            OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_TYPE) {
+            OGS_NAS_EPS_TRACKING_AREA_UPDATE_REQUEST_EPS_BEARER_CONTEXT_STATUS_PRESENT) {
             ogs_info("[%s] LU reject + TAU accept(active_flag=%d, BCS)",
                 mme_ue->imsi_bcd,
                 mme_ue->nas_eps.update.active_flag);


### PR DESCRIPTION
Use EPS_BEARER_CONTEXT_STATUS_PRESENT when checking the TAU Request presence mask for EPS Bearer Context Status.

The previous code used EPS_BEARER_CONTEXT_STATUS_TYPE, which is the IEI/type value rather than the presence-mask bit. As a result, the BCS handling path could be skipped even when the EPS Bearer Context Status IE was present.

Apply the same fix to both normal TAU handling and combined SGsAP LU accept/reject paths.

Original PR: #4505