### PR TITLE
sgwc: reclaim orphaned indirect forwarding tunnels

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1273,6 +1273,27 @@ void ogs_pfcp_sess_clear(ogs_pfcp_sess_t *sess)
     if (sess->bar) ogs_pfcp_bar_delete(sess->bar);
 }
 
+static void pdr_log_state(ogs_pfcp_sess_t *sess, const char *reason)
+{
+    ogs_pfcp_pdr_t *pdr = NULL;
+
+    ogs_assert(sess);
+    ogs_assert(reason);
+
+    ogs_error("%s [PDR:%d/%d] [PDR-ID-available:%lld] "
+            "[PDR-pool-available:%lld] [PDR-TEID-pool-available:%lld]",
+            reason, ogs_list_count(&sess->pdr_list), OGS_MAX_NUM_OF_PDR,
+            (long long)sess->pdr_id_pool.avail,
+            (long long)ogs_pfcp_pdr_pool.avail,
+            (long long)ogs_pfcp_pdr_teid_pool.avail);
+
+    ogs_list_for_each(&sess->pdr_list, pdr) {
+        ogs_error("    PDR [id:%u] [teid:0x%x] [src-if:%d] [FAR-id:%u]",
+                (unsigned)pdr->id, pdr->teid, pdr->src_if,
+                pdr->far ? (unsigned)pdr->far->id : 0);
+    }
+}
+
 static int precedence_compare(ogs_pfcp_pdr_t *pdr1, ogs_pfcp_pdr_t *pdr2)
 {
     if (pdr1->precedence == pdr2->precedence)
@@ -1291,7 +1312,7 @@ ogs_pfcp_pdr_t *ogs_pfcp_pdr_add(ogs_pfcp_sess_t *sess)
 
     ogs_pool_alloc(&ogs_pfcp_pdr_pool, &pdr);
     if (pdr == NULL) {
-        ogs_error("pdr_pool() failed");
+        pdr_log_state(sess, "PDR pool exhausted");
         return NULL;
     }
     memset(pdr, 0, sizeof *pdr);
@@ -1301,15 +1322,20 @@ ogs_pfcp_pdr_t *ogs_pfcp_pdr_add(ogs_pfcp_sess_t *sess)
 
     /* Set TEID */
     ogs_pool_alloc(&ogs_pfcp_pdr_teid_pool, &pdr->teid_node);
-    ogs_assert(pdr->teid_node);
+    if (pdr->teid_node == NULL) {
+        ogs_pool_free(&ogs_pfcp_pdr_pool, pdr);
+        pdr_log_state(sess, "PDR TEID pool exhausted");
+        return NULL;
+    }
 
     pdr->teid = *(pdr->teid_node);
 
     /* Set PDR-ID */
     ogs_pool_alloc(&sess->pdr_id_pool, &pdr->id_node);
     if (pdr->id_node == NULL) {
-        ogs_error("pdr_id_pool() failed");
+        ogs_pool_free(&ogs_pfcp_pdr_teid_pool, pdr->teid_node);
         ogs_pool_free(&ogs_pfcp_pdr_pool, pdr);
+        pdr_log_state(sess, "PDR ID pool exhausted");
         return NULL;
     }
 

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -671,6 +671,7 @@ sgwc_tunnel_t *sgwc_tunnel_add(
 
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
+    sgwc_ue_t *sgwc_ue = NULL;
 
     ogs_pfcp_interface_t src_if = OGS_PFCP_INTERFACE_UNKNOWN;
     ogs_pfcp_interface_t dst_if = OGS_PFCP_INTERFACE_UNKNOWN;
@@ -728,7 +729,13 @@ sgwc_tunnel_t *sgwc_tunnel_add(
 
     pdr = ogs_pfcp_pdr_add(&sess->pfcp);
     if (!pdr) {
-        ogs_error("ogs_pfcp_pdr_add() failed");
+        sgwc_ue = sgwc_ue_find_by_id(bearer->sgwc_ue_id);
+        ogs_error("Cannot add PDR [IMSI:%s] [APN:%s] [EBI:%u] "
+                "[interface-type:%u] [PDR:%d/%d]",
+                sgwc_ue ? sgwc_ue->imsi_bcd : "unknown",
+                sess->session.name ? sess->session.name : "unknown",
+                (unsigned)bearer->ebi, (unsigned)interface_type,
+                ogs_list_count(&sess->pfcp.pdr_list), OGS_MAX_NUM_OF_PDR);
         sgwc_tunnel_remove(tunnel);
         return NULL;
     }

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -747,12 +747,13 @@ void sgwc_sxa_handle_session_modification_response(
      */
     if (flags & OGS_PFCP_MODIFY_REMOVE) {
         if (flags & OGS_PFCP_MODIFY_INDIRECT) {
-            s11_xact = ogs_gtp_xact_find_by_id(pfcp_xact->assoc_xact_id);
+            uint32_t assoc_xact_id = pfcp_xact->assoc_xact_id;
+
+            s11_xact = ogs_gtp_xact_find_by_id(assoc_xact_id);
             if (!s11_xact) {
-                ogs_error("GTP transaction(S11) has already been removed [%d]",
+                ogs_warn("[PDR-TRACE] S11 transaction has already been "
+                        "removed [%u]; continue local indirect tunnel cleanup",
                         pfcp_xact->assoc_xact_id);
-                ogs_pfcp_xact_commit(pfcp_xact);
-                return;
             }
 
             ogs_pfcp_xact_commit(pfcp_xact);
@@ -760,7 +761,7 @@ void sgwc_sxa_handle_session_modification_response(
             ogs_assert(flags & OGS_PFCP_MODIFY_SESSION);
             if (SGWC_SESSION_SYNC_DONE(sgwc_ue,
                 OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE, flags)) {
-
+                int removed_tunnel_count = 0;
                 sgwc_tunnel_t *tunnel = NULL, *next_tunnel = NULL;
                 ogs_gtp2_delete_indirect_data_forwarding_tunnel_response_t
                     *gtp_rsp = NULL;
@@ -773,10 +774,18 @@ void sgwc_sxa_handle_session_modification_response(
                             OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING ||
                                 tunnel->interface_type ==
                             OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING) {
+                                removed_tunnel_count++;
                                 sgwc_tunnel_remove(tunnel);
                             }
                         }
                     }
+                }
+
+                if (!s11_xact) {
+                    ogs_warn("S11 transaction has already been removed [%u]; "
+                            "reclaimed [%d] local indirect tunnels",
+                            assoc_xact_id, removed_tunnel_count);
+                    return;
                 }
 
                 gtp_rsp = &send_message.


### PR DESCRIPTION
Remove local indirect forwarding tunnels after PFCP modification synchronization even when the associated S11 transaction has expired.

Also release the PDR TEID node on per-session PDR ID allocation failure and add diagnostics for PDR resource exhaustion.

Issues: #4653