### PR TITLE
sbi: rebuild NFProfile atomically with shadow instance

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -1477,13 +1477,26 @@ ogs_sbi_nf_service_t *ogs_sbi_nf_service_add(
     ogs_assert(name);
 
     ogs_pool_alloc(&nf_service_pool, &nf_service);
-    ogs_assert(nf_service);
+    if (!nf_service) {
+        ogs_error("OVERFLOW nf_service_pool [pool:%llu]",
+                (unsigned long long)ogs_app()->pool.nf_service);
+        return NULL;
+    }
     memset(nf_service, 0, sizeof(ogs_sbi_nf_service_t));
 
     nf_service->id = ogs_strdup(id);
-    ogs_assert(nf_service->id);
+    if (!nf_service->id) {
+        ogs_error("ogs_strdup() failed for nf_service->id");
+        ogs_pool_free(&nf_service_pool, nf_service);
+        return NULL;
+    }
     nf_service->name = ogs_strdup(name);
-    ogs_assert(nf_service->name);
+    if (!nf_service->name) {
+        ogs_error("ogs_strdup() failed for nf_service->name");
+        ogs_free(nf_service->id);
+        ogs_pool_free(&nf_service_pool, nf_service);
+        return NULL;
+    }
     nf_service->scheme = scheme;
     ogs_assert(nf_service->scheme);
 
@@ -1676,7 +1689,9 @@ ogs_sbi_nf_info_t *ogs_sbi_nf_info_add(
 
     ogs_pool_alloc(&nf_info_pool, &nf_info);
     if (!nf_info) {
-        ogs_fatal("ogs_pool_alloc() failed");
+        ogs_error("OVERFLOW nf_info_pool [pool:%llu]",
+                (unsigned long long)(ogs_app()->pool.nf *
+                    OGS_MAX_NUM_OF_NF_INFO));
         return NULL;
     }
     memset(nf_info, 0, sizeof(*nf_info));
@@ -1937,7 +1952,15 @@ ogs_sbi_nf_service_t *ogs_sbi_nf_service_build_default(
     ogs_assert(scheme);
 
     nf_service = ogs_sbi_nf_service_add(nf_instance, id, name, scheme);
-    ogs_assert(nf_service);
+    if (!nf_service) {
+        ogs_error("Cannot build default NF service [%s]: "
+                "nf_service_pool exhausted at startup. "
+                "Increase 'max.peer' (current pool capacity = "
+                "max.peer * 16 = %llu).",
+                name,
+                (unsigned long long)ogs_app()->pool.nf_service);
+        return NULL;
+    }
 
     hostname = NULL;
     for (server = ogs_sbi_server_first();

--- a/lib/sbi/context.h
+++ b/lib/sbi/context.h
@@ -110,20 +110,35 @@ typedef struct ogs_sbi_context_s {
     const char *service_name[OGS_SBI_MAX_NUM_OF_SERVICE_TYPE];
 } ogs_sbi_context_t;
 
+/*
+ * Each member is tagged [RUNTIME], [PROFILE_REQUIRED],
+ * [PROFILE_OPTIONAL_FLAGGED], or [PROFILE_OPTIONAL_DATA] for the
+ * NFProfile shadow-swap rebuild in ogs_nnrf_nfm_handle_nf_profile().
+ * See lib/sbi/nnrf-handler.c for the category taxonomy and the
+ * maintainer workflow when adding new fields.
+ */
 typedef struct ogs_sbi_nf_instance_s {
+    /* [RUNTIME] Registry list linkage. */
     ogs_lnode_t lnode;
 
-    ogs_fsm_t sm;                           /* A state machine */
-    ogs_timer_t *t_registration_interval;   /* timer to retry
-                                               to register peer node */
+    /* [RUNTIME] Per-NF state machine. */
+    ogs_fsm_t sm;
+    /* [RUNTIME] Retry timer for outbound registration to a peer NRF. */
+    ogs_timer_t *t_registration_interval;
+
+    /* [PROFILE_OPTIONAL_FLAGGED] heartBeatTimer.heart_beat_timer
+     * maps to time.heartbeat_interval; validity_duration is
+     * consumer-side bookkeeping with the same flagged-overwrite
+     * pattern. */
     struct {
         int heartbeat_interval;
         int validity_duration;
     } time;
 
-    ogs_timer_t *t_heartbeat_interval;      /* heartbeat interval */
-    ogs_timer_t *t_no_heartbeat;            /* check heartbeat */
-    ogs_timer_t *t_validity;                /* check validation */
+    /* [RUNTIME] Heartbeat/validity bookkeeping timers. */
+    ogs_timer_t *t_heartbeat_interval;
+    ogs_timer_t *t_no_heartbeat;
+    ogs_timer_t *t_validity;
 
     /*
      * Issues #2034
@@ -148,27 +163,42 @@ typedef struct ogs_sbi_nf_instance_s {
 #define NF_INSTANCE_ID_IS_OTHERS(_iD) \
     (_iD) && ogs_sbi_self()->nf_instance && \
         strcmp((_iD), ogs_sbi_self()->nf_instance->id) != 0
+    /* [RUNTIME] Instance identity. Set once by
+     * ogs_sbi_nf_instance_set_id(), kept stable across rebuilds. */
     char *id;
 
 #define NF_INSTANCE_TYPE(__nFInstance) \
     ((__nFInstance) ? ((__nFInstance)->nf_type) : OpenAPI_nf_type_NULL)
 #define NF_INSTANCE_TYPE_IS_NRF(__nFInstance) \
     (NF_INSTANCE_TYPE(__nFInstance) == OpenAPI_nf_type_NRF)
+    /* [PROFILE_REQUIRED] NFProfile.nfType. */
     OpenAPI_nf_type_e nf_type;
+    /* [PROFILE_REQUIRED] NFProfile.nfStatus. */
     OpenAPI_nf_status_e nf_status;
 
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.plmnList. Builder writes the
+     * count + array based on what's present in NFProfile. */
     ogs_plmn_id_t plmn_id[OGS_MAX_NUM_OF_PLMN];
     int num_of_plmn_id;
 
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.fqdn. Owned string; commit
+     * transfers ownership, discard frees. */
     char *fqdn;
-    char *hnrf_uri; /* NRF Only */
+    /* [RUNTIME] Home-NRF URI cached on the instance (NRF only).
+     * Not part of NFProfile; not touched by shadow-swap. */
+    char *hnrf_uri;
 
 #define OGS_SBI_MAX_NUM_OF_IP_ADDRESS 8
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.ipv4Addresses. Owned
+     * sockaddr_t* array (ogs_freeaddrinfo); commit transfers
+     * ownership, discard frees per-slot. */
     int num_of_ipv4;
     ogs_sockaddr_t *ipv4[OGS_SBI_MAX_NUM_OF_IP_ADDRESS];
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.ipv6Addresses. Same as above. */
     int num_of_ipv6;
     ogs_sockaddr_t *ipv6[OGS_SBI_MAX_NUM_OF_IP_ADDRESS];
 
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.allowedNfTypes. */
     int num_of_allowed_nf_type;
 #define OGS_SBI_MAX_NUM_OF_NF_TYPE 128
     OpenAPI_nf_type_e allowed_nf_type[OGS_SBI_MAX_NUM_OF_NF_TYPE];
@@ -183,24 +213,44 @@ typedef struct ogs_sbi_nf_instance_s {
      *                  (from NFProfile.allowedNssais).
      *                  Used to filter target NFs during NF discovery.
      */
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.sNssais. */
     int num_of_s_nssai;
     ogs_s_nssai_t s_nssai[OGS_MAX_NUM_OF_SLICE];
 
+    /* [PROFILE_OPTIONAL_DATA] NFProfile.allowedNssais. */
     int num_of_allowed_nssai;
     ogs_s_nssai_t allowed_nssai[OGS_MAX_NUM_OF_SLICE];
 
 #define OGS_SBI_DEFAULT_PRIORITY 0
 #define OGS_SBI_DEFAULT_CAPACITY 100
 #define OGS_SBI_DEFAULT_LOAD 0
+    /* [PROFILE_OPTIONAL_FLAGGED] NFProfile.priority / .capacity /
+     * .load. Carry-forward in init(), overwrite in builder only when
+     * NFProfile->is_priority / is_capacity / is_load is true. */
     int priority;
     int capacity;
     int load;
 
+    /*
+     * [PROFILE_OPTIONAL_DATA] NFProfile.nfServices / nfServiceList.
+     * List head only - the actual nf_service_t objects are pool-
+     * allocated and carry an nf_instance back-pointer. During the
+     * shadow-swap rebuild the back-pointer points at the staged
+     * shadow; commit re-parents to the live instance.
+     */
     ogs_list_t nf_service_list;
+    /*
+     * [PROFILE_OPTIONAL_DATA] NFProfile.{smf,amf,scp,sepp,...}Info
+     * (per-NF-type structured info). List head only; nodes are
+     * heap-allocated and released by ogs_sbi_nf_info_remove_all().
+     */
     ogs_list_t nf_info_list;
 
 #define NF_INSTANCE_CLIENT(__nFInstance) \
     ((__nFInstance) ? ((__nFInstance)->client) : NULL)
+    /* [RUNTIME] HTTP client binding (consumer side only). Refreshed
+     * by ogs_sbi_client_associate() AFTER a successful profile
+     * commit, never inside the shadow-swap helpers. */
     void *client;                       /* only used in CLIENT */
 } ogs_sbi_nf_instance_t;
 

--- a/lib/sbi/nf-sm.c
+++ b/lib/sbi/nf-sm.c
@@ -46,7 +46,11 @@ static void handle_nf_profile_retrieval(
 
     ogs_sbi_nf_instance_set_id(nf_instance, nf_instance_id);
 
-    ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
+    if (ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile) == false) {
+        ogs_error("[%s] (NRF-profile-get) Invalid NFProfile", nf_instance_id);
+        ogs_sbi_nf_instance_remove(nf_instance);
+        return;
+    }
 
     /* verify against our subscription list that we want to save this
      * nf instance to our context */

--- a/lib/sbi/nnrf-handler.c
+++ b/lib/sbi/nnrf-handler.c
@@ -23,9 +23,9 @@ static void handle_nf_service(
         ogs_sbi_nf_service_t *nf_service, OpenAPI_nf_service_t *NFService);
 static bool handle_smf_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_smf_info_t *SmfInfo);
-static void handle_scp_info(
+static bool handle_scp_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_scp_info_t *ScpInfo);
-static void handle_sepp_info(
+static bool handle_sepp_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_sepp_info_t *SeppInfo);
 static bool handle_amf_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_amf_info_t *AmfInfo);
@@ -72,7 +72,97 @@ void ogs_nnrf_nfm_handle_nf_register(
     }
 }
 
-bool ogs_nnrf_nfm_handle_nf_profile(
+/* ====================================================================
+ * NFProfile shadow-swap rebuild
+ * ====================================================================
+ *
+ * ogs_nnrf_nfm_handle_nf_profile() rebuilds an nf_instance's profile
+ * from a wire NFProfile. To make the rebuild atomic, the work is
+ * performed against a stack-allocated "staged" nf_instance and the
+ * result is committed onto the live nf_instance only on success;
+ * on failure the staged shadow is freed and the live instance is
+ * left exactly as it was.
+ *
+ * Field category taxonomy
+ * -----------------------
+ * Each member of ogs_sbi_nf_instance_t falls into one of four
+ * categories, tagged inline in lib/sbi/context.h:
+ *
+ * [RUNTIME]
+ *   Lifecycle / identity / binding state. NOT part of NFProfile.
+ *   Set by nf_instance_add(), FSM init, ID setter, or client
+ *   association code paths. The shadow-swap MUST NOT touch these
+ *   fields - they live on the live instance throughout. The staged
+ *   shadow is memset(0) so RUNTIME slots are zero there; they are
+ *   never copied to the live instance during commit.
+ *
+ * [PROFILE_REQUIRED]
+ *   NFProfile mandatory per 3GPP TS 29.510 (nfInstanceId, nfType,
+ *   nfStatus). The public wrapper validates these BEFORE staged
+ *   init, so they never enter the build path with NULL values.
+ *
+ * [PROFILE_OPTIONAL_FLAGGED]
+ *   NFProfile optional, OpenAPI generates an `is_xxx` flag to
+ *   distinguish "explicitly set to zero" from "absent". If the
+ *   flag is false on the wire, the field must keep its previous
+ *   value - otherwise re-registering with a partial NFProfile
+ *   would clobber working values with zero. Examples: priority,
+ *   capacity, load, heartBeatTimer.
+ *
+ * [PROFILE_OPTIONAL_DATA]
+ *   NFProfile optional fields whose presence is signalled by data
+ *   shape: a non-NULL pointer (e.g. fqdn) or a non-empty list
+ *   (e.g. nfServices). The staged shadow starts these at zero /
+ *   NULL; the builder fills them when NFProfile carries the data,
+ *   leaves them empty otherwise.
+ *
+ * Maintainer workflow when adding a new ogs_sbi_nf_instance_t field
+ * ----------------------------------------------------------------
+ *
+ *   [RUNTIME]
+ *     Touch nothing in this file. The staged shadow leaves the slot
+ *     at zero and commit never copies it.
+ *
+ *   [PROFILE_REQUIRED]
+ *     - ogs_nnrf_nfm_handle_nf_profile(): add a non-null/non-zero
+ *       check before nf_profile_payload_init().
+ *     - nnrf_nfm_build_nf_profile_payload(): write into staged
+ *       unconditionally.
+ *     - nf_profile_payload_commit(): copy from staged to live.
+ *
+ *   [PROFILE_OPTIONAL_FLAGGED]
+ *     - nf_profile_payload_init(): carry forward base->field so
+ *       an omitted is_xxx flag preserves the live value.
+ *     - nnrf_nfm_build_nf_profile_payload(): write into staged
+ *       only when NFProfile->is_xxx is true.
+ *     - nf_profile_payload_commit(): copy from staged to live.
+ *
+ *   [PROFILE_OPTIONAL_DATA]
+ *     - nnrf_nfm_build_nf_profile_payload(): populate from
+ *       NFProfile when present.
+ *     - nf_profile_payload_commit(): copy (scalars / fixed-size
+ *       value arrays) or move ownership (heap pointers, list
+ *       nodes with back-pointer rewriting).
+ *     - nf_profile_payload_free(): release the resource for owned
+ *       heap or list fields. Plain scalars and fixed-size value
+ *       arrays need no free hook.
+ *
+ * Forgetting to update commit() silently drops the new field on
+ * every successful rebuild - the build succeeds but the field
+ * never reaches the registry. There is no compiler warning for
+ * this; reviewers must explicitly check commit() when builder
+ * changes.
+ * ==================================================================== */
+
+/*
+ * Build the new NFProfile into a staged nf_instance.
+ *
+ * The live nf_instance must NOT be modified until the staged rebuild
+ * succeeds; on failure we discard the staged payload, on success
+ * ogs_nnrf_nfm_handle_nf_profile()'s commit step transfers the
+ * staged profile payload onto the live nf_instance.
+ */
+static bool nnrf_nfm_build_nf_profile_payload(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_nf_profile_t *NFProfile)
 {
     int rv;
@@ -80,20 +170,26 @@ bool ogs_nnrf_nfm_handle_nf_profile(
 
     ogs_assert(nf_instance);
     ogs_assert(NFProfile);
-    ogs_assert(NFProfile->nf_instance_id);
-    ogs_assert(NFProfile->nf_type);
-    ogs_assert(NFProfile->nf_status);
 
-    ogs_sbi_nf_instance_clear(nf_instance);
+    /*
+     * Note: no nf_instance_clear() here. The staged shadow arrives
+     * already memset(0)+list_init() via nf_profile_payload_init(),
+     * so there is nothing to clear. The live instance's old payload
+     * is freed later by nf_profile_payload_free() inside commit.
+     */
 
+    /* [PROFILE_REQUIRED] nf_type, nf_status. */
     nf_instance->nf_type = NFProfile->nf_type;
     nf_instance->nf_status = NFProfile->nf_status;
+    /* [PROFILE_OPTIONAL_FLAGGED] heartBeatTimer. */
     if (NFProfile->is_heart_beat_timer == true)
         nf_instance->time.heartbeat_interval = NFProfile->heart_beat_timer;
 
+    /* [PROFILE_OPTIONAL_DATA] fqdn. Owned string. */
     if (NFProfile->fqdn)
         nf_instance->fqdn = ogs_strdup(NFProfile->fqdn);
 
+    /* [PROFILE_OPTIONAL_FLAGGED] priority / capacity / load. */
     if (NFProfile->is_priority == true)
         nf_instance->priority = NFProfile->priority;
     if (NFProfile->is_capacity == true)
@@ -101,6 +197,7 @@ bool ogs_nnrf_nfm_handle_nf_profile(
     if (NFProfile->is_load == true)
         nf_instance->load = NFProfile->load;
 
+    /* [PROFILE_OPTIONAL_DATA] plmnList. Fixed-size value array. */
     nf_instance->num_of_plmn_id = 0;
     OpenAPI_list_for_each(NFProfile->plmn_list, node) {
         OpenAPI_plmn_id_t *PlmnId = node->data;
@@ -118,6 +215,8 @@ bool ogs_nnrf_nfm_handle_nf_profile(
         }
     }
 
+    /* [PROFILE_OPTIONAL_DATA] ipv4Addresses. Owned sockaddr_t* array.
+     * Per-slot ownership; discard releases each non-NULL slot. */
     OpenAPI_list_for_each(NFProfile->ipv4_addresses, node) {
         ogs_sockaddr_t *addr = NULL;
 
@@ -141,6 +240,7 @@ bool ogs_nnrf_nfm_handle_nf_profile(
             nf_instance->num_of_ipv4++;
         }
     }
+    /* [PROFILE_OPTIONAL_DATA] ipv6Addresses. Same ownership as ipv4. */
     OpenAPI_list_for_each(NFProfile->ipv6_addresses, node) {
         ogs_sockaddr_t *addr = NULL;
 
@@ -165,6 +265,7 @@ bool ogs_nnrf_nfm_handle_nf_profile(
         }
     }
 
+    /* [PROFILE_OPTIONAL_DATA] allowedNfTypes. Fixed-size value array. */
     OpenAPI_list_for_each(NFProfile->allowed_nf_types, node) {
         OpenAPI_nf_type_e AllowedNfType = (uintptr_t)node->data;
 
@@ -187,6 +288,7 @@ bool ogs_nnrf_nfm_handle_nf_profile(
      * allowedNssais restricts for which slices the NF may be discovered.
      */
     nf_instance->num_of_s_nssai = 0;
+    /* [PROFILE_OPTIONAL_DATA] sNssais. Fixed-size value array. */
     OpenAPI_list_for_each(NFProfile->s_nssais, node) {
         OpenAPI_ext_snssai_t *sNssai = node->data;
         if (sNssai) {
@@ -204,6 +306,7 @@ bool ogs_nnrf_nfm_handle_nf_profile(
     }
 
     nf_instance->num_of_allowed_nssai = 0;
+    /* [PROFILE_OPTIONAL_DATA] allowedNssais. Fixed-size value array. */
     OpenAPI_list_for_each(NFProfile->allowed_nssais, node) {
         OpenAPI_ext_snssai_t *sNssai = node->data;
         if (sNssai) {
@@ -220,6 +323,9 @@ bool ogs_nnrf_nfm_handle_nf_profile(
         }
     }
 
+    /* [PROFILE_OPTIONAL_DATA] nfServices. List of pool-allocated
+     * nf_service_t objects with back-pointers to the owning instance.
+     * Commit re-parents the back-pointer from staged to live. */
     OpenAPI_list_for_each(NFProfile->nf_services, node) {
         ogs_sbi_nf_service_t *nf_service = NULL;
         OpenAPI_nf_service_t *NFService = node->data;
@@ -251,7 +357,11 @@ bool ogs_nnrf_nfm_handle_nf_profile(
                             nf_instance,
                             NFService->service_instance_id,
                             NFService->service_name, NFService->scheme);
-            ogs_assert(nf_service);
+            if (!nf_service) {
+                ogs_error("Failed to add NFService [%s]",
+                        NFService->service_instance_id);
+                return false;
+            }
         }
 
         ogs_sbi_nf_service_clear(nf_service);
@@ -259,6 +369,9 @@ bool ogs_nnrf_nfm_handle_nf_profile(
         handle_nf_service(nf_service, NFService);
     }
 
+    /* [PROFILE_OPTIONAL_DATA] nfServiceList (legacy MAP form,
+     * 3GPP TS 29.510 Release 16+). Same ownership semantics as the
+     * nf_services list above. */
     OpenAPI_list_for_each(NFProfile->nf_service_list, node) {
         ogs_sbi_nf_service_t *nf_service = NULL;
         OpenAPI_map_t *NFServiceMap = NULL;
@@ -294,7 +407,11 @@ bool ogs_nnrf_nfm_handle_nf_profile(
                                 nf_instance,
                                 NFService->service_instance_id,
                                 NFService->service_name, NFService->scheme);
-                ogs_assert(nf_service);
+                if (!nf_service) {
+                    ogs_error("Failed to add NFService [%s]",
+                            NFService->service_instance_id);
+                    return false;
+                }
             }
 
             ogs_sbi_nf_service_clear(nf_service);
@@ -303,7 +420,15 @@ bool ogs_nnrf_nfm_handle_nf_profile(
         }
     }
 
-    ogs_sbi_nf_info_remove_all(&nf_instance->nf_info_list);
+    /*
+     * [PROFILE_OPTIONAL_DATA] nfInfo list (smfInfo / amfInfo /
+     * scpInfo / seppInfo / their *_list MAP variants). Heap-allocated
+     * nf_info_t nodes linked through nf_info_list. Owned by the
+     * containing instance; released by ogs_sbi_nf_info_remove_all().
+     *
+     * Note: no nf_info_remove_all() reset here. The staged
+     * shadow's nf_info_list starts empty from init().
+     */
 
     if (NFProfile->smf_info &&
             handle_smf_info(nf_instance, NFProfile->smf_info) == false)
@@ -325,10 +450,271 @@ bool ogs_nnrf_nfm_handle_nf_profile(
                 handle_amf_info(nf_instance, AmfInfoMap->value) == false)
             return false;
     }
-    if (NFProfile->scp_info)
-        handle_scp_info(nf_instance, NFProfile->scp_info);
-    if (NFProfile->sepp_info)
-        handle_sepp_info(nf_instance, NFProfile->sepp_info);
+    if (NFProfile->scp_info &&
+            handle_scp_info(nf_instance, NFProfile->scp_info) == false)
+        return false;
+    if (NFProfile->sepp_info &&
+            handle_sepp_info(nf_instance, NFProfile->sepp_info) == false)
+        return false;
+
+    return true;
+}
+
+/*
+ * Initialise a staged nf_instance for shadow rebuild.
+ *
+ * The staged copy starts out as memset(0), then carries forward the
+ * [PROFILE_OPTIONAL_FLAGGED] fields from the live instance. See the
+ * field category taxonomy in lib/sbi/context.h.
+ *
+ * Carry-forward is required for FLAGGED fields specifically because
+ * the builder only overwrites them when NFProfile->is_xxx is true.
+ * Without the carry-forward, a wire profile that omits the is_xxx
+ * flag would let the staged value remain zero, and commit would
+ * then silently zero out the live priority / capacity / load on
+ * every such rebuild.
+ *
+ * Categories handled here:
+ *   [PROFILE_OPTIONAL_FLAGGED] time, priority, capacity, load
+ *                              (copied from base).
+ *
+ * Categories NOT handled here:
+ *   [RUNTIME]                  stays on the live instance, never
+ *                              touched on staged.
+ *   [PROFILE_REQUIRED]         always overwritten by the builder.
+ *   [PROFILE_OPTIONAL_DATA]    starts at zero/NULL on staged and is
+ *                              populated by the builder if NFProfile
+ *                              provides the data.
+ *
+ * When you add a new [PROFILE_OPTIONAL_FLAGGED] field to
+ * ogs_sbi_nf_instance_t, extend the carry-forward below.
+ */
+static void nf_profile_payload_init(
+        ogs_sbi_nf_instance_t *staged, ogs_sbi_nf_instance_t *base)
+{
+    ogs_assert(staged);
+    ogs_assert(base);
+
+    memset(staged, 0, sizeof(*staged));
+
+    /* [PROFILE_OPTIONAL_FLAGGED] carry-forward. */
+    staged->time = base->time;
+    staged->priority = base->priority;
+    staged->capacity = base->capacity;
+    staged->load = base->load;
+
+    /* [PROFILE_OPTIONAL_DATA] list heads: explicit init even though
+     * memset(0) already zeroed them, for self-documenting code. */
+    ogs_list_init(&staged->nf_service_list);
+    ogs_list_init(&staged->nf_info_list);
+}
+
+/*
+ * Free a profile payload from the given nf_instance.
+ *
+ * Releases all owned heap and list resources that fall under
+ * [PROFILE_OPTIONAL_DATA]; leaves [RUNTIME] state alone (FSM,
+ * timers, id, lnode linkage). [PROFILE_OPTIONAL_FLAGGED] and
+ * [PROFILE_REQUIRED] scalars are zeroed implicitly by
+ * ogs_sbi_nf_instance_clear() where applicable, or simply left
+ * alone where not - either way they are not "owned" and require
+ * no explicit cleanup.
+ *
+ * Used in two contexts:
+ *   - To clean up a staged payload after a failed build, before
+ *     the stack-allocated staged goes out of scope;
+ *   - As the first step inside nf_profile_payload_commit() to drop
+ *     the live nf_instance's old profile before transferring the
+ *     staged one onto it.
+ *
+ * Both nf_info_remove_all() and nf_service_remove_all() identify
+ * services / infos via the per-instance list head and (for
+ * services) the back-pointer ogs_sbi_nf_service_t::nf_instance, so
+ * this works correctly for both the staged shadow (whose services
+ * were added with nf_instance == staged) and the live instance
+ * (whose services were added with nf_instance == live).
+ *
+ * When you add a new [PROFILE_OPTIONAL_DATA] field that owns heap
+ * or list resources, extend this function to release them.
+ */
+static void nf_profile_payload_free(ogs_sbi_nf_instance_t *nf_instance)
+{
+    ogs_assert(nf_instance);
+
+    /* [PROFILE_OPTIONAL_DATA] nf_info_list - heap-allocated nodes. */
+    ogs_sbi_nf_info_remove_all(&nf_instance->nf_info_list);
+    /* [PROFILE_OPTIONAL_DATA] nf_service_list - pool-allocated
+     * services with owned id/name strings and back-pointer. */
+    ogs_sbi_nf_service_remove_all(nf_instance);
+    /* [PROFILE_OPTIONAL_DATA] fqdn (heap), ipv4/ipv6 (sockaddr).
+     * ogs_sbi_nf_instance_clear() handles all of these. */
+    ogs_sbi_nf_instance_clear(nf_instance);
+}
+
+/*
+ * Commit the staged profile payload onto the live nf_instance.
+ *
+ * This is the only place where staged profile state crosses the
+ * boundary onto the live instance. Every [PROFILE_REQUIRED],
+ * [PROFILE_OPTIONAL_FLAGGED], and [PROFILE_OPTIONAL_DATA] field
+ * must be transferred here. [RUNTIME] fields are deliberately
+ * left untouched: id / sm / t_* / lnode / client / hnrf_uri stay
+ * on the live nf_instance, and the staged copy was memset(0) at
+ * init so its zero values for those fields must not leak across.
+ *
+ * Transfer rules by category:
+ *
+ *   [PROFILE_REQUIRED]         direct assignment (always present).
+ *   [PROFILE_OPTIONAL_FLAGGED] direct assignment (init() guaranteed
+ *                              a valid staged value via carry-forward
+ *                              or builder overwrite).
+ *   [PROFILE_OPTIONAL_DATA] scalar / fixed-size value array:
+ *                              copy by assignment / memcpy.
+ *   [PROFILE_OPTIONAL_DATA] owned heap pointer (e.g. fqdn):
+ *                              pointer-transfer + NULL the staged
+ *                              side so a subsequent discard of
+ *                              staged does not double-free.
+ *   [PROFILE_OPTIONAL_DATA] owned pointer array (e.g. ipv4/ipv6):
+ *                              memcpy + zero the staged side, same
+ *                              double-free protection.
+ *   [PROFILE_OPTIONAL_DATA] list of objects with back-pointer
+ *                              (nf_service_list):
+ *                              for each node, unlink from staged,
+ *                              rewrite back-pointer to nf_instance,
+ *                              link onto nf_instance's list head.
+ *   [PROFILE_OPTIONAL_DATA] list of plain objects (nf_info_list):
+ *                              for each node, unlink from staged,
+ *                              link onto nf_instance's list head.
+ *
+ * Step 1 discards the previously registered profile so the
+ * transfers below don't leak the old fqdn / sockaddr / lists.
+ */
+static void nf_profile_payload_commit(
+        ogs_sbi_nf_instance_t *nf_instance, ogs_sbi_nf_instance_t *staged)
+{
+    ogs_sbi_nf_service_t *nf_service = NULL, *next_nf_service = NULL;
+    ogs_sbi_nf_info_t *nf_info = NULL, *next_nf_info = NULL;
+
+    ogs_assert(nf_instance);
+    ogs_assert(staged);
+
+    /* Step 1: drop the previously registered profile. */
+    nf_profile_payload_free(nf_instance);
+
+    /* [PROFILE_OPTIONAL_FLAGGED] time (struct copy). */
+    nf_instance->time = staged->time;
+    /* [PROFILE_REQUIRED] nf_type, nf_status. */
+    nf_instance->nf_type = staged->nf_type;
+    nf_instance->nf_status = staged->nf_status;
+    /* [PROFILE_OPTIONAL_FLAGGED] priority / capacity / load. */
+    nf_instance->priority = staged->priority;
+    nf_instance->capacity = staged->capacity;
+    nf_instance->load = staged->load;
+
+    /* [PROFILE_OPTIONAL_DATA] plmn_id (fixed-size value array). */
+    nf_instance->num_of_plmn_id = staged->num_of_plmn_id;
+    memcpy(nf_instance->plmn_id, staged->plmn_id,
+            sizeof(nf_instance->plmn_id));
+
+    /* [PROFILE_OPTIONAL_DATA] allowed_nf_type (fixed-size value array). */
+    nf_instance->num_of_allowed_nf_type = staged->num_of_allowed_nf_type;
+    memcpy(nf_instance->allowed_nf_type, staged->allowed_nf_type,
+            sizeof(nf_instance->allowed_nf_type));
+
+    /* [PROFILE_OPTIONAL_DATA] s_nssai (fixed-size value array). */
+    nf_instance->num_of_s_nssai = staged->num_of_s_nssai;
+    memcpy(nf_instance->s_nssai, staged->s_nssai,
+            sizeof(nf_instance->s_nssai));
+
+    /* [PROFILE_OPTIONAL_DATA] allowed_nssai (fixed-size value array). */
+    nf_instance->num_of_allowed_nssai = staged->num_of_allowed_nssai;
+    memcpy(nf_instance->allowed_nssai, staged->allowed_nssai,
+            sizeof(nf_instance->allowed_nssai));
+
+    /* [PROFILE_OPTIONAL_DATA] fqdn: owned heap pointer transfer. */
+    nf_instance->fqdn = staged->fqdn;
+    staged->fqdn = NULL;
+
+    /* [PROFILE_OPTIONAL_DATA] ipv4 / ipv6: owned pointer array.
+     * memcpy + zero on staged so a subsequent discard is a no-op
+     * for these slots. */
+    nf_instance->num_of_ipv4 = staged->num_of_ipv4;
+    memcpy(nf_instance->ipv4, staged->ipv4, sizeof(nf_instance->ipv4));
+    staged->num_of_ipv4 = 0;
+    memset(staged->ipv4, 0, sizeof(staged->ipv4));
+
+    nf_instance->num_of_ipv6 = staged->num_of_ipv6;
+    memcpy(nf_instance->ipv6, staged->ipv6, sizeof(nf_instance->ipv6));
+    staged->num_of_ipv6 = 0;
+    memset(staged->ipv6, 0, sizeof(staged->ipv6));
+
+    /* [PROFILE_OPTIONAL_DATA] nf_service_list: re-parent.
+     *
+     * While in staged, each service had
+     *   nf_service->nf_instance == staged
+     * which let ogs_sbi_nf_service_clear() and remove_all() identify
+     * the staged list correctly during the build. After commit they
+     * live on the live instance, so the back-pointer must be
+     * rewritten before relinking. */
+    ogs_list_for_each_safe(&staged->nf_service_list,
+            next_nf_service, nf_service) {
+        ogs_list_remove(&staged->nf_service_list, nf_service);
+        nf_service->nf_instance = nf_instance;
+        ogs_list_add(&nf_instance->nf_service_list, nf_service);
+    }
+
+    /* [PROFILE_OPTIONAL_DATA] nf_info_list: relink (no back-pointer). */
+    ogs_list_for_each_safe(&staged->nf_info_list, next_nf_info, nf_info) {
+        ogs_list_remove(&staged->nf_info_list, nf_info);
+        ogs_list_add(&nf_instance->nf_info_list, nf_info);
+    }
+}
+
+/*
+ * Public entry point: atomically rebuild nf_instance's profile from
+ * NFProfile.
+ *
+ * On failure the live nf_instance is guaranteed to be unmodified.
+ * The build is performed against a stack-allocated staged shadow,
+ * which is either committed (on success) or discarded (on failure).
+ */
+bool ogs_nnrf_nfm_handle_nf_profile(
+        ogs_sbi_nf_instance_t *nf_instance, OpenAPI_nf_profile_t *NFProfile)
+{
+    ogs_sbi_nf_instance_t staged;
+
+    ogs_assert(nf_instance);
+
+    /*
+     * Top-level NFProfile validation. These checks never touch any
+     * state, so we do them before initialising staged to avoid the
+     * memset+carry-forward cost on trivially malformed input.
+     */
+    if (!NFProfile) {
+        ogs_error("No NFProfile");
+        return false;
+    }
+    if (!NFProfile->nf_instance_id) {
+        ogs_error("No NFProfile.nf_instance_id");
+        return false;
+    }
+    if (!NFProfile->nf_type) {
+        ogs_error("No NFProfile.nf_type");
+        return false;
+    }
+    if (!NFProfile->nf_status) {
+        ogs_error("No NFProfile.nf_status");
+        return false;
+    }
+
+    nf_profile_payload_init(&staged, nf_instance);
+
+    if (nnrf_nfm_build_nf_profile_payload(&staged, NFProfile) == false) {
+        nf_profile_payload_free(&staged);
+        return false;
+    }
+
+    nf_profile_payload_commit(nf_instance, &staged);
 
     return true;
 }
@@ -458,7 +844,10 @@ static bool handle_smf_info(
 
     nf_info = ogs_sbi_nf_info_add(
             &nf_instance->nf_info_list, OpenAPI_nf_type_SMF);
-    ogs_assert(nf_info);
+    if (!nf_info) {
+        ogs_error("Failed to add SMF nfInfo");
+        return false;
+    }
 
     sNssaiSmfInfoList = SmfInfo->s_nssai_smf_info_list;
     OpenAPI_list_for_each(sNssaiSmfInfoList, node) {
@@ -614,7 +1003,20 @@ out:
     return true;
 }
 
-static void handle_scp_info(
+static void scp_info_free(ogs_sbi_scp_info_t *scp_info)
+{
+    int i;
+
+    ogs_assert(scp_info);
+
+    for (i = 0; i < scp_info->num_of_domain; i++) {
+        ogs_free(scp_info->domain[i].name);
+        ogs_free(scp_info->domain[i].fqdn);
+    }
+    memset(scp_info, 0, sizeof(*scp_info));
+}
+
+static bool handle_scp_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_scp_info_t *ScpInfo)
 {
     ogs_sbi_nf_info_t *nf_info = NULL;
@@ -712,13 +1114,19 @@ static void handle_scp_info(
         scp_info.num_of_domain) {
         nf_info = ogs_sbi_nf_info_add(
                 &nf_instance->nf_info_list, OpenAPI_nf_type_SCP);
-        ogs_assert(nf_info);
+        if (!nf_info) {
+            ogs_error("Failed to add SCP nfInfo");
+            scp_info_free(&scp_info);
+            return false;
+        }
 
         memcpy(&nf_info->scp, &scp_info, sizeof(scp_info));
     }
+
+    return true;
 }
 
-static void handle_sepp_info(
+static bool handle_sepp_info(
         ogs_sbi_nf_instance_t *nf_instance, OpenAPI_sepp_info_t *SeppInfo)
 {
     ogs_sbi_nf_info_t *nf_info = NULL;
@@ -768,7 +1176,10 @@ static void handle_sepp_info(
     if (http.presence || https.presence) {
         nf_info = ogs_sbi_nf_info_add(
                 &nf_instance->nf_info_list, OpenAPI_nf_type_SEPP);
-        ogs_assert(nf_info);
+        if (!nf_info) {
+            ogs_error("Failed to add SEPP nfInfo");
+            return false;
+        }
 
         nf_info->sepp.http.presence = http.presence;
         nf_info->sepp.http.port = http.port;
@@ -776,6 +1187,8 @@ static void handle_sepp_info(
         nf_info->sepp.https.presence = https.presence;
         nf_info->sepp.https.port = https.port;
     }
+
+    return true;
 }
 
 static bool handle_amf_info(
@@ -798,7 +1211,10 @@ static bool handle_amf_info(
 
     nf_info = ogs_sbi_nf_info_add(
             &nf_instance->nf_info_list, OpenAPI_nf_type_AMF);
-    ogs_assert(nf_info);
+    if (!nf_info) {
+        ogs_error("Failed to add AMF nfInfo");
+        return false;
+    }
 
     nf_info->amf.amf_set_id = ogs_uint64_from_string_hexadecimal(
             AmfInfo->amf_set_id);
@@ -1144,6 +1560,7 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
     ogs_sbi_response_t *response = NULL;
     OpenAPI_notification_data_t *NotificationData = NULL;
     ogs_sbi_nf_instance_t *nf_instance = NULL;
+    bool nf_instance_created = false;
 
     ogs_sbi_message_t message;
     ogs_sbi_header_t header;
@@ -1254,6 +1671,7 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
             ogs_sbi_nf_instance_set_id(
                     nf_instance, message.h.resource.component[1]);
             ogs_sbi_nf_fsm_init(nf_instance);
+            nf_instance_created = true;
 
             ogs_info("[%s] (NRF-notify) NF registered", nf_instance->id);
         } else {
@@ -1267,7 +1685,31 @@ bool ogs_nnrf_nfm_handle_nf_status_notify(
             }
         }
 
-        ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile);
+        if (ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile) == false) {
+            ogs_error("[%s] (NRF-notify) Invalid NFProfile [type:%s]",
+                    NFProfile->nf_instance_id,
+                    OpenAPI_nf_type_ToString(NFProfile->nf_type));
+
+            /*
+             * ogs_nnrf_nfm_handle_nf_profile() rebuilds the NF profile in
+             * place. If parsing fails for a newly created cache entry, remove
+             * it because it may contain a partial profile. If the entry
+             * already existed, keep it in the registry to avoid deleting a
+             * previously usable local cache entry because of one bad notify.
+             */
+            if (nf_instance_created == true) {
+                ogs_sbi_nf_fsm_fini(nf_instance);
+                ogs_sbi_nf_instance_remove(nf_instance);
+            }
+
+            ogs_assert(true ==
+                ogs_sbi_server_send_error(
+                    stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                    recvmsg, "Invalid NFProfile",
+                    NFProfile->nf_instance_id, NULL));
+            ogs_sbi_header_free(&header);
+            return false;
+        }
 
         ogs_info("[%s] (NRF-notify) NF Profile updated [type:%s]",
                     nf_instance->id,
@@ -1334,6 +1776,7 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
 
     OpenAPI_list_for_each(SearchResult->nf_instances, node) {
         OpenAPI_nf_profile_t *NFProfile = NULL;
+        bool nf_instance_created = false;
 
         if (!node->data) continue;
 
@@ -1366,6 +1809,7 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
 
             ogs_sbi_nf_instance_set_id(nf_instance, NFProfile->nf_instance_id);
             ogs_sbi_nf_fsm_init(nf_instance);
+            nf_instance_created = true;
 
             ogs_info("[%s] (NRF-discover) NF registered [type:%s]",
                     nf_instance->id,
@@ -1385,8 +1829,19 @@ void ogs_nnrf_disc_handle_nf_discover_search_result(
             if (ogs_nnrf_nfm_handle_nf_profile(
                         nf_instance, NFProfile) == false) {
                 ogs_error("[%s] (NRF-discover) Invalid NFProfile [type:%s]",
-                        nf_instance->id,
+                        NFProfile->nf_instance_id,
                         OpenAPI_nf_type_ToString(NFProfile->nf_type));
+
+                /*
+                 * Do not leave a newly created partial NFProfile in the
+                 * registry. If the entry already existed, keep it to avoid
+                 * deleting a previously usable local cache entry because of
+                 * one bad discovery result.
+                 */
+                if (nf_instance_created == true) {
+                    ogs_sbi_nf_fsm_fini(nf_instance);
+                    ogs_sbi_nf_instance_remove(nf_instance);
+                }
                 continue;
             }
 

--- a/src/nrf/nf-sm.c
+++ b/src/nrf/nf-sm.c
@@ -260,8 +260,33 @@ void nrf_nf_state_registered(ogs_fsm_t *s, nrf_event_t *e)
 
                     handled = nrf_nnrf_handle_nf_update(
                             nf_instance, stream, message);
-                    if (handled == false)
-                        OGS_FSM_TRAN(s, nrf_nf_state_exception);
+                    if (handled == false) {
+                        ogs_error("[%s] Invalid NF update [type:%s] - "
+                                "keeping existing registration",
+                                nf_instance->id,
+                                OpenAPI_nf_type_ToString(
+                                    nf_instance->nf_type));
+                        /*
+                         * ogs_nnrf_nfm_handle_nf_profile() now guarantees
+                         * that the live nf_instance is unchanged on failure
+                         * (shadow-swap rebuild). nrf_nnrf_handle_nf_update()
+                         * has already sent the HTTP error response, so we
+                         * keep the existing registration intact - treating
+                         * a malformed PUT/PATCH update as an implicit
+                         * de-registration would evict an otherwise healthy
+                         * peer because of one bad message.
+                         *
+                         * The previous behaviour was to transition to
+                         * nrf_nf_state_exception, which causes the FSM
+                         * dispatcher in nrf_state_operational() to call
+                         * nrf_nf_fsm_fini() + ogs_sbi_nf_instance_remove().
+                         * That eviction is the correct response for
+                         * nrf_nf_state_will_register (initial registration
+                         * never completed), but is wrong for
+                         * nrf_nf_state_registered (the registration is
+                         * still valid - only this one update was bad).
+                         */
+                    }
                     break;
 
                 CASE(OGS_SBI_HTTP_METHOD_DELETE)

--- a/src/nrf/nnrf-handler.c
+++ b/src/nrf/nnrf-handler.c
@@ -122,11 +122,20 @@ bool nrf_nnrf_handle_nf_register(ogs_sbi_nf_instance_t *nf_instance,
     }
 
     if (ogs_nnrf_nfm_handle_nf_profile(nf_instance, NFProfile) == false) {
-        ogs_error("[%s] Invalid NFProfile", nf_instance->id);
+        ogs_error("[%s] Invalid NFProfile", NFProfile->nf_instance_id);
 
+        /*
+         * Do not finalize or remove nf_instance here. This handler is called
+         * from the NRF NF state machine. The caller performs OGS_FSM_TRAN()
+         * on &nf_instance->sm immediately after this function returns, so
+         * freeing nf_instance here would cause a use-after-free.
+         *
+         * Return failure and let the FSM dispatcher perform cleanup after the
+         * transition to nrf_nf_state_exception.
+         */
         ogs_assert(true == ogs_sbi_server_send_error(
             stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
-            recvmsg, "Invalid NFProfile", nf_instance->id, NULL));
+            recvmsg, "Invalid NFProfile", NFProfile->nf_instance_id, NULL));
 
         return false;
     }
@@ -1473,6 +1482,7 @@ static void handle_nf_discover_search_result(
 
     OpenAPI_list_for_each(SearchResult->nf_instances, node) {
         OpenAPI_nf_profile_t *NFProfile = NULL;
+        bool nf_instance_created = false;
 
         if (!node->data) continue;
 
@@ -1504,6 +1514,7 @@ static void handle_nf_discover_search_result(
             ogs_assert(nf_instance);
 
             ogs_sbi_nf_instance_set_id(nf_instance, NFProfile->nf_instance_id);
+            nf_instance_created = true;
 
             /*
              * If nrf_nf_fsm_init() is not executed, nf_instance->sm is NULL.
@@ -1528,6 +1539,17 @@ static void handle_nf_discover_search_result(
                 ogs_error("[%s] (NF-discover) Invalid NFProfile [type:%s]",
                         NFProfile->nf_instance_id,
                         OpenAPI_nf_type_ToString(NFProfile->nf_type));
+
+                /*
+                 * Only roll back nf_instances we just created here. A
+                 * pre-existing cache entry will be corrected by the next
+                 * inter-NRF discovery cycle; removing it now would cause
+                 * a temporary blackhole. (No fsm_fini: this code path
+                 * never calls nrf_nf_fsm_init() for newly added entries
+                 * per the comment at line 1517-1522, so sm is NULL.)
+                 */
+                if (nf_instance_created)
+                    ogs_sbi_nf_instance_remove(nf_instance);
                 continue;
             }
 

--- a/src/nrf/nrf-sm.c
+++ b/src/nrf/nrf-sm.c
@@ -191,6 +191,14 @@ void nrf_state_operational(ogs_fsm_t *s, nrf_event_t *e)
                             ogs_error("[%s] State machine exception",
                                     nf_instance->id);
 
+                            /*
+                             * Handlers invoked from the NF FSM must not free
+                             * nf_instance before returning because the FSM
+                             * transition writes to &nf_instance->sm.  Cleanup
+                             * of failed registration/update attempts is
+                             * centralized here, after ogs_fsm_dispatch()
+                             * completes.
+                             */
                             nrf_nf_fsm_fini(nf_instance);
                             ogs_sbi_nf_instance_remove(nf_instance);
                         }


### PR DESCRIPTION
Previously, ogs_nnrf_nfm_handle_nf_profile() rebuilt an NFProfile directly on the live nf_instance. If nf_service_pool or nf_info_pool was exhausted while parsing nfServices or nfInfo, the rebuild could fail after the existing profile had already been partially cleared or replaced.

Build the incoming NFProfile into a staged shadow nf_instance first, and commit it to the live nf_instance only after the entire rebuild succeeds. On failure, release the staged payload and leave the live instance unchanged.

Also handle nf_service_pool and nf_info_pool exhaustion by returning errors instead of aborting the process. Propagate those failures through the NFProfile handlers so oversized or malformed profiles are rejected rather than silently truncated.

For already registered NFs, keep the existing registration when a PUT/PATCH update fails, since the shadow rebuild guarantees the live profile remains unchanged. Initial registration failures still transition to the exception cleanup path.

Issues #4466
Related to PR #4534