### PR TITLE
[MME] Add network policy (TS 24.301 9.9.3.52)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,45 @@
+open5gs (2.8.0) unstable; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 23:17:47 +0900
+
+open5gs (2.8.0~resolute) resolute; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 23:13:49 +0900
+
+open5gs (2.8.0~questing) questing; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 23:11:19 +0900
+
+open5gs (2.8.0~noble) noble; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 23:06:00 +0900
+
+open5gs (2.8.0~jammy) jammy; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 23:02:46 +0900
+
+open5gs (2.8.0~focal) focal; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 22:59:14 +0900
+
+open5gs (2.8.0~bionic) bionic; urgency=medium
+
+  * Upgrade to Release-19
+
+ -- Sukchan Lee <acetcom@gmail.com>  Wed, 17 Jun 2026 22:48:53 +0900
+
 open5gs (2.7.7) unstable; urgency=medium
 
   * Bug Fixed

--- a/docs/assets/webui/install
+++ b/docs/assets/webui/install
@@ -10,7 +10,7 @@
 #
 
 PACKAGE="open5gs"
-VERSION="2.7.7"
+VERSION="2.8.0"
 
 print_status() {
     echo

--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -259,6 +259,9 @@ int ogs_app_parse_global_conf(ogs_yaml_iter_t *parent)
                 } else if (!strcmp(parameter_key, "no_ims")) {
                     global_conf.parameter.no_ims =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(parameter_key, "no_network_policy")) {
+                    global_conf.parameter.no_network_policy =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else if (!strcmp(parameter_key,
                             "no_ipv4v6_local_addr_in_packet_filter")) {
                     global_conf.parameter.

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -71,6 +71,7 @@ typedef struct ogs_global_conf_s {
         int use_openair;
         int fake_csfb;
         int no_ims;
+        int no_network_policy;
         int use_upg_vpp;
         int no_ipv4v6_local_addr_in_packet_filter;
 

--- a/lib/asn1c/ngap/meson.build
+++ b/lib/asn1c/ngap/meson.build
@@ -1326,12 +1326,59 @@ libasn1c_ngap_sources = files('''
 
 libasn1c_ngap_inc = include_directories('.')
 
+# The generated NGAP ASN.1 code has a very large number of source
+# files. Linking all of the resulting object files in a single command can
+# exceed the system's maximum command-line length (ARG_MAX), which makes the
+# build fail with "ninja: fatal: posix_spawn: Argument list too long" on some
+# builders (e.g. Launchpad/focal).
+#
+# To avoid this, the sources are split into fixed-size groups, each built as
+# an intermediate static library, which are then combined into the final
+# shared library with link_whole. Using a fixed chunk size (rather than a
+# fixed number of chunks) keeps each archive command-line bounded even as
+# more files are added over time, while link_whole preserves every symbol in
+# the resulting library.
+
+libasn1c_ngap_chunk_size = 400
+
+libasn1c_ngap_static_libs = []
+libasn1c_ngap_chunk_sources = []
+libasn1c_ngap_chunk_index = 0
+
+foreach source : libasn1c_ngap_sources
+    libasn1c_ngap_chunk_sources += [source]
+
+    if libasn1c_ngap_chunk_sources.length() == libasn1c_ngap_chunk_size
+        libasn1c_ngap_static_libs += [static_library(
+            'ogsasn1c-ngap-@0@'.format(libasn1c_ngap_chunk_index),
+            sources : libasn1c_ngap_chunk_sources,
+            c_args : libasn1c_common_cc_flags,
+            include_directories : libasn1c_ngap_inc,
+            dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+            pic : true,
+            install : false)]
+
+        libasn1c_ngap_chunk_sources = []
+        libasn1c_ngap_chunk_index += 1
+    endif
+endforeach
+
+if libasn1c_ngap_chunk_sources.length() > 0
+    libasn1c_ngap_static_libs += [static_library(
+        'ogsasn1c-ngap-@0@'.format(libasn1c_ngap_chunk_index),
+        sources : libasn1c_ngap_chunk_sources,
+        c_args : libasn1c_common_cc_flags,
+        include_directories : libasn1c_ngap_inc,
+        dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+        pic : true,
+        install : false)]
+endif
+
 libasn1c_ngap = library('ogsasn1c-ngap',
-    sources : libasn1c_ngap_sources,
     version : libogslib_version,
-    c_args : libasn1c_common_cc_flags,
     include_directories : libasn1c_ngap_inc,
     dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+    link_whole : libasn1c_ngap_static_libs,
     install : true)
 
 libasn1c_ngap_dep = declare_dependency(

--- a/lib/asn1c/s1ap/meson.build
+++ b/lib/asn1c/s1ap/meson.build
@@ -700,12 +700,59 @@ libasn1c_s1ap_sources = files('''
 
 libasn1c_s1ap_inc = include_directories('.')
 
+# The generated S1AP ASN.1 code has a very large number of source
+# files. Linking all of the resulting object files in a single command can
+# exceed the system's maximum command-line length (ARG_MAX), which makes the
+# build fail with "ninja: fatal: posix_spawn: Argument list too long" on some
+# builders (e.g. Launchpad/focal).
+#
+# To avoid this, the sources are split into fixed-size groups, each built as
+# an intermediate static library, which are then combined into the final
+# shared library with link_whole. Using a fixed chunk size (rather than a
+# fixed number of chunks) keeps each archive command-line bounded even as
+# more files are added over time, while link_whole preserves every symbol in
+# the resulting library.
+
+libasn1c_s1ap_chunk_size = 400
+
+libasn1c_s1ap_static_libs = []
+libasn1c_s1ap_chunk_sources = []
+libasn1c_s1ap_chunk_index = 0
+
+foreach source : libasn1c_s1ap_sources
+    libasn1c_s1ap_chunk_sources += [source]
+
+    if libasn1c_s1ap_chunk_sources.length() == libasn1c_s1ap_chunk_size
+        libasn1c_s1ap_static_libs += [static_library(
+            'ogsasn1c-s1ap-@0@'.format(libasn1c_s1ap_chunk_index),
+            sources : libasn1c_s1ap_chunk_sources,
+            c_args : libasn1c_common_cc_flags,
+            include_directories : libasn1c_s1ap_inc,
+            dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+            pic : true,
+            install : false)]
+
+        libasn1c_s1ap_chunk_sources = []
+        libasn1c_s1ap_chunk_index += 1
+    endif
+endforeach
+
+if libasn1c_s1ap_chunk_sources.length() > 0
+    libasn1c_s1ap_static_libs += [static_library(
+        'ogsasn1c-s1ap-@0@'.format(libasn1c_s1ap_chunk_index),
+        sources : libasn1c_s1ap_chunk_sources,
+        c_args : libasn1c_common_cc_flags,
+        include_directories : libasn1c_s1ap_inc,
+        dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+        pic : true,
+        install : false)]
+endif
+
 libasn1c_s1ap = library('ogsasn1c-s1ap',
-    sources : libasn1c_s1ap_sources,
     version : libogslib_version,
-    c_args : libasn1c_common_cc_flags,
     include_directories : libasn1c_s1ap_inc,
     dependencies : [libasn1c_common_dep, libasn1c_util_dep],
+    link_whole : libasn1c_s1ap_static_libs,
     install : true)
 
 libasn1c_s1ap_dep = declare_dependency(

--- a/lib/sbi/openapi/meson.build
+++ b/lib/sbi/openapi/meson.build
@@ -1813,12 +1813,59 @@ if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
     ])
 endif
 
+# The generated OpenAPI model has a very large number of source files
+# (~1,800). Linking all of the resulting object files in a single command
+# can exceed the system's maximum command-line length (ARG_MAX), which
+# makes the build fail with "ninja: fatal: posix_spawn: Argument list too
+# long" on some builders (e.g. Launchpad/focal).
+#
+# To avoid this, the sources are split into fixed-size groups, each built as
+# an intermediate static library, which are then combined into the final
+# shared library with link_whole. Using a fixed chunk size (rather than a
+# fixed number of chunks) keeps each archive command-line bounded even as
+# more model files are added over time, while link_whole preserves every
+# symbol in the resulting library.
+
+libsbi_openapi_chunk_size = 400
+
+libsbi_openapi_static_libs = []
+libsbi_openapi_chunk_sources = []
+libsbi_openapi_chunk_index = 0
+
+foreach source : libsbi_openapi_sources
+    libsbi_openapi_chunk_sources += [source]
+
+    if libsbi_openapi_chunk_sources.length() == libsbi_openapi_chunk_size
+        libsbi_openapi_static_libs += [static_library(
+            'ogssbi-openapi-@0@'.format(libsbi_openapi_chunk_index),
+            sources : libsbi_openapi_chunk_sources,
+            c_args : sbi_openapi_cc_flags,
+            include_directories : [libsbi_openapi_inc, libinc],
+            dependencies : libcore_dep,
+            pic : true,
+            install : false)]
+
+        libsbi_openapi_chunk_sources = []
+        libsbi_openapi_chunk_index += 1
+    endif
+endforeach
+
+if libsbi_openapi_chunk_sources.length() > 0
+    libsbi_openapi_static_libs += [static_library(
+        'ogssbi-openapi-@0@'.format(libsbi_openapi_chunk_index),
+        sources : libsbi_openapi_chunk_sources,
+        c_args : sbi_openapi_cc_flags,
+        include_directories : [libsbi_openapi_inc, libinc],
+        dependencies : libcore_dep,
+        pic : true,
+        install : false)]
+endif
+
 libsbi_openapi = library('ogssbi-openapi',
-    sources : libsbi_openapi_sources,
     version : libogslib_version,
-    c_args : sbi_openapi_cc_flags,
     include_directories : [libsbi_openapi_inc, libinc],
     dependencies : libcore_dep,
+    link_whole : libsbi_openapi_static_libs,
     install : true)
 
 libsbi_openapi_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 project('open5gs', 'c', 'cpp',
-    version : '2.7.7',
+    version : '2.8.0',
     license : 'AGPL-3.0-or-later',
     meson_version : '>= 0.43.0',
     default_options : [
@@ -25,7 +25,7 @@ project('open5gs', 'c', 'cpp',
     ],
 )
 
-libogslib_version = '2.7.7'
+libogslib_version = '2.8.0'
 
 prefix = get_option('prefix')
 bindir = join_paths(prefix, get_option('bindir'))

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -265,6 +265,18 @@ ogs_pkbuf_t *emm_build_attach_accept(
         ogs_debug("    P-TMSI: 0x%08x", tmsi->tmsi);
     }
 
+    attach_accept->presencemask |=
+        OGS_NAS_EPS_ATTACH_ACCEPT_NETWORK_POLICY_PRESENT;
+    attach_accept->network_policy.type =
+            OGS_NAS_EPS_ATTACH_ACCEPT_NETWORK_POLICY_TYPE >> 4;
+    if (ogs_global_conf()->parameter.no_network_policy == true) {
+        attach_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 0;
+    } else {
+        attach_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 1;
+    }
+
     pkbuf = nas_eps_security_encode(mme_ue, &message);
     ogs_pkbuf_free(esmbuf);
 
@@ -693,6 +705,18 @@ ogs_pkbuf_t *emm_build_tau_accept(mme_ue_t *mme_ue)
     }
     tau_accept->eps_network_feature_support.
         extended_protocol_configuration_options = 1;
+
+    tau_accept->presencemask |=
+        OGS_NAS_EPS_TRACKING_AREA_UPDATE_ACCEPT_NETWORK_POLICY_PRESENT;
+    tau_accept->network_policy.type =
+        OGS_NAS_EPS_TRACKING_AREA_UPDATE_ACCEPT_NETWORK_POLICY_TYPE >> 4;
+    if (ogs_global_conf()->parameter.no_network_policy == true) {
+        tau_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 0;
+    } else {
+        tau_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 1;
+    }
 
     return nas_eps_security_encode(mme_ue, &message);
 }

--- a/src/scp/sbi-path.c
+++ b/src/scp/sbi-path.c
@@ -593,6 +593,7 @@ static int request_handler(ogs_sbi_request_t *request, void *data)
                         nnrf_oauth2 = ogs_strndup(v_start, v_end-v_start);
                         break;
                     default:
+                        break;
                     }
                 }
             }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open5gs",
-  "version": "2.7.7",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open5gs",
-      "version": "2.7.7",
+      "version": "2.8.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open5gs",
-  "version": "2.7.7",
+  "version": "2.8.0",
   "description": "Open5gs",
   "main": "index.js",
   "repository": "https://github.com/open5gs/open5gs/webui",


### PR DESCRIPTION
[MME] Add network policy (TS 24.301 9.9.3.52)

This commit adds the network policy IE, part of ATTACH ACCEPT and
TAU ACCEPT messages. This prevents unsecured redirection to GERAN
or UTRAN, protecting the UEs from unsecured redirection attacks.
This IE is mandatory in Rel.19

This patch changes the default behavior!

In case you want to allow unsecured redirects, add the following:

```
global:
  parameter:
    no_network_policy: true
```

to your mme.yaml