### PR TITLE
[MME] DNS-based SGW/PGW selection per 3GPP TS 29.303 (S-NAPTR, c-ares)

### DIFF
--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install the dependencies for building the source code.
       run: |
           sudo apt update
-          sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
+          sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev libc-ares-dev meson
     - name: Check out repository code
       uses: actions/checkout@main
     - name: Setup Meson Build

--- a/configs/dns.yaml.in
+++ b/configs/dns.yaml.in
@@ -1,0 +1,343 @@
+db_uri: mongodb://localhost/open5gs
+
+logger:
+
+test:
+  serving:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+
+global:
+  parameter:
+#    no_nrf: true
+#    no_scp: true
+    no_sepp: true
+#    no_amf: true
+#    no_smf: true
+#    no_upf: true
+#    no_ausf: true
+#    no_udm: true
+#    no_pcf: true
+#    no_nssf: true
+#    no_bsf: true
+#    no_udr: true
+#    no_mme: true
+#    no_sgwc: true
+#    no_sgwu: true
+#    no_pcrf: true
+#    no_hss: true
+
+mme:
+  freeDiameter:
+    identity: mme.localdomain
+    realm: localdomain
+    listen_on: 127.0.0.2
+    no_fwd: true
+    load_extension:
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dbg_msg_dumps.fdx
+        conf: 0x8888
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_rfc5777.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_mip6i.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nasreq.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nas_mipv6.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca_3gpp/dict_dcca_3gpp.fdx
+    connect:
+      - identity: hss.localdomain
+        address: 127.0.0.8
+
+  s1ap:
+    server:
+      - address: 127.0.0.2
+  gtpc:
+    server:
+      - address: 127.0.0.2
+    client:
+      sgwc:
+        - address: 127.0.0.3
+      smf:
+        - address: 127.0.0.4
+  dns:
+    server:
+      - address: 127.0.0.200
+        port: 10053
+    timeout: 1
+    retries: 1
+    cache_ttl: 1
+    guard_timeout: 1500
+  metrics:
+    server:
+      - address: 127.0.0.2
+        port: 9090
+  gummei:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+      mme_gid: 2
+      mme_code: 1
+  tai:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+      tac: 1
+  security:
+    integrity_order : [ EIA2, EIA1, EIA0 ]
+    ciphering_order : [ EEA0, EEA1, EEA2 ]
+  network_name:
+    full: Open5GS
+  time:
+    t3412:
+      value: 540
+
+sgwc:
+  gtpc:
+    server:
+      - address: 127.0.0.3
+  pfcp:
+    server:
+      - address: 127.0.0.3
+    client:
+      sgwu:
+        - address: 127.0.0.6
+
+smf:
+#  sbi:
+#    server:
+#      - address: 127.0.0.4
+#        port: 7777
+#    client:
+#      scp:
+#        - uri: http://127.0.0.200:7777
+  pfcp:
+    server:
+      - address: 127.0.0.4
+    client:
+      upf:
+        - address: 127.0.0.7
+  gtpc:
+    server:
+      - address: 127.0.0.4
+  gtpu:
+    server:
+      - address: 127.0.0.4
+  metrics:
+    server:
+      - address: 127.0.0.4
+        port: 9090
+  session:
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
+      gateway: 2001:db8:cafe::1
+  dns:
+    - 8.8.8.8
+    - 8.8.4.4
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+  mtu: 1400
+  freeDiameter:
+    identity: smf.localdomain
+    realm: localdomain
+    listen_on: 127.0.0.4
+    no_fwd: true
+    load_extension:
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dbg_msg_dumps.fdx
+        conf: 0x8888
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_rfc5777.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_mip6i.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nasreq.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nas_mipv6.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca_3gpp/dict_dcca_3gpp.fdx
+    connect:
+      - identity: pcrf.localdomain
+        address: 127.0.0.9
+
+amf:
+  sbi:
+    server:
+      - address: 127.0.0.5
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+  ngap:
+    server:
+      - address: 127.0.0.5
+  metrics:
+    server:
+      - address: 127.0.0.5
+        port: 9090
+  guami:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+      amf_id:
+        region: 2
+        set: 1
+  tai:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+      tac: 1
+  plmn_support:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+      s_nssai:
+        - sst: 1
+  security:
+    integrity_order : [ NIA2, NIA1, NIA0 ]
+    ciphering_order : [ NEA0, NEA1, NEA2 ]
+  network_name:
+    full: Open5GS
+  amf_name: open5gs-amf0
+  time:
+    t3512:
+      value: 540     # 9 mintues * 60 = 540 seconds
+
+sgwu:
+  pfcp:
+    server:
+      - address: 127.0.0.6
+  gtpu:
+    server:
+      - address: 127.0.0.6
+
+upf:
+  pfcp:
+    server:
+      - address: 127.0.0.7
+  gtpu:
+    server:
+      - address: 127.0.0.7
+  session:
+    - subnet: 10.45.0.0/16
+      gateway: 10.45.0.1
+    - subnet: 2001:db8:cafe::/48
+      gateway: 2001:db8:cafe::1
+  metrics:
+    server:
+      - address: 127.0.0.7
+        port: 9090
+
+hss:
+  freeDiameter:
+    identity: hss.localdomain
+    realm: localdomain
+    listen_on: 127.0.0.8
+    no_fwd: true
+    load_extension:
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dbg_msg_dumps.fdx
+        conf: 0x8888
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_rfc5777.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_mip6i.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nasreq.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nas_mipv6.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca_3gpp/dict_dcca_3gpp.fdx
+    connect:
+      - identity: mme.localdomain
+        address: 127.0.0.2
+pcrf:
+  freeDiameter:
+    identity: pcrf.localdomain
+    realm: localdomain
+    listen_on: 127.0.0.9
+    no_fwd: true
+    load_extension:
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dbg_msg_dumps.fdx
+        conf: 0x8888
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_rfc5777.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_mip6i.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nasreq.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_nas_mipv6.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca.fdx
+      - module: @build_subprojects_freeDiameter_extensions_dir@/dict_dcca_3gpp/dict_dcca_3gpp.fdx
+    connect:
+      - identity: smf.localdomain
+        address: 127.0.0.4
+
+nrf:
+  sbi:
+    server:
+      - address: 127.0.0.10
+        port: 7777
+
+scp:
+  sbi:
+    server:
+      - address: 127.0.0.200
+        port: 7777
+    client:
+      nrf:
+        - uri: http://127.0.0.10:7777
+
+ausf:
+  sbi:
+    server:
+      - address: 127.0.0.11
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+
+udm:
+  hnet:
+    - id: 1
+      scheme: 1
+      key: @build_configs_dir@/open5gs/hnet/curve25519-1.key
+    - id: 2
+      scheme: 2
+      key: @build_configs_dir@/open5gs/hnet/secp256r1-2.key
+  sbi:
+    server:
+      - address: 127.0.0.12
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+
+pcf:
+  sbi:
+    server:
+      - address: 127.0.0.13
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+  metrics:
+    server:
+      - address: 127.0.0.13
+        port: 9090
+
+nssf:
+  sbi:
+    server:
+      - address: 127.0.0.14
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+      nsi:
+        - uri: http://127.0.0.10:7777
+          s_nssai:
+            sst: 1
+bsf:
+  sbi:
+    server:
+      - address: 127.0.0.15
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777
+
+udr:
+  sbi:
+    server:
+      - address: 127.0.0.20
+        port: 7777
+    client:
+      scp:
+        - uri: http://127.0.0.200:7777

--- a/configs/meson.build
+++ b/configs/meson.build
@@ -33,6 +33,7 @@ conf_data.set('build_subprojects_freeDiameter_extensions_dir',
 example_conf = '''
     sample.yaml
     attach.yaml
+    dns.yaml
     310014.yaml
     csfb.yaml
     volte.yaml

--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -122,6 +122,22 @@ mme:
 #        - address: 127.0.2.4
 #          e_cell_id: [12345, a9413, 98765]
 #
+#  o DNS-based SGW/PGW selection (3GPP TS 29.303 S-NAPTR)
+#    When the `dns` section is present (and the MME was built with c-ares),
+#    the SGW is selected by TAI-FQDN and the PGW by APN-FQDN via
+#    NAPTR -> SRV -> A / NAPTR -> A lookups. On any DNS failure the MME
+#    falls back to the static gtpc.client.sgwc/smf configuration above.
+#  dns:
+#    server:
+#      - address: 10.11.12.13
+#      - address: 10.11.12.14
+#        port: 53
+#    timeout: 2            # seconds per query round
+#    retries: 2
+#    protocol: auto        # auto | s5 | s8 (auto: s8 for inbound roamers)
+#    cache_ttl: 60         # NAPTR/SRV cache TTL in seconds
+#    guard_timeout: 3000   # overall resolution guard in milliseconds
+#
 #  o One SGSN is defined.
 #    If prefer_ipv4 is not true, [fd69:f21d:873c:fa::2] is selected.
 #  gtpc:

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -47,6 +47,7 @@ libmme_sources = files('''
     mme-sm.h
     mme-path.h
     mme-dns-select.h
+    mme-dns.h
     metrics.h
 
     mme-init.c
@@ -88,6 +89,11 @@ libmme_sources = files('''
     ue-info.c
     ../../lib/metrics/prometheus/json_pager.c
 '''.split())
+
+if libcares_dep.found()
+    libmme_sources += files('mme-dns.c')
+    libmme_c_args += '-DMME_HAVE_CARES=1'
+endif
 
 libmme = static_library('mme',
     sources : libmme_sources,

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+libcares_dep = dependency('libcares', required : false)
+libmme_c_args = []
+
 libmme_sources = files('''
     mme-event.h
     mme-timer.h
@@ -86,13 +89,15 @@ libmme_sources = files('''
 
 libmme = static_library('mme',
     sources : libmme_sources,
+    c_args : libmme_c_args,
     dependencies : [libmetrics_dep,
                     libsctp_dep,
                     libs1ap_dep,
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libgtp_dep,
-                    libsbi_dep],
+                    libsbi_dep,
+                    libcares_dep],
     install : false)
 
 libmme_dep = declare_dependency(
@@ -103,7 +108,8 @@ libmme_dep = declare_dependency(
                     libnas_eps_dep,
                     libdiameter_s6a_dep,
                     libsbi_dep,
-                    libgtp_dep])
+                    libgtp_dep,
+                    libcares_dep])
 
 mme_sources = files('''
     app-init.c

--- a/src/mme/meson.build
+++ b/src/mme/meson.build
@@ -46,6 +46,7 @@ libmme_sources = files('''
     sbc-handler.h
     mme-sm.h
     mme-path.h
+    mme-dns-select.h
     metrics.h
 
     mme-init.c
@@ -80,6 +81,7 @@ libmme_sources = files('''
     mme-s11-handler.c
     mme-sm.c
     mme-path.c
+    mme-dns-select.c
     sbc-handler.c
     metrics.c
     enb-info.c

--- a/src/mme/metrics.c
+++ b/src/mme/metrics.c
@@ -65,6 +65,23 @@ mme_metrics_spec_def_t mme_metrics_spec_def_global[_MME_METR_GLOB_MAX] = {
     .name = "enb",
     .description = "eNodeBs",
 },
+/* Global Counters: */
+[MME_METR_GLOB_CTR_DNS_QUERY_TOTAL] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "dns_query_total",
+    .description = "DNS queries issued for SGW/PGW selection",
+},
+[MME_METR_GLOB_CTR_DNS_QUERY_FAILED] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "dns_query_failed",
+    .description = "Failed DNS-based SGW/PGW selections "
+                   "(fell back to static configuration)",
+},
+[MME_METR_GLOB_CTR_DNS_CACHE_HIT] = {
+    .type = OGS_METRICS_METRIC_TYPE_COUNTER,
+    .name = "dns_cache_hit",
+    .description = "DNS lookups answered from the local cache",
+},
 };
 int mme_metrics_init_inst_global(void)
 {

--- a/src/mme/metrics.h
+++ b/src/mme/metrics.h
@@ -12,6 +12,9 @@ typedef enum mme_metric_type_global_s {
     MME_METR_GLOB_GAUGE_ENB_UE,
     MME_METR_GLOB_GAUGE_MME_SESS,
     MME_METR_GLOB_GAUGE_ENB,
+    MME_METR_GLOB_CTR_DNS_QUERY_TOTAL,
+    MME_METR_GLOB_CTR_DNS_QUERY_FAILED,
+    MME_METR_GLOB_CTR_DNS_CACHE_HIT,
     _MME_METR_GLOB_MAX,
 } mme_metric_type_global_t;
 extern ogs_metrics_inst_t *mme_metrics_inst_global[_MME_METR_GLOB_MAX];

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -27,6 +27,7 @@
 #include "s1ap-handler.h"
 #include "mme-sm.h"
 #include "mme-gtp-path.h"
+#include "mme-dns.h"
 
 #define MAX_CELL_PER_ENB            8
 
@@ -219,6 +220,15 @@ static int mme_context_prepare(void)
     self.time.t3396.value = 720;
     /* Set the default T3412 to 9 minutes for backward compatibility. */
     self.time.t3412.value = 540;
+
+    /* DNS-based SGW/PGW selection defaults (inactive until `mme.dns`
+     * is present in the configuration file) */
+    self.dns.enabled = false;
+    self.dns.timeout = 2;
+    self.dns.retries = 2;
+    self.dns.protocol = 0;      /* MME_DNS_PROTO_AUTO */
+    self.dns.cache_ttl = 60;
+    self.dns.guard_timeout = 3000;
 
     return OGS_OK;
 }
@@ -2562,6 +2572,106 @@ int mme_context_parse_config(void)
                     }
                 } else if (!strcmp(mme_key, "metrics")) {
                     /* handle config in metrics library */
+                } else if (!strcmp(mme_key, "dns")) {
+#ifndef MME_HAVE_CARES
+                    ogs_error("`mme.dns` is configured, but this MME was "
+                            "built without c-ares support");
+                    return OGS_ERROR;
+#else
+                    ogs_yaml_iter_t dns_iter;
+                    ogs_yaml_iter_recurse(&mme_iter, &dns_iter);
+                    self.dns.enabled = true;
+                    while (ogs_yaml_iter_next(&dns_iter)) {
+                        const char *dns_key = ogs_yaml_iter_key(&dns_iter);
+                        ogs_assert(dns_key);
+                        if (!strcmp(dns_key, "server")) {
+                            ogs_yaml_iter_t server_array, server_iter;
+                            ogs_yaml_iter_recurse(&dns_iter, &server_array);
+                            do {
+                                const char *address = NULL;
+                                uint16_t port = 53;
+
+                                if (ogs_yaml_iter_type(&server_array) ==
+                                        YAML_MAPPING_NODE) {
+                                    memcpy(&server_iter, &server_array,
+                                            sizeof(ogs_yaml_iter_t));
+                                } else if (ogs_yaml_iter_type(&server_array) ==
+                                        YAML_SEQUENCE_NODE) {
+                                    if (!ogs_yaml_iter_next(&server_array))
+                                        break;
+                                    ogs_yaml_iter_recurse(
+                                            &server_array, &server_iter);
+                                } else if (ogs_yaml_iter_type(&server_array) ==
+                                        YAML_SCALAR_NODE) {
+                                    break;
+                                } else
+                                    ogs_assert_if_reached();
+
+                                while (ogs_yaml_iter_next(&server_iter)) {
+                                    const char *server_key =
+                                        ogs_yaml_iter_key(&server_iter);
+                                    ogs_assert(server_key);
+                                    if (!strcmp(server_key, "address")) {
+                                        address =
+                                            ogs_yaml_iter_value(&server_iter);
+                                    } else if (!strcmp(server_key, "port")) {
+                                        const char *v =
+                                            ogs_yaml_iter_value(&server_iter);
+                                        if (v) port = atoi(v);
+                                    } else
+                                        ogs_warn("unknown key `%s`",
+                                                server_key);
+                                }
+
+                                if (address &&
+                                    self.dns.num_of_server <
+                                        MME_DNS_MAX_SERVER) {
+                                    self.dns.server[
+                                        self.dns.num_of_server].address =
+                                            address;
+                                    self.dns.server[
+                                        self.dns.num_of_server].port = port;
+                                    self.dns.num_of_server++;
+                                }
+                            } while (ogs_yaml_iter_type(&server_array) ==
+                                    YAML_SEQUENCE_NODE);
+                        } else if (!strcmp(dns_key, "timeout")) {
+                            const char *v = ogs_yaml_iter_value(&dns_iter);
+                            if (v) self.dns.timeout = atoi(v);
+                        } else if (!strcmp(dns_key, "retries")) {
+                            const char *v = ogs_yaml_iter_value(&dns_iter);
+                            if (v) self.dns.retries = atoi(v);
+                        } else if (!strcmp(dns_key, "cache_ttl")) {
+                            const char *v = ogs_yaml_iter_value(&dns_iter);
+                            if (v) self.dns.cache_ttl = atoi(v);
+                        } else if (!strcmp(dns_key, "guard_timeout")) {
+                            const char *v = ogs_yaml_iter_value(&dns_iter);
+                            if (v) self.dns.guard_timeout = atoi(v);
+                        } else if (!strcmp(dns_key, "protocol")) {
+                            const char *v = ogs_yaml_iter_value(&dns_iter);
+                            if (v) {
+                                if (!strcmp(v, "auto"))
+                                    self.dns.protocol = 0;
+                                else if (!strcmp(v, "s5"))
+                                    self.dns.protocol = 1;
+                                else if (!strcmp(v, "s8"))
+                                    self.dns.protocol = 2;
+                                else {
+                                    ogs_error("unknown mme.dns.protocol "
+                                            "`%s` (auto|s5|s8)", v);
+                                    return OGS_ERROR;
+                                }
+                            }
+                        } else
+                            ogs_warn("unknown key `%s`", dns_key);
+                    }
+
+                    if (self.dns.num_of_server == 0) {
+                        ogs_error("`mme.dns` is configured "
+                                "without any `server`");
+                        return OGS_ERROR;
+                    }
+#endif /* MME_HAVE_CARES */
                 } else if (!strcmp(mme_key, "emergency")) {
                     ogs_yaml_iter_t emerg_iter;
                     ogs_yaml_iter_recurse(&mme_iter, &emerg_iter);
@@ -4609,6 +4719,8 @@ void mme_sess_remove(mme_sess_t *sess)
     OGS_NAS_CLEAR_DATA(&sess->ue_epco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_pco);
     OGS_TLV_CLEAR_DATA(&sess->pgw_epco);
+
+    mme_dns_sess_clear(sess);
 
     ogs_pool_id_free(&mme_sess_pool, sess);
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -94,6 +94,22 @@ typedef struct mme_context_s {
     ogs_sockaddr_t  *pgw_addr;      /* First IPv4 Address Selected */
     ogs_sockaddr_t  *pgw_addr6;     /* First IPv6 Address Selected */
 
+    /* DNS-based SGW/PGW selection (3GPP TS 29.303) */
+#define MME_DNS_MAX_SERVER 4
+    struct {
+        bool enabled;               /* `mme.dns` section present */
+        int num_of_server;
+        struct {
+            const char *address;
+            uint16_t port;          /* default 53 */
+        } server[MME_DNS_MAX_SERVER];
+        int timeout;                /* seconds per query round, default 2 */
+        int retries;                /* default 2 */
+        int protocol;               /* mme_dns_proto_e: auto | s5 | s8 */
+        int cache_ttl;              /* NAPTR/SRV cache TTL (s), default 60 */
+        int guard_timeout;          /* overall guard (ms), default 3000 */
+    } dns;
+
     ogs_list_t      enb_list;       /* ENB S1AP Client List */
 
     ogs_list_t      vlr_list;       /* VLR SGsAP Client List */
@@ -190,6 +206,10 @@ typedef struct mme_sgw_s {
     int             num_of_tac;
     uint32_t        e_cell_id[OGS_MAX_NUM_OF_CELL_ID];
     int             num_of_e_cell_id;
+
+    /* Node discovered via DNS (TS 29.303), not from the configuration
+     * file. Such nodes are kept for the lifetime of the process. */
+    bool            dns_origin;
 
     ogs_list_t      sgw_ue_list;
 } mme_sgw_t;
@@ -965,6 +985,9 @@ typedef struct mme_sess_s {
 
     /* Save Extended Protocol Configuration Options from PGW */
     ogs_tlv_octet_t pgw_epco;
+
+    /* DNS-based gateway selection state (mme-dns.c pool id) */
+    ogs_pool_id_t   dns_id;
 } mme_sess_t;
 
 #define MME_HAVE_ENB_S1U_PATH(__bEARER) \

--- a/src/mme/mme-dns-select.c
+++ b/src/mme/mme-dns-select.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mme-dns-select.h"
+
+int mme_dns_build_apn_fqdn(char *buf, size_t sz,
+        const char *apn_ni, const ogs_plmn_id_t *plmn_id)
+{
+    int rc;
+
+    ogs_assert(buf);
+    ogs_assert(plmn_id);
+
+    if (!apn_ni || !apn_ni[0])
+        return OGS_ERROR;
+
+    rc = snprintf(buf, sz, "%s.apn.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+            apn_ni, ogs_plmn_id_mnc(plmn_id), ogs_plmn_id_mcc(plmn_id));
+    if (rc <= 0 || (size_t)rc >= sz)
+        return OGS_ERROR;
+
+    return OGS_OK;
+}
+
+int mme_dns_build_tai_fqdn(char *buf, size_t sz, const ogs_eps_tai_t *tai)
+{
+    int rc;
+
+    ogs_assert(buf);
+    ogs_assert(tai);
+
+    rc = snprintf(buf, sz,
+            "tac-lb%02x.tac-hb%02x.tac.epc.mnc%03d.mcc%03d.3gppnetwork.org",
+            tai->tac & 0xff, (tai->tac >> 8) & 0xff,
+            ogs_plmn_id_mnc(&tai->plmn_id), ogs_plmn_id_mcc(&tai->plmn_id));
+    if (rc <= 0 || (size_t)rc >= sz)
+        return OGS_ERROR;
+
+    return OGS_OK;
+}
+
+mme_dns_proto_e mme_dns_decide_proto(const char *imsi_bcd,
+        const ogs_plmn_id_t *serving_plmn, mme_dns_proto_e override)
+{
+    char prefix[OGS_PLMNIDSTRLEN];
+    int rc;
+
+    if (override != MME_DNS_PROTO_AUTO)
+        return override;
+
+    ogs_assert(serving_plmn);
+
+    if (!imsi_bcd || !imsi_bcd[0])
+        return MME_DNS_PROTO_S5;
+
+    rc = snprintf(prefix, sizeof(prefix), "%03d%0*d",
+            ogs_plmn_id_mcc(serving_plmn),
+            ogs_plmn_id_mnc_len(serving_plmn),
+            ogs_plmn_id_mnc(serving_plmn));
+    if (rc <= 0 || (size_t)rc >= sizeof(prefix))
+        return MME_DNS_PROTO_S5;
+
+    if (strncmp(imsi_bcd, prefix, strlen(prefix)) == 0)
+        return MME_DNS_PROTO_S5;
+
+    return MME_DNS_PROTO_S8;
+}
+
+static bool token_equal_nocase(const char *tok, size_t len, const char *ref)
+{
+    if (strlen(ref) != len)
+        return false;
+    return strncasecmp(tok, ref, len) == 0;
+}
+
+bool mme_dns_service_match(const char *service,
+        mme_dns_service_e svc, mme_dns_proto_e proto)
+{
+    const char *node_tag = NULL;
+    const char *p = NULL, *sep = NULL;
+    size_t len;
+    bool proto_found = false;
+
+    if (!service || !service[0])
+        return false;
+
+    switch (svc) {
+    case MME_DNS_SVC_SGW:
+        node_tag = "x-3gpp-sgw";
+        break;
+    case MME_DNS_SVC_PGW:
+        node_tag = "x-3gpp-pgw";
+        break;
+    default:
+        return false;
+    }
+
+    /* First token: the node type */
+    sep = strchr(service, ':');
+    len = sep ? (size_t)(sep - service) : strlen(service);
+    if (!token_equal_nocase(service, len, node_tag))
+        return false;
+    if (!sep) /* no protocol tokens at all */
+        return false;
+
+    /* Remaining tokens: protocols */
+    p = sep + 1;
+    while (p && *p) {
+        sep = strchr(p, ':');
+        len = sep ? (size_t)(sep - p) : strlen(p);
+
+        if (proto == MME_DNS_PROTO_S5 || proto == MME_DNS_PROTO_AUTO)
+            if (token_equal_nocase(p, len, "x-s5-gtp"))
+                proto_found = true;
+        if (proto == MME_DNS_PROTO_S8 || proto == MME_DNS_PROTO_AUTO)
+            if (token_equal_nocase(p, len, "x-s8-gtp"))
+                proto_found = true;
+
+        p = sep ? sep + 1 : NULL;
+    }
+
+    return proto_found;
+}
+
+void mme_dns_canonical_name(const char *fqdn, char *canon, size_t sz)
+{
+    const char *rest = NULL, *second = NULL;
+
+    ogs_assert(fqdn);
+    ogs_assert(canon);
+    ogs_assert(sz > 0);
+
+    if (strncasecmp(fqdn, "topon.", 6) == 0)
+        rest = fqdn + 6;
+    else if (strncasecmp(fqdn, "topoff.", 7) == 0)
+        rest = fqdn + 7;
+
+    if (rest) {
+        /* Skip the single interface label following the prefix */
+        second = strchr(rest, '.');
+        if (second && second[1])
+            fqdn = second + 1;
+    }
+
+    ogs_cpystrn(canon, fqdn, sz);
+}
+
+static bool flags_terminal(const char *flags, bool *needs_srv)
+{
+    if (!flags)
+        return false;
+    if (flags[0] && !flags[1]) {
+        if (flags[0] == 'a' || flags[0] == 'A') {
+            *needs_srv = false;
+            return true;
+        }
+        if (flags[0] == 's' || flags[0] == 'S') {
+            *needs_srv = true;
+            return true;
+        }
+    }
+    /* Empty (non-terminal NAPTR) and any other flag are not supported */
+    return false;
+}
+
+int mme_dns_candidates_from_naptr(
+        const mme_dns_naptr_record_t *recs, int num_recs,
+        mme_dns_service_e svc, mme_dns_proto_e proto,
+        mme_dns_candidate_t *cand, int max_cand)
+{
+    const mme_dns_naptr_record_t *sorted[OGS_MAX_NUM_OF_HOSTNAME * 4];
+    int num_sorted = 0;
+    int num_cand = 0;
+    int i, j, k;
+
+    ogs_assert(cand);
+    ogs_assert(max_cand > 0);
+
+    if (!recs || num_recs <= 0)
+        return 0;
+
+    /* Filter + insertion sort: stable on (order, preference) */
+    for (i = 0; i < num_recs && num_sorted < (int)OGS_ARRAY_SIZE(sorted);
+            i++) {
+        const mme_dns_naptr_record_t *r = &recs[i];
+        bool needs_srv = false;
+
+        if (!flags_terminal(r->flags, &needs_srv))
+            continue;
+        if (!mme_dns_service_match(r->service, svc, proto))
+            continue;
+        if (!r->replacement[0] || strcmp(r->replacement, ".") == 0)
+            continue;
+
+        for (j = 0; j < num_sorted; j++) {
+            if (sorted[j]->order > r->order ||
+                (sorted[j]->order == r->order &&
+                 sorted[j]->preference > r->preference))
+                break;
+        }
+        for (k = num_sorted; k > j; k--)
+            sorted[k] = sorted[k-1];
+        sorted[j] = r;
+        num_sorted++;
+    }
+
+    /* Dedup on canonical name, best (order, preference) wins */
+    for (i = 0; i < num_sorted && num_cand < max_cand; i++) {
+        const mme_dns_naptr_record_t *r = sorted[i];
+        char canon[MME_DNS_MAX_FQDN_LEN+1];
+        bool needs_srv = false;
+        bool dup = false;
+
+        (void)flags_terminal(r->flags, &needs_srv);
+        mme_dns_canonical_name(r->replacement, canon, sizeof(canon));
+
+        for (j = 0; j < num_cand; j++) {
+            if (strcasecmp(cand[j].canon, canon) == 0) {
+                dup = true;
+                break;
+            }
+        }
+        if (dup)
+            continue;
+
+        memset(&cand[num_cand], 0, sizeof(cand[num_cand]));
+        ogs_cpystrn(cand[num_cand].fqdn,
+                r->replacement, sizeof(cand[num_cand].fqdn));
+        ogs_cpystrn(cand[num_cand].canon, canon,
+                sizeof(cand[num_cand].canon));
+        cand[num_cand].order = r->order;
+        cand[num_cand].preference = r->preference;
+        cand[num_cand].needs_srv = needs_srv;
+        cand[num_cand].resolved = false;
+        num_cand++;
+    }
+
+    return num_cand;
+}
+
+void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
+        const mme_dns_srv_record_t *recs, int num_recs)
+{
+    const mme_dns_srv_record_t *best = NULL;
+    int i;
+
+    ogs_assert(cand);
+
+    if (!recs || num_recs <= 0)
+        return;
+
+    for (i = 0; i < num_recs; i++) {
+        if (!recs[i].target[0] || strcmp(recs[i].target, ".") == 0)
+            continue;
+        if (!best || recs[i].priority < best->priority)
+            best = &recs[i];
+    }
+
+    if (!best)
+        return;
+
+    ogs_cpystrn(cand->fqdn, best->target, sizeof(cand->fqdn));
+    cand->port = best->port;
+    cand->needs_srv = false;
+}

--- a/src/mme/mme-dns-select.h
+++ b/src/mme/mme-dns-select.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * 3GPP TS 29.303 S-NAPTR gateway selection: pure record-processing logic.
+ *
+ * This module has no dependency on any DNS library or on MME context;
+ * it operates on already-parsed NAPTR/SRV record structs so that the
+ * selection rules are unit-testable in isolation.
+ */
+
+#ifndef MME_DNS_SELECT_H
+#define MME_DNS_SELECT_H
+
+#include "ogs-proto.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MME_DNS_MAX_CANDIDATES      8
+#define MME_DNS_MAX_FQDN_LEN        255
+#define MME_DNS_MAX_SERVICE_LEN     63
+#define MME_DNS_MAX_FLAGS_LEN       7
+
+typedef enum {
+    MME_DNS_SVC_SGW,
+    MME_DNS_SVC_PGW,
+} mme_dns_service_e;
+
+typedef enum {
+    MME_DNS_PROTO_AUTO = 0,
+    MME_DNS_PROTO_S5,
+    MME_DNS_PROTO_S8,
+} mme_dns_proto_e;
+
+typedef struct mme_dns_naptr_record_s {
+    uint16_t order;
+    uint16_t preference;
+    char flags[MME_DNS_MAX_FLAGS_LEN+1];
+    char service[MME_DNS_MAX_SERVICE_LEN+1];
+    char replacement[MME_DNS_MAX_FQDN_LEN+1];
+} mme_dns_naptr_record_t;
+
+typedef struct mme_dns_srv_record_s {
+    uint16_t priority;
+    uint16_t weight;    /* ignored: candidates are ordered by priority only */
+    uint16_t port;
+    char target[MME_DNS_MAX_FQDN_LEN+1];
+} mme_dns_srv_record_t;
+
+typedef struct mme_dns_candidate_s {
+    /* Name to resolve with an A query, verbatim from the NAPTR/SRV answer
+     * (topon./topoff. prefix kept - such names are resolvable as-is) */
+    char fqdn[MME_DNS_MAX_FQDN_LEN+1];
+    /* Canonical node name per TS 29.303 4.3.2 (topon./topoff. and the
+     * following interface label stripped); used only as the dedup key */
+    char canon[MME_DNS_MAX_FQDN_LEN+1];
+    uint16_t order;         /* NAPTR sort keys */
+    uint16_t preference;
+    uint16_t port;          /* from SRV, 0 = use the default GTP-C port */
+    bool needs_srv;         /* NAPTR flag "s": SRV lookup still pending */
+    bool resolved;          /* addr is valid */
+    ogs_sockaddr_t addr;
+} mme_dns_candidate_t;
+
+/*
+ * APN-FQDN (TS 23.003 19.4.2.2):
+ *   <APN-NI>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ * Returns OGS_OK or OGS_ERROR (overflow/invalid input).
+ */
+int mme_dns_build_apn_fqdn(char *buf, size_t sz,
+        const char *apn_ni, const ogs_plmn_id_t *plmn_id);
+
+/*
+ * TAI-FQDN (TS 23.003 19.4.2.3):
+ *   tac-lb<TAC-low-byte>.tac-hb<TAC-high-byte>.tac.epc
+ *       .mnc<MNC>.mcc<MCC>.3gppnetwork.org
+ * TAC bytes are lowercase hex, zero-padded to 2 digits.
+ */
+int mme_dns_build_tai_fqdn(char *buf, size_t sz, const ogs_eps_tai_t *tai);
+
+/*
+ * s5 vs s8 decision: s8 if and only if the IMSI does not begin with the
+ * serving PLMN digits (MCC + MNC honoring mnc_len). A non-AUTO override
+ * always wins.
+ */
+mme_dns_proto_e mme_dns_decide_proto(const char *imsi_bcd,
+        const ogs_plmn_id_t *serving_plmn, mme_dns_proto_e override);
+
+/*
+ * Case-insensitive S-NAPTR service-field match. The field format is
+ *   x-3gpp-<node>:x-<proto>[:x-<proto>]...
+ * The first token must equal x-3gpp-sgw / x-3gpp-pgw and the remaining
+ * tokens must contain the protocol selected by 'proto'
+ * (x-s5-gtp / x-s8-gtp).
+ */
+bool mme_dns_service_match(const char *service,
+        mme_dns_service_e svc, mme_dns_proto_e proto);
+
+/*
+ * Canonical node name: strip a leading "topon." or "topoff." label
+ * together with the single following interface label (TS 29.303 4.3.2).
+ * Copies the input unchanged when no prefix is present.
+ */
+void mme_dns_canonical_name(const char *fqdn, char *canon, size_t sz);
+
+/*
+ * Filter a NAPTR answer set by flags ("a"/"s" only) and service match,
+ * stable-sort by (order, preference), dedup on the canonical name and
+ * append up to max_cand candidates. Returns the candidate count.
+ */
+int mme_dns_candidates_from_naptr(
+        const mme_dns_naptr_record_t *recs, int num_recs,
+        mme_dns_service_e svc, mme_dns_proto_e proto,
+        mme_dns_candidate_t *cand, int max_cand);
+
+/*
+ * Resolve an "s"-flagged candidate's target name from its SRV answer:
+ * pick the lowest-priority record (RFC 2782 weight is ignored).
+ * Clears needs_srv.
+ */
+void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
+        const mme_dns_srv_record_t *recs, int num_recs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MME_DNS_SELECT_H */

--- a/src/mme/mme-dns.c
+++ b/src/mme/mme-dns.c
@@ -1,0 +1,1026 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Asynchronous DNS-based (3GPP TS 29.303 S-NAPTR) SGW/PGW selection.
+ *
+ * All functions here run on the MME main thread: queries are kicked from
+ * FSM handlers, c-ares sockets are polled by ogs_app()->pollset and query
+ * timeouts by ogs_app()->timer_mgr, both pumped in mme_main(). Completion
+ * is still marshalled through the event queue (MME_EVENT_DNS_RESOLVED) to
+ * keep FSM discipline.
+ */
+
+#include <ares.h>
+
+#include "mme-dns.h"
+#include "mme-dns-select.h"
+#include "mme-event.h"
+#include "mme-gtp-path.h"
+#include "metrics.h"
+
+/* DNS wire constants (avoid a resolv.h dependency) */
+#define MME_DNS_C_IN        1
+#define MME_DNS_T_A         1
+#define MME_DNS_T_SRV       33
+#define MME_DNS_T_NAPTR     35
+
+#define MME_DNS_MAX_RR      8
+#define MME_DNS_MAX_CSR_ATTEMPTS 3
+#define MME_DNS_NEGATIVE_TTL     5  /* seconds, capped by dns.cache_ttl */
+
+static int negative_ttl(void)
+{
+    if (mme_self()->dns.cache_ttl < MME_DNS_NEGATIVE_TTL)
+        return mme_self()->dns.cache_ttl;
+    return MME_DNS_NEGATIVE_TTL;
+}
+
+typedef enum {
+    MME_DNS_ST_PENDING = 0,
+    MME_DNS_ST_DONE,        /* event posted, not yet consumed */
+    MME_DNS_ST_CONSUMED,    /* result applied, CSR sent */
+} mme_dns_state_e;
+
+typedef struct mme_dns_leg_s {
+    bool active;
+    mme_dns_service_e svc;
+    char fqdn[MME_DNS_MAX_FQDN_LEN+1];      /* NAPTR query name */
+    bool naptr_fetched;
+    int num_cand;
+    mme_dns_candidate_t cand[MME_DNS_MAX_CANDIDATES];
+    int cursor;
+    bool query_pending;
+    /* set when the entry now in cache was fetched by our own query,
+     * so the immediate cache read is not counted as a cache hit */
+    bool just_answered;
+    bool done;
+    bool fallback;
+} mme_dns_leg_t;
+
+typedef struct mme_dns_resolution_s {
+    ogs_lnode_t lnode;
+    ogs_pool_id_t id;
+
+    ogs_pool_id_t sess_id;
+    ogs_pool_id_t enb_ue_id;
+    int create_action;
+
+    mme_dns_state_e state;
+    ogs_timer_t *t_guard;
+
+    mme_dns_proto_e proto;
+    mme_dns_leg_t sgw;
+    mme_dns_leg_t pgw;
+
+    int csr_attempts;
+} mme_dns_resolution_t;
+
+typedef struct mme_dns_query_ctx_s {
+    ogs_pool_id_t res_id;
+    uint8_t leg_idx;                        /* 0 = sgw, 1 = pgw */
+    int qtype;
+    char qname[MME_DNS_MAX_FQDN_LEN+1];
+} mme_dns_query_ctx_t;
+
+typedef struct mme_dns_cache_entry_s {
+    char key[MME_DNS_MAX_FQDN_LEN+4];
+    ogs_time_t expire;
+    int num;                                /* 0 = negative entry */
+    union {
+        mme_dns_naptr_record_t naptr[MME_DNS_MAX_RR];
+        mme_dns_srv_record_t srv[MME_DNS_MAX_RR];
+        struct {
+            struct in_addr addr;
+            uint16_t port;                  /* unused, alignment only */
+        } a[MME_DNS_MAX_RR];
+    } u;
+} mme_dns_cache_entry_t;
+
+static OGS_POOL(mme_dns_resolution_pool, mme_dns_resolution_t);
+
+static bool g_enabled = false;
+static bool g_closing = false;
+static ares_channel g_channel = NULL;
+static bool g_channel_up = false;
+static ogs_timer_t *g_t_process = NULL;
+static ogs_hash_t *g_cache = NULL;
+
+static struct {
+    ares_socket_t fd;
+    ogs_poll_t *rpoll;
+    ogs_poll_t *wpoll;
+} g_fdmap[ARES_GETSOCK_MAXNUM * 2];
+
+static void leg_advance(mme_dns_resolution_t *res, mme_dns_leg_t *leg);
+static void check_completion(mme_dns_resolution_t *res);
+
+/*****************************************************************
+ * c-ares <-> ogs_pollset / ogs_timer glue
+ *****************************************************************/
+
+static void dns_rearm_process_timer(void)
+{
+    struct timeval tv, *tvp = NULL;
+
+    if (!g_channel_up || g_closing)
+        return;
+
+    tvp = ares_timeout(g_channel, NULL, &tv);
+    if (tvp) {
+        ogs_time_t duration =
+            (ogs_time_t)tvp->tv_sec * OGS_USEC_PER_SEC + tvp->tv_usec;
+        if (duration < ogs_time_from_msec(1))
+            duration = ogs_time_from_msec(1);
+        ogs_timer_start(g_t_process, duration);
+    } else {
+        ogs_timer_stop(g_t_process);
+    }
+}
+
+static void dns_poll_cb(short when, ogs_socket_t fd, void *data)
+{
+    ares_process_fd(g_channel,
+            (when & OGS_POLLIN) ? fd : ARES_SOCKET_BAD,
+            (when & OGS_POLLOUT) ? fd : ARES_SOCKET_BAD);
+    dns_rearm_process_timer();
+}
+
+static void dns_process_timer_cb(void *data)
+{
+    ares_process_fd(g_channel, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
+    dns_rearm_process_timer();
+}
+
+static void dns_sock_state_cb(
+        void *data, ares_socket_t socket_fd, int readable, int writable)
+{
+    int i, free_slot = -1;
+
+    for (i = 0; i < (int)OGS_ARRAY_SIZE(g_fdmap); i++) {
+        if (g_fdmap[i].rpoll || g_fdmap[i].wpoll) {
+            if (g_fdmap[i].fd == socket_fd)
+                break;
+        } else if (free_slot < 0) {
+            free_slot = i;
+        }
+    }
+    if (i == (int)OGS_ARRAY_SIZE(g_fdmap)) {
+        if (!readable && !writable)
+            return;
+        if (free_slot < 0) {
+            ogs_error("mme-dns: no free fd slot for c-ares socket %d",
+                    (int)socket_fd);
+            return;
+        }
+        i = free_slot;
+        g_fdmap[i].fd = socket_fd;
+    }
+
+    if (readable && !g_fdmap[i].rpoll) {
+        g_fdmap[i].rpoll = ogs_pollset_add(ogs_app()->pollset,
+                OGS_POLLIN, socket_fd, dns_poll_cb, NULL);
+        ogs_assert(g_fdmap[i].rpoll);
+    } else if (!readable && g_fdmap[i].rpoll) {
+        ogs_pollset_remove(g_fdmap[i].rpoll);
+        g_fdmap[i].rpoll = NULL;
+    }
+
+    if (writable && !g_fdmap[i].wpoll) {
+        g_fdmap[i].wpoll = ogs_pollset_add(ogs_app()->pollset,
+                OGS_POLLOUT, socket_fd, dns_poll_cb, NULL);
+        ogs_assert(g_fdmap[i].wpoll);
+    } else if (!writable && g_fdmap[i].wpoll) {
+        ogs_pollset_remove(g_fdmap[i].wpoll);
+        g_fdmap[i].wpoll = NULL;
+    }
+}
+
+/*****************************************************************
+ * Cache
+ *****************************************************************/
+
+static mme_dns_cache_entry_t *cache_get(int qtype, const char *fqdn)
+{
+    char key[sizeof(((mme_dns_cache_entry_t *)0)->key)];
+    mme_dns_cache_entry_t *entry = NULL;
+
+    ogs_snprintf(key, sizeof(key), "%d:%s", qtype, fqdn);
+    entry = ogs_hash_get(g_cache, key, OGS_HASH_KEY_STRING);
+    if (!entry)
+        return NULL;
+
+    if (entry->expire < ogs_time_now()) {
+        ogs_hash_set(g_cache, entry->key, OGS_HASH_KEY_STRING, NULL);
+        ogs_free(entry);
+        return NULL;
+    }
+
+    return entry;
+}
+
+static mme_dns_cache_entry_t *cache_put(
+        int qtype, const char *fqdn, int ttl_sec)
+{
+    mme_dns_cache_entry_t *entry = NULL, *old = NULL;
+
+    entry = ogs_calloc(1, sizeof(*entry));
+    ogs_assert(entry);
+    ogs_snprintf(entry->key, sizeof(entry->key), "%d:%s", qtype, fqdn);
+    entry->expire = ogs_time_now() + ogs_time_from_sec(ttl_sec);
+
+    old = ogs_hash_get(g_cache, entry->key, OGS_HASH_KEY_STRING);
+    if (old) {
+        ogs_hash_set(g_cache, old->key, OGS_HASH_KEY_STRING, NULL);
+        ogs_free(old);
+    }
+    ogs_hash_set(g_cache, entry->key, OGS_HASH_KEY_STRING, entry);
+
+    return entry;
+}
+
+static void cache_flush(void)
+{
+    ogs_hash_index_t *hi = NULL;
+
+    if (!g_cache)
+        return;
+
+    for (hi = ogs_hash_first(g_cache); hi; hi = ogs_hash_next(hi)) {
+        mme_dns_cache_entry_t *entry = ogs_hash_this_val(hi);
+        ogs_hash_set(g_cache, entry->key, OGS_HASH_KEY_STRING, NULL);
+        ogs_free(entry);
+    }
+}
+
+/*****************************************************************
+ * Resolution lifecycle
+ *****************************************************************/
+
+static mme_dns_resolution_t *resolution_find_by_sess(mme_sess_t *sess)
+{
+    if (!sess || sess->dns_id == OGS_INVALID_POOL_ID)
+        return NULL;
+    return ogs_pool_find_by_id(&mme_dns_resolution_pool, sess->dns_id);
+}
+
+static void resolution_free(mme_dns_resolution_t *res)
+{
+    ogs_assert(res);
+    if (res->t_guard)
+        ogs_timer_delete(res->t_guard);
+    ogs_pool_id_free(&mme_dns_resolution_pool, res);
+}
+
+void mme_dns_sess_clear(mme_sess_t *sess)
+{
+    mme_dns_resolution_t *res = NULL;
+
+    ogs_assert(sess);
+    res = resolution_find_by_sess(sess);
+    if (res)
+        resolution_free(res);
+    sess->dns_id = OGS_INVALID_POOL_ID;
+}
+
+static void post_resolved(mme_dns_resolution_t *res)
+{
+    int rv;
+    mme_event_t *e = NULL;
+
+    ogs_assert(res);
+    ogs_assert(res->state == MME_DNS_ST_PENDING);
+
+    res->state = MME_DNS_ST_DONE;
+    if (res->t_guard)
+        ogs_timer_stop(res->t_guard);
+
+    if (g_closing)
+        return;
+
+    e = mme_event_new(MME_EVENT_DNS_RESOLVED);
+    ogs_assert(e);
+    e->sess_id = res->sess_id;
+    e->enb_ue_id = res->enb_ue_id;
+    e->create_action = res->create_action;
+
+    rv = ogs_queue_push(ogs_app()->queue, e);
+    if (rv != OGS_OK) {
+        ogs_error("mme-dns: ogs_queue_push() failed:%d", (int)rv);
+        mme_event_free(e);
+        return;
+    }
+    ogs_pollset_notify(ogs_app()->pollset);
+}
+
+static void check_completion(mme_dns_resolution_t *res)
+{
+    if (res->state != MME_DNS_ST_PENDING)
+        return;
+    if (res->sgw.active && !res->sgw.done)
+        return;
+    if (res->pgw.active && !res->pgw.done)
+        return;
+    post_resolved(res);
+}
+
+static void leg_fail(mme_dns_resolution_t *res, mme_dns_leg_t *leg,
+        const char *reason)
+{
+    ogs_warn("mme-dns: %s selection via [%s] failed (%s), "
+            "falling back to static configuration",
+            leg->svc == MME_DNS_SVC_SGW ? "SGW" : "PGW",
+            leg->fqdn, reason);
+    leg->done = true;
+    leg->fallback = true;
+    mme_metrics_inst_global_inc(MME_METR_GLOB_CTR_DNS_QUERY_FAILED);
+}
+
+static void guard_expire_cb(void *data)
+{
+    ogs_pool_id_t res_id = OGS_POINTER_TO_UINT(data);
+    mme_dns_resolution_t *res = NULL;
+
+    res = ogs_pool_find_by_id(&mme_dns_resolution_pool, res_id);
+    if (!res || res->state != MME_DNS_ST_PENDING)
+        return;
+
+    if (res->sgw.active && !res->sgw.done)
+        leg_fail(res, &res->sgw, "timeout");
+    if (res->pgw.active && !res->pgw.done)
+        leg_fail(res, &res->pgw, "timeout");
+
+    check_completion(res);
+}
+
+/*****************************************************************
+ * Query issue & callbacks
+ *****************************************************************/
+
+static mme_dns_leg_t *leg_ptr(mme_dns_resolution_t *res, uint8_t leg_idx)
+{
+    return leg_idx == 0 ? &res->sgw : &res->pgw;
+}
+
+static void dns_query_cb(
+        void *arg, int status, int timeouts, unsigned char *abuf, int alen);
+
+static void issue_query(mme_dns_resolution_t *res, mme_dns_leg_t *leg,
+        int qtype, const char *qname)
+{
+    mme_dns_query_ctx_t *ctx = NULL;
+
+    ctx = ogs_calloc(1, sizeof(*ctx));
+    ogs_assert(ctx);
+    ctx->res_id = res->id;
+    ctx->leg_idx = (leg == &res->sgw) ? 0 : 1;
+    ctx->qtype = qtype;
+    ogs_cpystrn(ctx->qname, qname, sizeof(ctx->qname));
+
+    leg->query_pending = true;
+    mme_metrics_inst_global_inc(MME_METR_GLOB_CTR_DNS_QUERY_TOTAL);
+
+    /* NOTE: on immediate failure c-ares invokes the callback synchronously
+     * from inside ares_query(); dns_query_cb tolerates that (it re-enters
+     * leg_advance which sees the failure already recorded). */
+    ares_query(g_channel, qname, MME_DNS_C_IN, qtype, dns_query_cb, ctx);
+    dns_rearm_process_timer();
+}
+
+static void handle_naptr_answer(mme_dns_query_ctx_t *ctx,
+        int status, unsigned char *abuf, int alen)
+{
+    struct ares_naptr_reply *reply = NULL, *r = NULL;
+    mme_dns_cache_entry_t *entry = NULL;
+    int num = 0;
+
+    if (status == ARES_SUCCESS &&
+        ares_parse_naptr_reply(abuf, alen, &reply) == ARES_SUCCESS) {
+        entry = cache_put(MME_DNS_T_NAPTR, ctx->qname,
+                mme_self()->dns.cache_ttl);
+        for (r = reply; r && num < MME_DNS_MAX_RR; r = r->next) {
+            mme_dns_naptr_record_t *rec = &entry->u.naptr[num];
+            rec->order = r->order;
+            rec->preference = r->preference;
+            ogs_cpystrn(rec->flags,
+                    r->flags ? (const char *)r->flags : "",
+                    sizeof(rec->flags));
+            ogs_cpystrn(rec->service,
+                    r->service ? (const char *)r->service : "",
+                    sizeof(rec->service));
+            ogs_cpystrn(rec->replacement,
+                    r->replacement ? r->replacement : "",
+                    sizeof(rec->replacement));
+            num++;
+        }
+        entry->num = num;
+        ares_free_data(reply);
+    } else {
+        entry = cache_put(MME_DNS_T_NAPTR, ctx->qname, negative_ttl());
+        entry->num = 0;
+    }
+}
+
+static void handle_srv_answer(mme_dns_query_ctx_t *ctx,
+        int status, unsigned char *abuf, int alen)
+{
+    struct ares_srv_reply *reply = NULL, *r = NULL;
+    mme_dns_cache_entry_t *entry = NULL;
+    int num = 0;
+
+    if (status == ARES_SUCCESS &&
+        ares_parse_srv_reply(abuf, alen, &reply) == ARES_SUCCESS) {
+        entry = cache_put(MME_DNS_T_SRV, ctx->qname,
+                mme_self()->dns.cache_ttl);
+        for (r = reply; r && num < MME_DNS_MAX_RR; r = r->next) {
+            mme_dns_srv_record_t *rec = &entry->u.srv[num];
+            rec->priority = r->priority;
+            rec->weight = r->weight;
+            rec->port = r->port;
+            ogs_cpystrn(rec->target,
+                    r->host ? r->host : "", sizeof(rec->target));
+            num++;
+        }
+        entry->num = num;
+        ares_free_data(reply);
+    } else {
+        entry = cache_put(MME_DNS_T_SRV, ctx->qname, negative_ttl());
+        entry->num = 0;
+    }
+}
+
+static void handle_a_answer(mme_dns_query_ctx_t *ctx,
+        int status, unsigned char *abuf, int alen)
+{
+    struct hostent *host = NULL;
+    struct ares_addrttl addrttls[MME_DNS_MAX_RR];
+    int naddrttls = MME_DNS_MAX_RR;
+    mme_dns_cache_entry_t *entry = NULL;
+    int i, num = 0, ttl = -1;
+
+    if (status == ARES_SUCCESS &&
+        ares_parse_a_reply(abuf, alen, &host, addrttls, &naddrttls) ==
+            ARES_SUCCESS) {
+        for (i = 0; i < naddrttls; i++) {
+            if (ttl < 0 || addrttls[i].ttl < ttl)
+                ttl = addrttls[i].ttl;
+        }
+        if (ttl <= 0)
+            ttl = mme_self()->dns.cache_ttl;
+        entry = cache_put(MME_DNS_T_A, ctx->qname, ttl);
+        for (i = 0; i < naddrttls && num < MME_DNS_MAX_RR; i++) {
+            entry->u.a[num].addr = addrttls[i].ipaddr;
+            num++;
+        }
+        entry->num = num;
+        if (host)
+            ares_free_hostent(host);
+    } else {
+        entry = cache_put(MME_DNS_T_A, ctx->qname, negative_ttl());
+        entry->num = 0;
+    }
+}
+
+static void dns_query_cb(
+        void *arg, int status, int timeouts, unsigned char *abuf, int alen)
+{
+    mme_dns_query_ctx_t *ctx = arg;
+    mme_dns_resolution_t *res = NULL;
+    mme_dns_leg_t *leg = NULL;
+
+    ogs_assert(ctx);
+
+    if (status == ARES_EDESTRUCTION || g_closing) {
+        ogs_free(ctx);
+        return;
+    }
+
+    /* Populate the cache regardless of resolution liveness */
+    switch (ctx->qtype) {
+    case MME_DNS_T_NAPTR:
+        handle_naptr_answer(ctx, status, abuf, alen);
+        break;
+    case MME_DNS_T_SRV:
+        handle_srv_answer(ctx, status, abuf, alen);
+        break;
+    case MME_DNS_T_A:
+        handle_a_answer(ctx, status, abuf, alen);
+        break;
+    default:
+        ogs_assert_if_reached();
+    }
+
+    res = ogs_pool_find_by_id(&mme_dns_resolution_pool, ctx->res_id);
+    if (res && res->state == MME_DNS_ST_PENDING) {
+        leg = leg_ptr(res, ctx->leg_idx);
+        leg->query_pending = false;
+        leg->just_answered = true;
+        leg_advance(res, leg);
+        check_completion(res);
+    }
+
+    ogs_free(ctx);
+}
+
+/*****************************************************************
+ * Per-leg resolution state machine (cache-driven)
+ *****************************************************************/
+
+static void count_cache_hit(mme_dns_leg_t *leg)
+{
+    if (leg->just_answered) {
+        leg->just_answered = false;
+        return;
+    }
+    mme_metrics_inst_global_inc(MME_METR_GLOB_CTR_DNS_CACHE_HIT);
+}
+
+static void leg_advance(mme_dns_resolution_t *res, mme_dns_leg_t *leg)
+{
+    mme_dns_cache_entry_t *entry = NULL;
+
+    while (leg->active && !leg->done && !leg->query_pending) {
+        if (!leg->naptr_fetched) {
+            entry = cache_get(MME_DNS_T_NAPTR, leg->fqdn);
+            if (!entry) {
+                issue_query(res, leg, MME_DNS_T_NAPTR, leg->fqdn);
+                return;
+            }
+            count_cache_hit(leg);
+            leg->naptr_fetched = true;
+            leg->num_cand = mme_dns_candidates_from_naptr(
+                    entry->u.naptr, entry->num,
+                    leg->svc, res->proto,
+                    leg->cand, MME_DNS_MAX_CANDIDATES);
+            leg->cursor = 0;
+            if (leg->num_cand == 0) {
+                leg_fail(res, leg, "no matching NAPTR records");
+                return;
+            }
+            continue;
+        }
+
+        if (leg->cursor >= leg->num_cand) {
+            leg_fail(res, leg, "candidates exhausted");
+            return;
+        }
+
+        if (leg->cand[leg->cursor].needs_srv) {
+            entry = cache_get(MME_DNS_T_SRV, leg->cand[leg->cursor].fqdn);
+            if (!entry) {
+                issue_query(res, leg, MME_DNS_T_SRV,
+                        leg->cand[leg->cursor].fqdn);
+                return;
+            }
+            count_cache_hit(leg);
+            if (entry->num == 0) {
+                /* No SRV target: skip this candidate */
+                leg->cursor++;
+                continue;
+            }
+            mme_dns_candidate_apply_srv(&leg->cand[leg->cursor],
+                    entry->u.srv, entry->num);
+            continue;
+        }
+
+        if (!leg->cand[leg->cursor].resolved) {
+            mme_dns_candidate_t *cand = &leg->cand[leg->cursor];
+            uint16_t port;
+
+            entry = cache_get(MME_DNS_T_A, cand->fqdn);
+            if (!entry) {
+                issue_query(res, leg, MME_DNS_T_A, cand->fqdn);
+                return;
+            }
+            count_cache_hit(leg);
+            if (entry->num == 0) {
+                leg->cursor++;
+                continue;
+            }
+            port = cand->port ? cand->port : ogs_gtp_self()->gtpc_port;
+            memset(&cand->addr, 0, sizeof(cand->addr));
+            cand->addr.ogs_sa_family = AF_INET;
+            cand->addr.sin.sin_addr = entry->u.a[0].addr;
+            cand->addr.ogs_sin_port = htobe16(port);
+            cand->resolved = true;
+        }
+
+        /* Candidate at cursor is fully resolved */
+        leg->done = true;
+        leg->fallback = false;
+    }
+}
+
+/*****************************************************************
+ * Applying results
+ *****************************************************************/
+
+static mme_dns_candidate_t *leg_result(mme_dns_leg_t *leg)
+{
+    if (!leg->active || !leg->done || leg->fallback)
+        return NULL;
+    if (leg->cursor >= leg->num_cand)
+        return NULL;
+    if (!leg->cand[leg->cursor].resolved)
+        return NULL;
+    return &leg->cand[leg->cursor];
+}
+
+static void apply_sgw(mme_dns_resolution_t *res, mme_sess_t *sess)
+{
+    mme_dns_candidate_t *cand = NULL;
+    mme_ue_t *mme_ue = NULL;
+    sgw_ue_t *sgw_ue = NULL;
+    mme_sgw_t *sgw = NULL;
+    char buf[OGS_ADDRSTRLEN];
+    int rv;
+
+    cand = leg_result(&res->sgw);
+    if (!cand)
+        return;
+
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue)
+        return;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
+    if (!sgw_ue)
+        return;
+
+    sgw = mme_sgw_find_by_addr(&cand->addr);
+    if (!sgw) {
+        ogs_sockaddr_t *addr = NULL;
+
+        addr = ogs_calloc(1, sizeof(*addr));
+        ogs_assert(addr);
+        memcpy(addr, &cand->addr, sizeof(*addr));
+
+        sgw = mme_sgw_add(addr);
+        if (!sgw) {
+            ogs_error("mme-dns: mme_sgw_add() failed, "
+                    "using statically selected SGW");
+            ogs_free(addr);
+            return;
+        }
+        sgw->dns_origin = true;
+
+        rv = ogs_gtp_connect(
+                ogs_gtp_self()->gtpc_sock, ogs_gtp_self()->gtpc_sock6,
+                &sgw->gnode);
+        if (rv != OGS_OK) {
+            ogs_error("mme-dns: ogs_gtp_connect() to [%s] failed, "
+                    "using statically selected SGW",
+                    OGS_ADDR(&cand->addr, buf));
+            mme_sgw_remove(sgw);
+            return;
+        }
+    }
+
+    if (sgw_ue->sgw != sgw) {
+        ogs_debug("mme-dns: switching UE to DNS-selected SGW [%s]",
+                OGS_ADDR(&cand->addr, buf));
+        sgw_ue_switch_to_sgw(sgw_ue, sgw);
+    }
+}
+
+ogs_sockaddr_t *mme_dns_sess_pgw_addr(mme_sess_t *sess)
+{
+    mme_dns_resolution_t *res = NULL;
+    mme_dns_candidate_t *cand = NULL;
+
+    res = resolution_find_by_sess(sess);
+    if (!res)
+        return NULL;
+
+    cand = leg_result(&res->pgw);
+    if (!cand)
+        return NULL;
+
+    return &cand->addr;
+}
+
+/*****************************************************************
+ * Entry points
+ *****************************************************************/
+
+bool mme_dns_enabled(void)
+{
+    return g_enabled;
+}
+
+int mme_dns_prepare(enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
+{
+    mme_dns_resolution_t *res = NULL;
+    mme_ue_t *mme_ue = NULL;
+
+    ogs_assert(sess);
+
+    if (!g_enabled)
+        return MME_DNS_SEND_NOW;
+
+    /* DNS-based selection applies to initial session creation only;
+     * TAU / Path-Switch keep both the statically relocated SGW and the
+     * existing PGW. */
+    if (create_action != OGS_GTP_CREATE_IN_ATTACH_REQUEST &&
+        create_action != OGS_GTP_CREATE_IN_UPLINK_NAS_TRANSPORT)
+        return MME_DNS_SEND_NOW;
+
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue || !sess->session || !sess->session->name)
+        return MME_DNS_SEND_NOW;
+
+    res = resolution_find_by_sess(sess);
+    if (res) {
+        if (res->state == MME_DNS_ST_PENDING)
+            return MME_DNS_DEFERRED;    /* already in flight */
+        return MME_DNS_SEND_NOW;        /* result already applied */
+    }
+
+    ogs_pool_id_calloc(&mme_dns_resolution_pool, &res);
+    if (!res) {
+        ogs_error("mme-dns: resolution pool exhausted, "
+                "using static selection");
+        return MME_DNS_SEND_NOW;
+    }
+    sess->dns_id = res->id;
+
+    res->sess_id = sess->id;
+    res->enb_ue_id = enb_ue ? enb_ue->id : OGS_INVALID_POOL_ID;
+    res->create_action = create_action;
+    res->state = MME_DNS_ST_PENDING;
+    res->csr_attempts = 0;
+
+    res->proto = mme_dns_decide_proto(mme_ue->imsi_bcd,
+            &mme_ue->tai.plmn_id,
+            (mme_dns_proto_e)mme_self()->dns.protocol);
+
+    /* SGW leg: only when the UE is not yet anchored on an SGW session
+     * (initial attach). Additional PDN connections must stay on the
+     * UE's current SGW. */
+    if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
+        res->sgw.svc = MME_DNS_SVC_SGW;
+        if (mme_dns_build_tai_fqdn(res->sgw.fqdn, sizeof(res->sgw.fqdn),
+                    &mme_ue->tai) == OGS_OK)
+            res->sgw.active = true;
+    }
+
+    /* PGW leg: skipped when the HSS provided a PGW address
+     * (MIP6-Agent-Info), which always takes precedence. */
+    if (!sess->session->smf_ip.ipv4 && !sess->session->smf_ip.ipv6) {
+        res->pgw.svc = MME_DNS_SVC_PGW;
+        if (mme_dns_build_apn_fqdn(res->pgw.fqdn, sizeof(res->pgw.fqdn),
+                    sess->session->name, &mme_ue->tai.plmn_id) == OGS_OK)
+            res->pgw.active = true;
+    }
+
+    if (!res->sgw.active && !res->pgw.active) {
+        resolution_free(res);
+        sess->dns_id = OGS_INVALID_POOL_ID;
+        return MME_DNS_SEND_NOW;
+    }
+
+    res->t_guard = ogs_timer_add(ogs_app()->timer_mgr,
+            guard_expire_cb, OGS_UINT_TO_POINTER(res->id));
+    ogs_assert(res->t_guard);
+    ogs_timer_start(res->t_guard,
+            ogs_time_from_msec(mme_self()->dns.guard_timeout));
+
+    if (res->sgw.active)
+        leg_advance(res, &res->sgw);
+    if (res->pgw.active)
+        leg_advance(res, &res->pgw);
+    check_completion(res);
+
+    return MME_DNS_DEFERRED;
+}
+
+void mme_dns_handle_resolved(mme_event_t *e)
+{
+    mme_sess_t *sess = NULL;
+    enb_ue_t *enb_ue = NULL;
+    mme_dns_resolution_t *res = NULL;
+    int rv;
+
+    ogs_assert(e);
+
+    sess = mme_sess_find_by_id(e->sess_id);
+    if (!sess) {
+        ogs_warn("mme-dns: session has already been removed");
+        return;
+    }
+
+    res = resolution_find_by_sess(sess);
+    if (!res || res->state != MME_DNS_ST_DONE)
+        return;    /* stale or duplicate event */
+
+    enb_ue = enb_ue_find_by_id(res->enb_ue_id);
+
+    apply_sgw(res, sess);
+
+    res->state = MME_DNS_ST_CONSUMED;
+    res->csr_attempts++;
+
+    rv = mme_gtp_send_create_session_request_now(
+            enb_ue, sess, res->create_action);
+    ogs_expect(rv == OGS_OK);
+}
+
+static bool retry_leg(mme_sess_t *sess, mme_dns_leg_t *leg)
+{
+    mme_dns_resolution_t *res = NULL;
+
+    res = resolution_find_by_sess(sess);
+    if (!res || res->state != MME_DNS_ST_CONSUMED)
+        return false;
+    if (res->csr_attempts >= MME_DNS_MAX_CSR_ATTEMPTS)
+        return false;
+
+    if (!leg->active || leg->fallback)
+        return false;
+    if (leg->cursor + 1 >= leg->num_cand)
+        return false;
+
+    leg->cursor++;
+    leg->done = false;
+
+    res->state = MME_DNS_ST_PENDING;
+    ogs_timer_start(res->t_guard,
+            ogs_time_from_msec(mme_self()->dns.guard_timeout));
+
+    leg_advance(res, leg);
+    check_completion(res);
+
+    return true;
+}
+
+bool mme_dns_retry_on_csr_failure(mme_sess_t *sess)
+{
+    mme_dns_resolution_t *res = NULL;
+    bool armed;
+
+    if (!g_enabled || !sess)
+        return false;
+
+    res = resolution_find_by_sess(sess);
+    if (!res)
+        return false;
+
+    /* The SGW answered (with a reject), so blame the PGW leg */
+    armed = retry_leg(sess, &res->pgw);
+    if (armed)
+        ogs_warn("mme-dns: Create Session rejected, "
+                "retrying with next PGW candidate");
+    return armed;
+}
+
+bool mme_dns_retry_on_gtp_timeout(mme_sess_t *sess)
+{
+    mme_dns_resolution_t *res = NULL;
+    bool armed;
+
+    if (!g_enabled || !sess)
+        return false;
+
+    res = resolution_find_by_sess(sess);
+    if (!res)
+        return false;
+
+    /* No answer at all: blame the SGW leg */
+    armed = retry_leg(sess, &res->sgw);
+    if (armed)
+        ogs_warn("mme-dns: Create Session timed out, "
+                "retrying with next SGW candidate");
+    return armed;
+}
+
+/*****************************************************************
+ * Init / final
+ *****************************************************************/
+
+int mme_dns_open(void)
+{
+    int i, rc, optmask = 0;
+    struct ares_options opt;
+    char csv[MME_DNS_MAX_SERVER * (OGS_ADDRSTRLEN + 8)];
+    size_t used = 0;
+
+    if (!mme_self()->dns.enabled)
+        return OGS_OK;
+
+    if (!ogs_gtp_self()->gtpc_sock) {
+        ogs_error("mme-dns: no IPv4 GTP-C socket; DNS-based selection "
+                "supports A records only and cannot be enabled");
+        return OGS_ERROR;
+    }
+
+    rc = ares_library_init(ARES_LIB_INIT_ALL);
+    if (rc != ARES_SUCCESS) {
+        ogs_error("ares_library_init() failed: %s", ares_strerror(rc));
+        return OGS_ERROR;
+    }
+
+    memset(&opt, 0, sizeof(opt));
+    opt.timeout = mme_self()->dns.timeout * 1000;
+    optmask |= ARES_OPT_TIMEOUTMS;
+    opt.tries = mme_self()->dns.retries;
+    optmask |= ARES_OPT_TRIES;
+    opt.flags = ARES_FLAG_NOSEARCH | ARES_FLAG_NOALIASES;
+    optmask |= ARES_OPT_FLAGS;
+    opt.sock_state_cb = dns_sock_state_cb;
+    optmask |= ARES_OPT_SOCK_STATE_CB;
+
+    rc = ares_init_options(&g_channel, &opt, optmask);
+    if (rc != ARES_SUCCESS) {
+        ogs_error("ares_init_options() failed: %s", ares_strerror(rc));
+        ares_library_cleanup();
+        return OGS_ERROR;
+    }
+
+    csv[0] = 0;
+    for (i = 0; i < mme_self()->dns.num_of_server; i++) {
+        used += ogs_snprintf(csv + used, sizeof(csv) - used, "%s%s:%d",
+                i ? "," : "",
+                mme_self()->dns.server[i].address,
+                mme_self()->dns.server[i].port);
+    }
+    rc = ares_set_servers_ports_csv(g_channel, csv);
+    if (rc != ARES_SUCCESS) {
+        ogs_error("ares_set_servers_ports_csv(%s) failed: %s",
+                csv, ares_strerror(rc));
+        ares_destroy(g_channel);
+        ares_library_cleanup();
+        return OGS_ERROR;
+    }
+
+    g_t_process = ogs_timer_add(ogs_app()->timer_mgr,
+            dns_process_timer_cb, NULL);
+    ogs_assert(g_t_process);
+
+    g_cache = ogs_hash_make();
+    ogs_assert(g_cache);
+
+    ogs_pool_init(&mme_dns_resolution_pool, ogs_global_conf()->max.ue);
+
+    g_channel_up = true;
+    g_enabled = true;
+    g_closing = false;
+
+    ogs_info("mme-dns: DNS-based SGW/PGW selection enabled [%s]", csv);
+
+    return OGS_OK;
+}
+
+void mme_dns_close(void)
+{
+    int i;
+
+    if (!g_channel_up)
+        return;
+
+    g_closing = true;
+    g_enabled = false;
+
+    ares_destroy(g_channel);
+    g_channel = NULL;
+    g_channel_up = false;
+    ares_library_cleanup();
+
+    for (i = 0; i < (int)OGS_ARRAY_SIZE(g_fdmap); i++) {
+        if (g_fdmap[i].rpoll) {
+            ogs_pollset_remove(g_fdmap[i].rpoll);
+            g_fdmap[i].rpoll = NULL;
+        }
+        if (g_fdmap[i].wpoll) {
+            ogs_pollset_remove(g_fdmap[i].wpoll);
+            g_fdmap[i].wpoll = NULL;
+        }
+    }
+
+    if (g_t_process) {
+        ogs_timer_delete(g_t_process);
+        g_t_process = NULL;
+    }
+
+    cache_flush();
+    if (g_cache) {
+        ogs_hash_destroy(g_cache);
+        g_cache = NULL;
+    }
+
+    ogs_pool_final(&mme_dns_resolution_pool);
+}

--- a/src/mme/mme-dns.h
+++ b/src/mme/mme-dns.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Asynchronous DNS-based SGW/PGW selection (3GPP TS 29.303) for the MME.
+ *
+ * Active only when the `mme.dns` configuration section is present AND the
+ * MME was built with c-ares. Without either, every entry point below is an
+ * inert no-op and the static (configuration-file) gateway selection is
+ * used, byte-for-byte identical to previous behavior.
+ */
+
+#ifndef MME_DNS_H
+#define MME_DNS_H
+
+#include "mme-context.h"
+#include "mme-event.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Return values of mme_dns_prepare() */
+#define MME_DNS_SEND_NOW    0   /* proceed with CSR immediately */
+#define MME_DNS_DEFERRED    1   /* CSR will be sent on MME_EVENT_DNS_RESOLVED */
+
+#ifdef MME_HAVE_CARES
+
+int mme_dns_open(void);
+void mme_dns_close(void);
+bool mme_dns_enabled(void);
+
+int mme_dns_prepare(enb_ue_t *enb_ue, mme_sess_t *sess, int create_action);
+
+/* DNS-resolved PGW address for this session, or NULL */
+ogs_sockaddr_t *mme_dns_sess_pgw_addr(mme_sess_t *sess);
+
+/* Retry hooks: true = a next candidate was armed, caller must not fail
+ * the procedure */
+bool mme_dns_retry_on_csr_failure(mme_sess_t *sess);
+bool mme_dns_retry_on_gtp_timeout(mme_sess_t *sess);
+
+/* MME_EVENT_DNS_RESOLVED handler body (called from mme-sm.c) */
+void mme_dns_handle_resolved(mme_event_t *e);
+
+/* Called from mme_sess_remove() */
+void mme_dns_sess_clear(mme_sess_t *sess);
+
+#else /* !MME_HAVE_CARES */
+
+static inline int mme_dns_open(void) { return OGS_OK; }
+static inline void mme_dns_close(void) {}
+static inline bool mme_dns_enabled(void) { return false; }
+static inline int mme_dns_prepare(
+        enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
+{ return MME_DNS_SEND_NOW; }
+static inline ogs_sockaddr_t *mme_dns_sess_pgw_addr(mme_sess_t *sess)
+{ return NULL; }
+static inline bool mme_dns_retry_on_csr_failure(mme_sess_t *sess)
+{ return false; }
+static inline bool mme_dns_retry_on_gtp_timeout(mme_sess_t *sess)
+{ return false; }
+static inline void mme_dns_handle_resolved(mme_event_t *e) {}
+static inline void mme_dns_sess_clear(mme_sess_t *sess) {}
+
+#endif /* MME_HAVE_CARES */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MME_DNS_H */

--- a/src/mme/mme-event.c
+++ b/src/mme/mme-event.c
@@ -101,6 +101,9 @@ const char *mme_event_get_name(mme_event_t *e)
         return "MME_EVENT_GN_MESSAGE";
     case MME_EVENT_GN_TIMER:
         return "MME_EVENT_GN_TIMER";
+
+    case MME_EVENT_DNS_RESOLVED:
+        return "MME_EVENT_DNS_RESOLVED";
     default:
        break;
     }

--- a/src/mme/mme-event.h
+++ b/src/mme/mme-event.h
@@ -53,6 +53,8 @@ typedef enum {
     MME_EVENT_GN_MESSAGE,
     MME_EVENT_GN_TIMER,
 
+    MME_EVENT_DNS_RESOLVED,
+
     MAX_NUM_OF_MME_EVENT,
 
 } mme_event_e;
@@ -98,6 +100,7 @@ typedef struct mme_event_s {
     ogs_pool_id_t enb_ue_id;
     ogs_pool_id_t sgw_ue_id;
     ogs_pool_id_t mme_ue_id;
+    ogs_pool_id_t sess_id;
     ogs_pool_id_t bearer_id;
     ogs_pool_id_t gtp_xact_id;
 

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -26,6 +26,7 @@
 #include "s1ap-path.h"
 #include "mme-s11-build.h"
 #include "mme-sm.h"
+#include "mme-dns.h"
 
 static void _gtpv1v2_c_recv_cb(short when, ogs_socket_t fd, void *data)
 {
@@ -165,6 +166,10 @@ static void timeout(ogs_gtp_xact_t *xact, void *data)
     ogs_assert(mme_ue);
     enb_ue = enb_ue_find_by_id(mme_ue->enb_ue_id);
 
+    if (type == OGS_GTP2_CREATE_SESSION_REQUEST_TYPE &&
+        mme_dns_retry_on_gtp_timeout(sess))
+        return;
+
     switch (type) {
     case OGS_GTP2_DELETE_SESSION_REQUEST_TYPE:
         /*
@@ -262,6 +267,18 @@ void mme_gtp_close(void)
 }
 
 int mme_gtp_send_create_session_request(
+        enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
+{
+    if (mme_dns_enabled()) {
+        int rc = mme_dns_prepare(enb_ue, sess, create_action);
+        if (rc == MME_DNS_DEFERRED)
+            return OGS_OK;  /* CSR is sent on MME_EVENT_DNS_RESOLVED */
+    }
+    return mme_gtp_send_create_session_request_now(
+            enb_ue, sess, create_action);
+}
+
+int mme_gtp_send_create_session_request_now(
         enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
 {
     int rv;

--- a/src/mme/mme-gtp-path.h
+++ b/src/mme/mme-gtp-path.h
@@ -31,6 +31,9 @@ void mme_gtp_close(void);
 
 int mme_gtp_send_create_session_request(
         enb_ue_t *enb_ue, mme_sess_t *sess, int create_action);
+/* Bypasses DNS-based gateway selection (used once selection is done) */
+int mme_gtp_send_create_session_request_now(
+        enb_ue_t *enb_ue, mme_sess_t *sess, int create_action);
 int mme_gtp_send_modify_bearer_request(
         enb_ue_t *enb_ue, mme_ue_t *mme_ue,
         int uli_presence, int modify_action);

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -29,6 +29,7 @@
 #include "s1ap-path.h"
 #include "sgsap-path.h"
 #include "mme-gtp-path.h"
+#include "mme-dns.h"
 #include "metrics.h"
 #include "metrics/prometheus/json_pager.h"
 #include "enb-info.h"
@@ -80,6 +81,9 @@ int mme_initialize(void)
     rv = mme_gtp_open();
     if (rv != OGS_OK) return OGS_ERROR;
 
+    rv = mme_dns_open();
+    if (rv != OGS_OK) return OGS_ERROR;
+
     rv = sgsap_open();
     if (rv != OGS_OK) return OGS_ERROR;
 
@@ -102,6 +106,7 @@ void mme_terminate(void)
 
     ogs_thread_destroy(thread);
 
+    mme_dns_close();
     mme_gtp_close();
     sgsap_close();
     s1ap_close();

--- a/src/mme/mme-s11-build.c
+++ b/src/mme/mme-s11-build.c
@@ -18,6 +18,7 @@
  */
 
 #include "mme-context.h"
+#include "mme-dns.h"
 
 #include "mme-s11-build.h"
 
@@ -145,13 +146,18 @@ ogs_pkbuf_t *mme_s11_build_create_session_request(
         ogs_sockaddr_t *pgw_addr = NULL;
         ogs_sockaddr_t *pgw_addr6 = NULL;
 
-        pgw_addr = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET, sess);
-        pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
-                &mme_self()->pgw_list, AF_INET6, sess);
-        if (!pgw_addr && !pgw_addr6) {
-            pgw_addr = mme_self()->pgw_addr;
-            pgw_addr6 = mme_self()->pgw_addr6;
+        /* DNS-resolved (TS 29.303) PGW address takes precedence over
+         * the statically configured PGW list */
+        pgw_addr = mme_dns_sess_pgw_addr(sess);
+        if (!pgw_addr) {
+            pgw_addr = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET, sess);
+            pgw_addr6 = mme_pgw_addr_find_by_apn_enb(
+                    &mme_self()->pgw_list, AF_INET6, sess);
+            if (!pgw_addr && !pgw_addr6) {
+                pgw_addr = mme_self()->pgw_addr;
+                pgw_addr6 = mme_self()->pgw_addr6;
+            }
         }
 
         rv = ogs_gtp2_sockaddr_to_f_teid(

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -24,6 +24,7 @@
 
 #include "s1ap-path.h"
 #include "mme-gtp-path.h"
+#include "mme-dns.h"
 #include "nas-path.h"
 #include "mme-fd-path.h"
 #include "sgsap-path.h"
@@ -608,6 +609,10 @@ void mme_s11_handle_create_session_response(
     return;
 
 fail:
+    /* DNS-based selection: try the next PGW candidate before giving up */
+    if (mme_dns_retry_on_csr_failure(sess))
+        return;
+
     mme_s11_create_session_fail(enb_ue, mme_ue,
             create_action, fail_cause, fail_reason);
     return;

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -34,6 +34,7 @@
 #include "mme-fd-path.h"
 #include "mme-s6a-handler.h"
 #include "mme-path.h"
+#include "mme-dns.h"
 
 void mme_state_initial(ogs_fsm_t *s, mme_event_t *e)
 {
@@ -857,6 +858,10 @@ cleanup:
             ogs_error("Unknown timer[%s:%d]",
                     mme_timer_get_name(e->timer_id), e->timer_id);
         }
+        break;
+
+    case MME_EVENT_DNS_RESOLVED:
+        mme_dns_handle_resolved(e);
         break;
 
     case MME_EVENT_GN_MESSAGE:

--- a/tests/dns/abts-main.c
+++ b/tests/dns/abts-main.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "test-app.h"
+#include "dns-server.h"
+
+abts_suite *test_dns_select(abts_suite *suite);
+
+const struct testlist {
+    abts_suite *(*func)(abts_suite *suite);
+} alltests[] = {
+    {test_dns_select},
+    {NULL},
+};
+
+static void terminate(void)
+{
+    ogs_msleep(50);
+
+    test_child_terminate();
+    app_terminate();
+
+    test_epc_final();
+    ogs_app_terminate();
+
+    test_dns_server_stop();
+}
+
+static void initialize(const char *const argv[])
+{
+    int rv;
+
+    /* The stub DNS server must be listening before the MME starts
+     * (see mme.dns in configs/dns.yaml.in) */
+    rv = test_dns_server_start("127.0.0.200", 10053);
+    ogs_assert(rv == OGS_OK);
+
+    rv = ogs_app_initialize(NULL, NULL, argv);
+    ogs_assert(rv == OGS_OK);
+    test_epc_init();
+
+    rv = app_initialize(argv);
+    ogs_assert(rv == OGS_OK);
+}
+
+int main(int argc, const char *const argv[])
+{
+    int i;
+    abts_suite *suite = NULL;
+
+    atexit(terminate);
+    test_app_run(argc, argv, "dns.yaml", initialize);
+
+    for (i = 0; alltests[i].func; i++)
+        suite = alltests[i].func(suite);
+
+    return abts_report(suite);
+}

--- a/tests/dns/dns-server.c
+++ b/tests/dns/dns-server.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ogs-core.h"
+#include "dns-server.h"
+
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#define MAX_RECORDS     32
+#define MAX_QUERIES     256
+#define MAX_NAME        256
+#define MAX_MSG         1024
+
+static struct {
+    int sock;
+    pthread_t thread;
+    bool running;
+
+    pthread_mutex_t lock;
+    int mode;
+    int num_records;
+    test_dns_record_t records[MAX_RECORDS];
+
+    int num_queries;
+    char queries[MAX_QUERIES][MAX_NAME];
+} g;
+
+/* Parse the question name at msg+12 into a dotted string.
+ * Returns the offset just past the name, or -1. */
+static int parse_qname(const uint8_t *msg, int len, char *name, size_t sz)
+{
+    int off = 12;
+    size_t used = 0;
+
+    while (off < len) {
+        uint8_t l = msg[off];
+        if (l == 0) {
+            off++;
+            break;
+        }
+        if (l >= 0xc0)  /* no compression expected in a question */
+            return -1;
+        if (off + 1 + l > len || used + l + 2 > sz)
+            return -1;
+        if (used) name[used++] = '.';
+        memcpy(name + used, msg + off + 1, l);
+        used += l;
+        off += 1 + l;
+    }
+    name[used] = 0;
+    return off;
+}
+
+static int put_name(uint8_t *buf, int off, const char *name)
+{
+    const char *p = name;
+
+    while (*p) {
+        const char *dot = strchr(p, '.');
+        size_t l = dot ? (size_t)(dot - p) : strlen(p);
+        ogs_assert(l > 0 && l < 64);
+        buf[off++] = l;
+        memcpy(buf + off, p, l);
+        off += l;
+        p += l;
+        if (*p == '.') p++;
+    }
+    buf[off++] = 0;
+    return off;
+}
+
+static int put_char_string(uint8_t *buf, int off, const char *s)
+{
+    size_t l = s ? strlen(s) : 0;
+    ogs_assert(l < 256);
+    buf[off++] = l;
+    if (l) memcpy(buf + off, s, l);
+    return off + l;
+}
+
+static int put_u16(uint8_t *buf, int off, uint16_t v)
+{
+    buf[off++] = v >> 8;
+    buf[off++] = v & 0xff;
+    return off;
+}
+
+static int put_u32(uint8_t *buf, int off, uint32_t v)
+{
+    buf[off++] = v >> 24;
+    buf[off++] = (v >> 16) & 0xff;
+    buf[off++] = (v >> 8) & 0xff;
+    buf[off++] = v & 0xff;
+    return off;
+}
+
+/* Append one answer RR (NAME = pointer to the question at offset 12) */
+static int put_answer(uint8_t *buf, int off, const test_dns_record_t *r)
+{
+    int rdlen_off, rdata_start;
+
+    off = put_u16(buf, off, 0xc00c);        /* name pointer */
+    off = put_u16(buf, off, r->qtype);
+    off = put_u16(buf, off, 1);             /* IN */
+    off = put_u32(buf, off, 60);            /* TTL */
+    rdlen_off = off;
+    off = put_u16(buf, off, 0);             /* rdlength placeholder */
+    rdata_start = off;
+
+    switch (r->qtype) {
+    case TEST_DNS_T_A: {
+        struct in_addr a;
+        ogs_assert(inet_pton(AF_INET, r->ipv4, &a) == 1);
+        memcpy(buf + off, &a, 4);
+        off += 4;
+        break;
+    }
+    case TEST_DNS_T_SRV:
+        off = put_u16(buf, off, r->priority);
+        off = put_u16(buf, off, r->weight);
+        off = put_u16(buf, off, r->port);
+        off = put_name(buf, off, r->target);
+        break;
+    case TEST_DNS_T_NAPTR:
+        off = put_u16(buf, off, r->order);
+        off = put_u16(buf, off, r->preference);
+        off = put_char_string(buf, off, r->flags);
+        off = put_char_string(buf, off, r->service);
+        off = put_char_string(buf, off, "");    /* regexp */
+        off = put_name(buf, off, r->replacement);
+        break;
+    default:
+        ogs_assert_if_reached();
+    }
+
+    put_u16(buf, rdlen_off, off - rdata_start);
+    return off;
+}
+
+static void *server_main(void *data)
+{
+    uint8_t msg[MAX_MSG], out[MAX_MSG];
+    struct sockaddr_in from;
+    socklen_t fromlen;
+    struct timeval tv;
+
+    tv.tv_sec = 0;
+    tv.tv_usec = 100000;
+    setsockopt(g.sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    while (g.running) {
+        int len, qend, i, out_len, ancount = 0;
+        char qname[MAX_NAME];
+        uint16_t qtype;
+
+        fromlen = sizeof(from);
+        len = recvfrom(g.sock, msg, sizeof(msg), 0,
+                (struct sockaddr *)&from, &fromlen);
+        if (len < 12 + 5)
+            continue;
+
+        qend = parse_qname(msg, len, qname, sizeof(qname));
+        if (qend < 0 || qend + 4 > len)
+            continue;
+        qtype = (msg[qend] << 8) | msg[qend+1];
+
+        pthread_mutex_lock(&g.lock);
+
+        if (g.num_queries < MAX_QUERIES) {
+            ogs_cpystrn(g.queries[g.num_queries], qname, MAX_NAME);
+            g.num_queries++;
+        }
+
+        if (g.mode == TEST_DNS_MODE_DROP) {
+            pthread_mutex_unlock(&g.lock);
+            continue;
+        }
+
+        /* header + question echo */
+        memcpy(out, msg, qend + 4);
+        out_len = qend + 4;
+        out[2] = 0x84;  /* QR|AA */
+        out[3] = 0x80;  /* RA, RCODE=0 */
+        put_u16(out, 4, 1);     /* QDCOUNT */
+        put_u16(out, 8, 0);     /* NSCOUNT */
+        put_u16(out, 10, 0);    /* ARCOUNT */
+
+        if (g.mode == TEST_DNS_MODE_ANSWER) {
+            for (i = 0; i < g.num_records; i++) {
+                const test_dns_record_t *r = &g.records[i];
+                if (r->qtype != qtype)
+                    continue;
+                if (strcasecmp(r->qname, qname) != 0)
+                    continue;
+                out_len = put_answer(out, out_len, r);
+                ancount++;
+            }
+        }
+        put_u16(out, 6, ancount);   /* ANCOUNT */
+
+        pthread_mutex_unlock(&g.lock);
+
+        (void)!sendto(g.sock, out, out_len, 0,
+                (struct sockaddr *)&from, fromlen);
+    }
+
+    return NULL;
+}
+
+int test_dns_server_start(const char *address, int port)
+{
+    struct sockaddr_in sin;
+
+    memset(&g, 0, sizeof(g));
+    pthread_mutex_init(&g.lock, NULL);
+
+    g.sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (g.sock < 0)
+        return OGS_ERROR;
+
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = htons(port);
+    if (inet_pton(AF_INET, address, &sin.sin_addr) != 1) {
+        close(g.sock);
+        return OGS_ERROR;
+    }
+    if (bind(g.sock, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+        close(g.sock);
+        return OGS_ERROR;
+    }
+
+    g.running = true;
+    if (pthread_create(&g.thread, NULL, server_main, NULL) != 0) {
+        close(g.sock);
+        return OGS_ERROR;
+    }
+
+    return OGS_OK;
+}
+
+void test_dns_server_stop(void)
+{
+    if (!g.running)
+        return;
+    g.running = false;
+    pthread_join(g.thread, NULL);
+    close(g.sock);
+    pthread_mutex_destroy(&g.lock);
+}
+
+void test_dns_server_set_records(const test_dns_record_t *records, int num)
+{
+    ogs_assert(num <= MAX_RECORDS);
+    pthread_mutex_lock(&g.lock);
+    memcpy(g.records, records, sizeof(*records) * num);
+    g.num_records = num;
+    g.mode = TEST_DNS_MODE_ANSWER;
+    pthread_mutex_unlock(&g.lock);
+}
+
+void test_dns_server_set_mode(int mode)
+{
+    pthread_mutex_lock(&g.lock);
+    g.mode = mode;
+    pthread_mutex_unlock(&g.lock);
+}
+
+int test_dns_server_num_queries(const char *qname_substr)
+{
+    int i, count = 0;
+
+    pthread_mutex_lock(&g.lock);
+    for (i = 0; i < g.num_queries; i++) {
+        if (!qname_substr || strstr(g.queries[i], qname_substr))
+            count++;
+    }
+    pthread_mutex_unlock(&g.lock);
+
+    return count;
+}
+
+void test_dns_server_reset_counters(void)
+{
+    pthread_mutex_lock(&g.lock);
+    g.num_queries = 0;
+    pthread_mutex_unlock(&g.lock);
+}

--- a/tests/dns/dns-server.h
+++ b/tests/dns/dns-server.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* Minimal programmable stub DNS server (UDP, A/SRV/NAPTR) for tests */
+
+#ifndef TEST_DNS_SERVER_H
+#define TEST_DNS_SERVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TEST_DNS_T_A        1
+#define TEST_DNS_T_SRV      33
+#define TEST_DNS_T_NAPTR    35
+
+#define TEST_DNS_MODE_ANSWER    0   /* answer from the record table */
+#define TEST_DNS_MODE_EMPTY     1   /* always NOERROR with 0 answers */
+#define TEST_DNS_MODE_DROP      2   /* never answer */
+
+typedef struct test_dns_record_s {
+    const char *qname;      /* owner name the query must match */
+    int qtype;              /* TEST_DNS_T_* */
+
+    /* NAPTR */
+    int order;
+    int preference;
+    const char *flags;
+    const char *service;
+    const char *replacement;
+
+    /* SRV */
+    int priority;
+    int weight;
+    int port;
+    const char *target;
+
+    /* A */
+    const char *ipv4;
+} test_dns_record_t;
+
+int test_dns_server_start(const char *address, int port);
+void test_dns_server_stop(void);
+
+void test_dns_server_set_records(const test_dns_record_t *records, int num);
+void test_dns_server_set_mode(int mode);
+
+/* Number of queries received whose qname contains the given substring
+ * (NULL = all queries) */
+int test_dns_server_num_queries(const char *qname_substr);
+void test_dns_server_reset_counters(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEST_DNS_SERVER_H */

--- a/tests/dns/dns-test.c
+++ b/tests/dns/dns-test.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "test-common.h"
+#include "dns-server.h"
+
+/* Serving PLMN 999/70, TAC 1 (see configs/dns.yaml.in) */
+#define TAI_FQDN "tac-lb01.tac-hb00.tac.epc.mnc070.mcc999.3gppnetwork.org"
+#define APN_FQDN "internet.apn.epc.mnc070.mcc999.3gppnetwork.org"
+
+#define SRV_NAME "_gtp._udp.sgw.epc.mnc070.mcc999.3gppnetwork.org"
+#define SGW_NAME "sgw.epc.mnc070.mcc999.3gppnetwork.org"
+#define PGW_NAME "topon.s5.pgw.epc.mnc070.mcc999.3gppnetwork.org"
+
+/*
+ * Records exercising both S-NAPTR chains:
+ *   SGW: NAPTR (flag "s") -> SRV -> A = 127.0.0.3
+ *   PGW: NAPTR (flag "a") -> A = 127.0.0.4
+ * The addresses match the SGW-C/SMF of configs/dns.yaml.in, so a
+ * successful attach proves the Create Session Request followed the
+ * DNS-provided gateways.
+ */
+static const test_dns_record_t good_records[] = {
+    { .qname = TAI_FQDN, .qtype = TEST_DNS_T_NAPTR,
+      .order = 10, .preference = 10, .flags = "s",
+      .service = "x-3gpp-sgw:x-s5-gtp", .replacement = SRV_NAME },
+    { .qname = SRV_NAME, .qtype = TEST_DNS_T_SRV,
+      .priority = 10, .weight = 0, .port = 2123, .target = SGW_NAME },
+    { .qname = SGW_NAME, .qtype = TEST_DNS_T_A, .ipv4 = "127.0.0.3" },
+    { .qname = APN_FQDN, .qtype = TEST_DNS_T_NAPTR,
+      .order = 10, .preference = 10, .flags = "a",
+      .service = "x-3gpp-pgw:x-s5-gtp:x-s8-gtp", .replacement = PGW_NAME },
+    { .qname = PGW_NAME, .qtype = TEST_DNS_T_A, .ipv4 = "127.0.0.4" },
+};
+
+static void attach_and_detach(abts_case *tc, const char *scheme_output)
+{
+    int rv;
+    ogs_socknode_t *s1ap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *emmbuf;
+    ogs_pkbuf_t *esmbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *bearer = NULL;
+
+    uint32_t enb_ue_s1ap_id;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, scheme_output);
+    ogs_assert(test_ue);
+
+    test_ue->e_cgi.cell_id = 0x1079baf0;
+    test_ue->nas.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.value = OGS_NAS_ATTACH_TYPE_EPS_ATTACH;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    sess = test_sess_add_by_apn(test_ue, "internet", OGS_GTP2_RAT_TYPE_EUTRAN);
+    ogs_assert(sess);
+
+    /* eNB connects to MME */
+    s1ap = tests1ap_client(AF_INET);
+    ABTS_PTR_NOTNULL(tc, s1ap);
+
+    /* eNB connects to SGW */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send S1-Setup Reqeust */
+    sendbuf = test_s1ap_build_s1_setup_request(
+            S1AP_ENB_ID_PR_macroENB_ID, 0x54f64);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive S1-Setup Response */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(NULL, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Attach Request */
+    memset(&sess->pdn_connectivity_param,
+            0, sizeof(sess->pdn_connectivity_param));
+    sess->pdn_connectivity_param.eit = 1;
+    sess->pdn_connectivity_param.request_type =
+        OGS_NAS_EPS_REQUEST_TYPE_INITIAL;
+    esmbuf = testesm_build_pdn_connectivity_request(
+            sess, false, OGS_NAS_EPS_PDN_TYPE_IPV4V6);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+
+    memset(&test_ue->attach_request_param,
+            0, sizeof(test_ue->attach_request_param));
+    test_ue->attach_request_param.drx_parameter = 1;
+    test_ue->attach_request_param.ms_network_capability = 1;
+    test_ue->attach_request_param.tmsi_status = 1;
+    test_ue->attach_request_param.mobile_station_classmark_2 = 1;
+    test_ue->attach_request_param.ue_usage_setting = 1;
+    emmbuf = testemm_build_attach_request(test_ue, esmbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+
+    memset(&test_ue->initial_ue_param, 0, sizeof(test_ue->initial_ue_param));
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    emmbuf = testemm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    test_ue->mobile_identity_imeisv_presence = true;
+    emmbuf = testemm_build_security_mode_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive ESM Information Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send ESM Information Response
+     * (the MME then resolves the gateways via DNS and sends the
+     *  Create Session Request) */
+    sess->esm_information_param.epco = 1;
+    esmbuf = testesm_build_esm_information_response(sess);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Initial Context Setup Request +
+     * Attach Accept +
+     * Activate Default Bearer Context Request */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Capability Info Indication */
+    sendbuf = tests1ap_build_ue_radio_capability_info_indication(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Initial Context Setup Response */
+    sendbuf = test_s1ap_build_initial_context_setup_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Attach Complete + Activate default EPS bearer cotext accept */
+    bearer = test_bearer_find_by_ue_ebi(test_ue, 5);
+    ogs_assert(bearer);
+    esmbuf = testesm_build_activate_default_eps_bearer_context_accept(
+            bearer, false);
+    ABTS_PTR_NOTNULL(tc, esmbuf);
+    emmbuf = testemm_build_attach_complete(test_ue, esmbuf);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_uplink_nas_transport(test_ue, emmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive EMM information */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send Detach Request */
+    emmbuf = testemm_build_detach_request(test_ue, 1, true, false);
+    ABTS_PTR_NOTNULL(tc, emmbuf);
+    sendbuf = test_s1ap_build_initial_ue_message(
+            test_ue, emmbuf, S1AP_RRC_Establishment_Cause_mo_Signalling, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive OLD UE Context Release Command */
+    enb_ue_s1ap_id = test_ue->enb_ue_s1ap_id;
+
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send OLD UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    test_ue->enb_ue_s1ap_id = enb_ue_s1ap_id;
+
+    /* Receive UE Context Release Command */
+    recvbuf = testenb_s1ap_read(s1ap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    tests1ap_recv(test_ue, recvbuf);
+
+    /* Send UE Context Release Complete */
+    sendbuf = test_s1ap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testenb_s1ap_send(s1ap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* eNB disonncect from MME */
+    testenb_s1ap_close(s1ap);
+
+    /* eNB disonncect from SGW */
+    test_gtpu_close(gtpu);
+
+    test_ue_remove(test_ue);
+}
+
+/* Attach with a fully working S-NAPTR chain: SGW via NAPTR->SRV->A,
+ * PGW via NAPTR->A. */
+static void test1_dns_selection(abts_case *tc, void *data)
+{
+    test_dns_server_set_records(
+            good_records, OGS_ARRAY_SIZE(good_records));
+    test_dns_server_reset_counters();
+
+    attach_and_detach(tc, "3746000060");
+
+    /* The MME must have queried both FQDNs */
+    ABTS_TRUE(tc, test_dns_server_num_queries("tac-lb01.tac-hb00") >= 1);
+    ABTS_TRUE(tc, test_dns_server_num_queries("internet.apn") >= 1);
+}
+
+/* DNS answers with NOERROR/0 records: the MME must fall back to the
+ * static sgwc/smf configuration and the attach must still succeed. */
+static void test2_empty_fallback(abts_case *tc, void *data)
+{
+    /* Let the cache entries of the previous case expire
+     * (cache_ttl is 1s in dns.yaml.in) */
+    ogs_msleep(1200);
+
+    test_dns_server_set_mode(TEST_DNS_MODE_EMPTY);
+    test_dns_server_reset_counters();
+
+    attach_and_detach(tc, "3746000061");
+
+    ABTS_TRUE(tc, test_dns_server_num_queries(NULL) >= 1);
+}
+
+/* DNS server drops all queries: the guard timer (1.5s in dns.yaml.in)
+ * must fire and the attach must still succeed via static fallback. */
+static void test3_timeout_fallback(abts_case *tc, void *data)
+{
+    /* Let the (negative) cache entries of the previous case expire */
+    ogs_msleep(1200);
+
+    test_dns_server_set_mode(TEST_DNS_MODE_DROP);
+    test_dns_server_reset_counters();
+
+    attach_and_detach(tc, "3746000062");
+
+    ABTS_TRUE(tc, test_dns_server_num_queries(NULL) >= 1);
+}
+
+abts_suite *test_dns_select(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite)
+
+    abts_run_test(suite, test1_dns_selection, NULL);
+    abts_run_test(suite, test2_empty_fallback, NULL);
+    abts_run_test(suite, test3_timeout_fallback, NULL);
+
+    return suite;
+}

--- a/tests/dns/meson.build
+++ b/tests/dns/meson.build
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 by Sukchan Lee <acetcom@gmail.com>
+# Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
 
 # This file is part of Open5GS.
 
@@ -15,23 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-testinc = include_directories('.')
+# DNS-based SGW/PGW selection: needs an MME built with c-ares
+if libcares_dep.found()
 
-subdir('core')
-subdir('crypt')
-subdir('sctp')
-subdir('unit')
-subdir('af')
-subdir('common')
-subdir('app')
-subdir('registration')
-subdir('vonr')
-subdir('slice')
-subdir('attach')
-subdir('dns')
-subdir('volte')
-subdir('csfb')
-subdir('310014')
-subdir('handover')
-subdir('non3gpp')
-subdir('transfer')
+testapp_dns_sources = files('''
+    abts-main.c
+    dns-server.c
+    dns-test.c
+'''.split())
+
+testapp_dns_exe = executable('dns',
+    sources : testapp_dns_sources,
+    c_args : testunit_core_cc_flags,
+    dependencies : libtestepc_dep)
+
+test('dns', testapp_dns_exe, is_parallel : false, suite: 'epc')
+
+endif

--- a/tests/unit/abts-main.c
+++ b/tests/unit/abts-main.c
@@ -38,6 +38,7 @@ abts_suite *test_sbi_message(abts_suite *suite);
 abts_suite *test_security(abts_suite *suite);
 abts_suite *test_nrf_discovery(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
+abts_suite *test_mme_dns_select(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -51,6 +52,7 @@ const struct testlist {
     {test_security},
     {test_nrf_discovery},
     {test_crash},
+    {test_mme_dns_select},
     {NULL},
 };
 

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -26,11 +26,14 @@ testunit_unit_sources = files('''
     security-test.c
     nrf-discovery-test.c
     crash-test.c
+    mme-dns-select-test.c
+    ../../src/mme/mme-dns-select.c
 '''.split())
 
 testunit_unit_exe = executable('unit',
     sources : testunit_unit_sources,
     c_args : [testunit_core_cc_flags, sbi_cc_flags],
+    include_directories : srcinc,
     dependencies : [libs1ap_dep,
                     libgtp_dep,
                     libngap_dep,

--- a/tests/unit/mme-dns-select-test.c
+++ b/tests/unit/mme-dns-select-test.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2026 by Evgenii Grigorev <tothe8c@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mme/mme-dns-select.h"
+#include "core/abts.h"
+
+static ogs_plmn_id_t plmn(uint16_t mcc, uint16_t mnc, uint16_t mnc_len)
+{
+    ogs_plmn_id_t id;
+    ogs_plmn_id_build(&id, mcc, mnc, mnc_len);
+    return id;
+}
+
+static void dns_select_test_apn_fqdn(abts_case *tc, void *data)
+{
+    char buf[MME_DNS_MAX_FQDN_LEN+1];
+    ogs_plmn_id_t id;
+
+    id = plmn(1, 1, 2);
+    ABTS_INT_EQUAL(tc, OGS_OK,
+            mme_dns_build_apn_fqdn(buf, sizeof(buf), "internet", &id));
+    ABTS_STR_EQUAL(tc,
+            "internet.apn.epc.mnc001.mcc001.3gppnetwork.org", buf);
+
+    id = plmn(302, 330, 3);
+    ABTS_INT_EQUAL(tc, OGS_OK,
+            mme_dns_build_apn_fqdn(buf, sizeof(buf), "ims", &id));
+    ABTS_STR_EQUAL(tc,
+            "ims.apn.epc.mnc330.mcc302.3gppnetwork.org", buf);
+
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            mme_dns_build_apn_fqdn(buf, sizeof(buf), "", &id));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            mme_dns_build_apn_fqdn(buf, sizeof(buf), NULL, &id));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            mme_dns_build_apn_fqdn(buf, 16, "internet", &id));
+}
+
+static void dns_select_test_tai_fqdn(abts_case *tc, void *data)
+{
+    char buf[MME_DNS_MAX_FQDN_LEN+1];
+    ogs_eps_tai_t tai;
+
+    memset(&tai, 0, sizeof(tai));
+    tai.plmn_id = plmn(1, 1, 2);
+    tai.tac = 0x0001;
+    ABTS_INT_EQUAL(tc, OGS_OK,
+            mme_dns_build_tai_fqdn(buf, sizeof(buf), &tai));
+    ABTS_STR_EQUAL(tc,
+            "tac-lb01.tac-hb00.tac.epc.mnc001.mcc001.3gppnetwork.org", buf);
+
+    tai.plmn_id = plmn(302, 330, 3);
+    tai.tac = 0xabcd;
+    ABTS_INT_EQUAL(tc, OGS_OK,
+            mme_dns_build_tai_fqdn(buf, sizeof(buf), &tai));
+    ABTS_STR_EQUAL(tc,
+            "tac-lbcd.tac-hbab.tac.epc.mnc330.mcc302.3gppnetwork.org", buf);
+}
+
+static void dns_select_test_service_match(abts_case *tc, void *data)
+{
+    ABTS_TRUE(tc, mme_dns_service_match(
+            "x-3gpp-sgw:x-s5-gtp", MME_DNS_SVC_SGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, mme_dns_service_match(
+            "x-3gpp-pgw:x-s5-gtp:x-s8-gtp", MME_DNS_SVC_PGW,
+            MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, mme_dns_service_match(
+            "x-3gpp-pgw:x-s5-gtp:x-s8-gtp", MME_DNS_SVC_PGW,
+            MME_DNS_PROTO_S8));
+    ABTS_TRUE(tc, mme_dns_service_match(
+            "X-3GPP-PGW:X-S5-GTP", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, mme_dns_service_match(
+            "x-3gpp-pgw:x-gn:x-s5-gtp", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+
+    /* Wrong node */
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-sgw:x-s5-gtp", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    /* Wrong protocol */
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-pgw:x-s8-gtp", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-pgw:x-gn:x-gp", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    /* Malformed */
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-pgw", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            NULL, MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-pgw-x-s5-gtp", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+    /* Substring must not match a token */
+    ABTS_TRUE(tc, !mme_dns_service_match(
+            "x-3gpp-pgw:x-s5-gtp-extra", MME_DNS_SVC_PGW, MME_DNS_PROTO_S5));
+}
+
+static void dns_select_test_proto_decide(abts_case *tc, void *data)
+{
+    ogs_plmn_id_t serving = plmn(1, 1, 2);
+
+    /* Home subscriber: IMSI 00101... on serving 001/01 */
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S5, mme_dns_decide_proto(
+            "001011234567890", &serving, MME_DNS_PROTO_AUTO));
+    /* Roamer: IMSI 26201... on serving 001/01 */
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S8, mme_dns_decide_proto(
+            "262011234567890", &serving, MME_DNS_PROTO_AUTO));
+    /* Trap: 3-digit-MNC serving PLMN must compare 6 digits */
+    serving = plmn(302, 330, 3);
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S5, mme_dns_decide_proto(
+            "302330123456789", &serving, MME_DNS_PROTO_AUTO));
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S8, mme_dns_decide_proto(
+            "302331123456789", &serving, MME_DNS_PROTO_AUTO));
+    /* Override always wins */
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S8, mme_dns_decide_proto(
+            "302330123456789", &serving, MME_DNS_PROTO_S8));
+    ABTS_INT_EQUAL(tc, MME_DNS_PROTO_S5, mme_dns_decide_proto(
+            "262011234567890", &serving, MME_DNS_PROTO_S5));
+}
+
+static void dns_select_test_canonical(abts_case *tc, void *data)
+{
+    char canon[MME_DNS_MAX_FQDN_LEN+1];
+
+    mme_dns_canonical_name(
+            "topon.s5.pgw1.node.epc.mnc001.mcc001.3gppnetwork.org",
+            canon, sizeof(canon));
+    ABTS_STR_EQUAL(tc,
+            "pgw1.node.epc.mnc001.mcc001.3gppnetwork.org", canon);
+
+    mme_dns_canonical_name(
+            "topoff.eth4.gw.example.org", canon, sizeof(canon));
+    ABTS_STR_EQUAL(tc, "gw.example.org", canon);
+
+    mme_dns_canonical_name("pgw1.example.org", canon, sizeof(canon));
+    ABTS_STR_EQUAL(tc, "pgw1.example.org", canon);
+
+    /* Prefix without an interface label: kept verbatim */
+    mme_dns_canonical_name("topon.", canon, sizeof(canon));
+    ABTS_STR_EQUAL(tc, "topon.", canon);
+}
+
+static void dns_select_test_candidates(abts_case *tc, void *data)
+{
+    mme_dns_naptr_record_t recs[6];
+    mme_dns_candidate_t cand[MME_DNS_MAX_CANDIDATES];
+    int n;
+
+    memset(recs, 0, sizeof(recs));
+
+    /* order 20 - "a" flag */
+    recs[0].order = 20; recs[0].preference = 10;
+    strcpy(recs[0].flags, "a");
+    strcpy(recs[0].service, "x-3gpp-sgw:x-s5-gtp");
+    strcpy(recs[0].replacement, "sgw2.example.org");
+    /* order 10 - "s" flag, must sort first */
+    recs[1].order = 10; recs[1].preference = 50;
+    strcpy(recs[1].flags, "S");
+    strcpy(recs[1].service, "x-3gpp-sgw:x-s5-gtp:x-s8-gtp");
+    strcpy(recs[1].replacement, "_gtp._udp.sgw1.example.org");
+    /* Non-terminal NAPTR: skipped */
+    recs[2].order = 5; recs[2].preference = 1;
+    strcpy(recs[2].flags, "");
+    strcpy(recs[2].service, "x-3gpp-sgw:x-s5-gtp");
+    strcpy(recs[2].replacement, "other.example.org");
+    /* Wrong service: skipped */
+    recs[3].order = 5; recs[3].preference = 1;
+    strcpy(recs[3].flags, "a");
+    strcpy(recs[3].service, "x-3gpp-pgw:x-s5-gtp");
+    strcpy(recs[3].replacement, "pgw.example.org");
+    /* Same order 10, lower preference: must sort before recs[1] */
+    recs[4].order = 10; recs[4].preference = 20;
+    strcpy(recs[4].flags, "a");
+    strcpy(recs[4].service, "x-3gpp-sgw:x-s5-gtp");
+    strcpy(recs[4].replacement, "topon.s11.sgw3.example.org");
+    /* Duplicate canonical name of recs[4] (topoff variant): deduped */
+    recs[5].order = 30; recs[5].preference = 1;
+    strcpy(recs[5].flags, "a");
+    strcpy(recs[5].service, "x-3gpp-sgw:x-s5-gtp");
+    strcpy(recs[5].replacement, "topoff.s4.sgw3.example.org");
+
+    n = mme_dns_candidates_from_naptr(recs, 6,
+            MME_DNS_SVC_SGW, MME_DNS_PROTO_S5,
+            cand, MME_DNS_MAX_CANDIDATES);
+
+    ABTS_INT_EQUAL(tc, 3, n);
+    ABTS_STR_EQUAL(tc, "topon.s11.sgw3.example.org", cand[0].fqdn);
+    ABTS_STR_EQUAL(tc, "sgw3.example.org", cand[0].canon);
+    ABTS_TRUE(tc, !cand[0].needs_srv);
+    ABTS_STR_EQUAL(tc, "_gtp._udp.sgw1.example.org", cand[1].fqdn);
+    ABTS_TRUE(tc, cand[1].needs_srv);
+    ABTS_STR_EQUAL(tc, "sgw2.example.org", cand[2].fqdn);
+    ABTS_TRUE(tc, !cand[2].needs_srv);
+
+    /* Candidate cap */
+    n = mme_dns_candidates_from_naptr(recs, 6,
+            MME_DNS_SVC_SGW, MME_DNS_PROTO_S5, cand, 1);
+    ABTS_INT_EQUAL(tc, 1, n);
+    ABTS_STR_EQUAL(tc, "topon.s11.sgw3.example.org", cand[0].fqdn);
+
+    /* Empty input */
+    n = mme_dns_candidates_from_naptr(NULL, 0,
+            MME_DNS_SVC_SGW, MME_DNS_PROTO_S5,
+            cand, MME_DNS_MAX_CANDIDATES);
+    ABTS_INT_EQUAL(tc, 0, n);
+}
+
+static void dns_select_test_srv(abts_case *tc, void *data)
+{
+    mme_dns_candidate_t cand;
+    mme_dns_srv_record_t srv[3];
+
+    memset(&cand, 0, sizeof(cand));
+    strcpy(cand.fqdn, "_gtp._udp.sgw1.example.org");
+    cand.needs_srv = true;
+
+    memset(srv, 0, sizeof(srv));
+    srv[0].priority = 20; srv[0].weight = 100; srv[0].port = 2100;
+    strcpy(srv[0].target, "host-b.example.org");
+    srv[1].priority = 10; srv[1].weight = 0; srv[1].port = 2123;
+    strcpy(srv[1].target, "host-a.example.org");
+    srv[2].priority = 10; srv[2].weight = 200; /* weight ignored */
+    strcpy(srv[2].target, "host-c.example.org");
+
+    mme_dns_candidate_apply_srv(&cand, srv, 3);
+    ABTS_STR_EQUAL(tc, "host-a.example.org", cand.fqdn);
+    ABTS_INT_EQUAL(tc, 2123, cand.port);
+    ABTS_TRUE(tc, !cand.needs_srv);
+
+    /* Empty SRV set leaves the candidate untouched */
+    memset(&cand, 0, sizeof(cand));
+    strcpy(cand.fqdn, "unchanged");
+    cand.needs_srv = true;
+    mme_dns_candidate_apply_srv(&cand, NULL, 0);
+    ABTS_STR_EQUAL(tc, "unchanged", cand.fqdn);
+    ABTS_TRUE(tc, cand.needs_srv);
+}
+
+abts_suite *test_mme_dns_select(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite)
+
+    abts_run_test(suite, dns_select_test_apn_fqdn, NULL);
+    abts_run_test(suite, dns_select_test_tai_fqdn, NULL);
+    abts_run_test(suite, dns_select_test_service_match, NULL);
+    abts_run_test(suite, dns_select_test_proto_decide, NULL);
+    abts_run_test(suite, dns_select_test_canonical, NULL);
+    abts_run_test(suite, dns_select_test_candidates, NULL);
+    abts_run_test(suite, dns_select_test_srv, NULL);
+
+    return suite;
+}


### PR DESCRIPTION
# MME: DNS-based SGW/PGW selection per 3GPP TS 29.303 (S-NAPTR, c-ares)

Implements DNS-based gateway selection in the MME, as requested in #2195
(GSMA IR.88 roaming P-GW selection) and described in 3GPP TS 29.303:

- **SGW** selected by TAI-FQDN
  (`tac-lb<xx>.tac-hb<xx>.tac.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org`),
- **PGW** selected by APN-FQDN
  (`<apn>.apn.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org`),
- S-NAPTR procedure: `NAPTR -> SRV -> A` (flag `s`) and `NAPTR -> A`
  (flag `a`), service fields `x-3gpp-sgw` / `x-3gpp-pgw` with protocol
  tokens `x-s5-gtp` / `x-s8-gtp` (multi-token, case-insensitive).
  `x-s8-gtp` is chosen automatically when the UE's IMSI PLMN differs
  from the serving PLMN (override available in config).

## Design

- **Opt-in and safe**: active only when a new `mme.dns` section is
  present in `mme.yaml` *and* the MME was built with c-ares
  (`dependency('libcares', required: false)`). Without either, behavior
  is bit-identical to the current static `gtpc.client.sgwc/smf`
  selection. On any DNS failure (timeout, empty answer, no matching
  records) the MME logs a warning and falls back to the static
  configuration — DNS problems never block attaches.
- **Fully asynchronous**: c-ares sockets are registered in the MME's
  `ogs_pollset`, query timeouts driven by `ogs_timer`; resolution
  completion is delivered via a new `MME_EVENT_DNS_RESOLVED` event.
  The single-threaded MME event loop is never blocked.
- **Integration point**: `mme_gtp_send_create_session_request()` defers
  the CSR while resolution is in flight; on completion the SGW is
  re-bound with the existing `sgw_ue_switch_to_sgw()` (safe pre-CSR,
  no S11 TEID exists yet) and the PGW address is injected into the
  PGW S5/S8 F-TEID (HSS-provided MIP6-Agent-Info still wins; static
  list remains the fallback).
- **Retry**: on Create Session reject the next PGW candidate is tried;
  on GTP xact timeout the next SGW candidate (max 3 CSR attempts),
  after which the existing failure path runs unchanged.
- **Cache**: per-FQDN TTL cache (real TTLs for A records, configurable
  `cache_ttl` for NAPTR/SRV — the legacy c-ares parsers do not expose
  their TTLs), short negative caching.
- **Scope**: initial attach and UE-requested PDN connectivity only;
  TAU / S1 Path-Switch keep the statically relocated SGW.
- 3 new Prometheus counters: `dns_query_total`, `dns_query_failed`,
  `dns_cache_hit`.

## Configuration

```yaml
mme:
  dns:
    server:
      - address: 10.11.12.13
      - address: 10.11.12.14
    timeout: 2            # seconds per query round
    retries: 2
    protocol: auto        # auto | s5 | s8
    cache_ttl: 60
    guard_timeout: 3000   # overall resolution guard (ms)
```

## Deliberate MVP limitations (documented in code)

- RFC 2782 SRV weights ignored (priority-only ordering).
- AAAA / IPv6 gateways out of scope (A records only).
- `topon.`/`topoff.` prefixes are recognized and stripped to the
  canonical node name for candidate deduplication per TS 29.303 4.3.2,
  but no topological/collocation matching is performed.
- Non-terminal NAPTR (empty flags) not followed.
- APN-FQDN is built with the serving PLMN; deriving the home-PLMN
  APN-OI for outbound roamers needs an MNC-length table and is left
  for follow-up.
- DNS-discovered SGW nodes are never garbage-collected (bounded by the
  operator's DNS zone content; deduplicated by address).

## Testing

- **Unit** (`tests/unit/mme-dns-select-test.c`): FQDN builders, service
  matching, flag handling, ordering, topon-stripping/dedup, s5-vs-s8
  decision, candidate caps — pure functions, no network, no c-ares.
- **E2E** (`tests/dns`, suite `epc`, built only with c-ares): a
  programmable stub DNS server (UDP NAPTR/SRV/A) inside the test
  binary; full attach through DNS-selected SGW/PGW (both `s` and `a`
  chains), empty-answer fallback, and unresponsive-DNS
  (guard-timeout) fallback.
- `meson test` passes with and without libc-ares-dev installed
  (16/16 with, all suites; the dns test is skipped without).
- Validated on a 2-site lab deployment (BIND, real NAPTR/SRV/A zone,
  eNB-simulator attaches over S1AP):
  - attach through DNS-selected SGW and PGW confirmed on the wire
    (Create Session Request went to the NAPTR->A SGW; PGW S5/S8
    F-TEID carried the NAPTR->SRV->A PGW);
  - both DNS servers dead: attach still succeeds via static fallback,
    the event loop stays responsive (`dns_query_failed` incremented);
  - primary DNS server down: transparent c-ares failover to the
    secondary, zero failures;
  - 110 attach/detach cycles: 110/110 OK, stable attach latency,
    26 DNS queries vs 524 cache hits, no RSS growth trend.

CI: `libc-ares-dev` added to the workflow package list so the feature
is compiled and exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
