### PR TITLE
bsf: reject invalid PCF binding IP address input

### DIFF
--- a/src/bsf/bsf-sm.c
+++ b/src/bsf/bsf-sm.c
@@ -42,6 +42,7 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
     int rv;
 
     bsf_sess_t *sess = NULL;
+    bool invalid = false;
 
     ogs_sbi_stream_t *stream = NULL;
     ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
@@ -143,28 +144,84 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
                             (message.PcfBinding->ipv4_addr ||
                              message.PcfBinding->ipv6_prefix)) {
 
-                            if (message.PcfBinding->ipv4_addr)
+                            if (message.PcfBinding->ipv4_addr) {
                                 sess = bsf_sess_find_by_ipv4addr(
+                                            message.PcfBinding->ipv4_addr,
+                                            &invalid);
+                                if (invalid) {
+                                    ogs_error("Invalid IPv4 address [%s]",
                                             message.PcfBinding->ipv4_addr);
-                            if (!sess && message.PcfBinding->ipv6_prefix)
+                                    ogs_assert(true ==
+                                        ogs_sbi_server_send_error(stream,
+                                            OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                            &message, "Invalid IPv4 address",
+                                            message.PcfBinding->ipv4_addr,
+                                            NULL));
+                                    goto cleanup;
+                                }
+                            }
+                            if (!sess && message.PcfBinding->ipv6_prefix) {
                                 sess = bsf_sess_find_by_ipv6prefix(
+                                            message.PcfBinding->ipv6_prefix,
+                                            &invalid);
+                                if (invalid) {
+                                    ogs_error("Invalid IPv6 prefix [%s]",
                                             message.PcfBinding->ipv6_prefix);
+                                    ogs_assert(true ==
+                                        ogs_sbi_server_send_error(stream,
+                                            OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                            &message, "Invalid IPv6 prefix",
+                                            message.PcfBinding->ipv6_prefix,
+                                            NULL));
+                                    goto cleanup;
+                                }
+                            }
 
                             if (!sess) {
                                 sess = bsf_sess_add_by_ip_address(
                                             message.PcfBinding->ipv4_addr,
                                             message.PcfBinding->ipv6_prefix);
-                                ogs_assert(sess);
+                                if (!sess) {
+                                    ogs_error("Cannot add BSF session");
+                                    ogs_assert(true ==
+                                        ogs_sbi_server_send_error(stream,
+                                            OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                            &message, "Cannot add BSF session",
+                                            NULL, NULL));
+                                    goto cleanup;
+                                }
                             }
                         }
                         break;
                     CASE(OGS_SBI_HTTP_METHOD_GET)
-                        if (message.param.ipv4addr)
+                        if (message.param.ipv4addr) {
                             sess = bsf_sess_find_by_ipv4addr(
+                                        message.param.ipv4addr, &invalid);
+                            if (invalid) {
+                                ogs_error("Invalid IPv4 address [%s]",
                                         message.param.ipv4addr);
-                        if (!sess && message.param.ipv6prefix)
+                                ogs_assert(true ==
+                                    ogs_sbi_server_send_error(stream,
+                                        OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                        &message, "Invalid IPv4 address",
+                                        message.param.ipv4addr, NULL));
+                                goto cleanup;
+                            }
+                        }
+                        if (!sess && message.param.ipv6prefix) {
                             sess = bsf_sess_find_by_ipv6prefix(
+                                        message.param.ipv6prefix, &invalid);
+                            if (invalid) {
+                                ogs_error("Invalid IPv6 prefix [%s]",
                                         message.param.ipv6prefix);
+                                ogs_assert(true ==
+                                    ogs_sbi_server_send_error(stream,
+                                        OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                                        &message, "Invalid IPv6 prefix",
+                                        message.param.ipv6prefix, NULL));
+                                goto cleanup;
+                            }
+                        }
                         break;
                     DEFAULT
                         ogs_error("Invalid HTTP method [%s]", message.h.method);
@@ -204,6 +261,7 @@ void bsf_state_operational(ogs_fsm_t *s, bsf_event_t *e)
         END
 
         /* In lib/sbi/server.c, notify_completed() releases 'request' buffer. */
+cleanup:
         ogs_sbi_message_free(&message);
         break;
 

--- a/src/bsf/context.c
+++ b/src/bsf/context.c
@@ -148,7 +148,12 @@ bsf_sess_t *bsf_sess_add_by_ip_address(
     }
     if (ipv6prefix_string &&
         bsf_sess_set_ipv6prefix(sess, ipv6prefix_string) == false) {
-        ogs_error("bsf_sess_set_ipv6prefix[%s] failed", ipv4addr_string);
+        ogs_error("bsf_sess_set_ipv6prefix[%s] failed", ipv6prefix_string);
+        if (sess->ipv4addr_string) {
+            ogs_hash_set(self.ipv4addr_hash,
+                    &sess->ipv4addr, sizeof(sess->ipv4addr), NULL);
+            ogs_free(sess->ipv4addr_string);
+        }
         ogs_pool_free(&bsf_sess_pool, sess);
         return NULL;
     }
@@ -273,7 +278,10 @@ bool bsf_sess_set_ipv6prefix(bsf_sess_t *sess, char *ipv6prefix_string)
         return false;
     }
 
-    ogs_assert(sess->ipv6prefix.len == OGS_IPV6_128_PREFIX_LEN);
+    if (sess->ipv6prefix.len != OGS_IPV6_128_PREFIX_LEN) {
+        ogs_error("Unsupported IPv6 prefix length [%d]", sess->ipv6prefix.len);
+        return false;
+    }
 
     sess->ipv6prefix_string = ogs_strdup(ipv6prefix_string);
     if (!sess->ipv6prefix_string) {
@@ -313,23 +321,30 @@ bsf_sess_t *bsf_sess_find_by_binding_id(char *binding_id)
     return bsf_sess_find(atoll(binding_id));
 }
 
-bsf_sess_t *bsf_sess_find_by_ipv4addr(char *ipv4addr_string)
+bsf_sess_t *bsf_sess_find_by_ipv4addr(
+        char *ipv4addr_string, bool *invalid)
 {
     uint32_t ipv4addr;
     int rv;
 
     ogs_assert(ipv4addr_string);
 
+    if (invalid)
+        *invalid = false;
+
     rv = ogs_ipv4_from_string(&ipv4addr, ipv4addr_string);
     if (rv != OGS_OK) {
         ogs_error("ogs_ipv4_from_string() failed");
+        if (invalid)
+            *invalid = true;
         return NULL;
     }
 
     return ogs_hash_get(self.ipv4addr_hash, &ipv4addr, sizeof(ipv4addr));
 }
 
-bsf_sess_t *bsf_sess_find_by_ipv6prefix(char *ipv6prefix_string)
+bsf_sess_t *bsf_sess_find_by_ipv6prefix(
+        char *ipv6prefix_string, bool *invalid)
 {
     int rv;
     struct {
@@ -339,11 +354,24 @@ bsf_sess_t *bsf_sess_find_by_ipv6prefix(char *ipv6prefix_string)
 
     ogs_assert(ipv6prefix_string);
 
+    if (invalid)
+        *invalid = false;
+
     rv = ogs_ipv6prefix_from_string(
             ipv6prefix.addr6, &ipv6prefix.len, ipv6prefix_string);
-    ogs_assert(rv == OGS_OK);
+    if (rv != OGS_OK) {
+        ogs_error("ogs_ipv6prefix_from_string() failed");
+        if (invalid)
+            *invalid = true;
+        return NULL;
+    }
 
-    ogs_assert(ipv6prefix.len == OGS_IPV6_128_PREFIX_LEN);
+    if (ipv6prefix.len != OGS_IPV6_128_PREFIX_LEN) {
+        ogs_error("Unsupported IPv6 prefix length [%d]", ipv6prefix.len);
+        if (invalid)
+            *invalid = true;
+        return NULL;
+    }
 
     return ogs_hash_get(self.ipv6prefix_hash,
             &ipv6prefix, (ipv6prefix.len >> 3) + 1);

--- a/src/bsf/context.h
+++ b/src/bsf/context.h
@@ -97,8 +97,10 @@ bool bsf_sess_set_ipv6prefix(bsf_sess_t *sess, char *ipv6prefix);
 bsf_sess_t *bsf_sess_find(uint32_t index);
 bsf_sess_t *bsf_sess_find_by_snssai_and_dnn(ogs_s_nssai_t *s_nssai, char *dnn);
 bsf_sess_t *bsf_sess_find_by_binding_id(char *binding_id);
-bsf_sess_t *bsf_sess_find_by_ipv4addr(char *ipv4addr_string);
-bsf_sess_t *bsf_sess_find_by_ipv6prefix(char *ipv6prefix_string);
+bsf_sess_t *bsf_sess_find_by_ipv4addr(
+        char *ipv4addr_string, bool *invalid);
+bsf_sess_t *bsf_sess_find_by_ipv6prefix(
+        char *ipv6prefix_string, bool *invalid);
 int get_sess_load(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Reject malformed IPv4 addresses and unsupported IPv6 prefixes in Nbsf_Management pcfBindings instead of aborting the BSF process.

Return Bad Request for invalid input, while preserving Not Found for valid but unmatched bindings. Also handle session creation failure without asserting.

Issues #4400 #4401