### PR TITLE
amf: refactor NRF discovery failure handling

### DIFF
--- a/src/amf/amf-sm.c
+++ b/src/amf/amf-sm.c
@@ -64,7 +64,6 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
     amf_ue_t *amf_ue = NULL;
     amf_sess_t *sess = NULL;
 
-    ogs_sbi_object_t *sbi_object = NULL;
     ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
     ogs_sbi_xact_t *sbi_xact = NULL;
     ogs_pool_id_t sbi_xact_id = OGS_INVALID_POOL_ID;
@@ -73,15 +72,12 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
     ogs_sbi_stream_t *stream = NULL;
     ogs_pool_id_t stream_id = OGS_INVALID_POOL_ID;
     ogs_sbi_request_t *sbi_request = NULL;
-    ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
 
     ogs_sbi_nf_instance_t *nf_instance = NULL;
     ogs_sbi_subscription_data_t *subscription_data = NULL;
     ogs_sbi_response_t *sbi_response = NULL;
     ogs_sbi_message_t sbi_message;
 
-    OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
-    ogs_sbi_discovery_option_t *discovery_option = NULL;
 
     amf_sm_debug(e);
 
@@ -799,145 +795,7 @@ void amf_state_operational(ogs_fsm_t *s, amf_event_t *e)
                 break;
             }
 
-            sbi_object = sbi_xact->sbi_object;
-            ogs_assert(sbi_object);
-
-            sbi_object_id = sbi_xact->sbi_object_id;
-            ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
-                    sbi_object_id <= OGS_MAX_POOL_ID);
-
-            if (sbi_xact->user_data) {
-                amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
-
-                if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
-                    ran_ue_id = ctx->ran_ue_id;
-            }
-
-            service_type = sbi_xact->service_type;
-            requester_nf_type = sbi_xact->requester_nf_type;
-            discovery_option = sbi_xact->discovery_option;
-
-            ogs_sbi_xact_remove(sbi_xact);
-
-            ogs_assert(sbi_object->type > OGS_SBI_OBJ_BASE &&
-                        sbi_object->type < OGS_SBI_OBJ_TOP);
-
-            switch(sbi_object->type) {
-            case OGS_SBI_OBJ_UE_TYPE:
-                amf_ue = amf_ue_find_by_id(sbi_object_id);
-                if (!amf_ue) {
-                    ogs_error("UE(amf_ue) Context has already been removed");
-                    break;
-                }
-
-                ogs_error("[%s:%s] Cannot receive SBI message "
-                        "[type:%d,value:%d]", amf_ue->supi, amf_ue->suci,
-                        amf_ue->nas.message_type,
-                        amf_ue->nas.registration.value);
-
-                /*
-                * TS 23.502
-                * 4.2.2.2.2 General Registration
-                * If the SUCI is not provided by the UE nor retrieved from the old AMF the Identity Request
-                * procedure is initiated by AMF sending an Identity Request message to the UE requesting the SUCI.
-                */
-
-                if (amf_ue->nas.message_type == OGS_NAS_5GS_REGISTRATION_REQUEST &&
-                        amf_ue->nas.registration.value == OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL &&
-                        requester_nf_type == OpenAPI_nf_type_AMF &&
-                        discovery_option->guami_presence) {
-
-                    amf_ue->amf_ue_context_transfer_state =
-                            UE_CONTEXT_INITIAL_STATE;
-
-                    if (!(AMF_UE_HAVE_SUCI(amf_ue) ||
-                            AMF_UE_HAVE_SUPI(amf_ue))) {
-                            CLEAR_AMF_UE_TIMER(amf_ue->t3570);
-                        rv = nas_5gs_send_identity_request(amf_ue);
-                        ogs_expect(rv == OGS_OK);
-                        ogs_assert(rv != OGS_ERROR);
-
-                        break;
-                    }
-                } else if (amf_ue->nas.message_type ==
-                        OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE) {
-                    ogs_error("T3522 expired");
-                    break;
-                }
-
-                r = nas_5gs_send_gmm_reject_from_sbi(amf_ue,
-                        OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT);
-                ogs_expect(r == OGS_OK);
-                ogs_assert(r != OGS_ERROR);
-                break;
-
-            case OGS_SBI_OBJ_SESS_TYPE:
-                sess = amf_sess_find_by_id(sbi_object_id);
-                if (!sess) {
-                    ogs_error("Session has already been removed");
-                    break;
-                }
-
-                amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
-                if (!amf_ue) {
-                    ogs_error("UE(amf_ue) Context has already been removed");
-                    break;
-                }
-
-                ogs_error("[%s:%s:%d:%d] Cannot receive SBI message",
-                        amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
-
-                if (ran_ue_id < OGS_MIN_POOL_ID ||
-                    ran_ue_id > OGS_MAX_POOL_ID) {
-                    ogs_error("No assoc RAN-UE id [%d]", ran_ue_id);
-                    break;
-                }
-
-                ran_ue = ran_ue_find_by_id(ran_ue_id);
-                if (!ran_ue) {
-                    ogs_error("[%s:%s:%d:%d] "
-                            "NG Context has already been removed",
-                            amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
-                    break;
-                }
-
-                if (ran_ue->amf_ue_id == OGS_INVALID_POOL_ID) {
-                    ogs_error("[%s:%s:%d:%d] "
-                            "RAN-UE has already been deassociated",
-                            amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
-                    break;
-                }
-
-                if (amf_ue->id != ran_ue->amf_ue_id) {
-                    ogs_error("[%s:%s:%d:%d] AMF-UE mismatched [%d!=%d]",
-                            amf_ue->supi, amf_ue->suci, sess->psi, sess->pti,
-                            amf_ue->id, ran_ue->amf_ue_id);
-                    break;
-                }
-
-                if (sess->payload_container_type) {
-                    r = nas_5gs_send_back_gsm_message(
-                            ran_ue, sess,
-                            OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
-                            AMF_NAS_BACKOFF_TIME);
-                    ogs_expect(r == OGS_OK);
-                    ogs_assert(r != OGS_ERROR);
-                } else {
-                    r = ngap_send_error_indication2(
-                            ran_ue,
-                            NGAP_Cause_PR_transport,
-                            NGAP_CauseTransport_transport_resource_unavailable);
-                    ogs_expect(r == OGS_OK);
-                    ogs_assert(r != OGS_ERROR);
-                }
-                break;
-
-            default:
-                ogs_fatal("Not implemented [%s:%d]",
-                    ogs_sbi_service_type_to_name(service_type),
-                    sbi_object->type);
-                ogs_assert_if_reached();
-            }
+            amf_nnrf_handle_failed_amf_discovery(sbi_xact);
             break;
 
         default:

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -22,6 +22,100 @@
 #include "ngap-path.h"
 #include "nnrf-handler.h"
 
+
+static bool amf_nnrf_try_old_amf_discovery_fallback(
+        amf_ue_t *amf_ue, OpenAPI_nf_type_e requester_nf_type,
+        ogs_sbi_discovery_option_t *discovery_option)
+{
+    int r;
+
+    ogs_assert(amf_ue);
+
+    /*
+     * TS 23.502
+     * 4.2.2.2.2 General Registration
+     * If the SUCI is not provided by the UE nor retrieved from the old AMF,
+     * the Identity Request procedure is initiated by AMF sending an Identity
+     * Request message to the UE requesting the SUCI.
+     */
+    if (amf_ue->nas.message_type != OGS_NAS_5GS_REGISTRATION_REQUEST ||
+            amf_ue->nas.registration.value !=
+                OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL ||
+            requester_nf_type != OpenAPI_nf_type_AMF ||
+            !discovery_option || !discovery_option->guami_presence)
+        return false;
+
+    /*
+     * Returns true only when Identity Request is sent.
+     * The context transfer state is reset even if SUCI/SUPI already exists,
+     * matching the original old-AMF discovery fallback behavior.
+     */
+    amf_ue->amf_ue_context_transfer_state = UE_CONTEXT_INITIAL_STATE;
+
+    if (AMF_UE_HAVE_SUCI(amf_ue) || AMF_UE_HAVE_SUPI(amf_ue))
+        return false;
+
+    CLEAR_AMF_UE_TIMER(amf_ue->t3570);
+    r = nas_5gs_send_identity_request(amf_ue);
+    ogs_expect(r == OGS_OK);
+    ogs_assert(r != OGS_ERROR);
+
+    return true;
+}
+
+static void amf_nnrf_send_session_failure_to_ran(
+        amf_ue_t *amf_ue, amf_sess_t *sess, ogs_pool_id_t ran_ue_id)
+{
+    int r;
+    ran_ue_t *ran_ue = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(sess);
+
+    if (ran_ue_id < OGS_MIN_POOL_ID || ran_ue_id > OGS_MAX_POOL_ID) {
+        ogs_error("[%s:%s:%d:%d] No assoc RAN-UE id [%d]",
+                amf_ue->supi, amf_ue->suci, sess->psi, sess->pti,
+                (int)ran_ue_id);
+        return;
+    }
+
+    ran_ue = ran_ue_find_by_id(ran_ue_id);
+    if (!ran_ue) {
+        ogs_error("[%s:%s:%d:%d] NG Context has already been removed",
+                amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
+        return;
+    }
+
+    if (ran_ue->amf_ue_id == OGS_INVALID_POOL_ID) {
+        ogs_error("[%s:%s:%d:%d] RAN-UE has already been deassociated",
+                amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
+        return;
+    }
+
+    if (amf_ue->id != ran_ue->amf_ue_id) {
+        ogs_error("[%s:%s:%d:%d] AMF-UE mismatched [%d!=%d]",
+                amf_ue->supi, amf_ue->suci, sess->psi, sess->pti,
+                amf_ue->id, ran_ue->amf_ue_id);
+        return;
+    }
+
+    if (sess->payload_container_type) {
+        r = nas_5gs_send_back_gsm_message(
+                ran_ue, sess,
+                OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
+                AMF_NAS_BACKOFF_TIME);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    } else {
+        r = ngap_send_error_indication2(
+                ran_ue,
+                NGAP_Cause_PR_transport,
+                NGAP_CauseTransport_transport_resource_unavailable);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+    }
+}
+
 void amf_nnrf_handle_nf_discover(
         ogs_sbi_xact_t *xact, ogs_sbi_message_t *recvmsg)
 {
@@ -36,7 +130,6 @@ void amf_nnrf_handle_nf_discover(
     ogs_sbi_discovery_option_t *discovery_option = NULL;
 
     amf_ue_t *amf_ue = NULL;
-    ran_ue_t *ran_ue = NULL;
     amf_sess_t *sess = NULL;
 
     ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
@@ -103,34 +196,18 @@ void amf_nnrf_handle_nf_discover(
 
         switch(sbi_object->type) {
         case OGS_SBI_OBJ_UE_TYPE:
-            amf_ue = (amf_ue_t *)sbi_object;
-            ogs_assert(amf_ue);
             ogs_warn("[%s] (NF discover) No [%s]", amf_ue->suci,
                         ogs_sbi_service_type_to_name(service_type));
 
-            /*
-            * TS 23.502
-            * 4.2.2.2.2 General Registration
-            * If the SUCI is not provided by the UE nor retrieved from the old AMF the Identity Request
-            * procedure is initiated by AMF sending an Identity Request message to the UE requesting the SUCI.
-            */
+            if (amf_nnrf_try_old_amf_discovery_fallback(
+                    amf_ue, requester_nf_type, discovery_option))
+                break;
 
-            if (amf_ue->nas.message_type == OGS_NAS_5GS_REGISTRATION_REQUEST &&
-                    amf_ue->nas.registration.value == OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL &&
-                    requester_nf_type == OpenAPI_nf_type_AMF &&
-                    discovery_option->guami_presence) {
-
-                amf_ue->amf_ue_context_transfer_state =
-                        UE_CONTEXT_INITIAL_STATE;
-
-                if (!(AMF_UE_HAVE_SUCI(amf_ue) ||
-                        AMF_UE_HAVE_SUPI(amf_ue))) {
-                    CLEAR_AMF_UE_TIMER(amf_ue->t3570);
-                    r = nas_5gs_send_identity_request(amf_ue);
-                    ogs_expect(r == OGS_OK);
-                    ogs_assert(r != OGS_ERROR);
-                    break;
-                }
+            if (amf_ue->nas.message_type ==
+                    OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE) {
+                ogs_error("[%s:%s] Deregistration request failed",
+                        amf_ue->supi, amf_ue->suci);
+                break;
             }
 
             r = nas_5gs_send_gmm_reject_from_sbi(amf_ue,
@@ -139,34 +216,10 @@ void amf_nnrf_handle_nf_discover(
             ogs_assert(r != OGS_ERROR);
             break;
         case OGS_SBI_OBJ_SESS_TYPE:
-            ogs_error("[%d:%d] (NF discover) No [%s]", sess->psi, sess->pti,
+            ogs_warn("[%d:%d] (NF discover) No [%s]", sess->psi, sess->pti,
                         ogs_sbi_service_type_to_name(service_type));
 
-            if (ran_ue_id >= OGS_MIN_POOL_ID &&
-                    ran_ue_id <= OGS_MAX_POOL_ID)
-                ran_ue = ran_ue_find_by_id(ran_ue_id);
-
-            if (!ran_ue) {
-                ogs_warn("[%s:%s:%d:%d] NG Context has already been removed",
-                        amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
-                break;
-            }
-
-            if (sess->payload_container_type) {
-                r = nas_5gs_send_back_gsm_message(
-                        ran_ue, sess,
-                        OGS_5GMM_CAUSE_PAYLOAD_WAS_NOT_FORWARDED,
-                        AMF_NAS_BACKOFF_TIME);
-                ogs_expect(r == OGS_OK);
-                ogs_assert(r != OGS_ERROR);
-            } else {
-                r = ngap_send_error_indication2(
-                        ran_ue,
-                        NGAP_Cause_PR_transport,
-                        NGAP_CauseTransport_transport_resource_unavailable);
-                ogs_expect(r == OGS_OK);
-                ogs_assert(r != OGS_ERROR);
-            }
+            amf_nnrf_send_session_failure_to_ran(amf_ue, sess, ran_ue_id);
             break;
         default:
             ogs_fatal("(NF discover) Not implemented [%s:%d]",
@@ -192,7 +245,11 @@ void amf_nnrf_handle_failed_amf_discovery(
     ogs_sbi_discovery_option_t *discovery_option = NULL;
     ogs_sbi_service_type_e service_type = OGS_SBI_SERVICE_TYPE_NULL;
     ogs_sbi_object_t *sbi_object = NULL;
+    ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
+    ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
+
     amf_ue_t *amf_ue = NULL;
+    amf_sess_t *sess = NULL;
 
     ogs_assert(sbi_xact);
     sbi_object = sbi_xact->sbi_object;
@@ -202,42 +259,76 @@ void amf_nnrf_handle_failed_amf_discovery(
     requester_nf_type = sbi_xact->requester_nf_type;
     ogs_assert(requester_nf_type);
 
+    sbi_object_id = sbi_xact->sbi_object_id;
+    ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
+            sbi_object_id <= OGS_MAX_POOL_ID);
+
     discovery_option = sbi_xact->discovery_option;
+
+    if (sbi_xact->user_data) {
+        amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
+
+        if (ctx->ran_ue_id != OGS_INVALID_POOL_ID)
+            ran_ue_id = ctx->ran_ue_id;
+    }
 
     ogs_assert(sbi_object->type > OGS_SBI_OBJ_BASE &&
                 sbi_object->type < OGS_SBI_OBJ_TOP);
 
     ogs_sbi_xact_remove(sbi_xact);
 
-    if (sbi_object->type == OGS_SBI_OBJ_UE_TYPE) {
-
-        amf_ue = (amf_ue_t *)sbi_object;
-        ogs_assert(amf_ue);
-
-        /*
-        * TS 23.502
-        * 4.2.2.2.2 General Registration
-        * If the SUCI is not provided by the UE nor retrieved from the old AMF the Identity Request
-        * procedure is initiated by AMF sending an Identity Request message to the UE requesting the SUCI.
-        */
-
-        if (amf_ue->nas.message_type == OGS_NAS_5GS_REGISTRATION_REQUEST &&
-                amf_ue->nas.registration.value == OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL &&
-                requester_nf_type == OpenAPI_nf_type_AMF &&
-                discovery_option->guami_presence) {
-
-            amf_ue->amf_ue_context_transfer_state =
-                    UE_CONTEXT_INITIAL_STATE;
-
-            if (!(AMF_UE_HAVE_SUCI(amf_ue) ||
-                    AMF_UE_HAVE_SUPI(amf_ue))) {
-                CLEAR_AMF_UE_TIMER(amf_ue->t3570);
-                r = nas_5gs_send_identity_request(amf_ue);
-                ogs_expect(r == OGS_OK);
-                ogs_assert(r != OGS_ERROR);
-            }
+    switch(sbi_object->type) {
+    case OGS_SBI_OBJ_UE_TYPE:
+        amf_ue = amf_ue_find_by_id(sbi_object_id);
+        if (!amf_ue) {
+            ogs_error("UE(amf_ue) Context has already been removed");
+            break;
         }
-    }
 
-    return;
+        ogs_error("[%s:%s] Cannot receive SBI message "
+                "[type:%d,value:%d]", amf_ue->supi, amf_ue->suci,
+                amf_ue->nas.message_type,
+                amf_ue->nas.registration.value);
+
+        if (amf_nnrf_try_old_amf_discovery_fallback(
+                amf_ue, requester_nf_type, discovery_option))
+            break;
+
+        if (amf_ue->nas.message_type ==
+                OGS_NAS_5GS_DEREGISTRATION_REQUEST_FROM_UE) {
+            ogs_error("[%s:%s] Deregistration request failed",
+                    amf_ue->supi, amf_ue->suci);
+            break;
+        }
+
+        r = nas_5gs_send_gmm_reject_from_sbi(amf_ue,
+                OGS_SBI_HTTP_STATUS_GATEWAY_TIMEOUT);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        break;
+
+    case OGS_SBI_OBJ_SESS_TYPE:
+        sess = amf_sess_find_by_id(sbi_object_id);
+        if (!sess) {
+            ogs_error("Session has already been removed");
+            break;
+        }
+
+        amf_ue = amf_ue_find_by_id(sess->amf_ue_id);
+        if (!amf_ue) {
+            ogs_error("UE(amf_ue) Context has already been removed");
+            break;
+        }
+
+        ogs_error("[%s:%s:%d:%d] Cannot receive SBI message",
+                amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
+
+        amf_nnrf_send_session_failure_to_ran(amf_ue, sess, ran_ue_id);
+        break;
+
+    default:
+        ogs_fatal("Not implemented [%s:%d]",
+            ogs_sbi_service_type_to_name(service_type), sbi_object->type);
+        ogs_assert_if_reached();
+    }
 }


### PR DESCRIPTION
Move NRF discovery failure handling into amf_nnrf_handle_failed_amf_discovery() so both SBI client timeout and NRF discovery failure paths use the same cleanup and recovery logic.

This removes the duplicated failure handling from amf-sm.c and centralizes UE- and session-scoped handling in nnrf-handler.c. For UE-scoped failures, keep the old AMF discovery fallback behavior by sending an Identity Request when SUCI/SUPI is not available during initial registration. For deregistration, avoid sending a GMM reject and log the failure instead.

For session-scoped failures, resolve the captured RAN-UE only at the point where a NAS/NGAP failure response must be sent, and handle stale, detached, or mismatched NG contexts without asserting.

Also make SBI transaction ownership explicit by removing the xact in the common failed-discovery handler before returning.

Related to #4517