### PR TITLE
ngap, s1ap: preserve UE security capabilities on path switch

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -444,6 +444,9 @@ struct amf_ue_s {
     /* Security Context */
     ogs_nas_ue_security_capability_t ue_security_capability;
     ogs_nas_ue_network_capability_t ue_network_capability;
+
+    /* Transient Path Switch state */
+    bool send_ue_security_capability_in_path_switch_ack;
 #define CHECK_5G_AKA_CONFIRMATION(__aMF) \
     ((__aMF) && ((__aMF)->confirmation_for_5g_aka.resource_uri))
 #define STORE_5G_AKA_CONFIRMATION(__aMF, __rESOURCE_URI) \

--- a/src/amf/ngap-build.c
+++ b/src/amf/ngap-build.c
@@ -2000,14 +2000,20 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
     NGAP_AMF_UE_NGAP_ID_t *AMF_UE_NGAP_ID = NULL;
     NGAP_RAN_UE_NGAP_ID_t *RAN_UE_NGAP_ID = NULL;
     NGAP_SecurityContext_t *SecurityContext = NULL;
+    NGAP_UESecurityCapabilities_t *UESecurityCapabilities = NULL;
     NGAP_PDUSessionResourceSwitchedList_t *PDUSessionResourceSwitchedList;
     NGAP_AllowedNSSAI_t *AllowedNSSAI = NULL;
+    bool send_ue_security_capability = false;
 
     ogs_assert(amf_ue);
     ran_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
     ogs_assert(ran_ue);
 
     ogs_debug("PathSwitchAcknowledge");
+
+    send_ue_security_capability =
+        amf_ue->send_ue_security_capability_in_path_switch_ack;
+    amf_ue->send_ue_security_capability_in_path_switch_ack = false;
 
     memset(&pdu, 0, sizeof (NGAP_NGAP_PDU_t));
     pdu.present = NGAP_NGAP_PDU_PR_successfulOutcome;
@@ -2076,6 +2082,50 @@ ogs_pkbuf_t *ngap_build_path_switch_ack(amf_ue_t *amf_ue)
 
     PDUSessionResourceSwitchedList =
         &ie->value.choice.PDUSessionResourceSwitchedList;
+
+    if (send_ue_security_capability) {
+        ie = CALLOC(1, sizeof(NGAP_PathSwitchRequestAcknowledgeIEs_t));
+        ASN_SEQUENCE_ADD(&PathSwitchRequestAcknowledge->protocolIEs, ie);
+
+        ie->id = NGAP_ProtocolIE_ID_id_UESecurityCapabilities;
+        ie->criticality = NGAP_Criticality_reject;
+        ie->value.present =
+            NGAP_PathSwitchRequestAcknowledgeIEs__value_PR_UESecurityCapabilities;
+
+        UESecurityCapabilities = &ie->value.choice.UESecurityCapabilities;
+
+        UESecurityCapabilities->nRencryptionAlgorithms.size = 2;
+        UESecurityCapabilities->nRencryptionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->
+                        nRencryptionAlgorithms.size, sizeof(uint8_t));
+        UESecurityCapabilities->nRencryptionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->nRencryptionAlgorithms.buf[0] =
+            (amf_ue->ue_security_capability.nr_ea << 1);
+
+        UESecurityCapabilities->nRintegrityProtectionAlgorithms.size = 2;
+        UESecurityCapabilities->nRintegrityProtectionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->
+                        nRintegrityProtectionAlgorithms.size, sizeof(uint8_t));
+        UESecurityCapabilities->nRintegrityProtectionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->nRintegrityProtectionAlgorithms.buf[0] =
+            (amf_ue->ue_security_capability.nr_ia << 1);
+
+        UESecurityCapabilities->eUTRAencryptionAlgorithms.size = 2;
+        UESecurityCapabilities->eUTRAencryptionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->
+                        eUTRAencryptionAlgorithms.size, sizeof(uint8_t));
+        UESecurityCapabilities->eUTRAencryptionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->eUTRAencryptionAlgorithms.buf[0] =
+            (amf_ue->ue_security_capability.eutra_ea << 1);
+
+        UESecurityCapabilities->eUTRAintegrityProtectionAlgorithms.size = 2;
+        UESecurityCapabilities->eUTRAintegrityProtectionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->
+                    eUTRAintegrityProtectionAlgorithms.size, sizeof(uint8_t));
+        UESecurityCapabilities->eUTRAintegrityProtectionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->eUTRAintegrityProtectionAlgorithms.buf[0] =
+            (amf_ue->ue_security_capability.eutra_ia << 1);
+    }
 
     ogs_list_for_each(&amf_ue->sess_list, sess) {
         OCTET_STRING_t *transfer = NULL;

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2750,7 +2750,8 @@ void ngap_handle_path_switch_request(
     NGAP_EUTRAintegrityProtectionAlgorithms_t
         *eUTRAintegrityProtectionAlgorithms = NULL;
     uint16_t nr_ea = 0, nr_ia = 0, eutra_ea = 0, eutra_ia = 0;
-    uint8_t nr_ea0 = 0, nr_ia0 = 0, eutra_ea0 = 0, eutra_ia0 = 0;
+    uint8_t received_nr_ea = 0, received_nr_ia = 0;
+    uint8_t received_eutra_ea = 0, received_eutra_ia = 0;
 
     NGAP_PDUSessionResourceToBeSwitchedDLItem_t *PDUSessionItem = NULL;
     OCTET_STRING_t *transfer = NULL;
@@ -2860,6 +2861,8 @@ void ngap_handle_path_switch_request(
         ogs_assert(r != OGS_ERROR);
         return;
     }
+
+    amf_ue->send_ue_security_capability_in_path_switch_ack = false;
 
     ogs_info("    [OLD] RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld] ",
         (long long)ran_ue->ran_ue_ngap_id, (long long)ran_ue->amf_ue_ngap_id);
@@ -3014,30 +3017,59 @@ void ngap_handle_path_switch_request(
         ogs_assert(r != OGS_ERROR);
         return;
     }
+    /*
+     * TS 33.501 6.7.3.1:
+     *
+     * The AMF shall verify that the UE's 5G security capabilities
+     * received from the target gNB/ng-eNB are the same as the UE's
+     * 5G security capabilities locally stored in the AMF.
+     *
+     * If there is a mismatch, the AMF shall send its locally stored
+     * UE security capabilities to the target gNB/ng-eNB in the
+     * Path Switch Request Acknowledge message.
+     *
+     * Therefore, do not overwrite amf_ue->ue_security_capability
+     * with the value received in PathSwitchRequest.
+     */
     memcpy(&nr_ea, nRencryptionAlgorithms->buf, sizeof(nr_ea));
     nr_ea = be16toh(nr_ea);
-    nr_ea0 = amf_ue->ue_security_capability.nr_ea0;
-    amf_ue->ue_security_capability.nr_ea = nr_ea >> 9;
-    amf_ue->ue_security_capability.nr_ea0 = nr_ea0;
+    received_nr_ea = nr_ea >> 9;
 
     memcpy(&nr_ia, nRintegrityProtectionAlgorithms->buf, sizeof(nr_ia));
     nr_ia = be16toh(nr_ia);
-    nr_ia0 = amf_ue->ue_security_capability.nr_ia0;
-    amf_ue->ue_security_capability.nr_ia = nr_ia >> 9;
-    amf_ue->ue_security_capability.nr_ia0 = nr_ia0;
+    received_nr_ia = nr_ia >> 9;
 
     memcpy(&eutra_ea, eUTRAencryptionAlgorithms->buf, sizeof(eutra_ea));
     eutra_ea = be16toh(eutra_ea);
-    eutra_ea0 = amf_ue->ue_security_capability.eutra_ea0;
-    amf_ue->ue_security_capability.eutra_ea = eutra_ea >> 9;
-    amf_ue->ue_security_capability.eutra_ea0 = eutra_ea0;
+    received_eutra_ea = eutra_ea >> 9;
 
     memcpy(&eutra_ia,
             eUTRAintegrityProtectionAlgorithms->buf, sizeof(eutra_ia));
     eutra_ia = be16toh(eutra_ia);
-    eutra_ia0 = amf_ue->ue_security_capability.eutra_ia0;
-    amf_ue->ue_security_capability.eutra_ia = eutra_ia >> 9;
-    amf_ue->ue_security_capability.eutra_ia0 = eutra_ia0;
+    received_eutra_ia = eutra_ia >> 9;
+
+    if (received_nr_ea != (amf_ue->ue_security_capability.nr_ea & 0x7f) ||
+        received_nr_ia != (amf_ue->ue_security_capability.nr_ia & 0x7f) ||
+        received_eutra_ea !=
+            (amf_ue->ue_security_capability.eutra_ea & 0x7f) ||
+        received_eutra_ia !=
+            (amf_ue->ue_security_capability.eutra_ia & 0x7f)) {
+        amf_ue->send_ue_security_capability_in_path_switch_ack = true;
+
+        ogs_warn("[%s] UE Security Capability mismatch in "
+                "PathSwitchRequest",
+                amf_ue->supi ? amf_ue->supi : "Unknown");
+        ogs_warn("    Stored  NR_EA[0x%x] NR_IA[0x%x] "
+                "EUTRA_EA[0x%x] EUTRA_IA[0x%x]",
+                amf_ue->ue_security_capability.nr_ea,
+                amf_ue->ue_security_capability.nr_ia,
+                amf_ue->ue_security_capability.eutra_ea,
+                amf_ue->ue_security_capability.eutra_ia);
+        ogs_warn("    Received NR_EA[0x%x] NR_IA[0x%x] "
+                "EUTRA_EA[0x%x] EUTRA_IA[0x%x]",
+                received_nr_ea, received_nr_ia,
+                received_eutra_ea, received_eutra_ia);
+    }
 
     /* Update Security Context (NextHop) */
     amf_ue->nhcc++;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -564,6 +564,10 @@ struct mme_ue_s {
 
     /* Security Context */
     ogs_nas_ue_network_capability_t ue_network_capability;
+
+    /* Transient Path Switch state */
+    bool send_ue_security_capability_in_path_switch_ack;
+
     ogs_nas_ms_network_capability_t ms_network_capability;
     ogs_nas_ue_additional_security_capability_t
         ue_additional_security_capability;

--- a/src/mme/s1ap-build.c
+++ b/src/mme/s1ap-build.c
@@ -1803,6 +1803,8 @@ ogs_pkbuf_t *s1ap_build_path_switch_ack(
     S1AP_ENB_UE_S1AP_ID_t *ENB_UE_S1AP_ID = NULL;
     S1AP_E_RABToBeSwitchedULList_t *E_RABToBeSwitchedULList = NULL;
     S1AP_SecurityContext_t *SecurityContext = NULL;
+    S1AP_UESecurityCapabilities_t *UESecurityCapabilities = NULL;
+    bool send_ue_security_capability = false;
 
     mme_sess_t *sess = NULL;
     mme_bearer_t *bearer = NULL;
@@ -1813,6 +1815,10 @@ ogs_pkbuf_t *s1ap_build_path_switch_ack(
     ogs_assert(enb_ue);
 
     ogs_debug("PathSwitchAcknowledge");
+
+    send_ue_security_capability =
+        mme_ue->send_ue_security_capability_in_path_switch_ack;
+    mme_ue->send_ue_security_capability_in_path_switch_ack = false;
 
     memset(&pdu, 0, sizeof (S1AP_S1AP_PDU_t));
     pdu.present = S1AP_S1AP_PDU_PR_successfulOutcome;
@@ -1908,6 +1914,35 @@ ogs_pkbuf_t *s1ap_build_path_switch_ack(
     SecurityContext->nextHopParameter.bits_unused = 0;
     memcpy(SecurityContext->nextHopParameter.buf,
             mme_ue->nh, SecurityContext->nextHopParameter.size);
+
+    if (send_ue_security_capability) {
+        ie = CALLOC(1, sizeof(S1AP_PathSwitchRequestAcknowledgeIEs_t));
+        ASN_SEQUENCE_ADD(&PathSwitchRequestAcknowledge->protocolIEs, ie);
+
+        ie->id = S1AP_ProtocolIE_ID_id_UESecurityCapabilities;
+        ie->criticality = S1AP_Criticality_ignore;
+        ie->value.present =
+            S1AP_PathSwitchRequestAcknowledgeIEs__value_PR_UESecurityCapabilities;
+
+        UESecurityCapabilities = &ie->value.choice.UESecurityCapabilities;
+
+        UESecurityCapabilities->encryptionAlgorithms.size = 2;
+        UESecurityCapabilities->encryptionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->encryptionAlgorithms.size,
+                        sizeof(uint8_t));
+        UESecurityCapabilities->encryptionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->encryptionAlgorithms.buf[0] =
+            (mme_ue->ue_network_capability.eea << 1);
+
+        UESecurityCapabilities->integrityProtectionAlgorithms.size = 2;
+        UESecurityCapabilities->integrityProtectionAlgorithms.buf =
+            CALLOC(UESecurityCapabilities->
+                            integrityProtectionAlgorithms.size,
+                        sizeof(uint8_t));
+        UESecurityCapabilities->integrityProtectionAlgorithms.bits_unused = 0;
+        UESecurityCapabilities->integrityProtectionAlgorithms.buf[0] =
+            (mme_ue->ue_network_capability.eia << 1);
+    }
 
     return ogs_s1ap_encode(&pdu);
 }

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -2537,7 +2537,7 @@ void s1ap_handle_path_switch_request(
     S1AP_EncryptionAlgorithms_t    *encryptionAlgorithms = NULL;
     S1AP_IntegrityProtectionAlgorithms_t *integrityProtectionAlgorithms = NULL;
     uint16_t eea = 0, eia = 0;
-    uint8_t eea0 = 0, eia0 = 0;
+    uint8_t received_eea = 0, received_eia = 0;
 
     enb_ue_t *enb_ue = NULL;
     mme_ue_t *mme_ue = NULL;
@@ -2711,6 +2711,8 @@ void s1ap_handle_path_switch_request(
         return;
     }
 
+    mme_ue->send_ue_security_capability_in_path_switch_ack = false;
+
     if (!SECURITY_CONTEXT_IS_VALID(mme_ue)) {
         ogs_error("No Security Context");
         s1apbuf = s1ap_build_path_switch_failure(
@@ -2836,11 +2838,21 @@ void s1ap_handle_path_switch_request(
         ogs_assert(r != OGS_ERROR);
         return;
     }
+    /*
+     * The MME shall verify that the UE security capabilities received
+     * from the target eNB are the same as the UE security capabilities
+     * locally stored in the MME.
+     *
+     * If there is a mismatch, the MME shall send its locally stored
+     * UE security capabilities to the target eNB in the
+     * Path Switch Request Acknowledge message.
+     *
+     * Therefore, do not overwrite mme_ue->ue_network_capability
+     * with the value received in PathSwitchRequest.
+     */
     memcpy(&eea, encryptionAlgorithms->buf, sizeof(eea));
     eea = be16toh(eea);
-    eea0 = mme_ue->ue_network_capability.eea0;
-    mme_ue->ue_network_capability.eea = eea >> 9;
-    mme_ue->ue_network_capability.eea0 = eea0;
+    received_eea = eea >> 9;
 
     if (integrityProtectionAlgorithms->size != sizeof(eia)) {
         ogs_error("Invalid integrityProtectionAlgorithms->size = %d "
@@ -2857,9 +2869,21 @@ void s1ap_handle_path_switch_request(
     }
     memcpy(&eia, integrityProtectionAlgorithms->buf, sizeof(eia));
     eia = be16toh(eia);
-    eia0 = mme_ue->ue_network_capability.eia0;
-    mme_ue->ue_network_capability.eia = eia >> 9;
-    mme_ue->ue_network_capability.eia0 = eia0;
+    received_eia = eia >> 9;
+
+    if (received_eea != (mme_ue->ue_network_capability.eea & 0x7f) ||
+        received_eia != (mme_ue->ue_network_capability.eia & 0x7f)) {
+        mme_ue->send_ue_security_capability_in_path_switch_ack = true;
+
+        ogs_warn("[%s] UE Security Capability mismatch in "
+                "PathSwitchRequest",
+                MME_UE_HAVE_IMSI(mme_ue) ? mme_ue->imsi_bcd : "Unknown");
+        ogs_warn("    Stored  EEA[0x%x] EIA[0x%x]",
+                mme_ue->ue_network_capability.eea,
+                mme_ue->ue_network_capability.eia);
+        ogs_warn("    Received EEA[0x%x] EIA[0x%x]",
+                received_eea, received_eia);
+    }
 
     /* Update Security Context (NextHop) */
     mme_ue->nhcc++;


### PR DESCRIPTION
Do not overwrite the locally stored UE security capabilities with the values received in PathSwitchRequest.

During path switch, the AMF/MME should verify the UE security capabilities received from the target RAN node against the locally stored values. If a mismatch is detected, keep the locally stored values and include them in PathSwitchRequestAcknowledge.

This patch adds mismatch detection for both NGAP and S1AP path switch procedures, logs the mismatch, and sends the locally stored UE security capabilities in the acknowledge message when required.

Issues #4393
Issues #4519 
Related to PR #4518
Related to PR #4520