### PR TITLE
sbi: Fix NULL list-add abort on map values of type DateTime/array

### DIFF
--- a/lib/sbi/openapi/model/_application_data_influence_data_subs_to_notify_post_request_inner.c
+++ b/lib/sbi/openapi/model/_application_data_influence_data_subs_to_notify_post_request_inner.c
@@ -1044,6 +1044,10 @@ OpenAPI__application_data_influence_data_subs_to_notify_post_request_inner_t *Op
                     ogs_error("OpenAPI__application_data_influence_data_subs_to_notify_post_request_inner_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI__application_data_influence_data_subs_to_notify_post_request_inner_parseFromJSON() failed [traffic_data_sets]");
+                    goto end;
+                }
                 OpenAPI_list_add(traffic_data_setsList, localMapKeyPair);
             }
         }
@@ -1387,6 +1391,10 @@ OpenAPI__application_data_influence_data_subs_to_notify_post_request_inner_t *Op
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI__application_data_influence_data_subs_to_notify_post_request_inner_parseFromJSON() failed [nsc_supp_feats]");
+                    goto end;
+                }
                 OpenAPI_list_add(nsc_supp_featsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/acceptable_service_info.c
+++ b/lib/sbi/openapi/model/acceptable_service_info.c
@@ -212,6 +212,10 @@ OpenAPI_acceptable_service_info_t *OpenAPI_acceptable_service_info_parseFromJSON
                     ogs_error("OpenAPI_acceptable_service_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_acceptable_service_info_parseFromJSON() failed [acc_bw_med_comps]");
+                    goto end;
+                }
                 OpenAPI_list_add(acc_bw_med_compsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data.c
@@ -1619,6 +1619,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [shared_vn_group_data_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_vn_group_data_idsList, localMapKeyPair);
             }
         }
@@ -1992,6 +1996,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [odb_exempted_dnn_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(odb_exempted_dnn_dataList, localMapKeyPair);
             }
         }
@@ -2052,6 +2060,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_mdt_user_consent_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [adjacent_plmn_mdt_user_consents]");
+                    goto end;
+                }
                 OpenAPI_list_add(adjacent_plmn_mdt_user_consentsList, localMapKeyPair);
             }
         }
@@ -2189,6 +2201,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [expected_ue_behaviour_data]");
                     goto end;
                 }
                 OpenAPI_list_add(expected_ue_behaviour_dataList, localMapKeyPair);
@@ -2331,6 +2347,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [adjacent_plmn_restrictions]");
                     goto end;
                 }
                 OpenAPI_list_add(adjacent_plmn_restrictionsList, localMapKeyPair);
@@ -2515,6 +2535,10 @@ OpenAPI_access_and_mobility_subscription_data_t *OpenAPI_access_and_mobility_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_parseFromJSON() failed [ladn_service_areas]");
                     goto end;
                 }
                 OpenAPI_list_add(ladn_service_areasList, localMapKeyPair);

--- a/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
+++ b/lib/sbi/openapi/model/access_and_mobility_subscription_data_1.c
@@ -1619,6 +1619,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [shared_vn_group_data_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_vn_group_data_idsList, localMapKeyPair);
             }
         }
@@ -1992,6 +1996,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [odb_exempted_dnn_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(odb_exempted_dnn_dataList, localMapKeyPair);
             }
         }
@@ -2052,6 +2060,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_mdt_user_consent_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [adjacent_plmn_mdt_user_consents]");
+                    goto end;
+                }
                 OpenAPI_list_add(adjacent_plmn_mdt_user_consentsList, localMapKeyPair);
             }
         }
@@ -2189,6 +2201,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [expected_ue_behaviour_data]");
                     goto end;
                 }
                 OpenAPI_list_add(expected_ue_behaviour_dataList, localMapKeyPair);
@@ -2331,6 +2347,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [adjacent_plmn_restrictions]");
                     goto end;
                 }
                 OpenAPI_list_add(adjacent_plmn_restrictionsList, localMapKeyPair);
@@ -2515,6 +2535,10 @@ OpenAPI_access_and_mobility_subscription_data_1_t *OpenAPI_access_and_mobility_s
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_access_and_mobility_subscription_data_1_parseFromJSON() failed [ladn_service_areas]");
                     goto end;
                 }
                 OpenAPI_list_add(ladn_service_areasList, localMapKeyPair);

--- a/lib/sbi/openapi/model/af_authorization_data.c
+++ b/lib/sbi/openapi/model/af_authorization_data.c
@@ -113,6 +113,10 @@ OpenAPI_af_authorization_data_t *OpenAPI_af_authorization_data_parseFromJSON(cJS
                     ogs_error("OpenAPI_af_authorization_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_af_authorization_data_parseFromJSON() failed [af_auth_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(af_auth_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/am_policy_data.c
+++ b/lib/sbi/openapi/model/am_policy_data.c
@@ -265,6 +265,10 @@ OpenAPI_am_policy_data_t *OpenAPI_am_policy_data_parseFromJSON(cJSON *am_policy_
                     ogs_error("OpenAPI_am_policy_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_policy_data_parseFromJSON() failed [pra_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_infosList, localMapKeyPair);
             }
         }
@@ -335,6 +339,10 @@ OpenAPI_am_policy_data_t *OpenAPI_am_policy_data_parseFromJSON(cJSON *am_policy_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_am_policy_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_policy_data_parseFromJSON() failed [spend_lim_info]");
                     goto end;
                 }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);

--- a/lib/sbi/openapi/model/am_policy_data_patch.c
+++ b/lib/sbi/openapi/model/am_policy_data_patch.c
@@ -159,6 +159,10 @@ OpenAPI_am_policy_data_patch_t *OpenAPI_am_policy_data_patch_parseFromJSON(cJSON
                     ogs_error("OpenAPI_am_policy_data_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_policy_data_patch_parseFromJSON() failed [spend_lim_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/am_policy_info_container.c
+++ b/lib/sbi/openapi/model/am_policy_info_container.c
@@ -108,6 +108,10 @@ OpenAPI_am_policy_info_container_t *OpenAPI_am_policy_info_container_parseFromJS
                     ogs_error("OpenAPI_am_policy_info_container_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_policy_info_container_parseFromJSON() failed [slice_usg_ctrl_info_sets]");
+                    goto end;
+                }
                 OpenAPI_list_add(slice_usg_ctrl_info_setsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/am_requested_value_rep.c
+++ b/lib/sbi/openapi/model/am_requested_value_rep.c
@@ -378,6 +378,10 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
                     ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [pra_statuses]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_statusesList, localMapKeyPair);
             }
         }
@@ -512,6 +516,10 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
                     ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [part_allowed_nssai]");
+                    goto end;
+                }
                 OpenAPI_list_add(part_allowed_nssaiList, localMapKeyPair);
             }
         }
@@ -536,6 +544,10 @@ OpenAPI_am_requested_value_rep_t *OpenAPI_am_requested_value_rep_parseFromJSON(c
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_am_requested_value_rep_parseFromJSON() failed [snssais_part_rejected]");
                     goto end;
                 }
                 OpenAPI_list_add(snssais_part_rejectedList, localMapKeyPair);

--- a/lib/sbi/openapi/model/amf_event.c
+++ b/lib/sbi/openapi/model/amf_event.c
@@ -827,6 +827,10 @@ OpenAPI_amf_event_t *OpenAPI_amf_event_parseFromJSON(cJSON *amf_eventJSON)
                     ogs_error("OpenAPI_amf_event_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_amf_event_parseFromJSON() failed [presence_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(presence_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/amf_event_subscription_add_info.c
+++ b/lib/sbi/openapi/model/amf_event_subscription_add_info.c
@@ -320,6 +320,10 @@ OpenAPI_amf_event_subscription_add_info_t *OpenAPI_amf_event_subscription_add_in
                     ogs_error("OpenAPI_amf_event_subscription_add_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_amf_event_subscription_add_info_parseFromJSON() failed [aoi_state_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(aoi_state_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/app_descriptor_2.c
+++ b/lib/sbi/openapi/model/app_descriptor_2.c
@@ -133,6 +133,10 @@ OpenAPI_app_descriptor_2_t *OpenAPI_app_descriptor_2_parseFromJSON(cJSON *app_de
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_app_descriptor_2_parseFromJSON() failed [app_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(app_idsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/app_session_context_req_data.c
+++ b/lib/sbi/openapi/model/app_session_context_req_data.c
@@ -803,6 +803,10 @@ OpenAPI_app_session_context_req_data_t *OpenAPI_app_session_context_req_data_par
                     ogs_error("OpenAPI_app_session_context_req_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_app_session_context_req_data_parseFromJSON() failed [med_components]");
+                    goto end;
+                }
                 OpenAPI_list_add(med_componentsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/app_session_context_update_data.c
+++ b/lib/sbi/openapi/model/app_session_context_update_data.c
@@ -617,6 +617,10 @@ OpenAPI_app_session_context_update_data_t *OpenAPI_app_session_context_update_da
                     ogs_error("OpenAPI_app_session_context_update_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_app_session_context_update_data_parseFromJSON() failed [med_components]");
+                    goto end;
+                }
                 OpenAPI_list_add(med_componentsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/app_specific_expected_ue_behaviour.c
+++ b/lib/sbi/openapi/model/app_specific_expected_ue_behaviour.c
@@ -157,6 +157,10 @@ OpenAPI_app_specific_expected_ue_behaviour_t *OpenAPI_app_specific_expected_ue_b
                     ogs_error("OpenAPI_app_specific_expected_ue_behaviour_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_app_specific_expected_ue_behaviour_parseFromJSON() failed [app_specific_expected_ue_behaviour_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(app_specific_expected_ue_behaviour_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/area_scope.c
+++ b/lib/sbi/openapi/model/area_scope.c
@@ -447,6 +447,10 @@ OpenAPI_area_scope_t *OpenAPI_area_scope_parseFromJSON(cJSON *area_scopeJSON)
                     ogs_error("OpenAPI_area_scope_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_parseFromJSON() failed [tac_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(tac_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -471,6 +475,10 @@ OpenAPI_area_scope_t *OpenAPI_area_scope_parseFromJSON(cJSON *area_scopeJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_area_scope_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_parseFromJSON() failed [cag_info_per_plmn]");
                     goto end;
                 }
                 OpenAPI_list_add(cag_info_per_plmnList, localMapKeyPair);
@@ -499,6 +507,10 @@ OpenAPI_area_scope_t *OpenAPI_area_scope_parseFromJSON(cJSON *area_scopeJSON)
                     ogs_error("OpenAPI_area_scope_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_parseFromJSON() failed [nid_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(nid_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -525,6 +537,10 @@ OpenAPI_area_scope_t *OpenAPI_area_scope_parseFromJSON(cJSON *area_scopeJSON)
                     ogs_error("OpenAPI_area_scope_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_parseFromJSON() failed [cell_id_nid_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(cell_id_nid_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -549,6 +565,10 @@ OpenAPI_area_scope_t *OpenAPI_area_scope_parseFromJSON(cJSON *area_scopeJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_area_scope_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_parseFromJSON() failed [tac_nid_info_per_plmn]");
                     goto end;
                 }
                 OpenAPI_list_add(tac_nid_info_per_plmnList, localMapKeyPair);

--- a/lib/sbi/openapi/model/area_scope_1.c
+++ b/lib/sbi/openapi/model/area_scope_1.c
@@ -447,6 +447,10 @@ OpenAPI_area_scope_1_t *OpenAPI_area_scope_1_parseFromJSON(cJSON *area_scope_1JS
                     ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [tac_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(tac_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -471,6 +475,10 @@ OpenAPI_area_scope_1_t *OpenAPI_area_scope_1_parseFromJSON(cJSON *area_scope_1JS
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [cag_info_per_plmn]");
                     goto end;
                 }
                 OpenAPI_list_add(cag_info_per_plmnList, localMapKeyPair);
@@ -499,6 +507,10 @@ OpenAPI_area_scope_1_t *OpenAPI_area_scope_1_parseFromJSON(cJSON *area_scope_1JS
                     ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [nid_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(nid_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -525,6 +537,10 @@ OpenAPI_area_scope_1_t *OpenAPI_area_scope_1_parseFromJSON(cJSON *area_scope_1JS
                     ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [cell_id_nid_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(cell_id_nid_info_per_plmnList, localMapKeyPair);
             }
         }
@@ -549,6 +565,10 @@ OpenAPI_area_scope_1_t *OpenAPI_area_scope_1_parseFromJSON(cJSON *area_scope_1JS
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_area_scope_1_parseFromJSON() failed [tac_nid_info_per_plmn]");
                     goto end;
                 }
                 OpenAPI_list_add(tac_nid_info_per_plmnList, localMapKeyPair);

--- a/lib/sbi/openapi/model/authorized_network_slice_info.c
+++ b/lib/sbi/openapi/model/authorized_network_slice_info.c
@@ -637,6 +637,10 @@ OpenAPI_authorized_network_slice_info_t *OpenAPI_authorized_network_slice_info_p
                 }
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_authorized_network_slice_info_parseFromJSON() failed [nrf_oauth2_required]");
+                    goto end;
+                }
                 OpenAPI_list_add(nrf_oauth2_requiredList, localMapKeyPair);
             }
         }
@@ -741,6 +745,10 @@ OpenAPI_authorized_network_slice_info_t *OpenAPI_authorized_network_slice_info_p
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_authorized_network_slice_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_authorized_network_slice_info_parseFromJSON() failed [snssai_info_rsp_data]");
                     goto end;
                 }
                 OpenAPI_list_add(snssai_info_rsp_dataList, localMapKeyPair);

--- a/lib/sbi/openapi/model/cag_data.c
+++ b/lib/sbi/openapi/model/cag_data.c
@@ -171,6 +171,10 @@ OpenAPI_cag_data_t *OpenAPI_cag_data_parseFromJSON(cJSON *cag_dataJSON)
                     ogs_error("OpenAPI_cag_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_data_parseFromJSON() failed [cag_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(cag_infosList, localMapKeyPair);
             }
         }
@@ -194,6 +198,10 @@ OpenAPI_cag_data_t *OpenAPI_cag_data_parseFromJSON(cJSON *cag_dataJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_cag_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_data_parseFromJSON() failed [conditional_cag_infos]");
                     goto end;
                 }
                 OpenAPI_list_add(conditional_cag_infosList, localMapKeyPair);

--- a/lib/sbi/openapi/model/cag_data_1.c
+++ b/lib/sbi/openapi/model/cag_data_1.c
@@ -171,6 +171,10 @@ OpenAPI_cag_data_1_t *OpenAPI_cag_data_1_parseFromJSON(cJSON *cag_data_1JSON)
                     ogs_error("OpenAPI_cag_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_data_1_parseFromJSON() failed [cag_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(cag_infosList, localMapKeyPair);
             }
         }
@@ -194,6 +198,10 @@ OpenAPI_cag_data_1_t *OpenAPI_cag_data_1_parseFromJSON(cJSON *cag_data_1JSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_cag_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_data_1_parseFromJSON() failed [conditional_cag_infos]");
                     goto end;
                 }
                 OpenAPI_list_add(conditional_cag_infosList, localMapKeyPair);

--- a/lib/sbi/openapi/model/cag_provision_information.c
+++ b/lib/sbi/openapi/model/cag_provision_information.c
@@ -220,6 +220,10 @@ OpenAPI_cag_provision_information_t *OpenAPI_cag_provision_information_parseFrom
                     ogs_error("OpenAPI_cag_provision_information_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_provision_information_parseFromJSON() failed [additional_valid_time_period_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_valid_time_period_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/cag_provision_information_1.c
+++ b/lib/sbi/openapi/model/cag_provision_information_1.c
@@ -220,6 +220,10 @@ OpenAPI_cag_provision_information_1_t *OpenAPI_cag_provision_information_1_parse
                     ogs_error("OpenAPI_cag_provision_information_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_cag_provision_information_1_parseFromJSON() failed [additional_valid_time_period_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_valid_time_period_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/conditional_cag_info.c
+++ b/lib/sbi/openapi/model/conditional_cag_info.c
@@ -208,6 +208,10 @@ OpenAPI_conditional_cag_info_t *OpenAPI_conditional_cag_info_parseFromJSON(cJSON
                     ogs_error("OpenAPI_conditional_cag_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_conditional_cag_info_parseFromJSON() failed [cag_specific_valid_time_period_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(cag_specific_valid_time_period_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/conditional_cag_info_1.c
+++ b/lib/sbi/openapi/model/conditional_cag_info_1.c
@@ -208,6 +208,10 @@ OpenAPI_conditional_cag_info_1_t *OpenAPI_conditional_cag_info_1_parseFromJSON(c
                     ogs_error("OpenAPI_conditional_cag_info_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_conditional_cag_info_1_parseFromJSON() failed [cag_specific_valid_time_period_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(cag_specific_valid_time_period_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/default_notification_subscription.c
+++ b/lib/sbi/openapi/model/default_notification_subscription.c
@@ -346,6 +346,10 @@ OpenAPI_default_notification_subscription_t *OpenAPI_default_notification_subscr
                     ogs_error("OpenAPI_default_notification_subscription_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_default_notification_subscription_parseFromJSON() failed [service_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(service_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/dnn_upf_info_item.c
+++ b/lib/sbi/openapi/model/dnn_upf_info_item.c
@@ -625,6 +625,10 @@ OpenAPI_dnn_upf_info_item_t *OpenAPI_dnn_upf_info_item_parseFromJSON(cJSON *dnn_
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_dnn_upf_info_item_parseFromJSON() failed [dnai_nw_instance_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(dnai_nw_instance_listList, localMapKeyPair);
             }
         }
@@ -673,6 +677,10 @@ OpenAPI_dnn_upf_info_item_t *OpenAPI_dnn_upf_info_item_parseFromJSON(cJSON *dnn_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_dnn_upf_info_item_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_dnn_upf_info_item_parseFromJSON() failed [private_ipv4_address_ranges_per_ip_domain]");
                     goto end;
                 }
                 OpenAPI_list_add(private_ipv4_address_ranges_per_ip_domainList, localMapKeyPair);

--- a/lib/sbi/openapi/model/eap_auth_method_200_response.c
+++ b/lib/sbi/openapi/model/eap_auth_method_200_response.c
@@ -139,6 +139,10 @@ OpenAPI_eap_auth_method_200_response_t *OpenAPI_eap_auth_method_200_response_par
                     ogs_error("OpenAPI_eap_auth_method_200_response_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_eap_auth_method_200_response_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/eap_session.c
+++ b/lib/sbi/openapi/model/eap_session.c
@@ -236,6 +236,10 @@ OpenAPI_eap_session_t *OpenAPI_eap_session_parseFromJSON(cJSON *eap_sessionJSON)
                     ogs_error("OpenAPI_eap_session_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_eap_session_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/easdf_info.c
+++ b/lib/sbi/openapi/model/easdf_info.c
@@ -283,6 +283,10 @@ OpenAPI_easdf_info_t *OpenAPI_easdf_info_parseFromJSON(cJSON *easdf_infoJSON)
                     ogs_error("OpenAPI_easdf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_easdf_info_parseFromJSON() failed [n6_tunnel_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(n6_tunnel_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ee_group_profile_data.c
+++ b/lib/sbi/openapi/model/ee_group_profile_data.c
@@ -214,6 +214,10 @@ OpenAPI_ee_group_profile_data_t *OpenAPI_ee_group_profile_data_parseFromJSON(cJS
                     ogs_error("OpenAPI_ee_group_profile_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ee_group_profile_data_parseFromJSON() failed [allowed_mtc_provider]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_mtc_providerList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ee_profile_data.c
+++ b/lib/sbi/openapi/model/ee_profile_data.c
@@ -222,6 +222,10 @@ OpenAPI_ee_profile_data_t *OpenAPI_ee_profile_data_parseFromJSON(cJSON *ee_profi
                     ogs_error("OpenAPI_ee_profile_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ee_profile_data_parseFromJSON() failed [allowed_mtc_provider]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_mtc_providerList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ee_subscription.c
+++ b/lib/sbi/openapi/model/ee_subscription.c
@@ -395,6 +395,10 @@ OpenAPI_ee_subscription_t *OpenAPI_ee_subscription_parseFromJSON(cJSON *ee_subsc
                     ogs_error("OpenAPI_ee_subscription_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ee_subscription_parseFromJSON() failed [monitoring_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(monitoring_configurationsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ee_subscription_1.c
+++ b/lib/sbi/openapi/model/ee_subscription_1.c
@@ -395,6 +395,10 @@ OpenAPI_ee_subscription_1_t *OpenAPI_ee_subscription_1_parseFromJSON(cJSON *ee_s
                     ogs_error("OpenAPI_ee_subscription_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ee_subscription_1_parseFromJSON() failed [monitoring_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(monitoring_configurationsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ee_subscription_ext.c
+++ b/lib/sbi/openapi/model/ee_subscription_ext.c
@@ -464,6 +464,10 @@ OpenAPI_ee_subscription_ext_t *OpenAPI_ee_subscription_ext_parseFromJSON(cJSON *
                     ogs_error("OpenAPI_ee_subscription_ext_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ee_subscription_ext_parseFromJSON() failed [monitoring_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(monitoring_configurationsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/eps_interworking_info.c
+++ b/lib/sbi/openapi/model/eps_interworking_info.c
@@ -122,6 +122,10 @@ OpenAPI_eps_interworking_info_t *OpenAPI_eps_interworking_info_parseFromJSON(cJS
                     ogs_error("OpenAPI_eps_interworking_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_eps_interworking_info_parseFromJSON() failed [eps_iwk_pgws]");
+                    goto end;
+                }
                 OpenAPI_list_add(eps_iwk_pgwsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/eps_interworking_info_1.c
+++ b/lib/sbi/openapi/model/eps_interworking_info_1.c
@@ -122,6 +122,10 @@ OpenAPI_eps_interworking_info_1_t *OpenAPI_eps_interworking_info_1_parseFromJSON
                     ogs_error("OpenAPI_eps_interworking_info_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_eps_interworking_info_1_parseFromJSON() failed [eps_iwk_pgws]");
+                    goto end;
+                }
                 OpenAPI_list_add(eps_iwk_pgwsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/events_notification.c
+++ b/lib/sbi/openapi/model/events_notification.c
@@ -1426,6 +1426,10 @@ OpenAPI_events_notification_t *OpenAPI_events_notification_parseFromJSON(cJSON *
                     ogs_error("OpenAPI_events_notification_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_events_notification_parseFromJSON() failed [qos_mon_cap_repos]");
+                    goto end;
+                }
                 OpenAPI_list_add(qos_mon_cap_reposList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/events_subsc_put_data.c
+++ b/lib/sbi/openapi/model/events_subsc_put_data.c
@@ -2007,6 +2007,10 @@ OpenAPI_events_subsc_put_data_t *OpenAPI_events_subsc_put_data_parseFromJSON(cJS
                     ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_events_subsc_put_data_parseFromJSON() failed [qos_mon_cap_repos]");
+                    goto end;
+                }
                 OpenAPI_list_add(qos_mon_cap_reposList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/expected_ue_behaviour_extension.c
+++ b/lib/sbi/openapi/model/expected_ue_behaviour_extension.c
@@ -166,6 +166,10 @@ OpenAPI_expected_ue_behaviour_extension_t *OpenAPI_expected_ue_behaviour_extensi
                     ogs_error("OpenAPI_expected_ue_behaviour_extension_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_expected_ue_behaviour_extension_parseFromJSON() failed [expected_ue_behaviour_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviour_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ext_amf_event_subscription.c
+++ b/lib/sbi/openapi/model/ext_amf_event_subscription.c
@@ -859,6 +859,10 @@ OpenAPI_ext_amf_event_subscription_t *OpenAPI_ext_amf_event_subscription_parseFr
                     ogs_error("OpenAPI_ext_amf_event_subscription_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ext_amf_event_subscription_parseFromJSON() failed [aoi_state_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(aoi_state_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/identity_data.c
+++ b/lib/sbi/openapi/model/identity_data.c
@@ -320,6 +320,10 @@ OpenAPI_identity_data_t *OpenAPI_identity_data_parseFromJSON(cJSON *identity_dat
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_identity_data_parseFromJSON() failed [application_port_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(application_port_idsList, localMapKeyPair);
             }
         }
@@ -344,6 +348,10 @@ OpenAPI_identity_data_t *OpenAPI_identity_data_parseFromJSON(cJSON *identity_dat
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_identity_data_parseFromJSON() failed [af_id_gpsis]");
+                    goto end;
+                }
                 OpenAPI_list_add(af_id_gpsisList, localMapKeyPair);
             }
         }
@@ -368,6 +376,10 @@ OpenAPI_identity_data_t *OpenAPI_identity_data_parseFromJSON(cJSON *identity_dat
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_identity_data_parseFromJSON() failed [mtc_provider_gpsis]");
+                    goto end;
+                }
                 OpenAPI_list_add(mtc_provider_gpsisList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ie_info.c
+++ b/lib/sbi/openapi/model/ie_info.c
@@ -234,6 +234,10 @@ OpenAPI_ie_info_t *OpenAPI_ie_info_parseFromJSON(cJSON *ie_infoJSON)
                 }
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ie_info_parseFromJSON() failed [is_modifiable_by_ipx]");
+                    goto end;
+                }
                 OpenAPI_list_add(is_modifiable_by_ipxList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/iptv_config_data.c
+++ b/lib/sbi/openapi/model/iptv_config_data.c
@@ -288,6 +288,10 @@ OpenAPI_iptv_config_data_t *OpenAPI_iptv_config_data_parseFromJSON(cJSON *iptv_c
                     ogs_error("OpenAPI_iptv_config_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_iptv_config_data_parseFromJSON() failed [multi_acc_ctrls]");
+                    goto end;
+                }
                 OpenAPI_list_add(multi_acc_ctrlsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/iptv_config_data_patch.c
+++ b/lib/sbi/openapi/model/iptv_config_data_patch.c
@@ -108,6 +108,10 @@ OpenAPI_iptv_config_data_patch_t *OpenAPI_iptv_config_data_patch_parseFromJSON(c
                     ogs_error("OpenAPI_iptv_config_data_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_iptv_config_data_patch_parseFromJSON() failed [multi_acc_ctrls]");
+                    goto end;
+                }
                 OpenAPI_list_add(multi_acc_ctrlsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/mb_smf_info.c
+++ b/lib/sbi/openapi/model/mb_smf_info.c
@@ -250,6 +250,10 @@ OpenAPI_mb_smf_info_t *OpenAPI_mb_smf_info_parseFromJSON(cJSON *mb_smf_infoJSON)
                     ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [s_nssai_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(s_nssai_info_listList, localMapKeyPair);
             }
         }
@@ -274,6 +278,10 @@ OpenAPI_mb_smf_info_t *OpenAPI_mb_smf_info_parseFromJSON(cJSON *mb_smf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [tmgi_range_list]");
                     goto end;
                 }
                 OpenAPI_list_add(tmgi_range_listList, localMapKeyPair);
@@ -348,6 +356,10 @@ OpenAPI_mb_smf_info_t *OpenAPI_mb_smf_info_parseFromJSON(cJSON *mb_smf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mb_smf_info_parseFromJSON() failed [mbs_session_list]");
                     goto end;
                 }
                 OpenAPI_list_add(mbs_session_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/mbs_session.c
+++ b/lib/sbi/openapi/model/mbs_session.c
@@ -142,6 +142,10 @@ OpenAPI_mbs_session_t *OpenAPI_mbs_session_parseFromJSON(cJSON *mbs_sessionJSON)
                     ogs_error("OpenAPI_mbs_session_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mbs_session_parseFromJSON() failed [mbs_area_sessions]");
+                    goto end;
+                }
                 OpenAPI_list_add(mbs_area_sessionsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/mdt_configuration.c
+++ b/lib/sbi/openapi/model/mdt_configuration.c
@@ -928,6 +928,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_report_amount_mdt_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [report_amount_per_measurement_lte]");
+                    goto end;
+                }
                 OpenAPI_list_add(report_amount_per_measurement_lteList, localMapKeyPair);
             }
         }
@@ -950,6 +954,10 @@ OpenAPI_mdt_configuration_t *OpenAPI_mdt_configuration_parseFromJSON(cJSON *mdt_
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_report_amount_mdt_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mdt_configuration_parseFromJSON() failed [report_amount_per_measurement_nr]");
+                    goto end;
+                }
                 OpenAPI_list_add(report_amount_per_measurement_nrList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/mdt_configuration_1.c
+++ b/lib/sbi/openapi/model/mdt_configuration_1.c
@@ -928,6 +928,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_report_amount_mdt_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [report_amount_per_measurement_lte]");
+                    goto end;
+                }
                 OpenAPI_list_add(report_amount_per_measurement_lteList, localMapKeyPair);
             }
         }
@@ -950,6 +954,10 @@ OpenAPI_mdt_configuration_1_t *OpenAPI_mdt_configuration_1_parseFromJSON(cJSON *
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_report_amount_mdt_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mdt_configuration_1_parseFromJSON() failed [report_amount_per_measurement_nr]");
+                    goto end;
+                }
                 OpenAPI_list_add(report_amount_per_measurement_nrList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/media_component.c
+++ b/lib/sbi/openapi/model/media_component.c
@@ -1207,6 +1207,10 @@ OpenAPI_media_component_t *OpenAPI_media_component_parseFromJSON(cJSON *media_co
                     ogs_error("OpenAPI_media_component_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_media_component_parseFromJSON() failed [med_sub_comps]");
+                    goto end;
+                }
                 OpenAPI_list_add(med_sub_compsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/media_component_rm.c
+++ b/lib/sbi/openapi/model/media_component_rm.c
@@ -1432,6 +1432,10 @@ OpenAPI_media_component_rm_t *OpenAPI_media_component_rm_parseFromJSON(cJSON *me
                     ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_media_component_rm_parseFromJSON() failed [med_sub_comps]");
+                    goto end;
+                }
                 OpenAPI_list_add(med_sub_compsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/mm_context.c
+++ b/lib/sbi/openapi/model/mm_context.c
@@ -947,6 +947,10 @@ OpenAPI_mm_context_t *OpenAPI_mm_context_parseFromJSON(cJSON *mm_contextJSON)
                     ogs_error("OpenAPI_mm_context_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_mm_context_parseFromJSON() failed [dereg_inact_timer_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(dereg_inact_timer_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/model_5_gvn_group_configuration.c
+++ b/lib/sbi/openapi/model/model_5_gvn_group_configuration.c
@@ -270,6 +270,10 @@ OpenAPI_model_5_gvn_group_configuration_t *OpenAPI_model_5_gvn_group_configurati
                     ogs_error("OpenAPI_model_5_gvn_group_configuration_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_model_5_gvn_group_configuration_parseFromJSON() failed [members_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(members_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/modify_200_response.c
+++ b/lib/sbi/openapi/model/modify_200_response.c
@@ -738,6 +738,10 @@ OpenAPI_modify_200_response_t *OpenAPI_modify_200_response_parseFromJSON(cJSON *
                     ogs_error("OpenAPI_modify_200_response_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_modify_200_response_parseFromJSON() failed [expected_ue_behaviour_thresholds]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviour_thresholdsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nf_instance_info.c
+++ b/lib/sbi/openapi/model/nf_instance_info.c
@@ -178,6 +178,10 @@ OpenAPI_nf_instance_info_t *OpenAPI_nf_instance_info_parseFromJSON(cJSON *nf_ins
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_instance_info_parseFromJSON() failed [nrf_altered_priorities]");
+                    goto end;
+                }
                 OpenAPI_list_add(nrf_altered_prioritiesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nf_profile.c
+++ b/lib/sbi/openapi/model/nf_profile.c
@@ -1979,6 +1979,10 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
                 ogs_error("OpenAPI_nf_profile_convertToJSON() failed [nf_set_recovery_time_list]");
                 goto end;
             }
+            if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [inner]");
+                goto end;
+            }
         }
     }
     }
@@ -1999,6 +2003,10 @@ cJSON *OpenAPI_nf_profile_convertToJSON(OpenAPI_nf_profile_t *nf_profile)
             }
             if (localKeyValue->key == NULL) {
                 ogs_error("OpenAPI_nf_profile_convertToJSON() failed [service_set_recovery_time_list]");
+                goto end;
+            }
+            if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
+                ogs_error("OpenAPI_nf_profile_convertToJSON() failed [inner]");
                 goto end;
             }
         }
@@ -3249,6 +3257,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [allowed_rule_set]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_rule_setList, localMapKeyPair);
             }
         }
@@ -3313,6 +3325,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [ext_locality]");
+                    goto end;
+                }
                 OpenAPI_list_add(ext_localityList, localMapKeyPair);
             }
         }
@@ -3346,6 +3362,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [udr_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(udr_info_listList, localMapKeyPair);
@@ -3383,6 +3403,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [udm_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(udm_info_listList, localMapKeyPair);
             }
         }
@@ -3416,6 +3440,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [ausf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(ausf_info_listList, localMapKeyPair);
@@ -3453,6 +3481,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [amf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(amf_info_listList, localMapKeyPair);
             }
         }
@@ -3486,6 +3518,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [smf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(smf_info_listList, localMapKeyPair);
@@ -3523,6 +3559,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [upf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(upf_info_listList, localMapKeyPair);
             }
         }
@@ -3556,6 +3596,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [pcf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(pcf_info_listList, localMapKeyPair);
@@ -3593,6 +3637,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [bsf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(bsf_info_listList, localMapKeyPair);
             }
         }
@@ -3626,6 +3674,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [chf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(chf_info_listList, localMapKeyPair);
@@ -3681,6 +3733,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [udsf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(udsf_info_listList, localMapKeyPair);
             }
         }
@@ -3716,6 +3772,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [nwdaf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(nwdaf_info_listList, localMapKeyPair);
             }
         }
@@ -3742,6 +3802,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [pcscf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(pcscf_info_listList, localMapKeyPair);
             }
         }
@@ -3766,6 +3830,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [hss_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(hss_info_listList, localMapKeyPair);
@@ -3841,6 +3909,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [nf_service_list]");
                     goto end;
                 }
                 OpenAPI_list_add(nf_service_listList, localMapKeyPair);
@@ -3986,6 +4058,15 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                 cJSON *localMapObject = nf_set_recovery_time_list_local_map;
                 double *localDouble = NULL;
                 int *localInt = NULL;
+                if (!cJSON_IsString(localMapObject) && !cJSON_IsNull(localMapObject)) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), cJSON_IsNull(localMapObject) ? NULL : ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [nf_set_recovery_time_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(nf_set_recovery_time_listList, localMapKeyPair);
             }
         }
@@ -4005,6 +4086,15 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                 cJSON *localMapObject = service_set_recovery_time_list_local_map;
                 double *localDouble = NULL;
                 int *localInt = NULL;
+                if (!cJSON_IsString(localMapObject) && !cJSON_IsNull(localMapObject)) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), cJSON_IsNull(localMapObject) ? NULL : ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [service_set_recovery_time_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(service_set_recovery_time_listList, localMapKeyPair);
             }
         }
@@ -4078,6 +4168,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [supported_vendor_specific_features]");
+                    goto end;
+                }
                 OpenAPI_list_add(supported_vendor_specific_featuresList, localMapKeyPair);
             }
         }
@@ -4102,6 +4196,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [aanf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(aanf_info_listList, localMapKeyPair);
@@ -4148,6 +4246,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [easdf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(easdf_info_listList, localMapKeyPair);
             }
         }
@@ -4183,6 +4285,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [nsacf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(nsacf_info_listList, localMapKeyPair);
             }
         }
@@ -4207,6 +4313,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [mb_smf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(mb_smf_info_listList, localMapKeyPair);
@@ -4235,6 +4345,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [tsctsf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(tsctsf_info_listList, localMapKeyPair);
             }
         }
@@ -4259,6 +4373,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [mb_upf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(mb_upf_info_listList, localMapKeyPair);
@@ -4353,6 +4471,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [dcsf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(dcsf_info_listList, localMapKeyPair);
             }
         }
@@ -4377,6 +4499,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [mrf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(mrf_info_listList, localMapKeyPair);
@@ -4405,6 +4531,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [mrfp_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(mrfp_info_listList, localMapKeyPair);
             }
         }
@@ -4431,6 +4561,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [mf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(mf_info_listList, localMapKeyPair);
             }
         }
@@ -4455,6 +4589,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [adrf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(adrf_info_listList, localMapKeyPair);
@@ -4560,6 +4698,10 @@ OpenAPI_nf_profile_t *OpenAPI_nf_profile_parseFromJSON(cJSON *nf_profileJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_profile_parseFromJSON() failed [aiotf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(aiotf_info_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/nf_service.c
+++ b/lib/sbi/openapi/model/nf_service.c
@@ -1141,6 +1141,10 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
                 cJSON *localMapObject = allowed_operations_per_nf_type_local_map;
                 double *localDouble = NULL;
                 int *localInt = NULL;
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_service_parseFromJSON() failed [allowed_operations_per_nf_type]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_operations_per_nf_typeList, localMapKeyPair);
             }
         }
@@ -1160,6 +1164,10 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
                 cJSON *localMapObject = allowed_operations_per_nf_instance_local_map;
                 double *localDouble = NULL;
                 int *localInt = NULL;
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_service_parseFromJSON() failed [allowed_operations_per_nf_instance]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_operations_per_nf_instanceList, localMapKeyPair);
             }
         }
@@ -1192,6 +1200,10 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_service_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_service_parseFromJSON() failed [allowed_scopes_rule_set]");
                     goto end;
                 }
                 OpenAPI_list_add(allowed_scopes_rule_setList, localMapKeyPair);
@@ -1343,6 +1355,10 @@ OpenAPI_nf_service_t *OpenAPI_nf_service_parseFromJSON(cJSON *nf_serviceJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nf_service_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nf_service_parseFromJSON() failed [supported_vendor_specific_features]");
                     goto end;
                 }
                 OpenAPI_list_add(supported_vendor_specific_featuresList, localMapKeyPair);

--- a/lib/sbi/openapi/model/nrf_info.c
+++ b/lib/sbi/openapi/model/nrf_info.c
@@ -2176,6 +2176,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udr_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_udr_infoList, localMapKeyPair);
             }
         }
@@ -2200,6 +2204,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udr_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_udr_info_listList, localMapKeyPair);
@@ -2228,6 +2236,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udm_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_udm_infoList, localMapKeyPair);
             }
         }
@@ -2252,6 +2264,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udm_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_udm_info_listList, localMapKeyPair);
@@ -2280,6 +2296,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_ausf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_ausf_infoList, localMapKeyPair);
             }
         }
@@ -2304,6 +2324,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_ausf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_ausf_info_listList, localMapKeyPair);
@@ -2332,6 +2356,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_amf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_amf_infoList, localMapKeyPair);
             }
         }
@@ -2356,6 +2384,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_amf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_amf_info_listList, localMapKeyPair);
@@ -2384,6 +2416,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_smf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_smf_infoList, localMapKeyPair);
             }
         }
@@ -2408,6 +2444,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_smf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_smf_info_listList, localMapKeyPair);
@@ -2436,6 +2476,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_upf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_upf_infoList, localMapKeyPair);
             }
         }
@@ -2460,6 +2504,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_upf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_upf_info_listList, localMapKeyPair);
@@ -2488,6 +2536,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_pcf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_pcf_infoList, localMapKeyPair);
             }
         }
@@ -2512,6 +2564,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_pcf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_pcf_info_listList, localMapKeyPair);
@@ -2540,6 +2596,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_bsf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_bsf_infoList, localMapKeyPair);
             }
         }
@@ -2564,6 +2624,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_bsf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_bsf_info_listList, localMapKeyPair);
@@ -2592,6 +2656,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_chf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_chf_infoList, localMapKeyPair);
             }
         }
@@ -2616,6 +2684,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_chf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_chf_info_listList, localMapKeyPair);
@@ -2644,6 +2716,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nef_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_nef_infoList, localMapKeyPair);
             }
         }
@@ -2668,6 +2744,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nwdaf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_nwdaf_infoList, localMapKeyPair);
@@ -2696,6 +2776,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nwdaf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_nwdaf_info_listList, localMapKeyPair);
             }
         }
@@ -2720,6 +2804,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_pcscf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_pcscf_info_listList, localMapKeyPair);
@@ -2748,6 +2836,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_gmlc_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_gmlc_infoList, localMapKeyPair);
             }
         }
@@ -2772,6 +2864,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_lmf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_lmf_infoList, localMapKeyPair);
@@ -2800,6 +2896,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_nf_infoList, localMapKeyPair);
             }
         }
@@ -2824,6 +2924,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_hss_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_hss_info_listList, localMapKeyPair);
@@ -2852,6 +2956,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udsf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_udsf_infoList, localMapKeyPair);
             }
         }
@@ -2876,6 +2984,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_udsf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_udsf_info_listList, localMapKeyPair);
@@ -2904,6 +3016,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_scp_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_scp_info_listList, localMapKeyPair);
             }
         }
@@ -2928,6 +3044,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_sepp_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_sepp_info_listList, localMapKeyPair);
@@ -2956,6 +3076,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_aanf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_aanf_info_listList, localMapKeyPair);
             }
         }
@@ -2980,6 +3104,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served5g_ddnmf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served5g_ddnmf_infoList, localMapKeyPair);
@@ -3008,6 +3136,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mfaf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_mfaf_info_listList, localMapKeyPair);
             }
         }
@@ -3032,6 +3164,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_easdf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_easdf_info_listList, localMapKeyPair);
@@ -3060,6 +3196,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_dccf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_dccf_info_listList, localMapKeyPair);
             }
         }
@@ -3084,6 +3224,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mb_smf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_mb_smf_info_listList, localMapKeyPair);
@@ -3112,6 +3256,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_tsctsf_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_tsctsf_info_listList, localMapKeyPair);
             }
         }
@@ -3136,6 +3284,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mb_upf_info_list]");
                     goto end;
                 }
                 OpenAPI_list_add(served_mb_upf_info_listList, localMapKeyPair);
@@ -3164,6 +3316,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_trust_af_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_trust_af_infoList, localMapKeyPair);
             }
         }
@@ -3188,6 +3344,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nssaaf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_nssaaf_infoList, localMapKeyPair);
@@ -3216,6 +3376,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_dcsf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_dcsf_infoList, localMapKeyPair);
             }
         }
@@ -3240,6 +3404,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_mf_infoList, localMapKeyPair);
@@ -3268,6 +3436,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mrf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_mrf_infoList, localMapKeyPair);
             }
         }
@@ -3292,6 +3464,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_mrfp_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_mrfp_infoList, localMapKeyPair);
@@ -3320,6 +3496,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_imsas_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_imsas_infoList, localMapKeyPair);
             }
         }
@@ -3344,6 +3524,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_aiotf_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_aiotf_infoList, localMapKeyPair);
@@ -3372,6 +3556,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_nssf_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(served_nssf_infoList, localMapKeyPair);
             }
         }
@@ -3396,6 +3584,10 @@ OpenAPI_nrf_info_t *OpenAPI_nrf_info_parseFromJSON(cJSON *nrf_infoJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_parseFromJSON() failed [served_adm_info]");
                     goto end;
                 }
                 OpenAPI_list_add(served_adm_infoList, localMapKeyPair);

--- a/lib/sbi/openapi/model/nrf_info_served_mb_smf_info_list_value_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_mb_smf_info_list_value_value.c
@@ -250,6 +250,10 @@ OpenAPI_nrf_info_served_mb_smf_info_list_value_value_t *OpenAPI_nrf_info_served_
                     ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [s_nssai_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(s_nssai_info_listList, localMapKeyPair);
             }
         }
@@ -274,6 +278,10 @@ OpenAPI_nrf_info_served_mb_smf_info_list_value_value_t *OpenAPI_nrf_info_served_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [tmgi_range_list]");
                     goto end;
                 }
                 OpenAPI_list_add(tmgi_range_listList, localMapKeyPair);
@@ -348,6 +356,10 @@ OpenAPI_nrf_info_served_mb_smf_info_list_value_value_t *OpenAPI_nrf_info_served_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_mb_smf_info_list_value_value_parseFromJSON() failed [mbs_session_list]");
                     goto end;
                 }
                 OpenAPI_list_add(mbs_session_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_scp_info_list_value.c
@@ -407,6 +407,10 @@ OpenAPI_nrf_info_served_scp_info_list_value_t *OpenAPI_nrf_info_served_scp_info_
                     ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_parseFromJSON() failed [scp_domain_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_domain_info_listList, localMapKeyPair);
             }
         }
@@ -445,6 +449,10 @@ OpenAPI_nrf_info_served_scp_info_list_value_t *OpenAPI_nrf_info_served_scp_info_
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_scp_info_list_value_parseFromJSON() failed [scp_ports]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_portsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nrf_info_served_sepp_info_list_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_sepp_info_list_value.c
@@ -210,6 +210,10 @@ OpenAPI_nrf_info_served_sepp_info_list_value_t *OpenAPI_nrf_info_served_sepp_inf
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_sepp_info_list_value_parseFromJSON() failed [sepp_ports]");
+                    goto end;
+                }
                 OpenAPI_list_add(sepp_portsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nrf_info_served_udsf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_udsf_info_value.c
@@ -181,6 +181,10 @@ OpenAPI_nrf_info_served_udsf_info_value_t *OpenAPI_nrf_info_served_udsf_info_val
                     ogs_error("OpenAPI_nrf_info_served_udsf_info_value_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_udsf_info_value_parseFromJSON() failed [storage_id_ranges]");
+                    goto end;
+                }
                 OpenAPI_list_add(storage_id_rangesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
+++ b/lib/sbi/openapi/model/nrf_info_served_upf_info_value.c
@@ -804,6 +804,10 @@ OpenAPI_nrf_info_served_upf_info_value_t *OpenAPI_nrf_info_served_upf_info_value
                     ogs_error("OpenAPI_nrf_info_served_upf_info_value_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nrf_info_served_upf_info_value_parseFromJSON() failed [n6_tunnel_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(n6_tunnel_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nsi_information.c
+++ b/lib/sbi/openapi/model/nsi_information.c
@@ -200,6 +200,10 @@ OpenAPI_nsi_information_t *OpenAPI_nsi_information_parseFromJSON(cJSON *nsi_info
                 }
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nsi_information_parseFromJSON() failed [nrf_oauth2_required]");
+                    goto end;
+                }
                 OpenAPI_list_add(nrf_oauth2_requiredList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nssai.c
+++ b/lib/sbi/openapi/model/nssai.c
@@ -270,6 +270,10 @@ OpenAPI_nssai_t *OpenAPI_nssai_parseFromJSON(cJSON *nssaiJSON)
                     ogs_error("OpenAPI_nssai_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nssai_parseFromJSON() failed [additional_snssai_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_snssai_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/nssai_1.c
+++ b/lib/sbi/openapi/model/nssai_1.c
@@ -270,6 +270,10 @@ OpenAPI_nssai_1_t *OpenAPI_nssai_1_parseFromJSON(cJSON *nssai_1JSON)
                     ogs_error("OpenAPI_nssai_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_nssai_1_parseFromJSON() failed [additional_snssai_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_snssai_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/odb_exempted_dnn_info.c
+++ b/lib/sbi/openapi/model/odb_exempted_dnn_info.c
@@ -160,6 +160,10 @@ OpenAPI_odb_exempted_dnn_info_t *OpenAPI_odb_exempted_dnn_info_parseFromJSON(cJS
                     ogs_error("OpenAPI_odb_exempted_dnn_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_odb_exempted_dnn_info_parseFromJSON() failed [odb_exempted_conditions_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(odb_exempted_conditions_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/odb_exempted_dnn_info_1.c
+++ b/lib/sbi/openapi/model/odb_exempted_dnn_info_1.c
@@ -160,6 +160,10 @@ OpenAPI_odb_exempted_dnn_info_1_t *OpenAPI_odb_exempted_dnn_info_1_parseFromJSON
                     ogs_error("OpenAPI_odb_exempted_dnn_info_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_odb_exempted_dnn_info_1_parseFromJSON() failed [odb_exempted_conditions_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(odb_exempted_conditions_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pcc_rule.c
+++ b/lib/sbi/openapi/model/pcc_rule.c
@@ -1193,6 +1193,10 @@ OpenAPI_pcc_rule_t *OpenAPI_pcc_rule_parseFromJSON(cJSON *pcc_ruleJSON)
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pcc_rule_parseFromJSON() failed [nsc_supp_feats]");
+                    goto end;
+                }
                 OpenAPI_list_add(nsc_supp_featsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/policy_association.c
+++ b/lib/sbi/openapi/model/policy_association.c
@@ -636,6 +636,10 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
                     ogs_error("OpenAPI_policy_association_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_parseFromJSON() failed [pras]");
+                    goto end;
+                }
                 OpenAPI_list_add(prasList, localMapKeyPair);
             }
         }
@@ -708,6 +712,10 @@ OpenAPI_policy_association_t *OpenAPI_policy_association_parseFromJSON(cJSON *po
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_policy_association_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_parseFromJSON() failed [slice_usg_ctrl_info_sets]");
                     goto end;
                 }
                 OpenAPI_list_add(slice_usg_ctrl_info_setsList, localMapKeyPair);

--- a/lib/sbi/openapi/model/policy_association_request.c
+++ b/lib/sbi/openapi/model/policy_association_request.c
@@ -1120,6 +1120,10 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
                     ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [part_allowed_nssai]");
+                    goto end;
+                }
                 OpenAPI_list_add(part_allowed_nssaiList, localMapKeyPair);
             }
         }
@@ -1144,6 +1148,10 @@ OpenAPI_policy_association_request_t *OpenAPI_policy_association_request_parseFr
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_request_parseFromJSON() failed [snssais_part_rejected]");
                     goto end;
                 }
                 OpenAPI_list_add(snssais_part_rejectedList, localMapKeyPair);

--- a/lib/sbi/openapi/model/policy_association_update_request.c
+++ b/lib/sbi/openapi/model/policy_association_update_request.c
@@ -1026,6 +1026,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
                     ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [pra_statuses]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_statusesList, localMapKeyPair);
             }
         }
@@ -1085,6 +1089,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
                     ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [part_allowed_nssai]");
+                    goto end;
+                }
                 OpenAPI_list_add(part_allowed_nssaiList, localMapKeyPair);
             }
         }
@@ -1109,6 +1117,10 @@ OpenAPI_policy_association_update_request_t *OpenAPI_policy_association_update_r
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_association_update_request_parseFromJSON() failed [snssais_part_rejected]");
                     goto end;
                 }
                 OpenAPI_list_add(snssais_part_rejectedList, localMapKeyPair);

--- a/lib/sbi/openapi/model/policy_data_change_notification.c
+++ b/lib/sbi/openapi/model/policy_data_change_notification.c
@@ -603,6 +603,10 @@ OpenAPI_policy_data_change_notification_t *OpenAPI_policy_data_change_notificati
                     ogs_error("OpenAPI_policy_data_change_notification_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_data_change_notification_parseFromJSON() failed [op_spec_data_map]");
+                    goto end;
+                }
                 OpenAPI_list_add(op_spec_data_mapList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/policy_data_for_individual_ue.c
+++ b/lib/sbi/openapi/model/policy_data_for_individual_ue.c
@@ -256,6 +256,10 @@ OpenAPI_policy_data_for_individual_ue_t *OpenAPI_policy_data_for_individual_ue_p
                     ogs_error("OpenAPI_policy_data_for_individual_ue_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_data_for_individual_ue_parseFromJSON() failed [um_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(um_dataList, localMapKeyPair);
             }
         }
@@ -280,6 +284,10 @@ OpenAPI_policy_data_for_individual_ue_t *OpenAPI_policy_data_for_individual_ue_p
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_policy_data_for_individual_ue_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_data_for_individual_ue_parseFromJSON() failed [operator_specific_data_set]");
                     goto end;
                 }
                 OpenAPI_list_add(operator_specific_data_setList, localMapKeyPair);

--- a/lib/sbi/openapi/model/policy_update.c
+++ b/lib/sbi/openapi/model/policy_update.c
@@ -663,6 +663,10 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
                     ogs_error("OpenAPI_policy_update_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_update_parseFromJSON() failed [pras]");
+                    goto end;
+                }
                 OpenAPI_list_add(prasList, localMapKeyPair);
             }
         }
@@ -739,6 +743,10 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
                     ogs_error("OpenAPI_policy_update_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_update_parseFromJSON() failed [snssai_repl_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(snssai_repl_infosList, localMapKeyPair);
             }
         }
@@ -764,6 +772,10 @@ OpenAPI_policy_update_t *OpenAPI_policy_update_parseFromJSON(cJSON *policy_updat
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_policy_update_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_policy_update_parseFromJSON() failed [slice_usg_ctrl_info_sets]");
                     goto end;
                 }
                 OpenAPI_list_add(slice_usg_ctrl_info_setsList, localMapKeyPair);

--- a/lib/sbi/openapi/model/pp5g_mbs_group_profile_data.c
+++ b/lib/sbi/openapi/model/pp5g_mbs_group_profile_data.c
@@ -122,6 +122,10 @@ OpenAPI_pp5g_mbs_group_profile_data_t *OpenAPI_pp5g_mbs_group_profile_data_parse
                     ogs_error("OpenAPI_pp5g_mbs_group_profile_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pp5g_mbs_group_profile_data_parseFromJSON() failed [allowed_mbs_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_mbs_infosList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pp5g_vn_group_profile_data.c
+++ b/lib/sbi/openapi/model/pp5g_vn_group_profile_data.c
@@ -122,6 +122,10 @@ OpenAPI_pp5g_vn_group_profile_data_t *OpenAPI_pp5g_vn_group_profile_data_parseFr
                     ogs_error("OpenAPI_pp5g_vn_group_profile_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pp5g_vn_group_profile_data_parseFromJSON() failed [allowed_mtc_providers]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_mtc_providersList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pp_data_entry.c
+++ b/lib/sbi/openapi/model/pp_data_entry.c
@@ -399,6 +399,10 @@ OpenAPI_pp_data_entry_t *OpenAPI_pp_data_entry_parseFromJSON(cJSON *pp_data_entr
                     ogs_error("OpenAPI_pp_data_entry_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pp_data_entry_parseFromJSON() failed [ecs_addr_config_info_per_plmn]");
+                    goto end;
+                }
                 OpenAPI_list_add(ecs_addr_config_info_per_plmnList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pp_profile_data.c
+++ b/lib/sbi/openapi/model/pp_profile_data.c
@@ -122,6 +122,10 @@ OpenAPI_pp_profile_data_t *OpenAPI_pp_profile_data_parseFromJSON(cJSON *pp_profi
                     ogs_error("OpenAPI_pp_profile_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pp_profile_data_parseFromJSON() failed [allowed_mtc_providers]");
+                    goto end;
+                }
                 OpenAPI_list_add(allowed_mtc_providersList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pro_se_authentication_ctx.c
+++ b/lib/sbi/openapi/model/pro_se_authentication_ctx.c
@@ -167,6 +167,10 @@ OpenAPI_pro_se_authentication_ctx_t *OpenAPI_pro_se_authentication_ctx_parseFrom
                     ogs_error("OpenAPI_pro_se_authentication_ctx_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pro_se_authentication_ctx_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/pro_se_eap_session.c
+++ b/lib/sbi/openapi/model/pro_se_eap_session.c
@@ -216,6 +216,10 @@ OpenAPI_pro_se_eap_session_t *OpenAPI_pro_se_eap_session_parseFromJSON(cJSON *pr
                     ogs_error("OpenAPI_pro_se_eap_session_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_pro_se_eap_session_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/prose_auth_200_response.c
+++ b/lib/sbi/openapi/model/prose_auth_200_response.c
@@ -139,6 +139,10 @@ OpenAPI_prose_auth_200_response_t *OpenAPI_prose_auth_200_response_parseFromJSON
                     ogs_error("OpenAPI_prose_auth_200_response_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_prose_auth_200_response_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/scp_domain_info.c
+++ b/lib/sbi/openapi/model/scp_domain_info.c
@@ -207,6 +207,10 @@ OpenAPI_scp_domain_info_t *OpenAPI_scp_domain_info_parseFromJSON(cJSON *scp_doma
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_scp_domain_info_parseFromJSON() failed [scp_ports]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_portsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/scp_domain_routing_information.c
+++ b/lib/sbi/openapi/model/scp_domain_routing_information.c
@@ -113,6 +113,10 @@ OpenAPI_scp_domain_routing_information_t *OpenAPI_scp_domain_routing_information
                     ogs_error("OpenAPI_scp_domain_routing_information_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_scp_domain_routing_information_parseFromJSON() failed [scp_domain_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_domain_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/scp_info.c
+++ b/lib/sbi/openapi/model/scp_info.c
@@ -407,6 +407,10 @@ OpenAPI_scp_info_t *OpenAPI_scp_info_parseFromJSON(cJSON *scp_infoJSON)
                     ogs_error("OpenAPI_scp_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_scp_info_parseFromJSON() failed [scp_domain_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_domain_info_listList, localMapKeyPair);
             }
         }
@@ -445,6 +449,10 @@ OpenAPI_scp_info_t *OpenAPI_scp_info_parseFromJSON(cJSON *scp_infoJSON)
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_scp_info_parseFromJSON() failed [scp_ports]");
+                    goto end;
+                }
                 OpenAPI_list_add(scp_portsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sdm_subs_modification.c
+++ b/lib/sbi/openapi/model/sdm_subs_modification.c
@@ -308,6 +308,10 @@ OpenAPI_sdm_subs_modification_t *OpenAPI_sdm_subs_modification_parseFromJSON(cJS
                     ogs_error("OpenAPI_sdm_subs_modification_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sdm_subs_modification_parseFromJSON() failed [expected_ue_behaviour_thresholds]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviour_thresholdsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sdm_subscription.c
+++ b/lib/sbi/openapi/model/sdm_subscription.c
@@ -750,6 +750,10 @@ OpenAPI_sdm_subscription_t *OpenAPI_sdm_subscription_parseFromJSON(cJSON *sdm_su
                     ogs_error("OpenAPI_sdm_subscription_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sdm_subscription_parseFromJSON() failed [expected_ue_behaviour_thresholds]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviour_thresholdsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sdm_subscription_1.c
+++ b/lib/sbi/openapi/model/sdm_subscription_1.c
@@ -750,6 +750,10 @@ OpenAPI_sdm_subscription_1_t *OpenAPI_sdm_subscription_1_parseFromJSON(cJSON *sd
                     ogs_error("OpenAPI_sdm_subscription_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sdm_subscription_1_parseFromJSON() failed [expected_ue_behaviour_thresholds]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviour_thresholdsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/search_result.c
+++ b/lib/sbi/openapi/model/search_result.c
@@ -450,6 +450,10 @@ OpenAPI_search_result_t *OpenAPI_search_result_parseFromJSON(cJSON *search_resul
                     ogs_error("OpenAPI_search_result_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_search_result_parseFromJSON() failed [nf_instance_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(nf_instance_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sepp_info.c
+++ b/lib/sbi/openapi/model/sepp_info.c
@@ -210,6 +210,10 @@ OpenAPI_sepp_info_t *OpenAPI_sepp_info_parseFromJSON(cJSON *sepp_infoJSON)
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sepp_info_parseFromJSON() failed [sepp_ports]");
+                    goto end;
+                }
                 OpenAPI_list_add(sepp_portsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sequence_number.c
+++ b/lib/sbi/openapi/model/sequence_number.c
@@ -177,6 +177,10 @@ OpenAPI_sequence_number_t *OpenAPI_sequence_number_parseFromJSON(cJSON *sequence
                 }
                 *localDouble = localMapObject->valuedouble;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localDouble);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sequence_number_parseFromJSON() failed [last_indexes]");
+                    goto end;
+                }
                 OpenAPI_list_add(last_indexesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/service_specific_authorization_info.c
+++ b/lib/sbi/openapi/model/service_specific_authorization_info.c
@@ -113,6 +113,10 @@ OpenAPI_service_specific_authorization_info_t *OpenAPI_service_specific_authoriz
                     ogs_error("OpenAPI_service_specific_authorization_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_service_specific_authorization_info_parseFromJSON() failed [service_specific_authorization_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(service_specific_authorization_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/session_management_subscription_data.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data.c
@@ -605,6 +605,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [dnn_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(dnn_configurationsList, localMapKeyPair);
             }
         }
@@ -650,6 +654,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [shared_vn_group_data_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_vn_group_data_idsList, localMapKeyPair);
             }
         }
@@ -691,6 +699,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [odb_exempted_dnn_data]");
                     goto end;
                 }
                 OpenAPI_list_add(odb_exempted_dnn_dataList, localMapKeyPair);
@@ -738,6 +750,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [expected_ue_behaviours_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviours_listList, localMapKeyPair);
             }
         }
@@ -762,6 +778,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [expected_ue_behaviour_data]");
                     goto end;
                 }
                 OpenAPI_list_add(expected_ue_behaviour_dataList, localMapKeyPair);
@@ -790,6 +810,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [app_specific_expected_ue_behaviour_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(app_specific_expected_ue_behaviour_dataList, localMapKeyPair);
             }
         }
@@ -814,6 +838,10 @@ OpenAPI_session_management_subscription_data_t *OpenAPI_session_management_subsc
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_parseFromJSON() failed [suggested_packet_num_dl_list]");
                     goto end;
                 }
                 OpenAPI_list_add(suggested_packet_num_dl_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/session_management_subscription_data_1.c
+++ b/lib/sbi/openapi/model/session_management_subscription_data_1.c
@@ -605,6 +605,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [dnn_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(dnn_configurationsList, localMapKeyPair);
             }
         }
@@ -650,6 +654,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [shared_vn_group_data_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_vn_group_data_idsList, localMapKeyPair);
             }
         }
@@ -691,6 +699,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [odb_exempted_dnn_data]");
                     goto end;
                 }
                 OpenAPI_list_add(odb_exempted_dnn_dataList, localMapKeyPair);
@@ -738,6 +750,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [expected_ue_behaviours_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(expected_ue_behaviours_listList, localMapKeyPair);
             }
         }
@@ -762,6 +778,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [expected_ue_behaviour_data]");
                     goto end;
                 }
                 OpenAPI_list_add(expected_ue_behaviour_dataList, localMapKeyPair);
@@ -790,6 +810,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [app_specific_expected_ue_behaviour_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(app_specific_expected_ue_behaviour_dataList, localMapKeyPair);
             }
         }
@@ -814,6 +838,10 @@ OpenAPI_session_management_subscription_data_1_t *OpenAPI_session_management_sub
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_session_management_subscription_data_1_parseFromJSON() failed [suggested_packet_num_dl_list]");
                     goto end;
                 }
                 OpenAPI_list_add(suggested_packet_num_dl_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/shared_data_1.c
+++ b/lib/sbi/openapi/model/shared_data_1.c
@@ -449,6 +449,10 @@ OpenAPI_shared_data_1_t *OpenAPI_shared_data_1_parseFromJSON(cJSON *shared_data_
                     ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [shared_dnn_configurations]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_dnn_configurationsList, localMapKeyPair);
             }
         }
@@ -486,6 +490,10 @@ OpenAPI_shared_data_1_t *OpenAPI_shared_data_1_parseFromJSON(cJSON *shared_data_
                     ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [shared_snssai_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_snssai_infosList, localMapKeyPair);
             }
         }
@@ -512,6 +520,10 @@ OpenAPI_shared_data_1_t *OpenAPI_shared_data_1_parseFromJSON(cJSON *shared_data_
                     ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [shared_vn_group_datas]");
+                    goto end;
+                }
                 OpenAPI_list_add(shared_vn_group_datasList, localMapKeyPair);
             }
         }
@@ -534,6 +546,10 @@ OpenAPI_shared_data_1_t *OpenAPI_shared_data_1_parseFromJSON(cJSON *shared_data_
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_shared_data_treatment_instruction_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_shared_data_1_parseFromJSON() failed [treatment_instructions]");
+                    goto end;
+                }
                 OpenAPI_list_add(treatment_instructionsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sm_context_create_data.c
+++ b/lib/sbi/openapi/model/sm_context_create_data.c
@@ -2348,6 +2348,10 @@ OpenAPI_sm_context_create_data_t *OpenAPI_sm_context_create_data_parseFromJSON(c
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_context_create_data_parseFromJSON() failed [additional_hsmf_set_id_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_hsmf_set_id_listList, localMapKeyPair);
             }
         }
@@ -2414,6 +2418,10 @@ OpenAPI_sm_context_create_data_t *OpenAPI_sm_context_create_data_parseFromJSON(c
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_context_create_data_parseFromJSON() failed [additional_smf_set_id_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(additional_smf_set_id_listList, localMapKeyPair);
             }
         }
@@ -2966,6 +2974,10 @@ OpenAPI_sm_context_create_data_t *OpenAPI_sm_context_create_data_parseFromJSON(c
                 }
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_context_create_data_parseFromJSON() failed [nrf_oauth2_required]");
+                    goto end;
+                }
                 OpenAPI_list_add(nrf_oauth2_requiredList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sm_policy_data.c
+++ b/lib/sbi/openapi/model/sm_policy_data.c
@@ -215,6 +215,10 @@ OpenAPI_sm_policy_data_t *OpenAPI_sm_policy_data_parseFromJSON(cJSON *sm_policy_
                     ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [sm_policy_snssai_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(sm_policy_snssai_dataList, localMapKeyPair);
             }
         }
@@ -238,6 +242,10 @@ OpenAPI_sm_policy_data_t *OpenAPI_sm_policy_data_parseFromJSON(cJSON *sm_policy_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [um_data_limits]");
                     goto end;
                 }
                 OpenAPI_list_add(um_data_limitsList, localMapKeyPair);
@@ -264,6 +272,10 @@ OpenAPI_sm_policy_data_t *OpenAPI_sm_policy_data_parseFromJSON(cJSON *sm_policy_
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_data_parseFromJSON() failed [um_data]");
                     goto end;
                 }
                 OpenAPI_list_add(um_dataList, localMapKeyPair);

--- a/lib/sbi/openapi/model/sm_policy_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_data_patch.c
@@ -160,6 +160,10 @@ OpenAPI_sm_policy_data_patch_t *OpenAPI_sm_policy_data_patch_parseFromJSON(cJSON
                     ogs_error("OpenAPI_sm_policy_data_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_data_patch_parseFromJSON() failed [um_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(um_dataList, localMapKeyPair);
             }
         }
@@ -185,6 +189,10 @@ OpenAPI_sm_policy_data_patch_t *OpenAPI_sm_policy_data_patch_parseFromJSON(cJSON
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_data_patch_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_data_patch_parseFromJSON() failed [sm_policy_snssai_data]");
                     goto end;
                 }
                 OpenAPI_list_add(sm_policy_snssai_dataList, localMapKeyPair);

--- a/lib/sbi/openapi/model/sm_policy_decision.c
+++ b/lib/sbi/openapi/model/sm_policy_decision.c
@@ -1072,6 +1072,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [sess_rules]");
+                    goto end;
+                }
                 OpenAPI_list_add(sess_rulesList, localMapKeyPair);
             }
         }
@@ -1097,6 +1101,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [pcc_rules]");
                     goto end;
                 }
                 OpenAPI_list_add(pcc_rulesList, localMapKeyPair);
@@ -1134,6 +1142,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [qos_decs]");
+                    goto end;
+                }
                 OpenAPI_list_add(qos_decsList, localMapKeyPair);
             }
         }
@@ -1159,6 +1171,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [chg_decs]");
                     goto end;
                 }
                 OpenAPI_list_add(chg_decsList, localMapKeyPair);
@@ -1205,6 +1221,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [traff_cont_decs]");
+                    goto end;
+                }
                 OpenAPI_list_add(traff_cont_decsList, localMapKeyPair);
             }
         }
@@ -1230,6 +1250,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [um_decs]");
                     goto end;
                 }
                 OpenAPI_list_add(um_decsList, localMapKeyPair);
@@ -1259,6 +1283,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [qos_chars]");
+                    goto end;
+                }
                 OpenAPI_list_add(qos_charsList, localMapKeyPair);
             }
         }
@@ -1284,6 +1312,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [qos_mon_decs]");
                     goto end;
                 }
                 OpenAPI_list_add(qos_mon_decsList, localMapKeyPair);
@@ -1320,6 +1352,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [conds]");
                     goto end;
                 }
                 OpenAPI_list_add(condsList, localMapKeyPair);
@@ -1445,6 +1481,10 @@ OpenAPI_sm_policy_decision_t *OpenAPI_sm_policy_decision_parseFromJSON(cJSON *sm
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_decision_parseFromJSON() failed [pra_infos]");
                     goto end;
                 }
                 OpenAPI_list_add(pra_infosList, localMapKeyPair);

--- a/lib/sbi/openapi/model/sm_policy_dnn_data.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data.c
@@ -678,6 +678,10 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [spend_lim_info]");
+                    goto end;
+                }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);
             }
         }
@@ -753,6 +757,10 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [ref_um_data_limit_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(ref_um_data_limit_idsList, localMapKeyPair);
             }
         }
@@ -819,6 +827,10 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [pra_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_infosList, localMapKeyPair);
             }
         }
@@ -844,6 +856,10 @@ OpenAPI_sm_policy_dnn_data_t *OpenAPI_sm_policy_dnn_data_parseFromJSON(cJSON *sm
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_parseFromJSON() failed [bdt_ref_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(bdt_ref_idsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_dnn_data_patch.c
@@ -214,6 +214,10 @@ OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_parseFromJS
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_patch_parseFromJSON() failed [bdt_ref_ids]");
+                    goto end;
+                }
                 OpenAPI_list_add(bdt_ref_idsList, localMapKeyPair);
             }
         }
@@ -264,6 +268,10 @@ OpenAPI_sm_policy_dnn_data_patch_t *OpenAPI_sm_policy_dnn_data_patch_parseFromJS
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_dnn_data_patch_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_dnn_data_patch_parseFromJSON() failed [spend_lim_info]");
                     goto end;
                 }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);

--- a/lib/sbi/openapi/model/sm_policy_snssai_data.c
+++ b/lib/sbi/openapi/model/sm_policy_snssai_data.c
@@ -163,6 +163,10 @@ OpenAPI_sm_policy_snssai_data_t *OpenAPI_sm_policy_snssai_data_parseFromJSON(cJS
                     ogs_error("OpenAPI_sm_policy_snssai_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_snssai_data_parseFromJSON() failed [sm_policy_dnn_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(sm_policy_dnn_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sm_policy_snssai_data_patch.c
+++ b/lib/sbi/openapi/model/sm_policy_snssai_data_patch.c
@@ -142,6 +142,10 @@ OpenAPI_sm_policy_snssai_data_patch_t *OpenAPI_sm_policy_snssai_data_patch_parse
                     ogs_error("OpenAPI_sm_policy_snssai_data_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_snssai_data_patch_parseFromJSON() failed [sm_policy_dnn_data]");
+                    goto end;
+                }
                 OpenAPI_list_add(sm_policy_dnn_dataList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/sm_policy_update_context_data.c
+++ b/lib/sbi/openapi/model/sm_policy_update_context_data.c
@@ -2081,6 +2081,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
                     ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [rep_pra_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(rep_pra_infosList, localMapKeyPair);
             }
         }
@@ -2610,6 +2614,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
                     ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [qos_mon_cap_repos]");
+                    goto end;
+                }
                 OpenAPI_list_add(qos_mon_cap_reposList, localMapKeyPair);
             }
         }
@@ -2634,6 +2642,10 @@ OpenAPI_sm_policy_update_context_data_t *OpenAPI_sm_policy_update_context_data_p
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_sm_policy_update_context_data_parseFromJSON() failed [n3g_dev_infos]");
                     goto end;
                 }
                 OpenAPI_list_add(n3g_dev_infosList, localMapKeyPair);

--- a/lib/sbi/openapi/model/smf_selection_data.c
+++ b/lib/sbi/openapi/model/smf_selection_data.c
@@ -192,6 +192,10 @@ OpenAPI_smf_selection_data_t *OpenAPI_smf_selection_data_parseFromJSON(cJSON *sm
                     ogs_error("OpenAPI_smf_selection_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_smf_selection_data_parseFromJSON() failed [candidates]");
+                    goto end;
+                }
                 OpenAPI_list_add(candidatesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/smf_selection_subscription_data.c
+++ b/lib/sbi/openapi/model/smf_selection_subscription_data.c
@@ -183,6 +183,10 @@ OpenAPI_smf_selection_subscription_data_t *OpenAPI_smf_selection_subscription_da
                     ogs_error("OpenAPI_smf_selection_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_smf_selection_subscription_data_parseFromJSON() failed [subscribed_snssai_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(subscribed_snssai_infosList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/smf_selection_subscription_data_1.c
+++ b/lib/sbi/openapi/model/smf_selection_subscription_data_1.c
@@ -183,6 +183,10 @@ OpenAPI_smf_selection_subscription_data_1_t *OpenAPI_smf_selection_subscription_
                     ogs_error("OpenAPI_smf_selection_subscription_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_smf_selection_subscription_data_1_parseFromJSON() failed [subscribed_snssai_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(subscribed_snssai_infosList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/spatial_validity.c
+++ b/lib/sbi/openapi/model/spatial_validity.c
@@ -113,6 +113,10 @@ OpenAPI_spatial_validity_t *OpenAPI_spatial_validity_parseFromJSON(cJSON *spatia
                     ogs_error("OpenAPI_spatial_validity_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_spatial_validity_parseFromJSON() failed [presence_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(presence_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/spatial_validity_rm.c
+++ b/lib/sbi/openapi/model/spatial_validity_rm.c
@@ -113,6 +113,10 @@ OpenAPI_spatial_validity_rm_t *OpenAPI_spatial_validity_rm_parseFromJSON(cJSON *
                     ogs_error("OpenAPI_spatial_validity_rm_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_spatial_validity_rm_parseFromJSON() failed [presence_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(presence_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/spatial_validity_rm_1.c
+++ b/lib/sbi/openapi/model/spatial_validity_rm_1.c
@@ -113,6 +113,10 @@ OpenAPI_spatial_validity_rm_1_t *OpenAPI_spatial_validity_rm_1_parseFromJSON(cJS
                     ogs_error("OpenAPI_spatial_validity_rm_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_spatial_validity_rm_1_parseFromJSON() failed [presence_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(presence_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/subscription_data.c
+++ b/lib/sbi/openapi/model/subscription_data.c
@@ -844,6 +844,10 @@ OpenAPI_subscription_data_t *OpenAPI_subscription_data_parseFromJSON(cJSON *subs
                     ogs_error("OpenAPI_subscription_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_subscription_data_parseFromJSON() failed [ext_preferred_locality]");
+                    goto end;
+                }
                 OpenAPI_list_add(ext_preferred_localityList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/traffic_influ_data.c
+++ b/lib/sbi/openapi/model/traffic_influ_data.c
@@ -1009,6 +1009,10 @@ OpenAPI_traffic_influ_data_t *OpenAPI_traffic_influ_data_parseFromJSON(cJSON *tr
                     ogs_error("OpenAPI_traffic_influ_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_traffic_influ_data_parseFromJSON() failed [traffic_data_sets]");
+                    goto end;
+                }
                 OpenAPI_list_add(traffic_data_setsList, localMapKeyPair);
             }
         }
@@ -1352,6 +1356,10 @@ OpenAPI_traffic_influ_data_t *OpenAPI_traffic_influ_data_parseFromJSON(cJSON *tr
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), ogs_strdup(localMapObject->valuestring));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_traffic_influ_data_parseFromJSON() failed [nsc_supp_feats]");
+                    goto end;
+                }
                 OpenAPI_list_add(nsc_supp_featsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/traffic_influ_data_patch.c
+++ b/lib/sbi/openapi/model/traffic_influ_data_patch.c
@@ -613,6 +613,10 @@ OpenAPI_traffic_influ_data_patch_t *OpenAPI_traffic_influ_data_patch_parseFromJS
                     ogs_error("OpenAPI_traffic_influ_data_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_traffic_influ_data_patch_parseFromJSON() failed [traffic_data_sets]");
+                    goto end;
+                }
                 OpenAPI_list_add(traffic_data_setsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/traffic_influence_info.c
+++ b/lib/sbi/openapi/model/traffic_influence_info.c
@@ -159,6 +159,10 @@ OpenAPI_traffic_influence_info_t *OpenAPI_traffic_influence_info_parseFromJSON(c
                     ogs_error("OpenAPI_traffic_influence_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_traffic_influence_info_parseFromJSON() failed [traff_cont_decs]");
+                    goto end;
+                }
                 OpenAPI_list_add(traff_cont_decsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/tsctsf_info.c
+++ b/lib/sbi/openapi/model/tsctsf_info.c
@@ -216,6 +216,10 @@ OpenAPI_tsctsf_info_t *OpenAPI_tsctsf_info_parseFromJSON(cJSON *tsctsf_infoJSON)
                     ogs_error("OpenAPI_tsctsf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_tsctsf_info_parseFromJSON() failed [s_nssai_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(s_nssai_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/uc_subscription_data.c
+++ b/lib/sbi/openapi/model/uc_subscription_data.c
@@ -99,6 +99,10 @@ OpenAPI_uc_subscription_data_t *OpenAPI_uc_subscription_data_parseFromJSON(cJSON
                     goto end;
                 }
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), (void *)OpenAPI_user_consent_FromString(localMapObject->string));
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_uc_subscription_data_parseFromJSON() failed [user_consent_per_purpose_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(user_consent_per_purpose_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/udsf_info.c
+++ b/lib/sbi/openapi/model/udsf_info.c
@@ -181,6 +181,10 @@ OpenAPI_udsf_info_t *OpenAPI_udsf_info_parseFromJSON(cJSON *udsf_infoJSON)
                     ogs_error("OpenAPI_udsf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_udsf_info_parseFromJSON() failed [storage_id_ranges]");
+                    goto end;
+                }
                 OpenAPI_list_add(storage_id_rangesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ue_authentication_ctx.c
+++ b/lib/sbi/openapi/model/ue_authentication_ctx.c
@@ -185,6 +185,10 @@ OpenAPI_ue_authentication_ctx_t *OpenAPI_ue_authentication_ctx_parseFromJSON(cJS
                     ogs_error("OpenAPI_ue_authentication_ctx_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_authentication_ctx_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ue_context.c
+++ b/lib/sbi/openapi/model/ue_context.c
@@ -2034,6 +2034,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                     ogs_error("OpenAPI_ue_context_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_parseFromJSON() failed [sub_ue_slice_mbr_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(sub_ue_slice_mbr_listList, localMapKeyPair);
             }
         }
@@ -2603,6 +2607,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                 }
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_parseFromJSON() failed [adjacen_plmn_mngt_mdt_inds]");
+                    goto end;
+                }
                 OpenAPI_list_add(adjacen_plmn_mngt_mdt_indsList, localMapKeyPair);
             }
         }
@@ -2721,6 +2729,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                     ogs_error("OpenAPI_ue_context_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_parseFromJSON() failed [pra_in_am_policy]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_in_am_policyList, localMapKeyPair);
             }
         }
@@ -2745,6 +2757,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_context_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_parseFromJSON() failed [pra_in_ue_policy]");
                     goto end;
                 }
                 OpenAPI_list_add(pra_in_ue_policyList, localMapKeyPair);
@@ -2858,6 +2874,10 @@ OpenAPI_ue_context_t *OpenAPI_ue_context_parseFromJSON(cJSON *ue_contextJSON)
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_context_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_parseFromJSON() failed [pcf_ue_slice_mbr_list]");
                     goto end;
                 }
                 OpenAPI_list_add(pcf_ue_slice_mbr_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/ue_context_in_smf_data.c
+++ b/lib/sbi/openapi/model/ue_context_in_smf_data.c
@@ -156,6 +156,10 @@ OpenAPI_ue_context_in_smf_data_t *OpenAPI_ue_context_in_smf_data_parseFromJSON(c
                     ogs_error("OpenAPI_ue_context_in_smf_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_in_smf_data_parseFromJSON() failed [pdu_sessions]");
+                    goto end;
+                }
                 OpenAPI_list_add(pdu_sessionsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ue_context_in_smf_data_1.c
+++ b/lib/sbi/openapi/model/ue_context_in_smf_data_1.c
@@ -156,6 +156,10 @@ OpenAPI_ue_context_in_smf_data_1_t *OpenAPI_ue_context_in_smf_data_1_parseFromJS
                     ogs_error("OpenAPI_ue_context_in_smf_data_1_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_context_in_smf_data_1_parseFromJSON() failed [pdu_sessions]");
+                    goto end;
+                }
                 OpenAPI_list_add(pdu_sessionsList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/ue_identifiers.c
+++ b/lib/sbi/openapi/model/ue_identifiers.c
@@ -152,6 +152,10 @@ OpenAPI_ue_identifiers_t *OpenAPI_ue_identifiers_parseFromJSON(cJSON *ue_identif
                     ogs_error("OpenAPI_ue_identifiers_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_identifiers_parseFromJSON() failed [ue_id_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(ue_id_listList, localMapKeyPair);
             }
         }
@@ -176,6 +180,10 @@ OpenAPI_ue_identifiers_t *OpenAPI_ue_identifiers_parseFromJSON(cJSON *ue_identif
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_identifiers_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_identifiers_parseFromJSON() failed [ue_id_gpsi_list]");
                     goto end;
                 }
                 OpenAPI_list_add(ue_id_gpsi_listList, localMapKeyPair);

--- a/lib/sbi/openapi/model/ue_policy_set.c
+++ b/lib/sbi/openapi/model/ue_policy_set.c
@@ -518,6 +518,10 @@ OpenAPI_ue_policy_set_t *OpenAPI_ue_policy_set_parseFromJSON(cJSON *ue_policy_se
                     ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [pra_infos]");
+                    goto end;
+                }
                 OpenAPI_list_add(pra_infosList, localMapKeyPair);
             }
         }
@@ -565,6 +569,10 @@ OpenAPI_ue_policy_set_t *OpenAPI_ue_policy_set_parseFromJSON(cJSON *ue_policy_se
                     ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [ue_policy_sections]");
+                    goto end;
+                }
                 OpenAPI_list_add(ue_policy_sectionsList, localMapKeyPair);
             }
         }
@@ -610,6 +618,10 @@ OpenAPI_ue_policy_set_t *OpenAPI_ue_policy_set_parseFromJSON(cJSON *ue_policy_se
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [allowed_route_sel_descs]");
                     goto end;
                 }
                 OpenAPI_list_add(allowed_route_sel_descsList, localMapKeyPair);
@@ -722,6 +734,10 @@ OpenAPI_ue_policy_set_t *OpenAPI_ue_policy_set_parseFromJSON(cJSON *ue_policy_se
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_parseFromJSON() failed [spend_lim_info]");
                     goto end;
                 }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);

--- a/lib/sbi/openapi/model/ue_policy_set_patch.c
+++ b/lib/sbi/openapi/model/ue_policy_set_patch.c
@@ -298,6 +298,10 @@ OpenAPI_ue_policy_set_patch_t *OpenAPI_ue_policy_set_patch_parseFromJSON(cJSON *
                     ogs_error("OpenAPI_ue_policy_set_patch_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_patch_parseFromJSON() failed [ue_policy_sections]");
+                    goto end;
+                }
                 OpenAPI_list_add(ue_policy_sectionsList, localMapKeyPair);
             }
         }
@@ -429,6 +433,10 @@ OpenAPI_ue_policy_set_patch_t *OpenAPI_ue_policy_set_patch_parseFromJSON(cJSON *
                     localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), NULL);
                 } else {
                     ogs_error("OpenAPI_ue_policy_set_patch_parseFromJSON() failed [inner]");
+                    goto end;
+                }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_policy_set_patch_parseFromJSON() failed [spend_lim_info]");
                     goto end;
                 }
                 OpenAPI_list_add(spend_lim_infoList, localMapKeyPair);

--- a/lib/sbi/openapi/model/ue_slice_mbr.c
+++ b/lib/sbi/openapi/model/ue_slice_mbr.c
@@ -157,6 +157,10 @@ OpenAPI_ue_slice_mbr_t *OpenAPI_ue_slice_mbr_parseFromJSON(cJSON *ue_slice_mbrJS
                     ogs_error("OpenAPI_ue_slice_mbr_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_ue_slice_mbr_parseFromJSON() failed [slice_mbr]");
+                    goto end;
+                }
                 OpenAPI_list_add(slice_mbrList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/upf_info.c
+++ b/lib/sbi/openapi/model/upf_info.c
@@ -804,6 +804,10 @@ OpenAPI_upf_info_t *OpenAPI_upf_info_parseFromJSON(cJSON *upf_infoJSON)
                     ogs_error("OpenAPI_upf_info_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_upf_info_parseFromJSON() failed [n6_tunnel_info_list]");
+                    goto end;
+                }
                 OpenAPI_list_add(n6_tunnel_info_listList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/uri_list.c
+++ b/lib/sbi/openapi/model/uri_list.c
@@ -120,6 +120,10 @@ OpenAPI_uri_list_t *OpenAPI_uri_list_parseFromJSON(cJSON *uri_listJSON)
                     ogs_error("OpenAPI_uri_list_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_uri_list_parseFromJSON() failed [_links]");
+                    goto end;
+                }
                 OpenAPI_list_add(_linksList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/usage_mon_data.c
+++ b/lib/sbi/openapi/model/usage_mon_data.c
@@ -219,6 +219,10 @@ OpenAPI_usage_mon_data_t *OpenAPI_usage_mon_data_parseFromJSON(cJSON *usage_mon_
                     ogs_error("OpenAPI_usage_mon_data_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_usage_mon_data_parseFromJSON() failed [scopes]");
+                    goto end;
+                }
                 OpenAPI_list_add(scopesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/openapi/model/usage_mon_data_limit.c
+++ b/lib/sbi/openapi/model/usage_mon_data_limit.c
@@ -215,6 +215,10 @@ OpenAPI_usage_mon_data_limit_t *OpenAPI_usage_mon_data_limit_parseFromJSON(cJSON
                     ogs_error("OpenAPI_usage_mon_data_limit_parseFromJSON() failed [inner]");
                     goto end;
                 }
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_usage_mon_data_limit_parseFromJSON() failed [scopes]");
+                    goto end;
+                }
                 OpenAPI_list_add(scopesList, localMapKeyPair);
             }
         }

--- a/lib/sbi/support/r19-20260402-openapitools-7.20.0/openapi-generator/templates/model-body.mustache
+++ b/lib/sbi/support/r19-20260402-openapitools-7.20.0/openapi-generator/templates/model-body.mustache
@@ -613,6 +613,18 @@ cJSON *OpenAPI_{{classname}}_convertToJSON(OpenAPI_{{classname}}_t *{{classname}
                 goto end;
             }
                             {{/isString}}
+                            {{#isDate}}
+            if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
+                ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+                goto end;
+            }
+                            {{/isDate}}
+                            {{#isDateTime}}
+            if (cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
+                ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
+                goto end;
+            }
+                            {{/isDateTime}}
                             {{#isByteArray}}
             if(cJSON_AddStringToObject(localMapObject, localKeyValue->key, (char*)localKeyValue->value) == NULL) {
                 ogs_error("OpenAPI_{{classname}}_convertToJSON() failed [{{{name}}}]");
@@ -1015,6 +1027,20 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
                 *localInt = localMapObject->valueint;
                 localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), localInt);
                             {{/isBoolean}}
+                            {{#isDate}}
+                if (!cJSON_IsString(localMapObject) && !cJSON_IsNull(localMapObject)) {
+                    ogs_error("OpenAPI_{{classname}}_parseFromJSON() failed [{{{name}}}]");
+                    goto end;
+                }
+                localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), cJSON_IsNull(localMapObject) ? NULL : ogs_strdup(localMapObject->valuestring));
+                            {{/isDate}}
+                            {{#isDateTime}}
+                if (!cJSON_IsString(localMapObject) && !cJSON_IsNull(localMapObject)) {
+                    ogs_error("OpenAPI_{{classname}}_parseFromJSON() failed [{{{name}}}]");
+                    goto end;
+                }
+                localMapKeyPair = OpenAPI_map_create(ogs_strdup(localMapObject->string), cJSON_IsNull(localMapObject) ? NULL : ogs_strdup(localMapObject->valuestring));
+                            {{/isDateTime}}
                         {{/isMap}}
                     {{/isPrimitiveType}}
                     {{^isPrimitiveType}}
@@ -1035,6 +1061,10 @@ OpenAPI_{{classname}}_t *OpenAPI_{{classname}}_parseFromJSON(cJSON *{{classname}
                     {{/isPrimitiveType}}
                 {{/items}}
             {{/isEnum}}
+                if (localMapKeyPair == NULL) {
+                    ogs_error("OpenAPI_{{classname}}_parseFromJSON() failed [{{{name}}}]");
+                    goto end;
+                }
                 OpenAPI_list_add({{{name}}}List, localMapKeyPair);
             }
         }


### PR DESCRIPTION
OpenAPI_nf_profile_parseFromJSON() aborts via ogs_assert(data) in listEntry_create() when an NFProfile carries a non-empty nfSetRecoveryTimeList / serviceSetRecoveryTimeList. OSS-Fuzz:

  listEntry_create: Assertion `data' failed (lib/sbi/openapi/src/list.c:10)
  OpenAPI_list_add (list.c:116)
  OpenAPI_nf_profile_parseFromJSON (nf_profile.c:3989)

Root cause is in the model-body.mustache map handler. The per-value type dispatch only emits assignments to localMapKeyPair for isString / isByteArray / isNumeric / isBoolean. For a map whose value is a DateTime (map<string,DateTime>, e.g. NfSetRecoveryTimeList) or an array (map<string,array<string>>, e.g. allowedOperationsPerNfType), no branch fires, localMapKeyPair stays NULL, and the generated code calls OpenAPI_list_add(list, NULL) -> listEntry_create(NULL) -> abort. This is remotely triggerable: NFProfile is parsed from peer/NRF input.

Template fix (r19, openapitools 7.20.0):
  - add isDate / isDateTime branches in both parseFromJSON and convertToJSON map blocks (DateTime is carried as a JSON string, handled like isString); convertToJSON previously also dropped the value silently for these maps.
  - guard OpenAPI_list_add with a NULL check so any remaining unhandled value category (e.g. array-valued maps) fails the parse gracefully instead of aborting the process.

Regenerated the two affected models (nf_profile, nf_service). DateTime maps now round-trip correctly; the array-valued maps are rejected instead of crashing pending full map<string,array> support.

Issues: #4649