### PR TITLE
amf/mme: enrich /gnb-info, /enb-info and /ue-info JSON dumpers

### DIFF
--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -142,6 +142,12 @@ typedef struct amf_gnb_s {
     bool            gnb_id_presence;
     uint32_t        gnb_id;     /* gNB_ID received from gNB */
     uint8_t         gnb_id_length; /* gNB-ID BIT STRING length(22..32) */
+    /* Optional human-readable RAN node name from the NGSetupRequest
+     * RANNodeName IE (NGAP id_RANNodeName).  Empty string when the gNB
+     * doesn't include the IE.  Capped at 64 octets to match the typical
+     * deployment use of short identifiers; the spec PrintableString
+     * upper bound is 150 but real-world names are short. */
+    char            ran_node_name[64];
     ogs_plmn_id_t   plmn_id;    /* gNB PLMN-ID received from gNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */
 

--- a/src/amf/gnb-info.c
+++ b/src/amf/gnb-info.c
@@ -160,6 +160,7 @@ size_t amf_dump_gnb_info_paged(char *buf, size_t buflen, size_t page, size_t pag
 
         /* basics */
         if (!cJSON_AddNumberToObject(g, "gnb_id", (double)(unsigned)gnb->gnb_id)) { cJSON_Delete(g); oom = true; break; }
+        if (!cJSON_AddStringToObject(g, "name", gnb->ran_node_name)) { cJSON_Delete(g); oom = true; break; }
         if (add_plmn_string(g, "plmn", &gnb->plmn_id) < 0) { cJSON_Delete(g); oom = true; break; }
 
         /* network */

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -267,6 +267,7 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
     NGAP_GlobalGNB_ID_t *globalGNB_ID = NULL;
     NGAP_SupportedTAList_t *SupportedTAList = NULL;
     NGAP_PagingDRX_t *PagingDRX = NULL;
+    NGAP_RANNodeName_t *RANNodeName_ng = NULL;
 
     NGAP_Cause_PR group = NGAP_Cause_PR_NOTHING;
     long cause = 0;
@@ -297,9 +298,25 @@ void ngap_handle_ng_setup_request(amf_gnb_t *gnb, ogs_ngap_message_t *message)
         case NGAP_ProtocolIE_ID_id_DefaultPagingDRX:
             PagingDRX = &ie->value.choice.PagingDRX;
             break;
+        case NGAP_ProtocolIE_ID_id_RANNodeName:
+            RANNodeName_ng = &ie->value.choice.RANNodeName;
+            break;
         default:
             break;
         }
+    }
+
+    /* Capture the optional RANNodeName IE (PrintableString) into the
+     * gNB context.  Truncated to fit ran_node_name[] less the NUL.
+     * Used by the /gnb-info JSON dumper so external monitors can show
+     * a friendly identifier alongside the SCTP peer address. */
+    gnb->ran_node_name[0] = '\0';
+    if (RANNodeName_ng && RANNodeName_ng->buf && RANNodeName_ng->size > 0) {
+        size_t copy_len = (size_t)RANNodeName_ng->size;
+        if (copy_len >= sizeof(gnb->ran_node_name))
+            copy_len = sizeof(gnb->ran_node_name) - 1;
+        memcpy(gnb->ran_node_name, RANNodeName_ng->buf, copy_len);
+        gnb->ran_node_name[copy_len] = '\0';
     }
 
     if (!GlobalRANNodeID) {

--- a/src/amf/ue-info.c
+++ b/src/amf/ue-info.c
@@ -110,6 +110,7 @@
 #include "ogs-core.h"
 #include "ogs-proto.h"
 #include "context.h"
+#include "amf-sm.h"
 #include "ue-info.h"
 
 #include "sbi/openapi/external/cJSON.h"
@@ -204,6 +205,32 @@ static int add_basic_identity(cJSON *o, const amf_ue_t *ue)
         const char *cm = CM_CONNECTED(ue) ? "connected" : "idle";
         cJSON *v = cJSON_CreateString(cm); if (!v) return -1;
         cJSON_AddItemToObjectCS(o, "cm_state", v);
+    }
+
+    /*
+     * mm_state: 5G GMM FSM state, exposed as a stable string so
+     * external consumers can distinguish in-progress NAS transitions
+     * from the steady-state {de,}registered values.  The string
+     * mirrors the name of the FSM state-handler function in gmm-sm.c,
+     * with "de_registered" rendered as "deregistered" for readability.
+     *
+     * The AMF keeps amf_ue_t contexts in amf_ue_list across explicit
+     * deregistration (only freed later via amf_ue_remove() in specific
+     * paths), so without this field a deregistered UE is
+     * indistinguishable from a CM-IDLE but still-registered UE in the
+     * JSON output.
+     */
+    {
+        const char *mm = "initial";
+        if      (OGS_FSM_CHECK(&ue->sm, gmm_state_de_registered))          mm = "deregistered";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_registered))             mm = "registered";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_authentication))         mm = "authentication";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_security_mode))          mm = "security_mode";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_initial_context_setup))  mm = "initial_context_setup";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_ue_context_will_remove)) mm = "ue_context_will_remove";
+        else if (OGS_FSM_CHECK(&ue->sm, gmm_state_exception))              mm = "exception";
+        cJSON *v = cJSON_CreateString(mm); if (!v) return -1;
+        cJSON_AddItemToObjectCS(o, "mm_state", v);
     }
 
     /* If M-TMSI present, expose GUTI string and m_tmsi numeric */

--- a/src/mme/enb-info.c
+++ b/src/mme/enb-info.c
@@ -147,6 +147,7 @@ size_t mme_dump_enb_info_paged(char *buf, size_t buflen, size_t page, size_t pag
 
         /* enb_id */
         if (!cJSON_AddNumberToObject(e, "enb_id", (double)(unsigned)enb->enb_id)) { cJSON_Delete(e); oom = true; break; }
+        if (!cJSON_AddStringToObject(e, "name", enb->enb_name)) { cJSON_Delete(e); oom = true; break; }
 
         /* plmn */
         {

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -4356,11 +4356,23 @@ int mme_ue_xact_count(mme_ue_t *mme_ue, uint8_t org)
 
 void enb_ue_associate_mme_ue(enb_ue_t *enb_ue, mme_ue_t *mme_ue)
 {
+    mme_enb_t *enb_obj = NULL;
+
     ogs_assert(mme_ue);
     ogs_assert(enb_ue);
 
     mme_ue->enb_ue_id = enb_ue->id;
     enb_ue->mme_ue_id = mme_ue->id;
+
+    /* Capture the eNB-ID so /ue-info can still report the last-attached
+     * cell after the enb_ue_t is freed at UE Context Release.  Skip
+     * silently if the eNB hasn't completed S1 Setup with an enb_id IE;
+     * a later association on a properly-set-up eNB will overwrite. */
+    enb_obj = mme_enb_find_by_id(enb_ue->enb_id);
+    if (enb_obj && enb_obj->enb_id_presence) {
+        mme_ue->last_enb_id = enb_obj->enb_id;
+        mme_ue->last_enb_id_presence = true;
+    }
 }
 
 void enb_ue_deassociate_mme_ue(enb_ue_t *enb_ue, mme_ue_t *mme_ue)

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -254,6 +254,11 @@ typedef struct mme_enb_s {
 
     bool            enb_id_presence;
     uint32_t        enb_id;     /* eNB_ID received from eNB */
+    /* Optional human-readable eNB name from the S1SetupRequest eNBname
+     * IE (S1AP id_eNBname).  Empty string when the eNB doesn't include
+     * the IE.  Capped at 64 octets; the spec PrintableString upper
+     * bound is 150 but real-world names are short. */
+    char            enb_name[64];
     ogs_plmn_id_t   plmn_id;    /* eNB PLMN-ID received from eNB */
     ogs_sctp_sock_t sctp;       /* SCTP socket */
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -528,6 +528,15 @@ struct mme_ue_s {
     uint16_t        enb_ostream_id;
     ogs_eps_tai_t   tai;
     ogs_e_cgi_t     e_cgi;
+    /* Last-known eNB-ID, captured in enb_ue_associate_mme_ue() and
+     * preserved across UE Context Release.  Mirrors how amf_ue_t->nr_cgi
+     * survives the freeing of ran_ue_t at NG UE Context Release: the
+     * S1 enb_ue_t is freed when the UE goes ECM-IDLE, but external
+     * monitors querying /mme/ue-info still want to know which cell a
+     * UE was last attached to.  presence flag tracks whether we've
+     * ever seen this UE on an eNB whose own enb_id_presence was true. */
+    bool            last_enb_id_presence;
+    uint32_t        last_enb_id;
     ogs_time_t      ue_location_timestamp;
     ogs_plmn_id_t   last_visited_plmn_id;
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -174,6 +174,7 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
     S1AP_Global_ENB_ID_t *Global_ENB_ID = NULL;
     S1AP_SupportedTAs_t *SupportedTAs = NULL;
     S1AP_PagingDRX_t *PagingDRX = NULL;
+    S1AP_ENBname_t *ENBname = NULL;
 
     uint32_t enb_id;
     S1AP_Cause_PR group = S1AP_Cause_PR_NOTHING;
@@ -202,9 +203,25 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         case S1AP_ProtocolIE_ID_id_DefaultPagingDRX:
             PagingDRX = &ie->value.choice.PagingDRX;
             break;
+        case S1AP_ProtocolIE_ID_id_eNBname:
+            ENBname = &ie->value.choice.ENBname;
+            break;
         default:
             break;
         }
+    }
+
+    /* Capture the optional eNBname IE (PrintableString) into the eNB
+     * context.  Truncated to fit enb_name[] less the NUL.  Used by
+     * the /enb-info JSON dumper so external monitors can show a
+     * friendly identifier alongside the SCTP peer address. */
+    enb->enb_name[0] = '\0';
+    if (ENBname && ENBname->buf && ENBname->size > 0) {
+        size_t copy_len = (size_t)ENBname->size;
+        if (copy_len >= sizeof(enb->enb_name))
+            copy_len = sizeof(enb->enb_name) - 1;
+        memcpy(enb->enb_name, ENBname->buf, copy_len);
+        enb->enb_name[copy_len] = '\0';
     }
 
     if (!Global_ENB_ID) {

--- a/src/mme/ue-info.c
+++ b/src/mme/ue-info.c
@@ -86,8 +86,8 @@
 #include "ogs-proto.h"
 
 #include "mme-context.h"
+#include "mme-sm.h"
 #include "ue-info.h"
-#include "mme-context.h"
 
 #include "metrics/prometheus/json_pager.h"
 #include "metrics/ogs-metrics.h"
@@ -306,6 +306,33 @@ static cJSON *ue_to_json(const mme_ue_t *ue)
     if (!cJSON_AddStringToObject(o, "domain", "EPS")) goto end;
     if (!cJSON_AddStringToObject(o, "rat", "E-UTRA")) goto end;
     if (!cJSON_AddStringToObject(o, "cm_state", cm_state_str(ue))) goto end;
+
+    /*
+     * mm_state: 4G EMM FSM state, exposed as a stable string so
+     * external consumers can distinguish in-progress NAS transitions
+     * from the steady-state {de,}registered values.  The string
+     * mirrors the name of the FSM state-handler function in emm-sm.c,
+     * with "de_registered" rendered as "deregistered" for readability.
+     *
+     * The MME keeps mme_ue_t contexts in mme_ue_list across explicit
+     * detach (see emm_state_de_registered's entry handler -- it clears
+     * timers and S1 state but does not call mme_ue_remove()), so
+     * without this field a detached UE is indistinguishable from an
+     * ECM-IDLE but still EMM-REGISTERED UE in the JSON output.  This
+     * is the LTE mirror of the equivalent AMF /ue-info field added in
+     * the prior mm_state patch.
+     */
+    {
+        const char *mm = "initial";
+        if      (OGS_FSM_CHECK(&ue->sm, emm_state_de_registered))          mm = "deregistered";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_registered))             mm = "registered";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_authentication))         mm = "authentication";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_security_mode))          mm = "security_mode";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_initial_context_setup))  mm = "initial_context_setup";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_ue_context_will_remove)) mm = "ue_context_will_remove";
+        else if (OGS_FSM_CHECK(&ue->sm, emm_state_exception))              mm = "exception";
+        if (!cJSON_AddStringToObject(o, "mm_state", mm)) goto end;
+    }
 
     /* enb */
     {

--- a/src/mme/ue-info.c
+++ b/src/mme/ue-info.c
@@ -149,6 +149,25 @@ static cJSON *build_enb(const mme_ue_t *ue)
             if (!cJSON_AddNumberToObject(enb, "cell_id", (double)cell_id))
                 goto end;
         }
+    } else {
+        /* ECM-IDLE: enb_ue_t has been freed at UE Context Release, so
+         * the live S1AP IDs are unavailable.  Fall back to the
+         * eNB-ID and ECI we captured at the most recent attach (see
+         * enb_ue_associate_mme_ue() in mme-context.c, and ue->e_cgi
+         * which is updated on Initial UE / TAU / Service Request).
+         * "status" stays "not-connected" via the cm_state field above
+         * to make it explicit to the consumer that these are
+         * last-known values. */
+        if (ue->last_enb_id_presence) {
+            if (!cJSON_AddNumberToObject(enb, "enb_id", (double)ue->last_enb_id))
+                goto end;
+        }
+        if (ue->e_cgi.cell_id) {
+            if (!cJSON_AddNumberToObject(enb, "cell_id", (double)ue->e_cgi.cell_id))
+                goto end;
+        }
+        if (!cJSON_AddStringToObject(enb, "status", "not-connected"))
+            goto end;
     }
 
     return enb;


### PR DESCRIPTION
Extends the JSON info dumpers added in #4093 with extra fields that let external monitors track UEs and RAN nodes without parsing NGAP/S1AP out-of-band. AMF (5G) and MME (4G) changes mirror each other.

## RAN node name
- amf: capture NGAP RANNodeName IE into amf_gnb_t, expose as `name` in /gnb-info
- mme: capture S1AP eNBname IE into mme_enb_t, expose as `name` in /enb-info

Empty string when the peer omits the IE.

## mm_state in /ue-info
Adds an `mm_state` field (derived from the FSM state handler) to both AMF and MME /ue-info, so an explicitly {de,}registered UE is distinguishable from one that is merely CM/ECM-IDLE, and in-progress NAS transitions (e.g. a stuck authentication) become visible — without waiting out the implicit dereg/detach timers.

## last-known eNB-ID for ECM-IDLE UEs (MME)
Stores the eNB-ID on mme_ue_t at attach association so /ue-info can anchor an ECM-IDLE UE to its last cell after UE Context Release, with `status: "not-connected"`. This mirrors how the AMF already exposes the last-attached gNB for CM-IDLE UEs.

All changes are read-only; no state-machine behavior is modified.