### PR TITLE
amf/udm/udr: Optimize SDM retrieval using dataset-names

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -2075,6 +2075,28 @@ static int parse_json(ogs_sbi_message_t *message,
             break;
 
         case OpenAPI_service_name_nudm_sdm:
+            if (!message->h.resource.component[1]) {
+                /*
+                 * Combined SDM retrieval:
+                 *   GET /nudm-sdm/v2/{supi}?dataset-names=AM,SMF_SEL
+                 *
+                 * The UDM relays the ProvisionedDataSets that the UDR
+                 * built from the requested dataset-names, so parse the
+                 * whole set here in a single response.
+                 */
+                if (message->res_status < 300) {
+                    message->ProvisionedDataSets =
+                        OpenAPI_provisioned_data_sets_parseFromJSON(item);
+                    if (!message->ProvisionedDataSets) {
+                        rv = OGS_ERROR;
+                        ogs_error("JSON parse error");
+                    }
+                } else {
+                    ogs_error("HTTP ERROR Status : %d", message->res_status);
+                }
+                break;
+            }
+
             SWITCH(message->h.resource.component[1])
             CASE(OGS_SBI_RESOURCE_NAME_NSSAI)
                 if (message->res_status < 300) {

--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -416,6 +416,20 @@ void gmm_state_de_registered(ogs_fsm_t *s, amf_event_t *e)
             break;
 
         case OpenAPI_service_name_nudm_sdm:
+            /*
+             * A combined SDM response (dataset-names) has no resource
+             * component[1] and is only handled in
+             * gmm_state_initial_context_setup(). Arriving here means the
+             * UE state has changed since the request was sent; ignore it
+             * instead of asserting in the SWITCH DEFAULT below.
+             */
+            if (!sbi_message->h.resource.component[1]) {
+                ogs_warn("[%s] Ignore late dataset-names response "
+                        "[%d] in (%s)",
+                        amf_ue->supi, sbi_message->res_status,
+                        sbi_message->h.method);
+                break;
+            }
             if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)) {
@@ -1236,6 +1250,20 @@ void gmm_state_registered(ogs_fsm_t *s, amf_event_t *e)
             break;
 
         case OpenAPI_service_name_nudm_sdm:
+            /*
+             * A combined SDM response (dataset-names) has no resource
+             * component[1] and is only handled in
+             * gmm_state_initial_context_setup(). Arriving here means the
+             * UE state has changed since the request was sent; ignore it
+             * instead of asserting in the SWITCH DEFAULT below.
+             */
+            if (!sbi_message->h.resource.component[1]) {
+                ogs_warn("[%s] Ignore late dataset-names response "
+                        "[%d] in (%s)",
+                        amf_ue->supi, sbi_message->res_status,
+                        sbi_message->h.method);
+                break;
+            }
             if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)) {
@@ -2412,6 +2440,20 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             break;
 
         case OpenAPI_service_name_nudm_sdm:
+            /*
+             * A combined SDM response (dataset-names) has no resource
+             * component[1] and is only handled in
+             * gmm_state_initial_context_setup(). Arriving here means the
+             * UE state has changed since the request was sent; ignore it
+             * instead of asserting in the SWITCH DEFAULT below.
+             */
+            if (!sbi_message->h.resource.component[1]) {
+                ogs_warn("[%s] Ignore late dataset-names response "
+                        "[%d] in (%s)",
+                        amf_ue->supi, sbi_message->res_status,
+                        sbi_message->h.method);
+                break;
+            }
             if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)) {
@@ -2994,9 +3036,8 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                 CASE(OGS_SBI_HTTP_METHOD_PUT)
                     r = amf_ue_sbi_discover_and_send(
                             OpenAPI_service_name_nudm_sdm, NULL,
-                            amf_nudm_sdm_build_get,
-                            amf_ue, state,
-                            (char *)OGS_SBI_RESOURCE_NAME_AM_DATA);
+                            amf_nudm_sdm_build_get_datasets,
+                            amf_ue, state, NULL);
                     ogs_expect(r == OGS_OK);
                     ogs_assert(r != OGS_ERROR);
                     break;
@@ -3016,7 +3057,8 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
             break;
 
         case OpenAPI_service_name_nudm_sdm:
-            if (!strcmp(sbi_message->h.resource.component[1],
+            if (sbi_message->h.resource.component[1] &&
+                !strcmp(sbi_message->h.resource.component[1],
                         OGS_SBI_RESOURCE_NAME_SDM_SUBSCRIPTIONS) &&
                 !strcmp(sbi_message->h.method, OGS_SBI_HTTP_METHOD_DELETE)) {
 /*
@@ -3040,6 +3082,38 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
                         sbi_message->h.resource.component[1]);
 
                 UDM_SDM_CLEAR(amf_ue);
+                break;
+            }
+
+            /*
+             * Combined SDM retrieval:
+             *   GET /nudm-sdm/v2/{supi}?dataset-names=AM,SMF_SEL
+             *
+             * The response carries a single ProvisionedDataSets and has
+             * no resource component[1].
+             */
+            if (!sbi_message->h.resource.component[1]) {
+                if (sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) {
+                    ogs_error("[%s] HTTP response error [%d] in "
+                            "(%s:dataset-names)",
+                            amf_ue->supi, sbi_message->res_status,
+                            sbi_message->h.method);
+                    r = nas_5gs_send_gmm_reject_from_sbi(
+                            amf_ue, sbi_message->res_status);
+                    ogs_expect(r == OGS_OK);
+                    ogs_assert(r != OGS_ERROR);
+                    OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
+                    break;
+                }
+
+                rv = amf_nudm_sdm_handle_provisioned_data_sets(
+                        amf_ue, state, sbi_message);
+                if (rv != OGS_OK) {
+                    ogs_error("[%s] amf_nudm_sdm_handle_provisioned"
+                            "_data_sets(%s) failed",
+                            amf_ue->supi, sbi_message->h.method);
+                    OGS_FSM_TRAN(&amf_ue->sm, &gmm_state_exception);
+                }
                 break;
             }
 
@@ -3701,6 +3775,20 @@ void gmm_state_exception(ogs_fsm_t *s, amf_event_t *e)
             break;
 
         case OpenAPI_service_name_nudm_sdm:
+            /*
+             * A combined SDM response (dataset-names) has no resource
+             * component[1] and is only handled in
+             * gmm_state_initial_context_setup(). Arriving here means the
+             * UE state has changed since the request was sent; ignore it
+             * instead of asserting in the SWITCH DEFAULT below.
+             */
+            if (!sbi_message->h.resource.component[1]) {
+                ogs_warn("[%s] Ignore late dataset-names response "
+                        "[%d] in (%s)",
+                        amf_ue->supi, sbi_message->res_status,
+                        sbi_message->h.method);
+                break;
+            }
             if ((sbi_message->res_status != OGS_SBI_HTTP_STATUS_OK) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_CREATED) &&
                 (sbi_message->res_status != OGS_SBI_HTTP_STATUS_NO_CONTENT)) {

--- a/src/amf/nudm-build.c
+++ b/src/amf/nudm-build.c
@@ -174,6 +174,48 @@ ogs_sbi_request_t *amf_nudm_sdm_build_get(amf_ue_t *amf_ue, void *data)
     return request;
 }
 
+ogs_sbi_request_t *amf_nudm_sdm_build_get_datasets(
+        amf_ue_t *amf_ue, void *data)
+{
+    ogs_sbi_message_t message;
+    ogs_sbi_request_t *request = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(amf_ue->supi);
+
+    memset(&message, 0, sizeof(message));
+    message.h.method = (char *)OGS_SBI_HTTP_METHOD_GET;
+    message.h.service.name =
+        OpenAPI_service_name_ToString(OpenAPI_service_name_nudm_sdm);
+    message.h.api.version = (char *)OGS_SBI_API_V2;
+    message.h.resource.component[0] = amf_ue->supi;
+
+    /*
+     * Retrieve Access and Mobility + SMF Selection subscription data
+     * in a single request:
+     *
+     *   GET /nudm-sdm/v2/{supi}?dataset-names=AM,SMF_SEL
+     *
+     * These are the two datasets carried by ProvisionedDataSets. UE
+     * context in SMF data is retrieved separately afterwards because it
+     * is not part of ProvisionedDataSets.
+     */
+    message.param.dataset_names[0] =
+        (char *)OGS_SBI_PARAM_DATASET_NAME_AM;
+    message.param.dataset_names[1] =
+        (char *)OGS_SBI_PARAM_DATASET_NAME_SMF_SEL;
+    message.param.num_of_dataset_names = 2;
+
+    message.param.plmn_id_presence = true;
+    memcpy(&message.param.plmn_id, &amf_ue->nr_tai.plmn_id,
+            sizeof(message.param.plmn_id));
+
+    request = ogs_sbi_build_request(&message);
+    ogs_expect(request);
+
+    return request;
+}
+
 ogs_sbi_request_t *amf_nudm_sdm_build_subscription(amf_ue_t *amf_ue, void *data)
 {
     ogs_sbi_message_t message;

--- a/src/amf/nudm-build.h
+++ b/src/amf/nudm-build.h
@@ -31,6 +31,8 @@ ogs_sbi_request_t *amf_nudm_uecm_build_registration(
 ogs_sbi_request_t *amf_nudm_uecm_build_registration_delete(
         amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nudm_sdm_build_get(amf_ue_t *amf_ue, void *data);
+ogs_sbi_request_t *amf_nudm_sdm_build_get_datasets(
+        amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nudm_sdm_build_subscription(
         amf_ue_t *amf_ue, void *data);
 ogs_sbi_request_t *amf_nudm_sdm_build_subscription_delete(

--- a/src/amf/nudm-handler.c
+++ b/src/amf/nudm-handler.c
@@ -22,8 +22,9 @@
 #include "sbi-path.h"
 #include "nas-path.h"
 
-int amf_nudm_sdm_handle_provisioned(
-        amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg)
+static int amf_nudm_sdm_handle_provisioned_internal(
+        amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg,
+        bool continue_chain)
 {
     int i, r;
 
@@ -201,6 +202,14 @@ int amf_nudm_sdm_handle_provisioned(
             ogs_assert(r != OGS_ERROR);
             return OGS_ERROR;
         }
+
+        /*
+         * When called from amf_nudm_sdm_handle_provisioned_data_sets(),
+         * the SMF Selection subscription data is already available from
+         * the same combined response; do not issue a separate GET.
+         */
+        if (!continue_chain)
+            break;
 
         r = amf_ue_sbi_discover_and_send(
                 OpenAPI_service_name_nudm_sdm, NULL,
@@ -440,4 +449,71 @@ int amf_nudm_sdm_handle_provisioned(
     END
 
     return OGS_OK;
+}
+
+int amf_nudm_sdm_handle_provisioned(
+        amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg)
+{
+    return amf_nudm_sdm_handle_provisioned_internal(
+            amf_ue, state, recvmsg, true);
+}
+
+int amf_nudm_sdm_handle_provisioned_data_sets(
+        amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg)
+{
+    int rv, r;
+    ogs_sbi_message_t message;
+    OpenAPI_provisioned_data_sets_t *ProvisionedDataSets = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(recvmsg);
+
+    ProvisionedDataSets = recvmsg->ProvisionedDataSets;
+
+    /*
+     * Both datasets were requested with dataset-names=AM,SMF_SEL, so a
+     * 200 response missing either one is treated as an error instead of
+     * silently skipping the missing dataset.
+     */
+    if (!ProvisionedDataSets ||
+        !ProvisionedDataSets->am_data ||
+        !ProvisionedDataSets->smf_sel_data) {
+        ogs_error("[%s] Incomplete ProvisionedDataSets [AM:%p SMF_SEL:%p]",
+                amf_ue->supi,
+                ProvisionedDataSets ?
+                    (void *)ProvisionedDataSets->am_data : NULL,
+                ProvisionedDataSets ?
+                    (void *)ProvisionedDataSets->smf_sel_data : NULL);
+        r = nas_5gs_send_gmm_reject_from_sbi(
+                amf_ue, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR);
+        ogs_expect(r == OGS_OK);
+        ogs_assert(r != OGS_ERROR);
+        return OGS_ERROR;
+    }
+
+    /*
+     * Dispatch each dataset to the existing per-dataset handling with a
+     * minimal temporary message: only the resource name and the borrowed
+     * dataset pointer are set, so the temporary message never owns any
+     * of the response memory (recvmsg keeps the ownership).
+     */
+    memset(&message, 0, sizeof(message));
+    message.h.resource.component[1] =
+        (char *)OGS_SBI_RESOURCE_NAME_AM_DATA;
+    message.AccessAndMobilitySubscriptionData =
+        ProvisionedDataSets->am_data;
+
+    rv = amf_nudm_sdm_handle_provisioned_internal(
+            amf_ue, state, &message, false);
+    if (rv != OGS_OK)
+        return rv;
+
+    memset(&message, 0, sizeof(message));
+    message.h.resource.component[1] =
+        (char *)OGS_SBI_RESOURCE_NAME_SMF_SELECT_DATA;
+    message.SmfSelectionSubscriptionData =
+        ProvisionedDataSets->smf_sel_data;
+
+    return amf_nudm_sdm_handle_provisioned_internal(
+            amf_ue, state, &message, true);
 }

--- a/src/amf/nudm-handler.h
+++ b/src/amf/nudm-handler.h
@@ -28,6 +28,8 @@ extern "C" {
 
 int amf_nudm_sdm_handle_provisioned(
         amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg);
+int amf_nudm_sdm_handle_provisioned_data_sets(
+        amf_ue_t *amf_ue, int state, ogs_sbi_message_t *recvmsg);
 
 #ifdef __cplusplus
 }

--- a/src/udm/nudr-build.c
+++ b/src/udm/nudr-build.c
@@ -222,8 +222,18 @@ ogs_sbi_request_t *udm_nudr_dr_build_query_subscription_provisioned(
     sendmsg.h.resource.component[0] =
         (char *)OGS_SBI_RESOURCE_NAME_SUBSCRIPTION_DATA;
     sendmsg.h.resource.component[1] = udm_ue->supi;
+    /*
+     * TS 29.503: the plmn-id query parameter of Nudm_SDM carries the
+     * serving PLMN ID. Prefer it for the {servingPlmnId} of the UDR
+     * resource URI; in network sharing (MOCN) the serving (TAI) PLMN
+     * can differ from the GUAMI PLMN of the AMF. Fall back to the
+     * GUAMI PLMN when the consumer did not send the parameter.
+     */
     sendmsg.h.resource.component[2] =
-        (char *)ogs_plmn_id_to_string(&udm_ue->guami.plmn_id, buf);
+        (char *)ogs_plmn_id_to_string(
+                recvmsg->param.plmn_id_presence ?
+                    &recvmsg->param.plmn_id : &udm_ue->guami.plmn_id,
+                buf);
     sendmsg.h.resource.component[3] =
         (char *)OGS_SBI_RESOURCE_NAME_PROVISIONED_DATA;
     if (recvmsg->h.resource.component[1]) {

--- a/src/udr/nudr-handler.c
+++ b/src/udr/nudr-handler.c
@@ -584,12 +584,6 @@ bool udr_nudr_dr_handle_subscription_provisioned(
         goto cleanup;
     }
 
-    if (!subscription_data.ambr.uplink && !subscription_data.ambr.downlink) {
-        strerror = ogs_msprintf("[%s] No UE-AMBR", supi);
-        status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
-        goto cleanup;
-    }
-
     if (recvmsg->h.resource.component[4]) {
         SWITCH(recvmsg->h.resource.component[4])
         CASE(OGS_SBI_RESOURCE_NAME_AM_DATA)
@@ -670,6 +664,20 @@ bool udr_nudr_dr_handle_subscription_provisioned(
             processGpsi = true;
             processUeAmbr = true;
             processNssai = true;
+        }
+
+        /*
+         * UE-AMBR is only meaningful for Access and Mobility
+         * subscription data. Checking it before the dataset dispatch
+         * rejected SMF Selection and Session Management queries of
+         * subscribers without UE-AMBR with 404 as well.
+         */
+        if (processUeAmbr &&
+            !subscription_data.ambr.uplink &&
+            !subscription_data.ambr.downlink) {
+            strerror = ogs_msprintf("[%s] No UE-AMBR", supi);
+            status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
+            goto cleanup;
         }
 
         if (processGpsi) {


### PR DESCRIPTION
Retrieve AM and SMF selection subscription data in a single Nudm_SDM request using the dataset-names query parameter.

Parse combined Nudm_SDM responses as ProvisionedDataSets and process the AM and SMF selection data sequentially while preserving the existing UE context in SMF lookup.

Forward the requested serving PLMN from UDM to UDR, falling back to the UE GUAMI PLMN when it is not provided.

Also limit the UDR UE-AMBR validation to requests that actually include subscribedUeAmbr, and safely ignore delayed combined responses received after the UE has moved to another GMM state.

Issues: #4683