### PR TITLE
mme: Do not assert on PDN type mismatch

### DIFF
--- a/src/mme/esm-build.c
+++ b/src/mme/esm-build.c
@@ -31,6 +31,8 @@ static bool esm_pdn_connectivity_reject_t3396_allowed(
     case OGS_NAS_ESM_CAUSE_MISSING_OR_UNKNOWN_APN:
     case OGS_NAS_ESM_CAUSE_SERVICE_OPTION_NOT_SUPPORTED:
     case OGS_NAS_ESM_CAUSE_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED:
+    case OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV4_ONLY_ALLOWED:
+    case OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV6_ONLY_ALLOWED:
         return true;
     default:
         return false;

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -137,9 +137,20 @@ int esm_handle_pdn_connectivity_request(
             if (derived_pdn_type == 0) {
                 ogs_error("Cannot derived PDN Type [UE:%d,HSS:%d]",
                     sess->ue_request_type.type, sess->session->session_type);
+                ogs_nas_esm_cause_t cause;
+                
+                if (sess->session->session_type == OGS_PDU_SESSION_TYPE_IPV4 &&
+                    sess->ue_request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV6) {
+                    cause = OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV4_ONLY_ALLOWED;
+                } else if (sess->session->session_type == OGS_PDU_SESSION_TYPE_IPV6 &&
+                           sess->ue_request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV4) {
+                    cause = OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV6_ONLY_ALLOWED;
+                } else {
+                    cause = OGS_NAS_ESM_CAUSE_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED;
+                }
+                
                 r = nas_eps_send_pdn_connectivity_reject(
-                        sess, OGS_NAS_ESM_CAUSE_UNKNOWN_PDN_TYPE,
-                        create_action);
+                        sess, cause, create_action);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 return OGS_ERROR;
@@ -269,9 +280,20 @@ int esm_handle_information_response(
             if (derived_pdn_type == 0) {
                 ogs_error("Cannot derived PDN Type [UE:%d,HSS:%d]",
                     sess->ue_request_type.type, sess->session->session_type);
+                ogs_nas_esm_cause_t cause;
+                
+                if (sess->session->session_type == OGS_PDU_SESSION_TYPE_IPV4 &&
+                    sess->ue_request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV6) {
+                    cause = OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV4_ONLY_ALLOWED;
+                } else if (sess->session->session_type == OGS_PDU_SESSION_TYPE_IPV6 &&
+                           sess->ue_request_type.type == OGS_NAS_EPS_PDN_TYPE_IPV4) {
+                    cause = OGS_NAS_ESM_CAUSE_PDN_TYPE_IPV6_ONLY_ALLOWED;
+                } else {
+                    cause = OGS_NAS_ESM_CAUSE_REQUESTED_SERVICE_OPTION_NOT_SUBSCRIBED;
+                }
+                
                 r = nas_eps_send_pdn_connectivity_reject(
-                        sess, OGS_NAS_ESM_CAUSE_UNKNOWN_PDN_TYPE,
-                        OGS_GTP_CREATE_IN_ATTACH_REQUEST);
+                        sess, cause, OGS_GTP_CREATE_IN_ATTACH_REQUEST);
                 ogs_expect(r == OGS_OK);
                 ogs_assert(r != OGS_ERROR);
                 return OGS_ERROR;

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -215,9 +215,10 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
             req->pdn_type.u8 =
                 (session->session_type & sess->ue_request_type.type);
             if (req->pdn_type.u8 == 0) {
-                ogs_fatal("Cannot derive PDN Type [UE:%d,HSS:%d]",
-                    sess->ue_request_type.type, session->session_type);
-                ogs_assert_if_reached();
+                ogs_error("Incompatible PDN Type [UE:%d,HSS:%d]",
+                    sess->ue_request_type.type,
+                    session->session_type);
+                return NULL;
             }
         } else {
             ogs_error("Invalid PDN-TYPE[%d]", session->session_type);


### PR DESCRIPTION
If the network is IPv4 only, and the UE is set to IPv6 only, the MME asserts, allowing a misconfigured UE to DoS the network.

Fix this by removing assert, and send an Attach Reject (ESM failure), PDN Connectivity reject (PDN type IPv4 only  allowed) instead. Add the reject causes PDN_TYPE_IPV4_ONLY_ALLOWED and PDN_TYPE_IPV6_ONLY_ALLOWED to the T3396 back-off timer to throttle the speed of these messages.