### PR TITLE
[MME] Add network policy (TS 24.301 9.9.3.52)

### DIFF
--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -259,6 +259,9 @@ int ogs_app_parse_global_conf(ogs_yaml_iter_t *parent)
                 } else if (!strcmp(parameter_key, "no_ims")) {
                     global_conf.parameter.no_ims =
                         ogs_yaml_iter_bool(&parameter_iter);
+                } else if (!strcmp(parameter_key, "allow_unsecured_redirection")) {
+                    global_conf.parameter.allow_unsecured_redirection =
+                        ogs_yaml_iter_bool(&parameter_iter);
                 } else if (!strcmp(parameter_key,
                             "no_ipv4v6_local_addr_in_packet_filter")) {
                     global_conf.parameter.

--- a/lib/app/ogs-config.h
+++ b/lib/app/ogs-config.h
@@ -71,6 +71,7 @@ typedef struct ogs_global_conf_s {
         int use_openair;
         int fake_csfb;
         int no_ims;
+        int allow_unsecured_redirection;
         int use_upg_vpp;
         int no_ipv4v6_local_addr_in_packet_filter;
 

--- a/src/mme/emm-build.c
+++ b/src/mme/emm-build.c
@@ -265,6 +265,18 @@ ogs_pkbuf_t *emm_build_attach_accept(
         ogs_debug("    P-TMSI: 0x%08x", tmsi->tmsi);
     }
 
+    attach_accept->presencemask |=
+        OGS_NAS_EPS_ATTACH_ACCEPT_NETWORK_POLICY_PRESENT;
+    attach_accept->network_policy.type =
+            OGS_NAS_EPS_ATTACH_ACCEPT_NETWORK_POLICY_TYPE >> 4;
+    if (ogs_global_conf()->parameter.allow_unsecured_redirection == true) {
+        attach_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 0;
+    } else {
+        attach_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 1;
+    }
+
     pkbuf = nas_eps_security_encode(mme_ue, &message);
     ogs_pkbuf_free(esmbuf);
 
@@ -693,6 +705,18 @@ ogs_pkbuf_t *emm_build_tau_accept(mme_ue_t *mme_ue)
     }
     tau_accept->eps_network_feature_support.
         extended_protocol_configuration_options = 1;
+
+    tau_accept->presencemask |=
+        OGS_NAS_EPS_TRACKING_AREA_UPDATE_ACCEPT_NETWORK_POLICY_PRESENT;
+    tau_accept->network_policy.type =
+        OGS_NAS_EPS_TRACKING_AREA_UPDATE_ACCEPT_NETWORK_POLICY_TYPE >> 4;
+    if (ogs_global_conf()->parameter.allow_unsecured_redirection == true) {
+        tau_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 0;
+    } else {
+        tau_accept->network_policy.
+            unsecured_redirection_to_geran_not_allowed = 1;
+    }
 
     return nas_eps_security_encode(mme_ue, &message);
 }


### PR DESCRIPTION
This commit adds the network policy IE, part of ATTACH ACCEPT and
TAU ACCEPT messages. This prevents unsecured redirection to GERAN
or UTRAN, protecting the UEs from unsecured redirection attacks.
This IE is mandatory in Rel.19

This patch changes the default behavior!

In case you want to allow unsecured redirects, add the following:

```
global:
  parameter:
    allow_unsecured_redirection: true
```

to your mme.yaml