### PR TITLE
pfcp: fix reversed Reporting Triggers byte order in handle_update_urr

### DIFF
--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -1702,9 +1702,9 @@ ogs_pfcp_urr_t *ogs_pfcp_handle_update_urr(ogs_pfcp_sess_t *sess,
         urr->meas_method = message->measurement_method.u8;
 
     if (message->reporting_triggers.presence) {
-        urr->rep_triggers.reptri_5 = message->reporting_triggers.u24 & 0xFF;
+        urr->rep_triggers.reptri_5 = (message->reporting_triggers.u24 >> 16) & 0xFF;
         urr->rep_triggers.reptri_6 = (message->reporting_triggers.u24 >> 8) & 0xFF;
-        urr->rep_triggers.reptri_7 = (message->reporting_triggers.u24 >> 16) & 0xFF;
+        urr->rep_triggers.reptri_7 = message->reporting_triggers.u24 & 0xFF;
     }
 
     if (message->measurement_period.presence) {


### PR DESCRIPTION
## Problem

`ogs_pfcp_handle_update_urr()` decodes the 3-octet Reporting Triggers IE (`reporting_triggers.u24`) in **reverse octet order** compared to the rest of the code base:

```c
urr->rep_triggers.reptri_5 = message->reporting_triggers.u24 & 0xFF;          // LSB
urr->rep_triggers.reptri_6 = (message->reporting_triggers.u24 >> 8) & 0xFF;
urr->rep_triggers.reptri_7 = (message->reporting_triggers.u24 >> 16) & 0xFF;  // MSB
```

Both `ogs_pfcp_handle_create_urr()` and `ogs_pfcp_build_update_urr()` use the opposite (and self-consistent) mapping — `reptri_5` in the MSB, `reptri_7` in the LSB:

```c
// handle_create_urr
urr->rep_triggers.reptri_5 = (message->reporting_triggers.u24 >> 16) & 0xFF;
urr->rep_triggers.reptri_7 = message->reporting_triggers.u24 & 0xFF;

// build_update_urr / build_create_urr
message->reporting_triggers.u24 =
    (urr->rep_triggers.reptri_5 << 16) | (urr->rep_triggers.reptri_6 << 8) | urr->rep_triggers.reptri_7;
```

Consequence: on an **Update URR** carrying Reporting Triggers, octet 5 and octet 7 are swapped — e.g. the `VOLTH` bit (octet 5) ends up read from octet 7. A trigger set correctly at session establishment gets corrupted when the URR is later modified (typical case: re-arming a volume threshold), because the encoder and the update decoder disagree on byte order.

## Fix

Align `ogs_pfcp_handle_update_urr()` with `ogs_pfcp_handle_create_urr()` and the encoder (two lines: swap `reptri_5`/`reptri_7`).

Found while implementing PFCP volume-threshold usage reporting on the SMF (Update URR re-arm path).
