### PR TITLE
docs: add SECURITY.md security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,11 +4,9 @@
 
 The Open5GS project takes security vulnerabilities seriously.
 
-If you believe you have discovered a security issue in Open5GS, please report it privately to the project maintainer before making any public disclosure.
+If you believe you have discovered a security issue in Open5GS, please report it privately and avoid public disclosure until the issue has been reviewed and addressed.
 
-Security reports may be submitted to:
-
-[acetcom@gmail.com](mailto:acetcom@gmail.com)
+Please report vulnerabilities privately using GitHub's "Report a vulnerability" button under the Security tab (Security → Advisories → Report a vulnerability). This opens a private advisory visible only to the maintainers.
 
 When reporting a vulnerability, please include:
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Open5GS project takes security vulnerabilities seriously.
+
+If you believe you have discovered a security issue in Open5GS, please report it privately to the project maintainer before making any public disclosure.
+
+Security reports may be submitted to:
+
+[acetcom@gmail.com](mailto:acetcom@gmail.com)
+
+When reporting a vulnerability, please include:
+
+* Description of the issue
+* Affected version(s)
+* Steps to reproduce
+* Proof of concept, if available
+* Potential impact
+
+## Supported Versions
+
+Users are encouraged to use the latest stable release of Open5GS.
+
+Security fixes are generally applied to actively maintained versions.
+
+## Responsible Disclosure
+
+Please allow maintainers reasonable time to investigate and address reported vulnerabilities before public disclosure.
+
+The Open5GS project appreciates responsible and coordinated vulnerability disclosure.


### PR DESCRIPTION
This pull request adds a SECURITY.md file to provide guidance for reporting security vulnerabilities and responsible disclosure.

This change is proposed following the discussion in issue #4598  .

Feedback and suggestions are welcome.
