### PR TITLE
smf: gracefully preserve session state on 5xx N1N2MessageTransfer responses

### DIFF
--- a/src/smf/namf-handler.c
+++ b/src/smf/namf-handler.c
@@ -22,6 +22,52 @@
 #include "binding.h"
 #include "namf-handler.h"
 
+/*
+ * Handle transient 5xx responses from the AMF on
+ * Namf_Communication_N1N2MessageTransfer.
+ *
+ * Per RFC 7231 §6.6 and TS 29.500 §6.7.4, 5xx HTTP responses indicate
+ * transient server-side conditions; the SMF should preserve session
+ * state and rely on the next UE-initiated event (Service Request,
+ * periodic Registration Update) to drive recovery against the
+ * post-recovery AMF, rather than tearing down a half-built session.
+ *
+ * Field-validated by @npm-sdr in https://github.com/open5gs/open5gs/issues/4427
+ * (validation comment on PR #4540): an N1N2MessageTransfer initiated
+ * immediately before an AMF restart received 504, was left without
+ * an FSM transition, and self-recovered on the UE's next Service
+ * Request landing against the post-restart AMF. The observable
+ * behaviour was already correct; this helper just cleans up the log
+ * channel so transient AMF maintenance windows do not pollute the
+ * SMF's ERROR stream.
+ *
+ * Returns true (with a warning-level log line) if the response is a
+ * transient 5xx; the caller should preserve session state and break
+ * out of further response processing. Returns false otherwise so the
+ * caller can fall through to its existing 4xx / unexpected-cause /
+ * non-5xx-with-no-RspData handling.
+ *
+ * `phase` is a short caller-supplied tag ("establishment" /
+ * "post-establishment" / "release") that ends up in the log line so
+ * operators can see which N1N2MessageTransfer code path was affected
+ * by the AMF transient.
+ */
+static bool n1n2_handle_transient_5xx_response(
+        smf_ue_t *smf_ue, smf_sess_t *sess,
+        ogs_sbi_message_t *recvmsg, const char *phase)
+{
+    if (recvmsg->res_status >=
+                OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR &&
+        recvmsg->res_status < 600) {
+        ogs_warn("[%s:%d] AMF transient %d on N1N2MessageTransfer "
+                 "(%s) — preserving session state, awaiting "
+                 "UE-initiated recovery",
+                 smf_ue->supi, sess->psi, recvmsg->res_status, phase);
+        return true;
+    }
+    return false;
+}
+
 bool smf_namf_comm_handle_n1_n2_message_transfer(
         smf_sess_t *sess, ogs_sbi_stream_t *stream,
         int state, ogs_sbi_message_t *recvmsg)
@@ -48,7 +94,8 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
  * to apply QoS updates without waiting for V-SMF or RAN setup.
  */
             smf_qos_flow_binding(sess);
-        } else {
+        } else if (!n1n2_handle_transient_5xx_response(
+                    smf_ue, sess, recvmsg, "establishment")) {
             ogs_error("[%s:%d] HTTP response error [%d]",
                 smf_ue->supi, sess->psi, recvmsg->res_status);
         }
@@ -58,8 +105,11 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
     case SMF_NETWORK_REQUESTED_QOS_FLOW_MODIFICATION:
         N1N2MessageTransferRspData = recvmsg->N1N2MessageTransferRspData;
         if (!N1N2MessageTransferRspData) {
-            ogs_error("No N1N2MessageTransferRspData [status:%d]",
-                    recvmsg->res_status);
+            if (!n1n2_handle_transient_5xx_response(
+                        smf_ue, sess, recvmsg, "post-establishment")) {
+                ogs_error("No N1N2MessageTransferRspData [status:%d]",
+                        recvmsg->res_status);
+            }
             break;
         }
 
@@ -141,8 +191,11 @@ bool smf_namf_comm_handle_n1_n2_message_transfer(
 
         N1N2MessageTransferRspData = recvmsg->N1N2MessageTransferRspData;
         if (!N1N2MessageTransferRspData) {
-            ogs_error("No N1N2MessageTransferRspData [status:%d]",
-                    recvmsg->res_status);
+            if (!n1n2_handle_transient_5xx_response(
+                        smf_ue, sess, recvmsg, "release")) {
+                ogs_error("No N1N2MessageTransferRspData [status:%d]",
+                        recvmsg->res_status);
+            }
             break;
         }
 


### PR DESCRIPTION
## Summary

Per RFC 7231 §6.6 and TS 29.500 §6.7.4, 5xx HTTP responses indicate transient server-side conditions; the SMF should preserve session state and rely on the next UE-initiated event (Service Request, periodic Registration Update) to drive recovery against the post-recovery AMF, rather than tearing down a half-built session.

The current handler in `smf_namf_comm_handle_n1_n2_message_transfer()` treats every non-2xx response uniformly through `ogs_error` plus `break`. For 4xx (typically 404 — AMF context permanently gone), that is correct: the session is non-recoverable and should be torn down. For 5xx (typically 504 — SCP timeout while AMF restarts, or 503 — AMF overload) the same log channel is misleading: the cascade self-recovers on the next UE event, but every transient AMF maintenance window leaves a sequence of ERROR-level entries in the SMF journal that look like real failures.

## Field reproducer

@npm-sdr's iPhone-16 organic-traffic validation on #4540 (see [comment thread on #4427](https://github.com/open5gs/open5gs/issues/4427)) reproduced exactly this:

```
14:45:25.111  [smf] ERROR: No N1N2MessageTransferRspData [status:504]
                                              (namf-handler.c:169)
```

> "an in-flight `N1N2MessageTransfer` initiated immediately before the AMF restart was left without an FSM transition. **Self-recovered when the UE's next Service Request landed against the post-restart AMF.**"

The **observable behaviour was already correct** (session self-recovered). The problem was the **log signal** — every AMF maintenance window emitted ERROR-level entries that look like real failures.

## Fix

Extract the 5xx-detection-and-warn pattern into a single static helper `n1n2_handle_transient_5xx_response()` and call it at the three sites in the message-transfer handler that previously logged 5xx as generic ERROR:

- `SMF_UE_REQUESTED_PDU_SESSION_ESTABLISHMENT`
- `SMF_NETWORK_TRIGGERED_SERVICE_REQUEST` / `SMF_NETWORK_REQUESTED_QOS_FLOW_MODIFICATION`
- `SMF_UE_OR_NETWORK_REQUESTED_PDU_SESSION_RELEASE` / `SMF_ERROR_INDICATON_RECEIVED_FROM_5G_AN`

The helper carries the spec rationale (RFC 7231 §6.6, TS 29.500 §6.7.4) and the field-attribution doc-comment in one place. Each call site reduces to a single boolean check; the helper's `return false` cascade keeps the existing 4xx / unexpected-cause / non-5xx-with-no-RspData handling intact.

**No functional behaviour change.** The graceful-on-5xx semantics (no FSM transition, session preserved) were already in place; only the log channel changes so AMF transient events no longer pollute the ERROR stream.

## Independent of #4528

This PR is purely additive on top of the existing handler and does **not** depend on #4528 (which adds FSM transitions for 4xx responses):

- If #4528 lands first: this patch sits cleanly alongside its 4xx transitions; the helper's `return false` cascade hands control back to the existing 4xx-teardown branch.
- If this patch lands first: #4528's 4xx transitions still apply exactly as designed; the helper only intercepts the 5xx range.
- If both land: the combined behaviour is the carrier-grade target — 4xx triggers teardown, 5xx preserves session, 2xx happy path unchanged.

Reviewable and mergeable in either order.

## Closes / Refs

- Closes the "Known limitation — 5xx handling" section of #4528.
- Refs #4427 (field reproducer thread).
- Refs #4540 (the validation stack that surfaced this).

## Test plan

- [x] `ninja -C build src/smf/open5gs-smfd` clean against `main @ 93b24ec21`.
- [x] Deployed against ep5g-local branch on a development EP5G appliance since 2026-05-10 15:50 UTC; SMF/AMF/MME daemons restarted cleanly, no anomalies in 60+ s post-deploy journal, organic-traffic inventory recovered to steady state.
- [x] No functional behaviour change for 2xx happy paths — verified across 1015+ successful `sm-context/modify` cycles during 2026-05-12 steady-state observation.
- [ ] No functional behaviour change for 4xx — existing teardown paths (404 lazy cleanup, etc.) untouched; helper's `return false` falls through to `ogs_error`.
- [x] On synthetic 5xx: AMF restart on 2026-05-12 11:35 triggered the helper twice within 90 seconds (IMSI 158558 + IMSI 158562); SMF journal showed exactly `WARNING: AMF transient 504 on N1N2MessageTransfer (release) — preserving session state, awaiting UE-initiated recovery (namf-handler.c:62)` instead of `ERROR: No N1N2MessageTransferRspData [status:504]`. ERROR stream during the restart window was clean.
- [x] Re-validation against @npm-sdr's reproducer scenario post-deploy: both UEs self-recovered via UE-initiated procedures (Service Request / PFCP-Delete-Trigger) within 20s, no stranded contexts. Full trace posted as a comment on this PR.