### PR TITLE
smf: harden UE-requested QoS modification handling

### DIFF
--- a/lib/nas/5gs/types.c
+++ b/lib/nas/5gs/types.c
@@ -477,6 +477,14 @@ int ogs_nas_build_qos_flow_descriptions(
     return OGS_OK;
 }
 
+static bool qos_flow_bitrate_unit_is_valid(ogs_nas_bitrate_t *br)
+{
+    ogs_assert(br);
+
+    return br->unit >= OGS_NAS_BR_UNIT_1K &&
+           br->unit <= OGS_NAS_BR_UNIT_256P;
+}
+
 int ogs_nas_parse_qos_flow_descriptions(
         ogs_nas_qos_flow_description_t *description,
         ogs_nas_qos_flow_descriptions_t *descriptions)
@@ -492,11 +500,11 @@ int ogs_nas_parse_qos_flow_descriptions(
 
     if (descriptions->length == 0) {
         ogs_error("Length is 0");
-        goto cleanup;
+        return 0;
     }
     if (descriptions->buffer == NULL) {
         ogs_error("Buffer is NULL");
-        goto cleanup;
+        return 0;
     }
 
     length = descriptions->length;
@@ -506,18 +514,30 @@ int ogs_nas_parse_qos_flow_descriptions(
     while (size < length) {
         memset(description, 0, sizeof(*description));
 
+        if ((description - first) >=
+                OGS_NAS_MAX_NUM_OF_QOS_FLOW_DESCRIPTION) {
+            ogs_error("Too many QoS flow descriptions");
+            return (int)(description-first);
+        }
+
         if (size+3 > length) {
             ogs_error("Overflow : size[%d] length[%d]", size, length);
-            goto cleanup;
+            return (int)(description-first);
         }
         memcpy(description, buffer+size, 3);
         size += 3;
 
-        for (i = 0; i < description->num_of_parameter &&
-                    i < OGS_NAS_MAX_NUM_OF_QOS_FLOW_PARAMETER; i++) {
+        if (description->num_of_parameter >
+                OGS_NAS_MAX_NUM_OF_QOS_FLOW_PARAMETER) {
+            ogs_error("Too many QoS flow parameters [%d]",
+                    description->num_of_parameter);
+            return (int)(description-first);
+        }
+
+        for (i = 0; i < description->num_of_parameter; i++) {
             if (size+sizeof(description->param[i].identifier) > length) {
                 ogs_error("Overflow : size[%d] length[%d]", size, length);
-                goto cleanup;
+                return (int)(description-first);
             }
             memcpy(&description->param[i].identifier, buffer+size,
                     sizeof(description->param[i].identifier));
@@ -525,7 +545,7 @@ int ogs_nas_parse_qos_flow_descriptions(
 
             if (size+sizeof(description->param[i].len) > length) {
                 ogs_error("Overflow : size[%d] length[%d]", size, length);
-                goto cleanup;
+                return (int)(description-first);
             }
             memcpy(&description->param[i].len, buffer+size,
                     sizeof(description->param[i].len));
@@ -535,12 +555,12 @@ int ogs_nas_parse_qos_flow_descriptions(
             case OGS_NAX_QOS_FLOW_PARAMETER_ID_5QI:
                 if (description->param[i].len != 1) {
                     ogs_error("Invalid len[%d]", description->param[i].len);
-                    goto cleanup;
+                    return (int)(description-first);
                 }
                 if (size+description->param[i].len > length) {
                     ogs_error("Overflow: len[%d] length[%d]",
                             description->param[i].len, length);
-                    goto cleanup;
+                    return (int)(description-first);
                 }
                 memcpy(&description->param[i].qos_index,
                         buffer+size, description->param[i].len);
@@ -553,30 +573,34 @@ int ogs_nas_parse_qos_flow_descriptions(
             case OGS_NAX_QOS_FLOW_PARAMETER_ID_MFBR_DOWNLINK:
                 if (description->param[i].len != 3) {
                     ogs_error("Invalid len[%d]", description->param[i].len);
-                    goto cleanup;
+                    return (int)(description-first);
                 }
                 if (size+description->param[i].len > length) {
                     ogs_error("Overflow: len[%d] length[%d]",
                             description->param[i].len, length);
-                    goto cleanup;
+                    return (int)(description-first);
                 }
                 memcpy(&description->param[i].br,
                         buffer+size, description->param[i].len);
                 description->param[i].br.value =
                     be16toh(description->param[i].br.value);
+                if (!qos_flow_bitrate_unit_is_valid(
+                        &description->param[i].br)) {
+                    ogs_error("Invalid QoS flow bitrate unit [%d]",
+                            description->param[i].br.unit);
+                    return (int)(description-first);
+                }
                 size += description->param[i].len;
                 break;
             default:
                 ogs_error("Unknown qos_flow parameter identifier [%d]",
                         description->param[i].identifier);
-                goto cleanup;
+                return (int)(description-first);
             }
         }
 
         description++;
     }
-
-cleanup:
 
     return (int)(description-first);
 }

--- a/src/smf/gsm-build.c
+++ b/src/smf/gsm-build.c
@@ -373,8 +373,12 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
                             qos_rules.buffer, qosFlowAddModRequestItem->qos_rules);
                 ogs_assert(qos_rules.length);
 
-                ogs_assert(1 ==
-                        ogs_nas_parse_qos_rules(&qos_rule[num], &qos_rules));
+                if (1 != ogs_nas_parse_qos_rules(&qos_rule[num],
+                            &qos_rules)) {
+                    ogs_error("ogs_nas_parse_qos_rules() failed");
+                    ogs_free(qos_rules.buffer);
+                    goto cleanup;
+                }
 
                 ogs_free(qos_rules.buffer);
 
@@ -395,8 +399,11 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
                             qos_rules.buffer, qosFlowRelRequestItem->qos_rules);
                 ogs_assert(qos_rules.length);
 
-                ogs_assert(1 ==
-                        ogs_nas_parse_qos_rules(&qos_rule[num], &qos_rules));
+                if (1 != ogs_nas_parse_qos_rules(&qos_rule[num], &qos_rules)) {
+                    ogs_error("ogs_nas_parse_qos_rules() failed");
+                    ogs_free(qos_rules.buffer);
+                    goto cleanup;
+                }
 
                 ogs_free(qos_rules.buffer);
 
@@ -461,10 +468,13 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
                             qosFlowAddModRequestItem->qos_flow_description);
                 ogs_assert(qos_flow_descriptions.length);
 
-                ogs_assert(1 ==
-                        ogs_nas_parse_qos_flow_descriptions(
+                if (1 != ogs_nas_parse_qos_flow_descriptions(
                             &qos_flow_description[num],
-                            &qos_flow_descriptions));
+                            &qos_flow_descriptions)) {
+                    ogs_error("ogs_nas_parse_qos_flow_descriptions() failed");
+                    ogs_free(qos_flow_descriptions.buffer);
+                    goto cleanup;
+                }
 
                 ogs_free(qos_flow_descriptions.buffer);
 
@@ -489,10 +499,13 @@ ogs_pkbuf_t *gsm_build_pdu_session_modification_command(
                             qosFlowRelRequestItem->qos_flow_description);
                 ogs_assert(qos_flow_descriptions.length);
 
-                ogs_assert(1 ==
-                        ogs_nas_parse_qos_flow_descriptions(
+                if (1 != ogs_nas_parse_qos_flow_descriptions(
                             &qos_flow_description[num],
-                            &qos_flow_descriptions));
+                            &qos_flow_descriptions)) {
+                    ogs_error("ogs_nas_parse_qos_flow_descriptions() failed");
+                    ogs_free(qos_flow_descriptions.buffer);
+                    goto cleanup;
+                }
 
                 ogs_free(qos_flow_descriptions.buffer);
 

--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -271,8 +271,12 @@ int gsm_handle_pdu_session_modification_qos_rules(
                 pf = smf_pf_add(qos_flow);
                 ogs_assert(pf);
 
-                ogs_assert(
-                    reconfigure_packet_filter(pf, &qos_rule[i], i) > 0);
+                if (reconfigure_packet_filter(pf, &qos_rule[i], j) <= 0) {
+                    ogs_error("[%s:%d] Invalid packet filter",
+                            smf_ue->supi, sess->psi);
+                    smf_pf_remove(pf);
+                    return OGS_ERROR;
+                }
 /*
  * Refer to lib/ipfw/ogs-ipfw.h
  * Issue #338
@@ -402,6 +406,7 @@ int gsm_handle_pdu_session_modification_qos_flow_descriptions(
     }
 
     for (i = 0; i < num_of_description; i++) {
+
         smf_bearer_t *qos_flow =
             smf_qos_flow_find_by_qfi(
                     sess, qos_flow_description[i].identifier);
@@ -432,9 +437,9 @@ int gsm_handle_pdu_session_modification_qos_flow_descriptions(
                         &qos_flow_description[i].param[j].br);
                 break;
             default:
-                ogs_fatal("Unknown qos_flow parameter identifier [%d]",
-                        qos_flow_description[i].param[i].identifier);
-                ogs_assert_if_reached();
+                ogs_error("Unknown qos_flow parameter identifier [%d]",
+                        qos_flow_description[i].param[j].identifier);
+                return OGS_ERROR;
             }
         }
 


### PR DESCRIPTION
Validate malformed NAS QoS flow descriptions before they can reach SMF QoS update logic. Reject unsupported QoS flow parameter counts and invalid bitrate units during parsing, so invalid input cannot trigger assertions in ogs_nas_bitrate_to_uint64().

Also avoid aborting while handling QoS rules and QoS flow descriptions in PDU Session Modification Request processing. Use the packet-filter index when reconfiguring packet filters, handle reconfiguration failures as invalid requests, and return an error instead of calling fatal/assert for unknown QoS flow parameters.

Finally, replace assert-based parsing of QoS rules and QoS flow descriptions in gsm-build.c with normal error handling, so malformed QoS data from HR roaming paths does not terminate the SMF process.

Issues #4429
Issues #4430
Issues #4511
Issues #4512
Related to PR #4513
Related to PR #4514