### PR TITLE
smf: Handle QoS flow description delete

### DIFF
--- a/src/smf/gsm-handler.c
+++ b/src/smf/gsm-handler.c
@@ -241,8 +241,16 @@ int gsm_handle_pdu_session_modification_qos_rules(
         smf_pf_t *pf = NULL;
         smf_bearer_t *qos_flow =
             smf_qos_flow_find_by_qfi(sess, qos_rule[i].identifier);
+
+        ogs_info("[%s:%d] Requested QoS rule "
+                "[code:%d id:%d num_of_packet_filter:%d]",
+                smf_ue->supi, sess->psi,
+                qos_rule[i].code, qos_rule[i].identifier,
+                qos_rule[i].num_of_packet_filter);
+
         if (!qos_flow) {
-            ogs_error("No Qos Flow");
+            ogs_error("[%s:%d] No QoS flow [QRI/QFI:%d]",
+                    smf_ue->supi, sess->psi, qos_rule[i].identifier);
             continue;
         }
 
@@ -410,8 +418,78 @@ int gsm_handle_pdu_session_modification_qos_flow_descriptions(
         smf_bearer_t *qos_flow =
             smf_qos_flow_find_by_qfi(
                     sess, qos_flow_description[i].identifier);
+
+        ogs_info("[%s:%d] Requested QoS flow description "
+                "[code:%d qfi:%d E_bit:%d num_of_parameter:%d]",
+                smf_ue->supi, sess->psi,
+                qos_flow_description[i].code,
+                qos_flow_description[i].identifier,
+                qos_flow_description[i].E_bit,
+                qos_flow_description[i].num_of_parameter);
+
         if (!qos_flow) {
-            ogs_error("No Qos Flow");
+            ogs_error("[%s:%d] No QoS flow [QFI:%d]",
+                    smf_ue->supi, sess->psi,
+                    qos_flow_description[i].identifier);
+            continue;
+        }
+
+        if (qos_flow_description[i].code ==
+                OGS_NAS_DELETE_NEW_QOS_FLOW_DESCRIPTION) {
+            /*
+             * Issue #4672: smfd aborted while tearing down a VoNR call.
+             *
+             * Root cause
+             * ----------
+             * The QoS rules IE (TS24.501 9.11.4.13) and the QoS flow
+             * descriptions IE (9.11.4.12) are independent IEs, each with
+             * its own operation codes. Deleting a QoS flow therefore has
+             * three valid encodings:
+             *   1) QoS rule delete only,
+             *   2) QoS flow description delete only,
+             *   3) QoS rule delete + QoS flow description delete, paired
+             *      on the same QFI.
+             * For a GBR QoS flow (e.g. VoNR voice, 5QI 1) form 3) is the
+             * one conformant UEs use: per 9.11.4.13/9.11.4.12 leaving a
+             * GBR QoS rule whose QFI has no associated QoS flow
+             * description (or vice versa) is a syntactical error in the
+             * QoS operation, so the rule and the flow description must be
+             * deleted together.
+             *
+             * In Open5GS, removal of a QoS flow is driven solely by
+             * OGS_PFCP_MODIFY_REMOVE, which only the QoS rules handler
+             * sets (via smf_pf_remove_all() + adding the flow to
+             * qos_flow_to_modify_list; the flow is finally freed by
+             * smf_bearer_remove() in the N4 handler once REMOVE is set).
+             * Previously this handler ignored the operation code and set
+             * OGS_PFCP_MODIFY_QOS_MODIFY for every flow description. On
+             * the paired delete (form 3) that left both REMOVE (from the
+             * rule) and QOS_MODIFY (from this description) set for the
+             * same flow, tripping the invariant asserted in
+             * gsm_handle_pdu_session_modification_request()
+             * (pfcp_flags 0x8080 = REMOVE | QOS_MODIFY) and aborting the
+             * SMF on an otherwise standards-compliant request.
+             *
+             * Fix
+             * ---
+             * A "Delete existing QoS flow description" carries no
+             * parameters (E bit = 0, number of parameters = 0), so there
+             * is nothing to modify here. Skip it and let the paired QoS
+             * rule delete drive the removal. This keeps forms 1) and 3)
+             * working and no longer manufactures QOS_MODIFY out of a
+             * delete.
+             *
+             * Note on form 2) (flow description delete without the paired
+             * rule delete): with this skip, nothing is added to
+             * qos_flow_to_modify_list, so the caller's count check
+             * rejects the request. We deliberately do not treat a lone
+             * flow description delete as a removal: removal in Open5GS is
+             * keyed off the QoS rule, and for a GBR flow a lone flow
+             * description delete is itself a syntactical error under
+             * 9.11.4.12. If future requirements need form 2) to actually
+             * remove the flow, this branch would instead set
+             * OGS_PFCP_MODIFY_REMOVE and add the flow to the modify list.
+             */
             continue;
         }
 
@@ -512,20 +590,45 @@ int gsm_handle_pdu_session_modification_request(
     }
 
     if (pfcp_flags & OGS_PFCP_MODIFY_REMOVE) {
-        ogs_assert((pfcp_flags &
-                    (OGS_PFCP_MODIFY_TFT_NEW|OGS_PFCP_MODIFY_TFT_ADD|
-                    OGS_PFCP_MODIFY_TFT_REPLACE|OGS_PFCP_MODIFY_TFT_DELETE|
-                    OGS_PFCP_MODIFY_QOS_MODIFY)) == 0);
+        /*
+         * Issue #4672
+         *
+         * pfcp_flags is derived from the content of the UE's
+         * PDU Session Modification Request, so a misbehaving UE can
+         * request a removal combined with a TFT/QoS modification for
+         * the same QoS flow. This is invalid input, not an internal
+         * error: log the exact flag combination and reject the
+         * request instead of aborting the SMF.
+         */
+        if (pfcp_flags &
+                (OGS_PFCP_MODIFY_TFT_NEW|OGS_PFCP_MODIFY_TFT_ADD|
+                OGS_PFCP_MODIFY_TFT_REPLACE|OGS_PFCP_MODIFY_TFT_DELETE|
+                OGS_PFCP_MODIFY_QOS_MODIFY)) {
+            ogs_error("[%s:%d] Invalid modification request "
+                    "[REMOVE combined with TFT/QOS-MODIFY "
+                    "pfcp_flags:0x%llx]",
+                    smf_ue->supi, sess->psi, (long long)pfcp_flags);
+            ogs_assert_if_reached();
+        }
 
     } else if (pfcp_flags &
                 (OGS_PFCP_MODIFY_TFT_NEW|OGS_PFCP_MODIFY_TFT_ADD|
                 OGS_PFCP_MODIFY_TFT_REPLACE|OGS_PFCP_MODIFY_TFT_DELETE|
                 OGS_PFCP_MODIFY_QOS_MODIFY)) {
 
-        ogs_assert((pfcp_flags & OGS_PFCP_MODIFY_REMOVE) == 0);
+        /* TFT/QoS modification without removal */
+        if (pfcp_flags & OGS_PFCP_MODIFY_REMOVE) {
+            ogs_error("[%s:%d] Invalid modification request "
+                    "[TFT/QOS-MODIFY combined with REMOVE "
+                    "pfcp_flags:0x%llx]",
+                    smf_ue->supi, sess->psi, (long long)pfcp_flags);
+            ogs_assert_if_reached();
+        }
 
     } else {
-        ogs_fatal("Unknown PFCP-Flags : [0x%llx]", (long long)pfcp_flags);
+        ogs_error("[%s:%d] Invalid modification request "
+                "[Unknown pfcp_flags:0x%llx]",
+                smf_ue->supi, sess->psi, (long long)pfcp_flags);
         ogs_assert_if_reached();
     }
 

--- a/tests/common/gsm-build.c
+++ b/tests/common/gsm-build.c
@@ -203,6 +203,16 @@ ogs_pkbuf_t *testgsm_build_pdu_session_modification_request(
             qos_rule[0].pf[2].identifier = 3;
             qos_rule[0].pf[3].identifier = 4;
 
+        } else if (qos_rule_code ==
+                OGS_NAS_QOS_CODE_DELETE_EXISTING_QOS_RULE) {
+            /*
+             * Delete existing QoS rule: no packet filters are carried
+             * and the encoder omits precedence and the QoS flow
+             * identifier for this operation (TS24.501 9.11.4.13).
+             */
+            qos_rule[0].DQR_bit = 0;
+            qos_rule[0].num_of_packet_filter = 0;
+
         } else {
             ogs_fatal("Unknown qos_rule_code[%d]", qos_rule_code);
             ogs_assert_if_reached();

--- a/tests/vonr/af-test.c
+++ b/tests/vonr/af-test.c
@@ -4839,6 +4839,131 @@ static void test13_func(abts_case *tc, void *data)
 }
 
 
+static void test_issue4672_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *ngap = NULL;
+    ogs_socknode_t *gtpu = NULL;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+    af_sess_t *af_sess = NULL;
+    af_npcf_policyauthorization_param_t af_param;
+
+    ogs_pkbuf_t *gmmbuf = NULL;
+    ogs_pkbuf_t *gsmbuf = NULL;
+    ogs_pkbuf_t *sendbuf = NULL;
+    ogs_pkbuf_t *recvbuf = NULL;
+
+    /*
+     * Issue #4672
+     *
+     * Reproduces the smfd crash observed on a VoNR call teardown.
+     */
+    test_af_qos_reference_setup(tc, "0000004672",
+            &test_ue, &sess, &af_sess, &ngap, &gtpu);
+
+    memset(&af_param, 0, sizeof(af_param));
+    af_param.med_type = OpenAPI_media_type_AUDIO;
+    af_param.qos_reference = "test-audio";
+    af_param.qos_type = 1;
+    af_param.flow_type = 99;
+
+    af_local_send_to_pcf(af_sess, &af_param,
+            af_npcf_policyauthorization_build_create);
+
+    qos_flow = test_af_complete_qos_flow_modify(tc, test_ue, sess, ngap);
+    ogs_assert(qos_flow);
+
+    /* UE-initiated deletion of the dedicated QoS flow (QFI 2) */
+    sess->pti = 8;
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_MODIFICATION_REQUEST;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 1;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_modification_request(
+        qos_flow,
+        OGS_5GSM_CAUSE_REGULAR_DEACTIVATION,
+        OGS_NAS_QOS_CODE_DELETE_EXISTING_QOS_RULE,
+        OGS_NAS_DELETE_NEW_QOS_FLOW_DESCRIPTION);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive PDUSessionResourceModifyRequest +
+     * DL NAS transport +
+     * PDU session modification command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceModify,
+            test_ue->ngap_procedure_code);
+
+    /*
+     * The QoS rule delete drives removal of the dedicated QoS flow, so
+     * smfd releases QFI 2. Acknowledge the release at NGAP and complete
+     * the modification at NAS, then drop the test-side bearer.
+     */
+    qos_flow = test_qos_flow_find_by_qfi(sess, 2);
+    ogs_assert(qos_flow);
+
+    sendbuf = testngap_build_qos_flow_resource_release_response(qos_flow);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_MODIFICATION_REQUEST;
+    sess->ul_nas_transport_param.dnn = 0;
+    sess->ul_nas_transport_param.s_nssai = 0;
+
+    sess->pdu_session_establishment_param.ssc_mode = 0;
+    sess->pdu_session_establishment_param.epco = 0;
+
+    gsmbuf = testgsm_build_pdu_session_modification_complete(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_bearer_remove(qos_flow);
+
+    ogs_msleep(100);
+
+    /*
+     * The dedicated QoS flow was removed by the UE, but the AF/PCF
+     * policy authorization that created it is still active. Tear it
+     * down through the AF (Npcf_PolicyAuthorization delete) so the app
+     * session is terminated cleanly and no dangling status
+     * notification is later sent to a removed app session. Because the
+     * QoS flow is already gone, smfd takes the "already removed" path
+     * in binding.c and issues no further PDUSessionResourceModify, so
+     * there is nothing more to read here. The AF removes af_sess itself
+     * on the delete response (tests/af/af-sm.c), so it must not be
+     * removed again.
+     */
+    af_local_send_to_pcf(af_sess, NULL,
+            af_npcf_policyauthorization_build_delete);
+
+    ogs_msleep(100);
+
+    test_af_qos_reference_cleanup(tc, test_ue, ngap, gtpu);
+}
+
 abts_suite *test_af(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -4863,6 +4988,7 @@ abts_suite *test_af(abts_suite *suite)
     abts_run_test(suite, test11_func, NULL);
     abts_run_test(suite, test12_func, NULL);
     abts_run_test(suite, test13_func, NULL);
+    abts_run_test(suite, test_issue4672_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
When processing a UE-requested PDU Session Modification Request, the SMF treated every Requested QoS flow description as a QoS parameter modification regardless of its operation code.

If the UE deletes a dedicated QoS flow by sending both:

    - Delete existing QoS rule
    - Delete existing QoS flow description

for the same QFI, the QoS rules handler sets OGS_PFCP_MODIFY_REMOVE, but the QoS flow descriptions handler also set
OGS_PFCP_MODIFY_QOS_MODIFY. This produced an invalid REMOVE|QOS_MODIFY combination and tripped the invariant in gsm_handle_pdu_session_modification_request(), aborting smfd during VoNR call teardown.

A "Delete existing QoS flow description" carries no QoS parameters, so skip the QoS-parameter update path for that operation and let the QoS rule deletion drive the actual PFCP removal.

Also update the test GSM message builder to encode QoS rule deletion without packet filters, and add a VoNR regression test for the UE-initiated dedicated QoS flow deletion case.

Issues #4672