### PR TITLE
smf: avoid empty PFCP modification for unmatched NGAP QFI

### DIFF
--- a/src/smf/ngap-handler.c
+++ b/src/smf/ngap-handler.c
@@ -34,6 +34,7 @@ int ngap_handle_pdu_session_resource_setup_response_transfer(
     ogs_ip_t remote_dl_ip;
 
     bool far_update = false;
+    int num_of_qos_flow_modified = 0;
 
     NGAP_PDUSessionResourceSetupResponseTransfer_t message;
 
@@ -119,9 +120,15 @@ int ngap_handle_pdu_session_resource_setup_response_transfer(
         sess->remote_dl_teid != remote_dl_teid)
         far_update = true;
 
-    /* Setup FAR */
-    memcpy(&sess->remote_dl_ip, &remote_dl_ip, sizeof(sess->remote_dl_ip));
-    sess->remote_dl_teid = remote_dl_teid;
+    /*
+     * Do NOT commit sess->remote_dl_ip/teid here.
+     * They are committed below, atomically with the PFCP Session
+     * Modification Request, only after we confirm at least one
+     * matching qos_flow exists. Otherwise an incomplete or stale
+     * PDUSessionResourceSetupResponseTransfer would leave SMF
+     * pointing at a new endpoint that UPF never learned about.
+     * See issue #4413.
+     */
 
     if (HOME_ROUTED_ROAMING_IN_VSMF(sess)) {
         ogs_list_for_each(&sess->bearer_list, qos_flow) {
@@ -134,10 +141,11 @@ int ngap_handle_pdu_session_resource_setup_response_transfer(
             dl_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
             ogs_assert(OGS_OK ==
                 ogs_pfcp_ip_to_outer_header_creation(
-                        &sess->remote_dl_ip,
+                        &remote_dl_ip,
                         &dl_far->outer_header_creation,
                         &dl_far->outer_header_creation_len));
-            dl_far->outer_header_creation.teid = sess->remote_dl_teid;
+            dl_far->outer_header_creation.teid = remote_dl_teid;
+            num_of_qos_flow_modified++;
         }
     } else {
         associatedQosFlowList =
@@ -161,17 +169,40 @@ int ngap_handle_pdu_session_resource_setup_response_transfer(
                     dl_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
                     ogs_assert(OGS_OK ==
                         ogs_pfcp_ip_to_outer_header_creation(
-                                &sess->remote_dl_ip,
+                                &remote_dl_ip,
                                 &dl_far->outer_header_creation,
                                 &dl_far->outer_header_creation_len));
-                    dl_far->outer_header_creation.teid = sess->remote_dl_teid;
+                    dl_far->outer_header_creation.teid = remote_dl_teid;
+                    num_of_qos_flow_modified++;
                 }
             }
         }
     }
 
+    /*
+     * Guard: if the session-level remote DL endpoint changed but no
+     * per-flow FAR was actually touched (e.g. AssociatedQosFlowList
+     * references QFIs that match no qos_flow in sess->bearer_list),
+     * sending a PFCP Session Modification Request would build an
+     * empty modify list and abort smf_n4_build_pdr_to_modify_list().
+     * Bail out without mutating sess state. See issue #4413.
+     */
+    if (far_update && num_of_qos_flow_modified == 0) {
+        ogs_error("[%s:%d] No matching QoS flow to modify - "
+                "skipping PFCP Session Modification",
+                smf_ue->supi, sess->psi);
+        smf_sbi_send_sm_context_update_error_log(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                "No matching QoS flow", smf_ue->supi);
+        goto cleanup;
+    }
+
     if (far_update) {
         uint64_t pfcp_flags = OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_ACTIVATE;
+
+        /* Atomically commit session state with the PFCP send below. */
+        memcpy(&sess->remote_dl_ip, &remote_dl_ip, sizeof(sess->remote_dl_ip));
+        sess->remote_dl_teid = remote_dl_teid;
     /*
      * UE-requested PDU Session Modification(ACTIVATED)
      *
@@ -512,6 +543,7 @@ int ngap_handle_path_switch_request_transfer(
     ogs_ip_t remote_dl_ip;
 
     bool far_update = false;
+    int num_of_qos_flow_modified = 0;
 
     NGAP_PathSwitchRequestTransfer_t message;
 
@@ -588,9 +620,7 @@ int ngap_handle_path_switch_request_transfer(
         sess->remote_dl_teid != remote_dl_teid)
         far_update = true;
 
-    /* Setup FAR */
-    memcpy(&sess->remote_dl_ip, &remote_dl_ip, sizeof(sess->remote_dl_ip));
-    sess->remote_dl_teid = remote_dl_teid;
+    /* sess->remote_dl_ip/teid are committed atomically below, see #4413 */
 
     if (HOME_ROUTED_ROAMING_IN_VSMF(sess)) {
         ogs_list_for_each(&sess->bearer_list, qos_flow) {
@@ -603,10 +633,11 @@ int ngap_handle_path_switch_request_transfer(
             dl_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
             ogs_assert(OGS_OK ==
                 ogs_pfcp_ip_to_outer_header_creation(
-                        &sess->remote_dl_ip,
+                        &remote_dl_ip,
                         &dl_far->outer_header_creation,
                         &dl_far->outer_header_creation_len));
-            dl_far->outer_header_creation.teid = sess->remote_dl_teid;
+            dl_far->outer_header_creation.teid = remote_dl_teid;
+            num_of_qos_flow_modified++;
         }
     } else {
         qosFlowAcceptedList = &message.qosFlowAcceptedList;
@@ -627,19 +658,35 @@ int ngap_handle_path_switch_request_transfer(
                     dl_far->apply_action = OGS_PFCP_APPLY_ACTION_FORW;
                     ogs_assert(OGS_OK ==
                         ogs_pfcp_ip_to_outer_header_creation(
-                            &sess->remote_dl_ip,
+                            &remote_dl_ip,
                             &dl_far->outer_header_creation,
                             &dl_far->outer_header_creation_len));
-                    dl_far->outer_header_creation.teid = sess->remote_dl_teid;
+                    dl_far->outer_header_creation.teid = remote_dl_teid;
+                    num_of_qos_flow_modified++;
                 }
             }
         }
+    }
+
+    /* See issue #4413 - same guard as in setup_response_transfer */
+    if (far_update && num_of_qos_flow_modified == 0) {
+        ogs_error("[%s:%d] No matching QoS flow to modify - "
+                "skipping PFCP Session Modification",
+                smf_ue->supi, sess->psi);
+        smf_sbi_send_sm_context_update_error_log(
+                stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+                "No matching QoS flow", smf_ue->supi);
+        goto cleanup;
     }
 
     if (far_update) {
         uint64_t pfcp_flags =
             OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_ACTIVATE|
             OGS_PFCP_MODIFY_XN_HANDOVER|OGS_PFCP_MODIFY_END_MARKER;
+
+        /* Atomically commit session state with the PFCP send below. */
+        memcpy(&sess->remote_dl_ip, &remote_dl_ip, sizeof(sess->remote_dl_ip));
+        sess->remote_dl_teid = remote_dl_teid;
 
         if (HOME_ROUTED_ROAMING_IN_VSMF(sess)) {
             pfcp_flags |= OGS_PFCP_MODIFY_HOME_ROUTED_ROAMING;

--- a/tests/registration/crash-test.c
+++ b/tests/registration/crash-test.c
@@ -1457,6 +1457,259 @@ static void test6_issues4087_func(abts_case *tc, void *data)
     testgnb_ngap_close(ngap);
 }
 
+static void test7_issues4413_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *ngap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *gmmbuf;
+    ogs_pkbuf_t *gsmbuf;
+    ogs_pkbuf_t *nasbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+    uint8_t saved_qfi;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "0000203190");
+    ogs_assert(test_ue);
+
+    test_ue->nr_cgi.cell_id = 0x40001;
+
+    test_ue->nas.registration.tsc = 0;
+    test_ue->nas.registration.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.registration.follow_on_request = 1;
+    test_ue->nas.registration.value = OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    /* gNB connects to AMF */
+    ngap = testngap_client(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, ngap);
+
+    /* gNB connects to UPF */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send NG-Setup Request */
+    sendbuf = testngap_build_ng_setup_request(0x4000, 22);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive NG-Setup Response */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Registration request */
+    test_ue->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    test_ue->registration_request_param.gmm_capability = 1;
+    test_ue->registration_request_param.s1_ue_network_capability = 1;
+    test_ue->registration_request_param.requested_nssai = 1;
+    test_ue->registration_request_param.last_visited_registered_tai = 1;
+    test_ue->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Identity request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Identity response */
+    gmmbuf = testgmm_build_identity_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    gmmbuf = testgmm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    gmmbuf = testgmm_build_security_mode_complete(test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send UERadioCapabilityInfoIndication */
+    sendbuf = testngap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send PDU session establishment request */
+    sess = test_sess_add_by_dnn_and_psi(test_ue, "internet", 5);
+    ogs_assert(sess);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 0;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive PDUSessionResourceSetupRequest +
+     * DL NAS transport +
+     * PDU session establishment accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            test_ue->ngap_procedure_code);
+
+    /*
+     * Corrupt the QFI in the response so AssociatedQosFlowList
+     * references a QoS Flow that does not exist in the SMF session.
+     *
+     * Without the patch in src/smf/ngap-handler.c, SMF reaches
+     * smf_5gc_pfcp_send_all_pdr_modification_request() with no actual
+     * dl_far modifications and aborts in
+     * smf_n4_build_pdr_to_modify_list() (n4-build.c:337).
+     *
+     * With the patch, SMF rejects the transfer with HTTP 400 and the
+     * subsequent UEContextRelease flow below completes normally,
+     * proving SMF stayed alive.
+     */
+    qos_flow = test_qos_flow_find_by_qfi(sess, 1);
+    ogs_assert(qos_flow);
+    saved_qfi = qos_flow->qfi;
+    qos_flow->qfi = 99;
+
+    /* Send PDUSessionResourceSetupResponse with unmatched QFI */
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    qos_flow->qfi = saved_qfi;
+
+    ogs_msleep(300);
+
+    /* Send UEContextReleaseRequest - if SMF crashed, this never completes */
+    sendbuf = testngap_build_ue_context_release_request(test_ue,
+            NGAP_Cause_PR_radioNetwork, NGAP_CauseRadioNetwork_user_inactivity,
+            true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    testgnb_gtpu_close(gtpu);
+    testgnb_ngap_close(ngap);
+
+    test_ue_remove(test_ue);
+}
+
 abts_suite *test_crash(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -1467,6 +1720,7 @@ abts_suite *test_crash(abts_suite *suite)
     abts_run_test(suite, test4_issues2842_func, NULL);
     abts_run_test(suite, test5_func, NULL);
     abts_run_test(suite, test6_issues4087_func, NULL);
+    abts_run_test(suite, test7_issues4413_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
Do not commit the session remote DL tunnel before confirming that at least one DL FAR is updated.

PDUSessionResourceSetupResponseTransfer and PathSwitchRequestTransfer update FARs only for QoS flows referenced by the received NGAP QoS flow list. If the remote DL IP or TEID changes but none of the listed QFIs matches a local QoS flow, far_update can be set without any actual FAR/PDR change and the SMF can reach the PFCP modification builder with nothing to modify.

Use the received remote DL tunnel directly while updating FARs, count the number of updated DL FARs, and reject the update if a PFCP modification would otherwise be sent with no FAR updated. Commit sess->remote_dl_ip/teid only after confirming that at least one DL FAR was updated.

Issues #4413