### PR TITLE
pcf: support AF qosReference profiles

### DIFF
--- a/configs/examples/5gc-no-scp-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-no-scp-sepp1-999-70.yaml.in
@@ -340,6 +340,11 @@ pcf:
     server:
       - address: 127.0.1.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - plmn_id:
         mcc: 001

--- a/configs/examples/5gc-no-scp-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-no-scp-sepp2-001-01.yaml.in
@@ -342,6 +342,11 @@ pcf:
     server:
       - address: 127.0.2.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - plmn_id:
         mcc: 999

--- a/configs/examples/5gc-no-scp-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-no-scp-sepp3-315-010.yaml.in
@@ -342,6 +342,11 @@ pcf:
     server:
       - address: 127.0.3.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - plmn_id:
         mcc: 999

--- a/configs/examples/5gc-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-sepp1-999-70.yaml.in
@@ -350,6 +350,11 @@ pcf:
     server:
       - address: 127.0.1.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 001010000000001-001019999999999

--- a/configs/examples/5gc-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-sepp2-001-01.yaml.in
@@ -351,6 +351,11 @@ pcf:
     server:
       - address: 127.0.2.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 999700000000001-999709999999999

--- a/configs/examples/5gc-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-sepp3-315-010.yaml.in
@@ -351,6 +351,11 @@ pcf:
     server:
       - address: 127.0.3.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 999700000000001-999709999999999

--- a/configs/examples/5gc-tls-sepp1-999-70.yaml.in
+++ b/configs/examples/5gc-tls-sepp1-999-70.yaml.in
@@ -355,6 +355,11 @@ pcf:
     server:
       - address: 127.0.1.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 001010000000001-001019999999999

--- a/configs/examples/5gc-tls-sepp2-001-01.yaml.in
+++ b/configs/examples/5gc-tls-sepp2-001-01.yaml.in
@@ -356,6 +356,11 @@ pcf:
     server:
       - address: 127.0.2.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 999700000000001-999709999999999

--- a/configs/examples/5gc-tls-sepp3-315-010.yaml.in
+++ b/configs/examples/5gc-tls-sepp3-315-010.yaml.in
@@ -356,6 +356,11 @@ pcf:
     server:
       - address: 127.0.3.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
   policy:
     - supi_range:
         - 999700000000001-999709999999999

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -25,6 +25,26 @@ pcf:
         port: 9090
 
 ################################################################################
+# QoS Profile Mapping (Npcf_PolicyAuthorization / TS 29.514)
+################################################################################
+# Maps AF-supplied qosReference strings to configured 5QI/QoS index values.
+# Required only when AFs send qosReference in MediaComponent.
+# If absent, the PCF falls back to media-type mapping (AUDIO->1, VIDEO->2,
+# CONTROL->5). Unknown qosReference values result in 403 Forbidden.
+#
+#  qos_profiles:
+#    - reference: "conversational-voice"
+#      qos_index: 1
+#    - reference: "conversational-video"
+#      qos_index: 2
+#    - reference: "ims-signalling"
+#      qos_index: 5
+#    - reference: "standard-data"
+#      qos_index: 9
+#    - reference: "low-latency"
+#      qos_index: 3
+
+################################################################################
 # PCF Policy Configuration: UE Home PLMN and SUPI Range Based Policies
 ################################################################################
 #

--- a/configs/vonr.yaml.in
+++ b/configs/vonr.yaml.in
@@ -286,6 +286,11 @@ pcf:
     server:
       - address: 127.0.0.13
         port: 9090
+  qos_profiles:
+    - reference: "test-audio"
+      qos_index: 1
+    - reference: "test-video"
+      qos_index: 2
 
 nssf:
   sbi:

--- a/src/pcf/context.c
+++ b/src/pcf/context.c
@@ -30,6 +30,7 @@ static OGS_POOL(pcf_app_pool, pcf_app_t);
 
 static int context_initialized = 0;
 
+static void pcf_qos_profile_clear(void);
 static void clear_ipv4addr(pcf_sess_t *sess);
 static void clear_ipv6prefix(pcf_sess_t *sess);
 
@@ -70,6 +71,8 @@ void pcf_context_final(void)
     pcf_ue_am_remove_all();
     pcf_ue_sm_remove_all();
 
+    pcf_qos_profile_clear();
+
     ogs_assert(self.supi_am_hash);
     ogs_hash_destroy(self.supi_am_hash);
     ogs_assert(self.supi_sm_hash);
@@ -92,8 +95,20 @@ pcf_context_t *pcf_self(void)
     return &self;
 }
 
+static void pcf_qos_profile_clear(void)
+{
+    int i;
+
+    for (i = 0; i < self.num_of_qos_profile; i++)
+        ogs_free(self.qos_profile[i].reference);
+
+    memset(self.qos_profile, 0, sizeof(self.qos_profile));
+    self.num_of_qos_profile = 0;
+}
+
 static int pcf_context_prepare(void)
 {
+    pcf_qos_profile_clear();
     return OGS_OK;
 }
 
@@ -204,6 +219,20 @@ static int policy_conf_validation(void)
     return OGS_OK;
 }
 
+static bool pcf_qos_profile_reference_exists(const char *reference)
+{
+    int i;
+
+    ogs_assert(reference);
+
+    for (i = 0; i < self.num_of_qos_profile; i++) {
+        if (!strcmp(self.qos_profile[i].reference, reference))
+            return true;
+    }
+
+    return false;
+}
+
 static int parse_policy_conf(ogs_yaml_iter_t *parent)
 {
     int rv;
@@ -288,6 +317,75 @@ static int parse_policy_conf(ogs_yaml_iter_t *parent)
     return OGS_OK;
 }
 
+static int parse_qos_profiles_conf(ogs_yaml_iter_t *parent)
+{
+    ogs_yaml_iter_t profile_array, profile_iter;
+
+    ogs_assert(parent);
+
+    ogs_yaml_iter_recurse(parent, &profile_array);
+    do {
+        const char *reference = NULL;
+        const char *qos_index_string = NULL;
+        char *end = NULL;
+        long qos_index = 0;
+
+        OGS_YAML_ARRAY_NEXT(&profile_array, &profile_iter);
+        while (ogs_yaml_iter_next(&profile_iter)) {
+            const char *profile_key = ogs_yaml_iter_key(&profile_iter);
+            ogs_assert(profile_key);
+
+            if (!strcmp(profile_key, "reference")) {
+                reference = ogs_yaml_iter_value(&profile_iter);
+            } else if (!strcmp(profile_key, "qos_index")) {
+                qos_index_string = ogs_yaml_iter_value(&profile_iter);
+            } else {
+                ogs_warn("unknown qos_profiles key `%s`", profile_key);
+            }
+        }
+
+        if (!reference || !reference[0]) {
+            ogs_warn("Ignore qos_profiles entry without reference");
+            goto next;
+        }
+
+        if (!qos_index_string || !qos_index_string[0]) {
+            ogs_warn("Ignore qos_profiles[%s] without qos_index", reference);
+            goto next;
+        }
+
+        qos_index = strtol(qos_index_string, &end, 10);
+        if (*end || qos_index <= 0 || qos_index > UINT8_MAX) {
+            ogs_warn("Ignore qos_profiles[%s] invalid qos_index [%s]",
+                    reference, qos_index_string);
+            goto next;
+        }
+
+        if (pcf_qos_profile_reference_exists(reference)) {
+            ogs_warn("Ignore duplicate qos_profiles reference [%s]", reference);
+            goto next;
+        }
+
+        if (self.num_of_qos_profile >= OGS_PCF_MAX_NUM_OF_QOS_PROFILE) {
+            ogs_warn("Ignore qos_profiles[%s] beyond max [%d]",
+                    reference, OGS_PCF_MAX_NUM_OF_QOS_PROFILE);
+            goto next;
+        }
+
+        self.qos_profile[self.num_of_qos_profile].reference =
+            ogs_strdup(reference);
+        ogs_assert(self.qos_profile[self.num_of_qos_profile].reference);
+        self.qos_profile[self.num_of_qos_profile].qos_index =
+            (uint8_t)qos_index;
+        self.num_of_qos_profile++;
+
+next:
+        ;
+    } while (ogs_yaml_iter_type(&profile_array) == YAML_SEQUENCE_NODE);
+
+    return OGS_OK;
+}
+
 int pcf_context_parse_config(void)
 {
     int rv;
@@ -326,6 +424,12 @@ int pcf_context_parse_config(void)
                     /* handle config in sbi library */
                 } else if (!strcmp(pcf_key, "metrics")) {
                     /* handle config in metrics library */
+                } else if (!strcmp(pcf_key, "qos_profiles")) {
+                    rv = parse_qos_profiles_conf(&pcf_iter);
+                    if (rv != OGS_OK) {
+                        ogs_error("parse_qos_profiles_conf() failed");
+                        return rv;
+                    }
                 } else if (!strcmp(pcf_key, OGS_POLICY_STRING)) {
                     rv = parse_policy_conf(&pcf_iter);
                     if (rv != OGS_OK) {

--- a/src/pcf/context.h
+++ b/src/pcf/context.h
@@ -37,6 +37,13 @@ extern int __pcf_log_domain;
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __pcf_log_domain
 
+#define OGS_PCF_MAX_NUM_OF_QOS_PROFILE  64
+
+typedef struct pcf_qos_profile_s {
+    char    *reference;
+    uint8_t  qos_index;
+} pcf_qos_profile_t;
+
 typedef struct pcf_context_s {
     ogs_list_t      pcf_ue_am_list;
 #define PCF_UE_SM_IS_LAST_SESSION(__pCF) \
@@ -47,6 +54,9 @@ typedef struct pcf_context_s {
 
     ogs_hash_t      *ipv4addr_hash;
     ogs_hash_t      *ipv6prefix_hash;
+
+    pcf_qos_profile_t  qos_profile[OGS_PCF_MAX_NUM_OF_QOS_PROFILE];
+    int                num_of_qos_profile;
 } pcf_context_t;
 
 struct pcf_ue_am_s {

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -21,6 +21,42 @@
 
 #include "npcf-handler.h"
 
+static uint8_t pcf_qos_index_from_media(
+        const char *qos_reference,
+        OpenAPI_media_type_e media_type,
+        const char **err_out)
+{
+    int i;
+
+    ogs_assert(err_out);
+    *err_out = NULL;
+
+    if (qos_reference) {
+        for (i = 0; i < pcf_self()->num_of_qos_profile; i++) {
+            if (!strcmp(pcf_self()->qos_profile[i].reference, qos_reference))
+                return pcf_self()->qos_profile[i].qos_index;
+        }
+
+        *err_out = "Unknown qosReference - check PCF qos_profiles config";
+        return 0;
+    }
+
+    switch (media_type) {
+    case OpenAPI_media_type_AUDIO:
+        return OGS_QOS_INDEX_1;
+    case OpenAPI_media_type_VIDEO:
+        return OGS_QOS_INDEX_2;
+    case OpenAPI_media_type_CONTROL:
+        return OGS_QOS_INDEX_5;
+    case OpenAPI_media_type_NULL:
+        *err_out = "Media-Type is Required";
+        return 0;
+    default:
+        *err_out = "Unknown Media-Type";
+        return 0;
+    }
+}
+
 bool pcf_npcf_am_policy_control_handle_create(pcf_ue_am_t *pcf_ue_am,
         ogs_sbi_stream_t *stream, ogs_sbi_message_t *message)
 {
@@ -648,6 +684,7 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
     ogs_ims_data_t ims_data;
     ogs_media_component_t *media_component = NULL;
     ogs_media_sub_component_t *sub = NULL;
+    const char *qos_reference[OGS_MAX_NUM_OF_MEDIA_COMPONENT] = {0};
 
     OpenAPI_list_t *MediaComponentList = NULL;
     OpenAPI_map_t *MediaComponentMap = NULL;
@@ -745,6 +782,7 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
         if (MediaComponentMap) {
             MediaComponent = MediaComponentMap->value;
             if (MediaComponent) {
+                int n;
                 if (ims_data.num_of_media_component >=
                         OGS_ARRAY_SIZE(ims_data.media_component)) {
                     ogs_error("OVERFLOW ims_data.num_of_media_component "
@@ -754,8 +792,10 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
                             (int)OGS_ARRAY_SIZE(ims_data.media_component));
                     break;
                 }
-                media_component = &ims_data.
-                    media_component[ims_data.num_of_media_component];
+                n = ims_data.num_of_media_component;
+
+                media_component = &ims_data.media_component[n];
+                qos_reference[n] = MediaComponent->qos_reference;
                 media_component->media_component_number =
                     MediaComponent->med_comp_n;
                 media_component->media_type = MediaComponent->med_type;
@@ -881,28 +921,17 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
         ogs_pcc_rule_t *db_pcc_rule = NULL;
         uint8_t qos_index = 0;
         ogs_media_component_t *media_component = &ims_data.media_component[i];
+        const char *reference = qos_reference[i];
+        const char *err_str = NULL;
 
-        if (media_component->media_type == OpenAPI_media_type_NULL) {
-            strerror = ogs_msprintf("[%s:%d] Media-Type is Required",
-                    pcf_ue_sm->supi, sess->psi);
-            status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-            goto cleanup;
-        }
-
-        switch(media_component->media_type) {
-        case OpenAPI_media_type_AUDIO:
-            qos_index = OGS_QOS_INDEX_1;
-            break;
-        case OpenAPI_media_type_VIDEO:
-            qos_index = OGS_QOS_INDEX_2;
-            break;
-        case OpenAPI_media_type_CONTROL:
-            qos_index = OGS_QOS_INDEX_5;
-            break;
-        default:
-            strerror = ogs_msprintf("[%s:%d] Unknown Media-Type [%d]",
-                    pcf_ue_sm->supi, sess->psi, media_component->media_type);
-            status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        qos_index = pcf_qos_index_from_media(
+                reference, media_component->media_type, &err_str);
+        if (qos_index == 0) {
+            strerror = ogs_msprintf("[%s:%d] %s",
+                    pcf_ue_sm->supi, sess->psi, err_str);
+            status = reference ?
+                     OGS_SBI_HTTP_STATUS_FORBIDDEN :
+                     OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
 
@@ -913,7 +942,7 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
             }
         }
 
-        if (!db_pcc_rule &&
+        if (!db_pcc_rule && !reference &&
             (media_component->media_type == OpenAPI_media_type_CONTROL)) {
             /*
              * Check for default bearer for IMS signalling
@@ -1102,7 +1131,14 @@ bool pcf_npcf_policyauthorization_handle_create(pcf_sess_t *sess,
 cleanup:
     ogs_assert(status);
     ogs_assert(strerror);
-    ogs_error("%s", strerror);
+
+    /*
+     * Unknown qosReference is rejected with 403 in a negative test case.
+     * Log it as warning to avoid treating the expected rejection as an error.
+     */
+    ogs_log_message(
+            status == OGS_SBI_HTTP_STATUS_FORBIDDEN ?
+                OGS_LOG_WARN : OGS_LOG_ERROR, 0, "%s", strerror);
     ogs_assert(true ==
         ogs_sbi_server_send_error(stream, status, recvmsg, strerror, NULL,
                 NULL));
@@ -1133,6 +1169,9 @@ cleanup:
     ogs_ims_data_free(&ims_data);
     OGS_SESSION_DATA_FREE(&session_data);
 
+    if (app_session)
+        pcf_app_remove(app_session);
+
     return false;
 }
 
@@ -1156,6 +1195,7 @@ bool pcf_npcf_policyauthorization_handle_update(
     ogs_ims_data_t ims_data;
     ogs_media_component_t *media_component = NULL;
     ogs_media_sub_component_t *sub = NULL;
+    const char *qos_reference[OGS_MAX_NUM_OF_MEDIA_COMPONENT] = {0};
 
     OpenAPI_list_t *MediaComponentList = NULL;
     OpenAPI_map_t *MediaComponentMap = NULL;
@@ -1218,6 +1258,7 @@ bool pcf_npcf_policyauthorization_handle_update(
         if (MediaComponentMap) {
             MediaComponent = MediaComponentMap->value;
             if (MediaComponent) {
+                int n;
                 if (ims_data.num_of_media_component >=
                         OGS_ARRAY_SIZE(ims_data.media_component)) {
                     ogs_error("OVERFLOW ims_data.num_of_media_component "
@@ -1227,9 +1268,10 @@ bool pcf_npcf_policyauthorization_handle_update(
                             (int)OGS_ARRAY_SIZE(ims_data.media_component));
                     break;
                 }
-                media_component = &ims_data.
-                    media_component[ims_data.num_of_media_component];
+                n = ims_data.num_of_media_component;
 
+                media_component = &ims_data.media_component[n];
+                qos_reference[n] = MediaComponent->qos_reference;
                 media_component->media_component_number =
                     MediaComponent->med_comp_n;
                 media_component->media_type = MediaComponent->med_type;
@@ -1329,28 +1371,17 @@ bool pcf_npcf_policyauthorization_handle_update(
         ogs_pcc_rule_t *db_pcc_rule = NULL;
         uint8_t qos_index = 0;
         ogs_media_component_t *media_component = &ims_data.media_component[i];
+        const char *reference = qos_reference[i];
+        const char *err_str = NULL;
 
-        if (media_component->media_type == OpenAPI_media_type_NULL) {
-            strerror = ogs_msprintf("[%s:%d] Media-Type is Required",
-                    pcf_ue_sm->supi, sess->psi);
-            status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
-            goto cleanup;
-        }
-
-        switch(media_component->media_type) {
-        case OpenAPI_media_type_AUDIO:
-            qos_index = OGS_QOS_INDEX_1;
-            break;
-        case OpenAPI_media_type_VIDEO:
-            qos_index = OGS_QOS_INDEX_2;
-            break;
-        case OpenAPI_media_type_CONTROL:
-            qos_index = OGS_QOS_INDEX_5;
-            break;
-        default:
-            strerror = ogs_msprintf("[%s:%d] Unknown Media-Type [%d]",
-                    pcf_ue_sm->supi, sess->psi, media_component->media_type);
-            status = OGS_SBI_HTTP_STATUS_BAD_REQUEST;
+        qos_index = pcf_qos_index_from_media(
+                reference, media_component->media_type, &err_str);
+        if (qos_index == 0) {
+            strerror = ogs_msprintf("[%s:%d] %s",
+                    pcf_ue_sm->supi, sess->psi, err_str);
+            status = reference ?
+                     OGS_SBI_HTTP_STATUS_FORBIDDEN :
+                     OGS_SBI_HTTP_STATUS_BAD_REQUEST;
             goto cleanup;
         }
 
@@ -1361,7 +1392,7 @@ bool pcf_npcf_policyauthorization_handle_update(
             }
         }
 
-        if (!db_pcc_rule &&
+        if (!db_pcc_rule && !reference &&
             (media_component->media_type == OpenAPI_media_type_CONTROL)) {
             /*
              * Check for default bearer for IMS signalling

--- a/tests/af/af-sm.c
+++ b/tests/af/af-sm.c
@@ -372,6 +372,7 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
             CASE(OGS_SBI_RESOURCE_NAME_APP_SESSIONS)
                 sess = e->h.sbi.data;
                 ogs_assert(sess);
+                sess->last_pcf_status = message.res_status;
 
                 if (message.h.resource.component[1]) {
                     if (message.h.resource.component[2]) {
@@ -406,6 +407,14 @@ void af_state_operational(ogs_fsm_t *s, af_event_t *e)
                         if (message.res_status == OGS_SBI_HTTP_STATUS_CREATED)
                             af_npcf_policyauthorization_handle_create(
                                     sess, &message);
+                        else if (message.res_status ==
+                                OGS_SBI_HTTP_STATUS_FORBIDDEN)
+        /*
+         * 403 may be expected in negative tests, such as unknown qosReference.
+         * Do not report it as an AF test error here.
+         */
+                            ogs_warn("HTTP response error [%d]",
+                                    message.res_status);
                         else
                             ogs_error("HTTP response error [%d]",
                                     message.res_status);

--- a/tests/af/context.h
+++ b/tests/af/context.h
@@ -51,6 +51,7 @@ typedef struct af_sess_s {
     ogs_sbi_object_t sbi;
 
     uint64_t policyauthorization_features;
+    int last_pcf_status;
 
 #define PCF_APP_SESSION_ASSOCIATED(__sESS) \
     ((__sESS) && ((__sESS)->app_session.pcf_id))

--- a/tests/af/npcf-build.c
+++ b/tests/af/npcf-build.c
@@ -58,7 +58,7 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
 
     af_param = data;
     ogs_assert(af_param);
-    ogs_assert(af_param->med_type);
+    ogs_assert(af_param->med_type || af_param->qos_reference);
 
     memset(&message, 0, sizeof(message));
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
@@ -135,7 +135,10 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
 
     MediaComponent->med_comp_n = (i++);
     MediaComponent->f_status = OpenAPI_flow_status_ENABLED;
-    MediaComponent->med_type = af_param->med_type;
+    if (!af_param->omit_med_type)
+        MediaComponent->med_type = af_param->med_type;
+    if (af_param->qos_reference)
+        MediaComponent->qos_reference = ogs_strdup(af_param->qos_reference);
     if (af_param->qos_type == 1) {
         MediaComponent->mar_bw_dl = ogs_sbi_bitrate_to_string(
                                         96000, OGS_SBI_BITRATE_BPS);
@@ -308,6 +311,8 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_create(
                     ogs_free(MediaComponent->rr_bw);
                 if (MediaComponent->rs_bw)
                     ogs_free(MediaComponent->rs_bw);
+                if (MediaComponent->qos_reference)
+                    ogs_free(MediaComponent->qos_reference);
 
                 codecList = MediaComponent->codecs;
                 OpenAPI_list_for_each(codecList, node2) {
@@ -408,7 +413,11 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_update(
 
     MediaComponent->med_comp_n = (i++);
     MediaComponent->f_status = OpenAPI_flow_status_ENABLED;
-    MediaComponent->med_type = OpenAPI_media_type_AUDIO;
+    if (!af_param->omit_med_type)
+        MediaComponent->med_type = af_param->med_type ?
+            af_param->med_type : OpenAPI_media_type_AUDIO;
+    if (af_param->qos_reference)
+        MediaComponent->qos_reference = ogs_strdup(af_param->qos_reference);
     if (af_param->qos_type == 1) {
         MediaComponent->mar_bw_dl = ogs_sbi_bitrate_to_string(
                                         96000, OGS_SBI_BITRATE_BPS);
@@ -549,6 +558,8 @@ ogs_sbi_request_t *af_npcf_policyauthorization_build_update(
                     ogs_free(MediaComponent->rr_bw);
                 if (MediaComponent->rs_bw)
                     ogs_free(MediaComponent->rs_bw);
+                if (MediaComponent->qos_reference)
+                    ogs_free(MediaComponent->qos_reference);
 
                 codecList = MediaComponent->codecs;
                 OpenAPI_list_for_each(codecList, node2) {

--- a/tests/af/npcf-build.h
+++ b/tests/af/npcf-build.h
@@ -30,6 +30,8 @@ typedef struct af_npcf_policyauthorization_param_s {
     OpenAPI_media_type_e med_type;
     int flow_type;
     int qos_type;
+    const char *qos_reference;
+    bool omit_med_type;
 } af_npcf_policyauthorization_param_t;
 
 ogs_sbi_request_t *af_npcf_policyauthorization_build_create(

--- a/tests/vonr/af-test.c
+++ b/tests/vonr/af-test.c
@@ -20,6 +20,372 @@
 #include "test-common.h"
 #include "af/sbi-path.h"
 
+static test_bearer_t *test_af_complete_qos_flow_modify(
+        abts_case *tc, test_ue_t *test_ue, test_sess_t *sess,
+        ogs_socknode_t *ngap)
+{
+    int rv;
+    ogs_pkbuf_t *gmmbuf = NULL;
+    ogs_pkbuf_t *gsmbuf = NULL;
+    ogs_pkbuf_t *sendbuf = NULL;
+    ogs_pkbuf_t *recvbuf = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceModify,
+            test_ue->ngap_procedure_code);
+
+    qos_flow = test_qos_flow_find_by_qfi(sess, 2);
+    ogs_assert(qos_flow);
+
+    sendbuf = testngap_build_qos_flow_resource_modify_response(qos_flow);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_MODIFICATION_REQUEST;
+    sess->ul_nas_transport_param.dnn = 0;
+    sess->ul_nas_transport_param.s_nssai = 0;
+
+    sess->pdu_session_establishment_param.ssc_mode = 0;
+    sess->pdu_session_establishment_param.epco = 0;
+
+    gsmbuf = testgsm_build_pdu_session_modification_complete(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(100);
+
+    return qos_flow;
+}
+
+static void test_af_qos_reference_setup(abts_case *tc, const char *msin,
+        test_ue_t **test_ue, test_sess_t **sess, af_sess_t **af_sess,
+        ogs_socknode_t **ngap, ogs_socknode_t **gtpu)
+{
+    int rv;
+    ogs_pkbuf_t *gmmbuf = NULL;
+    ogs_pkbuf_t *gsmbuf = NULL;
+    ogs_pkbuf_t *nasbuf = NULL;
+    ogs_pkbuf_t *sendbuf = NULL;
+    ogs_pkbuf_t *recvbuf = NULL;
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_sess_t *internet_sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    bson_t *doc = NULL;
+
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    *test_ue = test_ue_add_by_suci(&mobile_identity_suci, msin);
+    ogs_assert(*test_ue);
+
+    (*test_ue)->nr_cgi.cell_id = 0x40001;
+
+    (*test_ue)->nas.registration.tsc = 0;
+    (*test_ue)->nas.registration.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    (*test_ue)->nas.registration.follow_on_request = 1;
+    (*test_ue)->nas.registration.value =
+        OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+
+    (*test_ue)->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    (*test_ue)->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    *ngap = testngap_client(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, *ngap);
+
+    *gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, *gtpu);
+
+    sendbuf = testngap_build_ng_setup_request(0x4000, 22);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    doc = test_db_new_ims(*test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(*test_ue, doc));
+
+    (*test_ue)->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(*test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    (*test_ue)->registration_request_param.gmm_capability = 1;
+    (*test_ue)->registration_request_param.requested_nssai = 1;
+    (*test_ue)->registration_request_param.last_visited_registered_tai = 1;
+    (*test_ue)->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(*test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(*test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    gmmbuf = testgmm_build_identity_response(*test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    gmmbuf = testgmm_build_authentication_response(*test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    gmmbuf = testgmm_build_security_mode_complete(*test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            (*test_ue)->ngap_procedure_code);
+
+    sendbuf = testngap_build_ue_radio_capability_info_indication(*test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    sendbuf = testngap_build_initial_context_setup_response(*test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    gmmbuf = testgmm_build_registration_complete(*test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    internet_sess = test_sess_add_by_dnn_and_psi(*test_ue, "internet", 5);
+    ogs_assert(internet_sess);
+
+    internet_sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    internet_sess->ul_nas_transport_param.dnn = 1;
+    internet_sess->ul_nas_transport_param.s_nssai = 1;
+
+    internet_sess->pdu_session_establishment_param.ssc_mode = 1;
+    internet_sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(internet_sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(internet_sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            (*test_ue)->ngap_procedure_code);
+
+    qos_flow = test_qos_flow_find_by_qfi(internet_sess, 1);
+    ogs_assert(qos_flow);
+    rv = test_gtpu_send_ping(*gtpu, qos_flow, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(
+            internet_sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_gtpu_read(*gtpu);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    *sess = test_sess_add_by_dnn_and_psi(*test_ue, "ims", 6);
+    ogs_assert(*sess);
+
+    (*sess)->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    (*sess)->ul_nas_transport_param.dnn = 1;
+    (*sess)->ul_nas_transport_param.s_nssai = 1;
+
+    (*sess)->pdu_session_establishment_param.ssc_mode = 1;
+    (*sess)->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(*sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(*sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(*test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(*ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(*test_ue, recvbuf);
+
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(*sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(*ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    *af_sess = af_sess_add_by_ue_address(&(*sess)->ue_ip);
+    ogs_assert(*af_sess);
+
+    (*af_sess)->supi = ogs_strdup((*test_ue)->supi);
+    ogs_assert((*af_sess)->supi);
+
+    (*af_sess)->dnn = ogs_strdup((*sess)->dnn);
+    ogs_assert((*af_sess)->dnn);
+
+    af_local_discover_and_send(
+            OGS_SBI_SERVICE_TYPE_NBSF_MANAGEMENT,
+            *af_sess, NULL,
+            af_nbsf_management_build_discover);
+
+    ogs_msleep(100);
+}
+
+static void test_af_qos_reference_delete(
+        abts_case *tc, test_ue_t *test_ue, test_sess_t *sess,
+        af_sess_t *af_sess, ogs_socknode_t *ngap)
+{
+    int rv;
+    ogs_pkbuf_t *gmmbuf = NULL;
+    ogs_pkbuf_t *gsmbuf = NULL;
+    ogs_pkbuf_t *sendbuf = NULL;
+    ogs_pkbuf_t *recvbuf = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    af_local_send_to_pcf(af_sess, NULL,
+            af_npcf_policyauthorization_build_delete);
+
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceModify,
+            test_ue->ngap_procedure_code);
+
+    qos_flow = test_qos_flow_find_by_qfi(sess, 2);
+    ogs_assert(qos_flow);
+
+    sendbuf = testngap_build_qos_flow_resource_release_response(qos_flow);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_MODIFICATION_REQUEST;
+    sess->ul_nas_transport_param.dnn = 0;
+    sess->ul_nas_transport_param.s_nssai = 0;
+
+    sess->pdu_session_establishment_param.ssc_mode = 0;
+    sess->pdu_session_establishment_param.epco = 0;
+
+    gsmbuf = testgsm_build_pdu_session_modification_complete(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_bearer_remove(qos_flow);
+
+    ogs_msleep(100);
+}
+
+static void test_af_qos_reference_cleanup(
+        abts_case *tc, test_ue_t *test_ue,
+        ogs_socknode_t *ngap, ogs_socknode_t *gtpu)
+{
+    int rv;
+    ogs_pkbuf_t *gmmbuf = NULL;
+    ogs_pkbuf_t *sendbuf = NULL;
+    ogs_pkbuf_t *recvbuf = NULL;
+
+    gmmbuf = testgmm_build_de_registration_request(test_ue, 1, true, true);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    testgnb_gtpu_close(gtpu);
+    testgnb_ngap_close(ngap);
+
+    test_ue_remove(test_ue);
+}
+
 static void test1_func(abts_case *tc, void *data)
 {
     int rv;
@@ -4341,6 +4707,137 @@ static void test8_func(abts_case *tc, void *data)
 }
 #endif
 
+static void test10_func(abts_case *tc, void *data)
+{
+    ogs_socknode_t *ngap = NULL;
+    ogs_socknode_t *gtpu = NULL;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    af_sess_t *af_sess = NULL;
+    af_npcf_policyauthorization_param_t af_param;
+
+    test_af_qos_reference_setup(tc, "0000000010",
+            &test_ue, &sess, &af_sess, &ngap, &gtpu);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.med_type = OpenAPI_media_type_AUDIO;
+    af_param.qos_reference = "test-audio";
+    af_param.qos_type = 1;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_create);
+
+    qos_flow = test_af_complete_qos_flow_modify(tc, test_ue, sess, ngap);
+    ogs_assert(qos_flow);
+
+    test_af_qos_reference_delete(tc, test_ue, sess, af_sess, ngap);
+    test_af_qos_reference_cleanup(tc, test_ue, ngap, gtpu);
+}
+
+static void test11_func(abts_case *tc, void *data)
+{
+    ogs_socknode_t *ngap = NULL;
+    ogs_socknode_t *gtpu = NULL;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    af_sess_t *af_sess = NULL;
+    af_npcf_policyauthorization_param_t af_param;
+
+    test_af_qos_reference_setup(tc, "0000000011",
+            &test_ue, &sess, &af_sess, &ngap, &gtpu);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.qos_reference = "test-audio";
+    af_param.omit_med_type = true;
+    af_param.qos_type = 1;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_create);
+
+    qos_flow = test_af_complete_qos_flow_modify(tc, test_ue, sess, ngap);
+    ogs_assert(qos_flow);
+
+    test_af_qos_reference_delete(tc, test_ue, sess, af_sess, ngap);
+    test_af_qos_reference_cleanup(tc, test_ue, ngap, gtpu);
+}
+
+static void test12_func(abts_case *tc, void *data)
+{
+    ogs_socknode_t *ngap = NULL;
+    ogs_socknode_t *gtpu = NULL;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    af_sess_t *af_sess = NULL;
+    af_npcf_policyauthorization_param_t af_param;
+
+    test_af_qos_reference_setup(tc, "0000000012",
+            &test_ue, &sess, &af_sess, &ngap, &gtpu);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.med_type = OpenAPI_media_type_AUDIO;
+    af_param.qos_reference = "UNKNOWN";
+    af_param.qos_type = 1;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_create);
+
+    ogs_msleep(100);
+    ABTS_INT_EQUAL(tc, OGS_SBI_HTTP_STATUS_FORBIDDEN,
+            af_sess->last_pcf_status);
+
+    qos_flow = test_qos_flow_find_by_qfi(sess, 2);
+    ABTS_TRUE(tc, qos_flow == NULL);
+
+    af_sess_remove(af_sess);
+    test_af_qos_reference_cleanup(tc, test_ue, ngap, gtpu);
+}
+
+static void test13_func(abts_case *tc, void *data)
+{
+    ogs_socknode_t *ngap = NULL;
+    ogs_socknode_t *gtpu = NULL;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    af_sess_t *af_sess = NULL;
+    af_npcf_policyauthorization_param_t af_param;
+
+    test_af_qos_reference_setup(tc, "0000000013",
+            &test_ue, &sess, &af_sess, &ngap, &gtpu);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.med_type = OpenAPI_media_type_AUDIO;
+    af_param.qos_type = 1;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_create);
+
+    qos_flow = test_af_complete_qos_flow_modify(tc, test_ue, sess, ngap);
+    ogs_assert(qos_flow);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.med_type = OpenAPI_media_type_AUDIO;
+    af_param.qos_reference = "test-audio";
+    af_param.qos_type = 2;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_update);
+
+    qos_flow = test_af_complete_qos_flow_modify(tc, test_ue, sess, ngap);
+    ogs_assert(qos_flow);
+
+    test_af_qos_reference_delete(tc, test_ue, sess, af_sess, ngap);
+    test_af_qos_reference_cleanup(tc, test_ue, ngap, gtpu);
+}
+
 
 abts_suite *test_af(abts_suite *suite)
 {
@@ -4362,6 +4859,10 @@ abts_suite *test_af(abts_suite *suite)
 #if !HOME_ROUTED_ROAMING_TEST
     abts_run_test(suite, test8_func, NULL);
 #endif
+    abts_run_test(suite, test10_func, NULL);
+    abts_run_test(suite, test11_func, NULL);
+    abts_run_test(suite, test12_func, NULL);
+    abts_run_test(suite, test13_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
## Summary

Add PCF support for AF-supplied `qosReference` values in Npcf Policy Authorization media components.

This lets operators configure named QoS profiles in `pcf.yaml` and map each `qosReference` to a 5QI/QoS index. When an AF provides `qosReference`, PCF resolves the configured profile instead of deriving the QoS index from `medType`. If no `qosReference` is present, the existing media-type mapping remains unchanged.

## Behavior

- Add `pcf.qos_profiles` config parsing.
- Map `qosReference` strings to configured QoS indexes.
- Return `403 Forbidden` for unknown `qosReference` values.
- Preserve fallback media-type behavior:
  - `AUDIO -> 1`
  - `VIDEO -> 2`
  - `CONTROL -> 5`
- Allow `qosReference` without `medType`.
- Document example QoS profile mappings in `pcf.yaml.in`.

## Validation

- Added coverage for `qosReference` authorization flows.
- Added coverage for `qosReference` without `medType`.
- Added coverage for unknown `qosReference` rejection.
- Full test suite passes locally.
