### PR TITLE
[AMF] Protect supi/suci_hash from orphan-overwrite on re-attach

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1736,11 +1736,35 @@ void amf_ue_remove(amf_ue_t *amf_ue)
         ogs_assert(amf_m_tmsi_free(amf_ue->next.m_tmsi) == OGS_OK);
     }
     if (amf_ue->suci) {
-        ogs_hash_set(self.suci_hash, amf_ue->suci, strlen(amf_ue->suci), NULL);
+        /*
+         * Only unset the SUCI hash entry if it still refers to THIS amf_ue.
+         * If a fresh registration arrived for the same SUCI before this
+         * removal runs, amf_ue_set_suci() has already overwritten the hash
+         * to point at the new amf_ue.  A blind unset there would orphan
+         * that newer entry, making the SUCI unfindable while the amf_ue
+         * remains in amf_ue_list — observed as the "No UE context [...]"
+         * 404 loop in nsmf-handler.c:96.
+         */
+        void *indexed = ogs_hash_get(self.suci_hash,
+                amf_ue->suci, strlen(amf_ue->suci));
+        if (indexed == amf_ue)
+            ogs_hash_set(self.suci_hash,
+                    amf_ue->suci, strlen(amf_ue->suci), NULL);
+        else
+            ogs_debug("[%s] suci_hash unset skipped — owned by newer amf_ue",
+                    amf_ue->suci);
         ogs_free(amf_ue->suci);
     }
     if (amf_ue->supi) {
-        ogs_hash_set(self.supi_hash, amf_ue->supi, strlen(amf_ue->supi), NULL);
+        /* Same protection for the SUPI index — see SUCI block above. */
+        void *indexed = ogs_hash_get(self.supi_hash,
+                amf_ue->supi, strlen(amf_ue->supi));
+        if (indexed == amf_ue)
+            ogs_hash_set(self.supi_hash,
+                    amf_ue->supi, strlen(amf_ue->supi), NULL);
+        else
+            ogs_debug("[%s] supi_hash unset skipped — owned by newer amf_ue",
+                    amf_ue->supi);
         ogs_free(amf_ue->supi);
     }
 
@@ -2199,7 +2223,15 @@ void amf_ue_set_suci(amf_ue_t *amf_ue,
     }
 
     if (amf_ue->suci) {
-        ogs_hash_set(self.suci_hash, amf_ue->suci, strlen(amf_ue->suci), NULL);
+        /* See amf_ue_remove() for rationale on the indexed-check. */
+        void *indexed = ogs_hash_get(self.suci_hash,
+                amf_ue->suci, strlen(amf_ue->suci));
+        if (indexed == amf_ue)
+            ogs_hash_set(self.suci_hash,
+                    amf_ue->suci, strlen(amf_ue->suci), NULL);
+        else
+            ogs_debug("[%s] suci_hash unset skipped — owned by newer amf_ue",
+                    amf_ue->suci);
         ogs_free(amf_ue->suci);
     }
     amf_ue->suci = suci;
@@ -2211,7 +2243,15 @@ void amf_ue_set_supi(amf_ue_t *amf_ue, char *supi)
     ogs_assert(supi);
 
     if (amf_ue->supi) {
-        ogs_hash_set(self.supi_hash, amf_ue->supi, strlen(amf_ue->supi), NULL);
+        /* See amf_ue_remove() for rationale on the indexed-check. */
+        void *indexed = ogs_hash_get(self.supi_hash,
+                amf_ue->supi, strlen(amf_ue->supi));
+        if (indexed == amf_ue)
+            ogs_hash_set(self.supi_hash,
+                    amf_ue->supi, strlen(amf_ue->supi), NULL);
+        else
+            ogs_debug("[%s] supi_hash unset skipped — owned by newer amf_ue",
+                    amf_ue->supi);
         ogs_free(amf_ue->supi);
     }
     amf_ue->supi = ogs_strdup(supi);


### PR DESCRIPTION
## Summary

`amf_ue_remove()`, `amf_ue_set_supi()` and `amf_ue_set_suci()` unset
their respective hash entries unconditionally before freeing the
keys.  When a UE re-attaches with the same SUPI/SUCI while an older
`amf_ue` context is still being torn down, this can wipe out a hash
entry that has meanwhile been re-claimed by a fresh `amf_ue`, making
the live UE unfindable through `amf_ue_find_by_supi()` and producing
a 404-on-N1N2MessageTransfer loop with cascading SMF session
release / UE re-attach / IP-pool burnout.

This is the AMF-side analogue of the SUPI/IMSI re-index race that
commit `eeeef3d1b` ("smf: unify IMSI and SUPI UE indexes") already
defends against on the SMF side.

## Race condition

```
T0  UE-X attaches fresh
    amf_ue id=20 created
    amf_ue_set_supi() sets supi_hash["imsi-X"] = id20

T1  UE-X drops RRC and immediately re-registers via fresh SUCI

T2  amf_ue id=31 created for the new attach
    amf_ue_set_suci() detects old_amf_ue=id20, dispatches
    amf_sbi_send_release_all_sessions(new_ran_ue, id20, NO_STATE)
    amf_ue_remove(id20) is deferred until xact_count drops to 0
    amf_ue_set_supi(id31, "imsi-X") sets supi_hash["imsi-X"] = id31

T3  SBI release-completion fires the deferred amf_ue_remove(id20)
    Old code: ogs_hash_set(supi_hash, "imsi-X", NULL) unconditionally
    → wipes the entry that now belongs to id=31

T4  SMF -> AMF Nsmf_PDUSession N1N2MessageTransfer for UE-X
    amf_ue_find_by_supi("imsi-X") returns NULL
    AMF responds with 404
    SMF releases the "stranded" session
    UE retries, cascade repeats
```

## Fix

Before unsetting `supi_hash[key]` / `suci_hash[key]`, look up the
entry and verify it still points at the `amf_ue` being torn down.
If a fresher context has taken ownership, leave the hash alone and
emit an `ogs_debug()` trace.

Four hunks, `src/amf/context.c` only:

  - `amf_ue_remove()` SUCI (line ~1739)
  - `amf_ue_remove()` SUPI (line ~1743)
  - `amf_ue_set_suci()` (line ~2202)
  - `amf_ue_set_supi()` (line ~2214)

Net change: +44 / -4 lines.  No behavioural change for single-context
UE flows.  `ogs_assert()`s are preserved.

## Field evidence

The bug was observed on a 5GC running v2.7.7 with organic UE traffic
(e.g., a commercial 5G smartphone on a standard internet DNN, and a
tablet on a management DNN).  Both UEs went into the cycle after
their gNB-UE associations flapped through RRC-IDLE drops, and stayed
stuck for ~27 minutes — repeatedly consuming fresh IPs out of the
SMF address pool, with `[amf] ERROR: No UE context [imsi-…]` matching
`[smf] ERROR: HTTP response error [404]` every ~17 seconds.

Recovery without this patch required restarting the AMF or otherwise
forcing the orphan and live `amf_ue_t` contexts out of band.  After
applying this patch the cycle cannot start because the live hash
entry is not overwritten.

This also resolves the AMF-side hash corruption that contributed to
the zombie contexts observed during the #4427 field investigations.

## Relation to `eeeef3d1b`

The SMF fix in `eeeef3d1b` chose to model identity-mismatch as an
`ogs_fatal` invariant.  This AMF patch deliberately stays defensive
(skip-and-log rather than assert) because the AMF still has multiple
in-flight paths that can legitimately race the same SUPI/SUCI
(SUCI re-attach with deferred SBI release, gNB UE Context Release,
mobile-reachable timer, deregistration request) and a hard abort
would amplify the original bug into a daemon crash.

The shape of the protection — pointer-check before hash unset — is
identical to the cross-UE orphan-cleanup pattern.  If preferred,
I'm happy to refactor to mirror `eeeef3d1b`'s identity-setter style
(`amf_ue_set_supi_internal()` with mismatch/already-indexed as
fatals) in a follow-up.

## Testing

  - meson build clean on debian-stable, no new warnings.
  - Patch deployed on a live 5GC handling roughly a dozen 5G UEs;
    no regressions in normal attach / data path / handover after
    several hours of UE traffic.
  - Reproducer: trigger the race by toggling flight-mode on a 5G
    handset twice in quick succession while it has at least one
    active PDU session.  Pre-fix: duplicate `amf_ue_t` entries in
    `/ue-info`, recurring 404 loop in the journal.  Post-fix:
    single `amf_ue_t` entry, occasional `ogs_debug` trace when
    the skip fires, no 404 loop.
