### PR TITLE
nas: fix uninitialized read in NAS DNN/APN decode

### DIFF
--- a/lib/nas/5gs/decoder.c
+++ b/lib/nas/5gs/decoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-15 16:17:36.453801 by acetcom
+ * Created on: 2026-06-27 11:33:22.443948 by acetcom
  * from r19.6.2/24501-j62-ch8-ch9.docx
  ******************************************************************************/
 
@@ -5047,7 +5047,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_registration_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_registration_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5056,7 +5056,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_registration_accept(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_registration_accept() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5065,7 +5065,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_registration_complete(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_registration_complete() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5074,7 +5074,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_registration_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_registration_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5083,7 +5083,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_deregistration_request_from_ue(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_deregistration_request_from_ue() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5094,7 +5094,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_deregistration_request_to_ue(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_deregistration_request_to_ue() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5105,7 +5105,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_service_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_service_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5114,7 +5114,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_service_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_service_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5123,7 +5123,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_service_accept(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_service_accept() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5132,7 +5132,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_configuration_update_command(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_configuration_update_command() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5143,7 +5143,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_authentication_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_authentication_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5152,7 +5152,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_authentication_response(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_authentication_response() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5161,7 +5161,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_authentication_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_authentication_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5170,7 +5170,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_authentication_failure(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_authentication_failure() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5179,7 +5179,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_authentication_result(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_authentication_result() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5188,7 +5188,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_identity_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_identity_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5197,7 +5197,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_identity_response(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_identity_response() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5206,7 +5206,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_security_mode_command(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_security_mode_command() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5215,7 +5215,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_security_mode_complete(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_security_mode_complete() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5224,7 +5224,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_security_mode_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_security_mode_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5233,7 +5233,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_5gmm_status(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_5gmm_status() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5242,7 +5242,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_notification(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_notification() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5251,7 +5251,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_notification_response(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_notification_response() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5260,7 +5260,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_ul_nas_transport(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_ul_nas_transport() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5269,7 +5269,7 @@ int ogs_nas_5gmm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_dl_nas_transport(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_dl_nas_transport() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5307,7 +5307,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_establishment_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_establishment_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5316,7 +5316,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_establishment_accept(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_establishment_accept() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5325,7 +5325,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_establishment_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_establishment_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5334,7 +5334,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_authentication_command(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_authentication_command() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5343,7 +5343,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_authentication_complete(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_authentication_complete() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5352,7 +5352,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_authentication_result(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_authentication_result() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5361,7 +5361,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_modification_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_modification_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5370,7 +5370,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_modification_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_modification_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5379,7 +5379,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_modification_command(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_modification_command() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5388,7 +5388,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_modification_complete(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_modification_complete() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5397,7 +5397,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_modification_command_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_modification_command_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5406,7 +5406,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_release_request(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_release_request() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5415,7 +5415,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_release_reject(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_release_reject() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5424,7 +5424,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_release_command(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_release_command() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5433,7 +5433,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_pdu_session_release_complete(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_pdu_session_release_complete() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;
@@ -5442,7 +5442,7 @@ int ogs_nas_5gsm_decode(ogs_nas_5gs_message_t *message, ogs_pkbuf_t *pkbuf)
         size = ogs_nas_5gs_decode_5gsm_status(message, pkbuf);
         if (size < 0) {
            ogs_error("ogs_nas_5gs_decode_5gsm_status() failed");
-           return size;
+           return OGS_ERROR;
         }
 
         decoded += size;

--- a/lib/nas/5gs/encoder.c
+++ b/lib/nas/5gs/encoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-15 16:17:36.466230 by acetcom
+ * Created on: 2026-06-27 11:33:22.456738 by acetcom
  * from r19.6.2/24501-j62-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/5gs/ies.c
+++ b/lib/nas/5gs/ies.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-15 16:17:36.434612 by acetcom
+ * Created on: 2026-06-27 11:33:22.424250 by acetcom
  * from r19.6.2/24501-j62-ch8-ch9.docx
  ******************************************************************************/
 
@@ -203,8 +203,9 @@ int ogs_nas_5gs_decode_dnn(ogs_nas_dnn_t *dnn, ogs_pkbuf_t *pkbuf)
 
     {
         char data_network_name[OGS_MAX_DNN_LEN+1];
-        dnn->length = ogs_fqdn_parse(data_network_name, dnn->value, ogs_min(dnn->length, OGS_MAX_DNN_LEN));
-        if (dnn->length > 0) {
+        int parsed = ogs_fqdn_parse(data_network_name, dnn->value, ogs_min(dnn->length, OGS_MAX_DNN_LEN));
+        if (parsed > 0) {
+            dnn->length = parsed;
             ogs_cpystrn(dnn->value, data_network_name, ogs_min(dnn->length, OGS_MAX_DNN_LEN)+1);
         } else {
             ogs_error("UE not APN setting");

--- a/lib/nas/5gs/ies.h
+++ b/lib/nas/5gs/ies.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-15 16:17:36.431252 by acetcom
+ * Created on: 2026-06-27 11:33:22.420826 by acetcom
  * from r19.6.2/24501-j62-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/5gs/message.h
+++ b/lib/nas/5gs/message.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.2.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-15 16:17:36.445831 by acetcom
+ * Created on: 2026-06-27 11:33:22.436023 by acetcom
  * from r19.6.2/24501-j62-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/5gs/support/type-list.py
+++ b/lib/nas/5gs/support/type-list.py
@@ -29,8 +29,9 @@ type_list["Header compression configuration"]["encode"] = \
 type_list["DNN"]["decode"] = \
 "    {\n" \
 "        char data_network_name[OGS_MAX_DNN_LEN+1];\n" \
-"        dnn->length = ogs_fqdn_parse(data_network_name, dnn->value, ogs_min(dnn->length, OGS_MAX_DNN_LEN));\n" \
-"        if (dnn->length > 0) {\n" \
+"        int parsed = ogs_fqdn_parse(data_network_name, dnn->value, ogs_min(dnn->length, OGS_MAX_DNN_LEN));\n" \
+"        if (parsed > 0) {\n" \
+"            dnn->length = parsed;\n" \
 "            ogs_cpystrn(dnn->value, data_network_name, ogs_min(dnn->length, OGS_MAX_DNN_LEN)+1);\n" \
 "        } else {\n" \
 "            ogs_error(\"UE not APN setting\");\n" \

--- a/lib/nas/eps/decoder.c
+++ b/lib/nas/eps/decoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-23 17:17:22.494221 by acetcom
+ * Created on: 2026-06-27 11:33:07.993784 by acetcom
  * from r19.6.0/24301-j60-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/eps/encoder.c
+++ b/lib/nas/eps/encoder.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-23 17:17:22.510213 by acetcom
+ * Created on: 2026-06-27 11:33:08.010257 by acetcom
  * from r19.6.0/24301-j60-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/eps/ies.c
+++ b/lib/nas/eps/ies.c
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-23 17:17:22.474073 by acetcom
+ * Created on: 2026-06-27 11:33:07.974030 by acetcom
  * from r19.6.0/24301-j60-ch8-ch9.docx
  ******************************************************************************/
 
@@ -3977,8 +3977,9 @@ int ogs_nas_eps_decode_access_point_name(ogs_nas_access_point_name_t *access_poi
 
     {
         char apn[OGS_MAX_APN_LEN+1];
-        access_point_name->length = ogs_fqdn_parse(apn, access_point_name->apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN));
-        if (access_point_name->length > 0) {
+        int parsed = ogs_fqdn_parse(apn, access_point_name->apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN));
+        if (parsed > 0) {
+            access_point_name->length = parsed;
             ogs_cpystrn(access_point_name->apn, apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN)+1);
         } else {
             ogs_error("UE not APN setting");

--- a/lib/nas/eps/ies.h
+++ b/lib/nas/eps/ies.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-23 17:17:22.470774 by acetcom
+ * Created on: 2026-06-27 11:33:07.970812 by acetcom
  * from r19.6.0/24301-j60-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/eps/message.h
+++ b/lib/nas/eps/message.h
@@ -28,7 +28,7 @@
 /*******************************************************************************
  * This file had been created by nas-message.py script v0.1.0
  * Please do not modify this file but regenerate it via script.
- * Created on: 2026-06-23 17:17:22.483598 by acetcom
+ * Created on: 2026-06-27 11:33:07.983342 by acetcom
  * from r19.6.0/24301-j60-ch8-ch9.docx
  ******************************************************************************/
 

--- a/lib/nas/eps/support/type-list.py
+++ b/lib/nas/eps/support/type-list.py
@@ -71,8 +71,9 @@ type_list["Short MAC"]["encode"] = \
 type_list["Access point name"]["decode"] = \
 "    {\n" \
 "        char apn[OGS_MAX_APN_LEN+1];\n" \
-"        access_point_name->length = ogs_fqdn_parse(apn, access_point_name->apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN));\n" \
-"        if (access_point_name->length > 0) {\n" \
+"        int parsed = ogs_fqdn_parse(apn, access_point_name->apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN));\n" \
+"        if (parsed > 0) {\n" \
+"            access_point_name->length = parsed;\n" \
 "            ogs_cpystrn(access_point_name->apn, apn, ogs_min(access_point_name->length, OGS_MAX_APN_LEN)+1);\n" \
 "        } else {\n" \
 "            ogs_error(\"UE not APN setting\");\n" \


### PR DESCRIPTION
ogs_fqdn_parse() returns -EINVAL on invalid FQDN encoding, but the DNN and APN decoders stored the result directly into the uint8_t length field. The negative value was truncated (-22 -> 234), so the "if (length > 0)" guard passed and ogs_cpystrn() copied up to 101 bytes from an uninitialized stack buffer that ogs_fqdn_parse() never wrote.

The guard was written when ogs_fqdn_parse() returned 0 on failure; the later switch to -EINVAL broke it via the unsigned truncation.

Capture the return value in a signed int, take the error branch on negative/zero, and assign to length only on success. Applied to both ogs_nas_5gs_decode_dnn and ogs_nas_eps_decode_access_point_name via the support/type-list.py templates; generated ies.c regenerated.

Found by OSS-Fuzz (nas_5gs_message_fuzz, MSan).

Issues: #4645