### PR TITLE
[MME] Store HSS identity from S6a answers and set Destination-Host

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3114,6 +3114,51 @@ mme_hssmap_t *mme_hssmap_find_by_imsi_bcd(const char *imsi_bcd)
     return NULL;
 }
 
+void mme_ue_set_hss_identity(mme_ue_t *mme_ue,
+        const uint8_t *host, size_t host_len,
+        const uint8_t *realm, size_t realm_len)
+{
+    ogs_assert(mme_ue);
+
+    /* Diameter AVPs are OctetStrings and not NUL-terminated,
+     * so a length-bounded duplication is required */
+    if (host && host_len) {
+        if (mme_ue->hss_host &&
+                (strlen(mme_ue->hss_host) != host_len ||
+                 memcmp(mme_ue->hss_host, host, host_len) != 0))
+            ogs_info("[%s] HSS identity changed [%s] -> [%.*s]",
+                    mme_ue->imsi_bcd, mme_ue->hss_host,
+                    (int)host_len, host);
+        if (mme_ue->hss_host)
+            ogs_free(mme_ue->hss_host);
+        mme_ue->hss_host = ogs_strndup((const char *)host, host_len);
+        ogs_assert(mme_ue->hss_host);
+    }
+
+    if (realm && realm_len) {
+        if (mme_ue->hss_realm)
+            ogs_free(mme_ue->hss_realm);
+        mme_ue->hss_realm = ogs_strndup((const char *)realm, realm_len);
+        ogs_assert(mme_ue->hss_realm);
+    }
+}
+
+void mme_ue_clear_hss_identity(mme_ue_t *mme_ue)
+{
+    ogs_assert(mme_ue);
+
+    if (mme_ue->hss_host) {
+        ogs_debug("[%s] Forget HSS identity [%s]",
+                mme_ue->imsi_bcd, mme_ue->hss_host);
+        ogs_free(mme_ue->hss_host);
+        mme_ue->hss_host = NULL;
+    }
+    if (mme_ue->hss_realm) {
+        ogs_free(mme_ue->hss_realm);
+        mme_ue->hss_realm = NULL;
+    }
+}
+
 mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
 {
     mme_enb_t *enb = NULL;
@@ -3853,6 +3898,9 @@ void mme_ue_remove(mme_ue_t *mme_ue)
 
     /* Clear Transparent Container */
     OGS_ASN_CLEAR_DATA(&mme_ue->container);
+
+    /* Clear learned HSS identity */
+    mme_ue_clear_hss_identity(mme_ue);
 
     /* Delete All Timers */
     CLEAR_MME_UE_ALL_TIMERS(mme_ue);

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -881,6 +881,12 @@ struct mme_ue_s {
 
     mme_csmap_t     *csmap;
     mme_hssmap_t    *hssmap;
+
+    /* HSS identity dynamically learned from the Origin-Host/Origin-Realm
+     * of successful S6a answers (AIA/ULA), used as Destination-Host/Realm
+     * in subsequent requests as per 3GPP TS 29.272 clause 7.16 */
+    char            *hss_host;
+    char            *hss_realm;
 };
 
 #define MME_UE_REMOVE_WITH_PAGING_FAIL(__mME) \
@@ -1128,6 +1134,11 @@ void mme_hssmap_remove(mme_hssmap_t *hssmap);
 void mme_hssmap_remove_all(void);
 
 mme_hssmap_t *mme_hssmap_find_by_imsi_bcd(const char *imsi_bcd);
+
+void mme_ue_set_hss_identity(mme_ue_t *mme_ue,
+        const uint8_t *host, size_t host_len,
+        const uint8_t *realm, size_t realm_len);
+void mme_ue_clear_hss_identity(mme_ue_t *mme_ue);
 
 mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr);
 int mme_enb_remove(mme_enb_t *enb);

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -69,6 +69,15 @@ static void mme_add_hss_destination(mme_ue_t *mme_ue, struct msg *req)
         host = mme_ue->hssmap->host;
     }
 
+    /* TS 29.272 clause 7.16: if the MME knows the identity of the HSS
+     * for this user (learned from the Origin-Host/Origin-Realm of a
+     * previous successful answer), it takes precedence over the
+     * statically configured HSS map */
+    if (mme_ue->hss_host)
+        host = mme_ue->hss_host;
+    if (mme_ue->hss_realm)
+        realm = mme_ue->hss_realm;
+
     if (realm == NULL)
         realm = fd_g_config->cnf_diamrlm;
 
@@ -90,6 +99,33 @@ static void mme_add_hss_destination(mme_ue_t *mme_ue, struct msg *req)
         ogs_assert(ret == 0);
         ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
         ogs_assert(ret == 0);
+    }
+}
+
+/* TS 29.272 clause 7.16: learn the HSS identity for this subscriber from
+ * the Origin-Host/Origin-Realm of a successful answer; forget it when the
+ * request could not be delivered (routing errors 3xxx, e.g. the learned
+ * HSS is down) or the HSS no longer knows the user (Experimental-Result
+ * 5001, e.g. the subscriber was migrated to another HSS), so that the
+ * next request is realm-routed again */
+static void mme_update_hss_identity(mme_ue_t *mme_ue,
+        ogs_diam_s6a_message_t *s6a_message,
+        const uint8_t *ohost, size_t ohost_len,
+        const uint8_t *orealm, size_t orealm_len)
+{
+    ogs_assert(mme_ue);
+    ogs_assert(s6a_message);
+
+    if (s6a_message->result_code == ER_DIAMETER_SUCCESS) {
+        mme_ue_set_hss_identity(mme_ue, ohost, ohost_len,
+                orealm, orealm_len);
+    } else if ((s6a_message->err &&
+                s6a_message->result_code >= 3000 &&
+                s6a_message->result_code < 4000) ||
+               (s6a_message->exp_err &&
+                s6a_message->result_code ==
+                    OGS_DIAM_S6A_ERROR_USER_UNKNOWN)) {
+        mme_ue_clear_hss_identity(mme_ue);
     }
 }
 
@@ -903,6 +939,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     ogs_diam_s6a_message_t *s6a_message;
     ogs_diam_s6a_aia_message_t *aia_message;
     ogs_diam_e_utran_vector_t *e_utran_vector;
+    const uint8_t *ohost = NULL, *orealm = NULL;
+    size_t ohost_len = 0, orealm_len = 0;
 
     /* Initialize variables */
     sess_data = NULL;
@@ -1022,6 +1060,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        ohost = hdr->avp_value->os.data;
+        ohost_len = hdr->avp_value->os.len;
         ogs_debug("    From '%.*s'",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1041,6 +1081,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        orealm = hdr->avp_value->os.data;
+        orealm_len = hdr->avp_value->os.len;
         ogs_debug("         ('%.*s')",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1048,6 +1090,10 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
         error++;
         goto cleanup;
     }
+
+    /* Learn or forget the HSS identity serving this subscriber */
+    mme_update_hss_identity(mme_ue, s6a_message,
+            ohost, ohost_len, orealm, orealm_len);
 
     if (s6a_message->result_code != ER_DIAMETER_SUCCESS) {
         if (s6a_message->err)
@@ -1458,6 +1504,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     ogs_diam_s6a_ula_message_t *ula_message;
     ogs_subscription_data_t *subscription_data;
     uint32_t subdatamask;
+    const uint8_t *ohost = NULL, *orealm = NULL;
+    size_t ohost_len = 0, orealm_len = 0;
 
     /* Initialize variables */
     sess_data = NULL;
@@ -1573,6 +1621,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        ohost = hdr->avp_value->os.data;
+        ohost_len = hdr->avp_value->os.len;
         ogs_debug("    From '%.*s'",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1592,6 +1642,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        orealm = hdr->avp_value->os.data;
+        orealm_len = hdr->avp_value->os.len;
         ogs_debug("         ('%.*s')",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1599,6 +1651,10 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
         error++;
         goto cleanup;
     }
+
+    /* Learn or forget the HSS identity serving this subscriber */
+    mme_update_hss_identity(mme_ue, s6a_message,
+            ohost, ohost_len, orealm, orealm_len);
 
     /* AVP: 'ULA-Flags'(1406)
      * The ULA-Flags AVP contains a bit mask, whose meanings are defined in
@@ -1862,6 +1918,8 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
     enb_ue_t *enb_ue;
     ogs_diam_s6a_message_t *s6a_message;
     ogs_diam_s6a_pua_message_t *pua_message;
+    const uint8_t *ohost = NULL, *orealm = NULL;
+    size_t ohost_len = 0, orealm_len = 0;
 
     /* Initialize variables */
     sess_data = NULL;
@@ -1974,6 +2032,8 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        ohost = hdr->avp_value->os.data;
+        ohost_len = hdr->avp_value->os.len;
         ogs_debug("    From '%.*s'",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1993,6 +2053,8 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        orealm = hdr->avp_value->os.data;
+        orealm_len = hdr->avp_value->os.len;
         ogs_debug("         ('%.*s')",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -2000,6 +2062,10 @@ static void mme_s6a_pua_cb(void *data, struct msg **msg)
         error++;
         goto cleanup;
     }
+
+    /* Learn or forget the HSS identity serving this subscriber */
+    mme_update_hss_identity(mme_ue, s6a_message,
+            ohost, ohost_len, orealm, orealm_len);
 
     /* AVP: 'PUA-Flags'(1442)
      * The PUA-Flags AVP contains a bit mask, whose meanings are defined in

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -311,6 +311,11 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
         break;
     case OGS_DIAM_S6A_CT_MME_UPDATE_PROCEDURE:
     case OGS_DIAM_S6A_CT_SGSN_UPDATE_PROCEDURE:
+        /* The subscriber is moving away from this MME: the learned HSS
+         * identity may no longer be valid, forget it so that any further
+         * request is realm-routed again */
+        mme_ue_clear_hss_identity(mme_ue);
+
         mme_ue->detach_type = MME_DETACH_TYPE_HSS_IMPLICIT;
 
         /* 3GPP TS 23.401 D.3.5.5 8), 3GPP TS 23.060 6.9.1.2.2 8):


### PR DESCRIPTION
Per 3GPP TS 29.272 clause 7.16, if the MME knows the identity of the HSS serving a user, both the Destination-Realm and Destination-Host AVPs shall be present in S6a requests. The MME currently discards the Origin-Host/Origin-Realm of received answers and never sets Destination-Host, so in deployments with a DRA and multiple HSS instances consecutive requests for the same subscriber may be routed to different HSS nodes (e.g. ULR to a different HSS than the one that answered AIR).

Learn: on any successful (2001) AIA/ULA/PUA, store the answer's Origin-Host/Origin-Realm in the UE context.

Use: mme_add_hss_destination() prefers the learned identity over the statically configured hss_map entry (which remains the bootstrap default for the first request); with neither present the behaviour is unchanged (realm-only routing).

Forget: on standard 3xxx routing errors (e.g. 3002 UNABLE_TO_DELIVER when the learned HSS is down), on Experimental-Result 5001 USER_UNKNOWN (subscriber migrated to another HSS), and on CLR with Cancellation-Type MME/SGSN_UPDATE_PROCEDURE, so the next request is realm-routed again and the identity is re-learned.

Note: requests are sent with fd_msg_send() (no expire callback), so a silent request timeout cannot clear the learned identity; converting to fd_msg_send_timeout() is a possible follow-up.