### PR TITLE
OSS-Fuzz: Add new fuzzer targets s1ap message processing

### DIFF
--- a/tests/fuzzing/meson.build
+++ b/tests/fuzzing/meson.build
@@ -23,6 +23,7 @@ lib_fuzzing_engine = get_option('lib_fuzzing_engine')
 gtp_message_source = files('gtp-message-fuzz.c')
 nas_message_source = files('nas-message-fuzz.c')
 ngap_message_source = files('ngap-message-fuzz.c')
+s1ap_message_source = files('s1ap-message-fuzz.c')
 
 # Build all executable
 executable(
@@ -46,5 +47,13 @@ executable(
     sources : ngap_message_source,
     c_args : [testunit_core_cc_flags, sbi_cc_flags],
     dependencies : [libngap_dep, libcore_dep],
+    link_args: lib_fuzzing_engine
+)
+
+executable(
+    's1ap_message_fuzz',
+    sources : s1ap_message_source,
+    c_args : [testunit_core_cc_flags, sbi_cc_flags],
+    dependencies : [libs1ap_dep, libcore_dep],
     link_args: lib_fuzzing_engine
 )

--- a/tests/fuzzing/s1ap-message-fuzz.c
+++ b/tests/fuzzing/s1ap-message-fuzz.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019-2026 by Arthur SC Chan <arthur.chan@adalogics.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "fuzzing.h"
+#include "ogs-s1ap.h"
+
+#define kMinInputLength 5
+#define kMaxInputLength 2048
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+
+    if (Size < kMinInputLength || Size > kMaxInputLength) {
+        return 1;
+    }
+
+    if (!initialized) {
+        initialize();
+        ogs_log_install_domain(&__ogs_s1ap_domain, "s1ap", OGS_LOG_NONE);
+    }
+
+    int result;
+    ogs_pkbuf_t *pkbuf;
+    ogs_s1ap_message_t message;
+
+    pkbuf = ogs_pkbuf_alloc(NULL, OGS_MAX_SDU_LEN);
+    if (pkbuf == NULL) {
+        return 1;
+    }
+
+    ogs_pkbuf_put_data(pkbuf, Data, Size);
+
+    result = ogs_s1ap_decode(&message, pkbuf);
+    if (result == OGS_OK) {
+        ogs_s1ap_free(&message);
+    }
+
+    ogs_pkbuf_free(pkbuf);
+
+    return 0;
+}


### PR DESCRIPTION
This PR creates a new OSS-Fuzz fuzzer targets s1ap message processing, mirroring the other message processing fuzzers, together with the fix of the build in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/15785).