### PR TITLE
debian: move mongodb dependency to recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -126,8 +126,9 @@ Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         mongodb-org | mongodb,
          open5gs-common (= ${binary:Version})
+Recommends:
+         mongodb-org | mongodb,
 Description: HSS (Home Subscriber Server)
  Open5GS is a C-language implementation of 5G Core and EPC
  Packet Core, i.e. the core network of an NR/LTE network (Release-17)
@@ -143,8 +144,9 @@ Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         mongodb-org | mongodb,
          open5gs-common (= ${binary:Version})
+Recommends:
+         mongodb-org | mongodb,
 Description: PCRF (Policy and Charging Rules Function)
  Open5GS is a C-language implementation of 5G Core and EPC
  Packet Core, i.e. the core network of an NR/LTE network (Release-17)

--- a/debian/control
+++ b/debian/control
@@ -222,6 +222,8 @@ Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          open5gs-common (= ${binary:Version})
+Recommends:
+         mongodb-org | mongodb,
 Description: PCF (Policy Control Function)
  Open5GS is a C-language implementation of 5G Core and EPC
  Packet Core, i.e. the core network of an NR/LTE network (Release-17)
@@ -258,6 +260,8 @@ Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          open5gs-common (= ${binary:Version})
+Recommends:
+         mongodb-org | mongodb,
 Description: UDR (Unified Data Repository)
  Open5GS is a C-language implementation of 5G Core and EPC
  Packet Core, i.e. the core network of an NR/LTE network (Release-17)

--- a/docs/_docs/guide/01-quickstart.md
+++ b/docs/_docs/guide/01-quickstart.md
@@ -75,6 +75,12 @@ With the exception of the SMF and UPF, all config files for the 5G SA core funct
 #### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
+**Note:** If you want to use an external MongoDB server, skip this step and use --no-install-recommends apt flag when installing open5gs packages.
+{: .notice--warning}
+
 Import the public key used by the package management system.
 
 ```bash

--- a/docs/_docs/guide/02-building-open5gs-from-sources.md
+++ b/docs/_docs/guide/02-building-open5gs-from-sources.md
@@ -13,6 +13,9 @@ This post explains how to compile and install the source code on **Debian/Ubuntu
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Import the public key used by the package management system.
 
 ```bash
@@ -26,18 +29,18 @@ Create the list file /etc/apt/sources.list.d/mongodb-org-8.0.list for your versi
 On ubuntu 22.04 (Jammy)
 ```bash
 $ echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+$ sudo apt update
 ```
+
+**Note:** If you want to use an external MongoDB server, skip this step.
+{: .notice--warning}
 
 Install the MongoDB packages.
 ```bash
-$ sudo apt update
 $ sudo apt install -y mongodb-org
 $ sudo systemctl start mongod (if '/usr/bin/mongod' is not running)
 $ sudo systemctl enable mongod (ensure to automatically start it on system boot)
 ```
-
-**Tip:** MongoDB is used as database for NRF/PCF/UDR and PCRF/HSS.
-{: .notice--info}
 
 ### Setting up TUN device (not persistent after rebooting)
 ---

--- a/docs/_docs/platform/02-centos.md
+++ b/docs/_docs/platform/02-centos.md
@@ -83,6 +83,9 @@ $ sudo dnf config-manager --set-enabled elrepo-testing
 ### Install MongoDB using the package manager:
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Create a repository file to install the MongoDB packages:
 
 ```bash

--- a/docs/_docs/platform/03-fedora.md
+++ b/docs/_docs/platform/03-fedora.md
@@ -12,6 +12,9 @@ This guide is based on **Fedora 33** Distribution.
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Install MongoDB with package manager.
 ```bash
 $ sudo dnf -y install mongodb-server

--- a/docs/_docs/platform/05-macosx-apple-silicon.md
+++ b/docs/_docs/platform/05-macosx-apple-silicon.md
@@ -25,6 +25,9 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Install MongoDB with Package Manager.
 ```bash
 $ brew tap mongodb/brew

--- a/docs/_docs/platform/06-macosx-intel.md
+++ b/docs/_docs/platform/06-macosx-intel.md
@@ -25,6 +25,9 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Install MongoDB with Package Manager.
 ```bash
 $ brew tap mongodb/brew

--- a/docs/_docs/platform/07-freebsd.md
+++ b/docs/_docs/platform/07-freebsd.md
@@ -53,6 +53,9 @@ user 'vagrant', or on your bare metal FreeBSD 14 system as any normal user.
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Install MongoDB with package manager.
 ```bash
 $ sudo pkg install mongodb50

--- a/docs/_docs/platform/08-alpine.md
+++ b/docs/_docs/platform/08-alpine.md
@@ -9,6 +9,9 @@ This guide is based on **Alpine 3.13** Distribution.
 ### Getting MongoDB
 ---
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 Install MongoDB with package manager.
 ```bash
 $ sudo apk update

--- a/docs/_docs/tutorial/01-your-first-lte.md
+++ b/docs/_docs/tutorial/01-your-first-lte.md
@@ -159,17 +159,26 @@ $ make
 $ make test
 ```
 
-#### 3. Open5GS
+#### 4. MongoDB
 
+**Tip:** MongoDB is used as database for PCRF/HSS.
+{: .notice--info}
 
-The Open5GS package is available on the recent versions of *Ubuntu*.
+**Note:** open5gs-hssd and open5gs-pcrfd services need a working MongoDB instance in order to work properly. If you want to use an external MongoDB server, skip this step and use --no-install-recommends apt flag when installing open5gs-hss or open5gs-pcrf packages.
+{: .notice--warning}
+
 ```bash
-# Install the MongoDB Packages
 $ curl -fsSL https://pgp.mongodb.com/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
 $ echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
 $ sudo apt update
 $ sudo apt install mongodb-org
+```
 
+#### 5. Open5GS
+
+The Open5GS package is available on the recent versions of *Ubuntu*.
+
+```bash
 # Installing Open5GS
 $ sudo add-apt-repository ppa:open5gs/latest
 $ sudo apt update

--- a/docs/_docs/tutorial/06-Open5GS-with-5G-Sharp-Orchestrator.md
+++ b/docs/_docs/tutorial/06-Open5GS-with-5G-Sharp-Orchestrator.md
@@ -82,6 +82,9 @@ To work with Open5GS core, it is recommended to build the project from source.
 
 **1. Getting MongoDB**
 
+**Tip:** MongoDB is used as database for PCF/UDR and PCRF/HSS.
+{: .notice--info}
+
 - Install GNU Privacy Guard tool:
 
 ```


### PR DESCRIPTION
This allows to use a mongodb server on an external system using apt ``–no-install-recommends`` flag when installing open5gs-hss or open5gs-pcrf.