### PR TITLE
pcf: send TerminationInfo body in policyauthorization terminate notify

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -209,6 +209,8 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_app_session_context_free(message->AppSessionContext);
     if (message->AppSessionContextUpdateDataPatch)
         OpenAPI_app_session_context_update_data_patch_free(message->AppSessionContextUpdateDataPatch);
+    if (message->TerminationInfo)
+        OpenAPI_termination_info_free(message->TerminationInfo);
     if (message->SmPolicyNotification)
         OpenAPI_sm_policy_notification_free(message->SmPolicyNotification);
     if (message->TerminationNotification)
@@ -1704,6 +1706,10 @@ static char *build_json(ogs_sbi_message_t *message)
         item = OpenAPI_app_session_context_update_data_patch_convertToJSON(
                 message->AppSessionContextUpdateDataPatch);
         ogs_assert(item);
+    } else if (message->TerminationInfo) {
+        item = OpenAPI_termination_info_convertToJSON(
+                message->TerminationInfo);
+        ogs_assert(item);
     } else if (message->SmPolicyNotification) {
         item = OpenAPI_sm_policy_notification_convertToJSON(
                 message->SmPolicyNotification);
@@ -2889,6 +2895,14 @@ static int parse_json(ogs_sbi_message_t *message,
                         SWITCH(message->h.resource.component[2])
                         CASE(OGS_SBI_RESOURCE_NAME_DELETE)
                             /* Nothing */
+                            break;
+                        CASE(OGS_SBI_RESOURCE_NAME_TERMINATE)
+                            message->TerminationInfo =
+                                OpenAPI_termination_info_parseFromJSON(item);
+                            if (!message->TerminationInfo) {
+                                rv = OGS_ERROR;
+                                ogs_error("JSON parse error");
+                            }
                             break;
                         DEFAULT
                             rv = OGS_ERROR;

--- a/lib/sbi/message.h
+++ b/lib/sbi/message.h
@@ -600,6 +600,7 @@ typedef struct ogs_sbi_message_s {
     OpenAPI_app_session_context_t *AppSessionContext;
     OpenAPI_app_session_context_update_data_patch_t
         *AppSessionContextUpdateDataPatch;
+    OpenAPI_termination_info_t *TerminationInfo;
     OpenAPI_sm_policy_notification_t *SmPolicyNotification;
     OpenAPI_termination_notification_t *TerminationNotification;
     OpenAPI_deregistration_data_t *DeregistrationData;

--- a/lib/sbi/ogs-sbi.h
+++ b/lib/sbi/ogs-sbi.h
@@ -87,6 +87,7 @@
 #include "model/app_session_context_update_data_patch.h"
 #include "model/policy_update.h"
 #include "model/sm_policy_notification.h"
+#include "model/termination_info.h"
 #include "model/termination_notification.h"
 #include "model/deregistration_data.h"
 #include "model/sdm_subscription.h"

--- a/src/pcf/naf-build.c
+++ b/src/pcf/naf-build.c
@@ -24,10 +24,38 @@ ogs_sbi_request_t *pcf_naf_callback_build_policyauthorization_terminate(
 {
     ogs_sbi_message_t message;
     ogs_sbi_request_t *request = NULL;
-    
+    ogs_sbi_server_t *server = NULL;
+    ogs_sbi_header_t header;
+    OpenAPI_termination_info_t TerminationInfo;
+
     ogs_assert(app_session);
 
     memset(&message, 0, sizeof(message));
+    memset(&TerminationInfo, 0, sizeof(TerminationInfo));
+
+    server = ogs_sbi_server_first();
+    if (!server) {
+        ogs_error("No server");
+        goto end;
+    }
+
+    memset(&header, 0, sizeof(header));
+    header.service.name =
+        OpenAPI_service_name_ToString(
+                OpenAPI_service_name_npcf_policyauthorization);
+    header.api.version = (char *)OGS_SBI_API_V1;
+    header.resource.component[0] = (char *)OGS_SBI_RESOURCE_NAME_APP_SESSIONS;
+    header.resource.component[1] = app_session->app_session_id;
+
+    TerminationInfo.res_uri = ogs_sbi_server_uri(server, &header);
+    if (!TerminationInfo.res_uri) {
+        ogs_error("No TerminationInfo.res_uri");
+        goto end;
+    }
+    TerminationInfo.term_cause = data ?
+        *(OpenAPI_termination_cause_e *)data :
+        OpenAPI_termination_cause_PDU_SESSION_TERMINATION;
+
     message.h.method = (char *)OGS_SBI_HTTP_METHOD_POST;
     message.h.uri = ogs_msprintf("%s/%s",
                 app_session->notif_uri, OGS_SBI_RESOURCE_NAME_TERMINATE);
@@ -36,11 +64,14 @@ ogs_sbi_request_t *pcf_naf_callback_build_policyauthorization_terminate(
         goto end;
     }
 
+    message.TerminationInfo = &TerminationInfo;
+
     request = ogs_sbi_build_request(&message);
     ogs_assert(request);
 
 end:
-
+    if (TerminationInfo.res_uri)
+        ogs_free(TerminationInfo.res_uri);
     if (message.h.uri)
         ogs_free(message.h.uri);
 

--- a/src/pcf/npcf-handler.c
+++ b/src/pcf/npcf-handler.c
@@ -623,7 +623,8 @@ bool pcf_npcf_smpolicycontrol_handle_delete(pcf_sess_t *sess,
     }
 
     ogs_list_for_each(&sess->app_list, app_session) {
-        pcf_sbi_send_policyauthorization_terminate_notify(app_session);
+        pcf_sbi_send_policyauthorization_terminate_notify(app_session,
+                OpenAPI_termination_cause_PDU_SESSION_TERMINATION);
     }
 
     if (pcf_sessions_number_by_snssai_and_dnn(

--- a/src/pcf/sbi-path.c
+++ b/src/pcf/sbi-path.c
@@ -684,7 +684,8 @@ bool pcf_sbi_send_smpolicycontrol_delete_notify(
     return rc;
 }
 
-bool pcf_sbi_send_policyauthorization_terminate_notify(pcf_app_t *app)
+bool pcf_sbi_send_policyauthorization_terminate_notify(pcf_app_t *app,
+        OpenAPI_termination_cause_e term_cause)
 {
     bool rc;
     ogs_sbi_request_t *request = NULL;
@@ -694,7 +695,8 @@ bool pcf_sbi_send_policyauthorization_terminate_notify(pcf_app_t *app)
     client = app->naf.client;
     ogs_assert(client);
 
-    request = pcf_naf_callback_build_policyauthorization_terminate(app, NULL);
+    request = pcf_naf_callback_build_policyauthorization_terminate(
+            app, &term_cause);
     if (!request) {
         ogs_error("pcf_naf_callback_build_policyauthorization_terminate() "
                 "failed");

--- a/src/pcf/sbi-path.h
+++ b/src/pcf/sbi-path.h
@@ -55,7 +55,8 @@ bool pcf_sbi_send_smpolicycontrol_delete_notify(
         pcf_sess_t *sess, pcf_app_t *app_session,
         OpenAPI_sm_policy_decision_t *SmPolicyDecision);
 
-bool pcf_sbi_send_policyauthorization_terminate_notify(pcf_app_t *app);
+bool pcf_sbi_send_policyauthorization_terminate_notify(pcf_app_t *app,
+        OpenAPI_termination_cause_e term_cause);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Problem**

When a PDU session ends, the PCF sends a POST to the AF/NEF termination callback URL. Per TS 29.514 §4.2.5.3, that request must carry a TerminationInfo body containing:

- `resUri` — the URI of the terminated app session on the PCF
- `termCause` — the reason for termination

The PCF was sending an empty body, so receivers had no way to identify which session was terminated without embedding the session ID in the callback URL as a workaround.

**Fix**

The termination cause is passed from the call site via the void *data parameter, following the convention used by other PCF builder functions. The current call site supplies PDU_SESSION_TERMINATION; future call sites can supply other causes (e.g. INSUFFICIENT_QOS_FLOW_RESOURCES) without modifying the builder.