### PR TITLE
mme, amf: rebind SCTP stream after RAN handover

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1458,6 +1458,53 @@ void ran_ue_switch_to_gnb(ran_ue_t *ran_ue, amf_gnb_t *new_gnb)
 
     /* Switch to gnb */
     ran_ue->gnb_id = new_gnb->id;
+
+    /*
+     * Re-bind the SCTP output stream to the target gNB if needed.
+     *
+     * ran_ue->gnb_ostream_id was allocated in ran_ue_add() in the range
+     * [1, max_num_of_ostreams-1] negotiated with the SOURCE gNB. gNBs
+     * from different vendors can negotiate a different number of SCTP
+     * streams; when the target gNB negotiated fewer streams, the
+     * carried-over stream id is out of range on the new association and
+     * ogs_sctp_senddata() fails with EINVAL(22), so e.g. the
+     * PathSwitchRequestAcknowledge is lost silently.
+     *
+     * The stream id is re-allocated from the target gNB's range only
+     * when it is out of range, so a handover between gNBs that
+     * negotiated the same stream count is not affected.
+     */
+    if (new_gnb->max_num_of_ostreams < 2) {
+        /*
+         * The target gNB negotiated a single SCTP stream: there is no
+         * UE-associated stream available (stream 0 is reserved for the
+         * sole use of non-UE-associated signalling, 3GPP TS 38.412
+         * clause 7, and ran_ue_add() rejects such a gNB as well).
+         * Keep the current stream id unchanged; UE-associated
+         * signalling toward this gNB will fail to be delivered, as
+         * before this change.
+         */
+        ogs_error("Target gNB has no UE-associated SCTP stream "
+                "[MAX:%d]; UE-associated signalling cannot be delivered",
+                new_gnb->max_num_of_ostreams);
+        return;
+    }
+
+    if (ran_ue->gnb_ostream_id >= new_gnb->max_num_of_ostreams) {
+        uint16_t old_ostream_id = ran_ue->gnb_ostream_id;
+
+        ran_ue->gnb_ostream_id =
+            OGS_NEXT_ID(new_gnb->ostream_id, 1,
+                    new_gnb->max_num_of_ostreams-1);
+
+        ogs_warn("SCTP output stream re-bound to the target gNB "
+                "[OLD:%d NEW:%d MAX:%d] "
+                "RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]",
+                old_ostream_id, ran_ue->gnb_ostream_id,
+                new_gnb->max_num_of_ostreams,
+                (long long)ran_ue->ran_ue_ngap_id,
+                (long long)ran_ue->amf_ue_ngap_id);
+    }
 }
 
 ran_ue_t *ran_ue_find_by_ran_ue_ngap_id(

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3341,6 +3341,53 @@ void enb_ue_switch_to_enb(enb_ue_t *enb_ue, mme_enb_t *new_enb)
 
     /* Switch to enb */
     enb_ue->enb_id = new_enb->id;
+
+    /*
+     * Re-bind the SCTP output stream to the target eNB if needed.
+     *
+     * enb_ue->enb_ostream_id was allocated in enb_ue_add() in the range
+     * [1, max_num_of_ostreams-1] negotiated with the SOURCE eNB. eNBs
+     * from different vendors can negotiate a different number of SCTP
+     * streams; when the target eNB negotiated fewer streams, the
+     * carried-over stream id is out of range on the new association and
+     * ogs_sctp_senddata() fails with EINVAL(22), so e.g. the
+     * PathSwitchRequestAcknowledge is lost silently and the eNB reports
+     * ho-failure-in-target-EPC-eNB-or-target-system.
+     *
+     * The stream id is re-allocated from the target eNB's range only
+     * when it is out of range, so a handover between eNBs that
+     * negotiated the same stream count is not affected.
+     */
+    if (new_enb->max_num_of_ostreams < 2) {
+        /*
+         * The target eNB negotiated a single SCTP stream: there is no
+         * UE-associated stream available (stream 0 is reserved for the
+         * sole use of non-UE-associated signalling, 3GPP TS 36.412
+         * clause 7, and enb_ue_add() rejects such an eNB as well).
+         * Keep the current stream id unchanged; UE-associated
+         * signalling toward this eNB will fail to be delivered, as
+         * before this change.
+         */
+        ogs_error("Target eNB has no UE-associated SCTP stream "
+                "[MAX:%d]; UE-associated signalling cannot be delivered",
+                new_enb->max_num_of_ostreams);
+        return;
+    }
+
+    if (enb_ue->enb_ostream_id >= new_enb->max_num_of_ostreams) {
+        uint16_t old_ostream_id = enb_ue->enb_ostream_id;
+
+        enb_ue->enb_ostream_id =
+            OGS_NEXT_ID(new_enb->ostream_id, 1,
+                    new_enb->max_num_of_ostreams-1);
+
+        ogs_warn("SCTP output stream re-bound to the target eNB "
+                "[OLD:%d NEW:%d MAX:%d] "
+                "ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
+                old_ostream_id, enb_ue->enb_ostream_id,
+                new_enb->max_num_of_ostreams,
+                enb_ue->enb_ue_s1ap_id, enb_ue->mme_ue_s1ap_id);
+    }
 }
 
 enb_ue_t *enb_ue_find_by_enb_ue_s1ap_id(


### PR DESCRIPTION
UE-associated SCTP streams are allocated per RAN association.

During X2 or Xn handover, the UE context can retain a stream ID that was valid for the source eNB or gNB but is outside the target RAN's negotiated stream range. Sending Path Switch Request Acknowledge on that stream then fails with EINVAL.

Rebind the stream using the target RAN allocator only when the existing stream ID is out of range.

Issues: #4670