### PR TITLE
[mme] Follow-up #4693: harden DNS-based gateway selection

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -127,8 +127,23 @@ mme:
 #    the SGW is selected by TAI-FQDN and the PGW by APN-FQDN via
 #    NAPTR -> SRV -> A / NAPTR -> A lookups. On any DNS failure the MME
 #    falls back to the static gtpc.client.sgwc/smf configuration above.
+#
+#    LIMITATION - ROAMING SUBSCRIBERS: the APN-FQDN is always built with
+#    the SERVING PLMN. For a roaming subscriber (IMSI PLMN differs from
+#    the serving PLMN) the home-PLMN APN-OI required to locate the home
+#    PGW over S8 (GSMA IR.88) is NOT derived yet. DNS-based PGW selection
+#    therefore only works for such subscribers if the serving operator
+#    provisions x-s8-gtp records for the APN in its own DNS zone;
+#    otherwise the MME falls back to the static PGW configuration.
+#    SGW selection (TAI-FQDN, serving PLMN) is unaffected.
+#
+#    Other limitations: A records only (no AAAA/IPv6 gateways), RFC 2782
+#    SRV weights ignored (priority-only), non-terminal NAPTR not followed,
+#    DNS-discovered SGW nodes are kept for the lifetime of the process.
 #  dns:
-#    server:
+#    server:                # bare IPv4/IPv6 literals only - no brackets,
+#                           # no %scope suffix (link-local resolvers are
+#                           # not supported)
 #      - address: 10.11.12.13
 #      - address: 10.11.12.14
 #        port: 53

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends: debhelper (>= 11),
                libnghttp2-dev,
                libtins-dev,
                libtalloc-dev,
+               libc-ares-dev,
 Standards-Version: 4.3.0
 Rules-Requires-Root: no
 Homepage: https://open5gs.org

--- a/docker/alpine/latest/base/Dockerfile
+++ b/docker/alpine/latest/base/Dockerfile
@@ -25,4 +25,5 @@ RUN apk update && \
         curl-dev \
         nghttp2-dev \
         talloc-dev \
+        c-ares-dev \
         iproute2

--- a/docker/debian/latest/base/Dockerfile
+++ b/docker/debian/latest/base/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
         libnghttp2-dev \
         libtins-dev \
         libtalloc-dev \
+        libc-ares-dev \
         iproute2 \
         ca-certificates \
         netbase \

--- a/docker/fedora/latest/base/Dockerfile
+++ b/docker/fedora/latest/base/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf -y install \
         libcurl-devel \
         libnghttp2-devel \
         libtalloc-devel \
+        c-ares-devel \
         iproute
 
 RUN dnf -y install meson

--- a/docker/ubuntu/latest/base/Dockerfile
+++ b/docker/ubuntu/latest/base/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
         libnghttp2-dev \
         libtins-dev \
         libtalloc-dev \
+        libc-ares-dev \
         iproute2 \
         ca-certificates \
         netbase \

--- a/docs/_docs/guide/02-building-open5gs-from-sources.md
+++ b/docs/_docs/guide/02-building-open5gs-from-sources.md
@@ -64,7 +64,7 @@ $ sudo ip link set ogstun up
 Install the common dependencies for building the source code.
 
 ```bash
-$ sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git cmake libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
+$ sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git cmake libsctp-dev libc-ares-dev libgnutls28-dev libgcrypt-dev libssl-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
 ```
 
 Install libidn-dev or libidn11-dev depending on your system

--- a/docs/_docs/platform/02-centos.md
+++ b/docs/_docs/platform/02-centos.md
@@ -115,7 +115,7 @@ a base CentOS Stream 8 installation.
 
 
 ```bash
-$ sudo dnf install python3 meson cmake ninja-build gcc gcc-c++ flex bison git cmake lksctp-tools-devel libidn-devel gnutls-devel libgcrypt-devel openssl-devel cyrus-sasl-devel libyaml-devel mongo-c-driver-devel libmicrohttpd-devel libcurl-devel libnghttp2-devel libtalloc-devel
+$ sudo dnf install python3 meson cmake ninja-build gcc gcc-c++ flex bison git cmake lksctp-tools-devel libidn-devel c-ares-devel gnutls-devel libgcrypt-devel openssl-devel cyrus-sasl-devel libyaml-devel mongo-c-driver-devel libmicrohttpd-devel libcurl-devel libnghttp2-devel libtalloc-devel
 ```
 
 ### Install iproute IP interface tools.

--- a/docs/_docs/platform/03-fedora.md
+++ b/docs/_docs/platform/03-fedora.md
@@ -76,7 +76,7 @@ $ ip link show
 
 Install the depedencies for building the source code.
 ```bash
-$ sudo dnf install python3 ninja-build gcc gcc-c++ flex bison git cmake lksctp-tools-devel libidn-devel gnutls-devel libgcrypt-devel openssl-devel cyrus-sasl-devel libyaml-devel mongo-c-driver-devel libmicrohttpd-devel libcurl-devel libnghttp2-devel libtalloc-devel iproute
+$ sudo dnf install python3 ninja-build gcc gcc-c++ flex bison git cmake lksctp-tools-devel libidn-devel c-ares-devel gnutls-devel libgcrypt-devel openssl-devel cyrus-sasl-devel libyaml-devel mongo-c-driver-devel libmicrohttpd-devel libcurl-devel libnghttp2-devel libtalloc-devel iproute
 ```
 
 Install Meson

--- a/docs/_docs/platform/05-macosx-apple-silicon.md
+++ b/docs/_docs/platform/05-macosx-apple-silicon.md
@@ -106,7 +106,7 @@ $ sudo pfctl -e -f /etc/pf.anchors/org.open5gs
 
 Install the depedencies for building the source code.
 ```bash
-$ brew install mongo-c-driver gnutls libgcrypt libidn libyaml libmicrohttpd nghttp2 pkg-config bison libusrsctp libtins talloc cmake
+$ brew install mongo-c-driver gnutls libgcrypt libidn c-ares libyaml libmicrohttpd nghttp2 pkg-config bison libusrsctp libtins talloc cmake
 ```
 
 Configure Homebrew PATH

--- a/docs/_docs/platform/06-macosx-intel.md
+++ b/docs/_docs/platform/06-macosx-intel.md
@@ -106,7 +106,7 @@ $ sudo pfctl -e -f /etc/pf.anchors/org.open5gs
 
 Install the depedencies for building the source code.
 ```bash
-$ brew install mongo-c-driver gnutls libgcrypt libidn libyaml libmicrohttpd nghttp2 pkg-config libusrsctp libtins talloc cmake
+$ brew install mongo-c-driver gnutls libgcrypt libidn c-ares libyaml libmicrohttpd nghttp2 pkg-config libusrsctp libtins talloc cmake
 ```
 
 Install Bison PATH

--- a/docs/_docs/platform/07-freebsd.md
+++ b/docs/_docs/platform/07-freebsd.md
@@ -148,7 +148,7 @@ This is important that you must reboot as shown below.
 
 Install the depedencies for building the source code.
 ```bash
-$ sudo pkg install meson cmake ninja gcc bison gsed pkgconf git cmake mongo-c-driver gnutls libgcrypt libidn libyaml libmicrohttpd nghttp2 talloc
+$ sudo pkg install meson cmake ninja gcc bison gsed pkgconf git cmake mongo-c-driver gnutls libgcrypt libidn c-ares libyaml libmicrohttpd nghttp2 talloc
 ```
 
 Configure gcc PATH

--- a/docs/_docs/platform/08-alpine.md
+++ b/docs/_docs/platform/08-alpine.md
@@ -59,7 +59,7 @@ $ ip link show
 
 Install the depedencies for building the source code.
 ```bash
-$ sudo apk add alpine-sdk bison flex git cmake meson bash sudo linux-headers bsd-compat-headers yaml-dev lksctp-tools-dev gnutls-dev libgcrypt-dev libidn-dev mongo-c-driver-dev libmicrohttpd-dev curl-dev nghttp2-dev talloc-dev
+$ sudo apk add alpine-sdk bison flex git cmake meson bash sudo linux-headers bsd-compat-headers yaml-dev lksctp-tools-dev gnutls-dev libgcrypt-dev libidn-dev c-ares-dev mongo-c-driver-dev libmicrohttpd-dev curl-dev nghttp2-dev talloc-dev
 ```
 
 Git clone.

--- a/docs/_pages/oss-notice.md
+++ b/docs/_pages/oss-notice.md
@@ -106,6 +106,11 @@ If you have any questions or concerns, please contact us at <a href="mailto:acet
 - Copyright (C) Andrew Tridgell 2004-2005, Stefan Metzmacher 2006
 - LICENSE: [LGPL-2.1-or-later](https://www.gnu.org/licenses/lgpl-3.0.html)
 
+##### c-ares
+- [https://c-ares.org/](https://c-ares.org/)
+- Copyright (c) The c-ares project and its contributors
+- LICENSE: [MIT](https://opensource.org/licenses/MIT)
+
 ##### usrsctp
 - [https://github.com/sctplab/usrsctp](https://github.com/sctplab/usrsctp)
 - Copyright (c) 2015, Randall Stewart and Michael Tuexen

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -4729,6 +4729,10 @@ mme_sess_t *mme_sess_add(mme_ue_t *mme_ue, uint8_t pti)
 
     sess->mme_ue_id = mme_ue->id;
     sess->pti = pti;
+    /* Explicit for clarity: OGS_INVALID_POOL_ID happens to be 0, so the
+     * pool calloc already guarantees this, but the DNS selection code
+     * depends on it and must not break if the constant ever changes. */
+    sess->dns_id = OGS_INVALID_POOL_ID;
 
     bearer = mme_bearer_add(sess);
     ogs_assert(bearer);

--- a/src/mme/mme-dns-select.c
+++ b/src/mme/mme-dns-select.c
@@ -254,7 +254,7 @@ int mme_dns_candidates_from_naptr(
     return num_cand;
 }
 
-void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
+bool mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
         const mme_dns_srv_record_t *recs, int num_recs)
 {
     const mme_dns_srv_record_t *best = NULL;
@@ -263,7 +263,7 @@ void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
     ogs_assert(cand);
 
     if (!recs || num_recs <= 0)
-        return;
+        return false;
 
     for (i = 0; i < num_recs; i++) {
         if (!recs[i].target[0] || strcmp(recs[i].target, ".") == 0)
@@ -273,9 +273,11 @@ void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
     }
 
     if (!best)
-        return;
+        return false;
 
     ogs_cpystrn(cand->fqdn, best->target, sizeof(cand->fqdn));
     cand->port = best->port;
     cand->needs_srv = false;
+
+    return true;
 }

--- a/src/mme/mme-dns-select.h
+++ b/src/mme/mme-dns-select.h
@@ -133,10 +133,14 @@ int mme_dns_candidates_from_naptr(
 
 /*
  * Resolve an "s"-flagged candidate's target name from its SRV answer:
- * pick the lowest-priority record (RFC 2782 weight is ignored).
- * Clears needs_srv.
+ * pick the lowest-priority record (RFC 2782 weight is ignored) and
+ * clear needs_srv. Returns false - leaving the candidate untouched,
+ * needs_srv still set - when the answer contains no usable target
+ * (every record has an empty target or "." = service not available,
+ * RFC 2782); the caller MUST then skip this candidate instead of
+ * retrying it.
  */
-void mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
+bool mme_dns_candidate_apply_srv(mme_dns_candidate_t *cand,
         const mme_dns_srv_record_t *recs, int num_recs);
 
 #ifdef __cplusplus

--- a/src/mme/mme-dns.c
+++ b/src/mme/mme-dns.c
@@ -27,6 +27,19 @@
  * keep FSM discipline.
  */
 
+/*
+ * c-ares >= 1.28 deprecates the legacy ares_query() /
+ * ares_parse_{naptr,srv,a}_reply() API in favor of
+ * ares_query_dnsrec() / ares_dns_parse(), which breaks the build under
+ * -Werror. We deliberately stay on the legacy API so the MME still
+ * builds against the c-ares shipped by current LTS distributions
+ * (e.g. Ubuntu 22.04 / Debian 12: 1.18). CARES_NO_DEPRECATED is the
+ * official c-ares switch to drop the deprecation attributes; it is a
+ * no-op on < 1.28. Migrating to the ares_dns_record API (which would
+ * also give us real NAPTR/SRV TTLs instead of the cache_ttl fallback)
+ * is left for when the minimum c-ares version can be raised.
+ */
+#define CARES_NO_DEPRECATED
 #include <ares.h>
 
 #include "mme-dns.h"
@@ -44,6 +57,15 @@
 #define MME_DNS_MAX_RR      8
 #define MME_DNS_MAX_CSR_ATTEMPTS 3
 #define MME_DNS_NEGATIVE_TTL     5  /* seconds, capped by dns.cache_ttl */
+
+/*
+ * Upper bound on cached entries. Expired entries are otherwise reclaimed
+ * only when the same key is read again, so without a cap a deployment
+ * with many TACs/APNs and short TTLs would accumulate dead entries
+ * indefinitely. When the cap is reached, expired entries are swept;
+ * if the cache is still full, the entries closest to expiry are evicted.
+ */
+#define MME_DNS_CACHE_MAX_ENTRIES 4096
 
 static int negative_ttl(void)
 {
@@ -88,6 +110,18 @@ typedef struct mme_dns_resolution_s {
     mme_dns_proto_e proto;
     mme_dns_leg_t sgw;
     mme_dns_leg_t pgw;
+
+    /*
+     * The SGW the UE was on when this resolution was created — the
+     * restore target if DNS selection ends in fallback AFTER the UE
+     * was already switched to a DNS-discovered SGW. On initial attach
+     * this is the statically selected SGW; for an additional PDN it
+     * may itself be a DNS-discovered node (which is then where the
+     * UE's S11 lives, i.e. still the right restore target). Any node
+     * stored here was successfully connected and is never removed
+     * afterwards, so the pointer stays valid.
+     */
+    mme_sgw_t *fallback_sgw;
 
     int csr_attempts;
 } mme_dns_resolution_t;
@@ -235,6 +269,40 @@ static mme_dns_cache_entry_t *cache_get(int qtype, const char *fqdn)
     return entry;
 }
 
+/* Sweep expired entries; if the cache is still at capacity, evict the
+ * entries closest to expiry until one slot is free. Runs on the MME
+ * main thread only. */
+static void cache_make_room(void)
+{
+    ogs_hash_index_t *hi = NULL;
+    mme_dns_cache_entry_t *entry = NULL, *victim = NULL;
+    ogs_time_t now = ogs_time_now();
+
+    if (ogs_hash_count(g_cache) < MME_DNS_CACHE_MAX_ENTRIES)
+        return;
+
+    for (hi = ogs_hash_first(g_cache); hi; hi = ogs_hash_next(hi)) {
+        entry = ogs_hash_this_val(hi);
+        if (entry->expire < now) {
+            ogs_hash_set(g_cache, entry->key, OGS_HASH_KEY_STRING, NULL);
+            ogs_free(entry);
+        }
+    }
+
+    while (ogs_hash_count(g_cache) >= MME_DNS_CACHE_MAX_ENTRIES) {
+        victim = NULL;
+        for (hi = ogs_hash_first(g_cache); hi; hi = ogs_hash_next(hi)) {
+            entry = ogs_hash_this_val(hi);
+            if (!victim || entry->expire < victim->expire)
+                victim = entry;
+        }
+        if (!victim)
+            break;
+        ogs_hash_set(g_cache, victim->key, OGS_HASH_KEY_STRING, NULL);
+        ogs_free(victim);
+    }
+}
+
 static mme_dns_cache_entry_t *cache_put(
         int qtype, const char *fqdn, int ttl_sec)
 {
@@ -243,9 +311,17 @@ static mme_dns_cache_entry_t *cache_put(
     entry = ogs_calloc(1, sizeof(*entry));
     ogs_assert(entry);
     ogs_snprintf(entry->key, sizeof(entry->key), "%d:%s", qtype, fqdn);
+
+    /* Only a genuinely new key needs a free slot: updating an existing
+     * key replaces it in place, and calling cache_make_room() in that
+     * case would evict one unrelated entry per refresh once the cache
+     * is at capacity. */
+    old = ogs_hash_get(g_cache, entry->key, OGS_HASH_KEY_STRING);
+    if (!old)
+        cache_make_room();
+
     entry->expire = ogs_time_now() + ogs_time_from_sec(ttl_sec);
 
-    old = ogs_hash_get(g_cache, entry->key, OGS_HASH_KEY_STRING);
     if (old) {
         ogs_hash_set(g_cache, old->key, OGS_HASH_KEY_STRING, NULL);
         ogs_free(old);
@@ -320,10 +396,33 @@ static void post_resolved(mme_dns_resolution_t *res)
     e->enb_ue_id = res->enb_ue_id;
     e->create_action = res->create_action;
 
-    rv = ogs_queue_push(ogs_app()->queue, e);
+    /*
+     * post_resolved() runs on the MME main loop - the same thread
+     * that drains the event queue. ogs_queue_push() would block
+     * indefinitely on a full queue, and since the only consumer is
+     * the thread doing the pushing, that is a self-deadlock. Use the
+     * non-blocking trypush and recover via the guard timer instead.
+     */
+    rv = ogs_queue_trypush(ogs_app()->queue, e);
     if (rv != OGS_OK) {
-        ogs_error("mme-dns: ogs_queue_push() failed:%d", (int)rv);
+        ogs_error("mme-dns: ogs_queue_trypush() failed:%d", (int)rv);
         mme_event_free(e);
+        if (rv == OGS_RETRY && !g_closing) {
+            /*
+             * The queue is temporarily full. Without the event the
+             * deferred CSR would never be sent and the attach would
+             * stall until the NAS timers give up. Return to PENDING
+             * and restart the guard timer: the legs are already
+             * done, so when it fires check_completion() simply
+             * posts the completed result again. OGS_DONE means the
+             * queue was terminated (shutdown) - no retry then.
+             */
+            res->state = MME_DNS_ST_PENDING;
+            if (res->t_guard)
+                ogs_timer_start(res->t_guard,
+                        ogs_time_from_msec(
+                            mme_self()->dns.guard_timeout));
+        }
         return;
     }
     ogs_pollset_notify(ogs_app()->pollset);
@@ -594,8 +693,15 @@ static void leg_advance(mme_dns_resolution_t *res, mme_dns_leg_t *leg)
                 leg->cursor++;
                 continue;
             }
-            mme_dns_candidate_apply_srv(&leg->cand[leg->cursor],
-                    entry->u.srv, entry->num);
+            if (!mme_dns_candidate_apply_srv(&leg->cand[leg->cursor],
+                    entry->u.srv, entry->num)) {
+                /* The answer had records but no usable target (e.g. all
+                 * targets are "." = service not available, RFC 2782).
+                 * The candidate is untouched: skip it, or this loop
+                 * would re-read the same cache entry forever and hang
+                 * the MME event loop. */
+                leg->cursor++;
+            }
             continue;
         }
 
@@ -642,6 +748,32 @@ static mme_dns_candidate_t *leg_result(mme_dns_leg_t *leg)
     return &leg->cand[leg->cursor];
 }
 
+/* Switch the UE back to the SGW it was on before this resolution
+ * switched it away (no-op when it never moved). Needed on every
+ * apply_sgw() path that gives up: after a previous pass already moved
+ * the UE to a DNS-discovered SGW, doing nothing would re-send the CSR
+ * to that (possibly dead) node instead of the intended fallback. */
+static void restore_fallback_sgw(mme_dns_resolution_t *res,
+        mme_sess_t *sess)
+{
+    mme_ue_t *mme_ue = NULL;
+    sgw_ue_t *sgw_ue = NULL;
+
+    if (!res->fallback_sgw)
+        return;
+
+    mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+    if (!mme_ue)
+        return;
+    sgw_ue = sgw_ue_find_by_id(mme_ue->sgw_ue_id);
+    if (!sgw_ue || sgw_ue->sgw == res->fallback_sgw)
+        return;
+
+    ogs_warn("mme-dns: restoring the SGW selected before "
+            "DNS-based selection");
+    sgw_ue_switch_to_sgw(sgw_ue, res->fallback_sgw);
+}
+
 static void apply_sgw(mme_dns_resolution_t *res, mme_sess_t *sess)
 {
     mme_dns_candidate_t *cand = NULL;
@@ -652,8 +784,20 @@ static void apply_sgw(mme_dns_resolution_t *res, mme_sess_t *sess)
     int rv;
 
     cand = leg_result(&res->sgw);
-    if (!cand)
+    if (!cand) {
+        /*
+         * SGW leg produced no usable candidate (fallback). Normally
+         * the UE is still on the SGW it started with and this is a
+         * no-op - but if a previous pass of this resolution already
+         * switched the UE to a DNS-discovered SGW (which then timed
+         * out, and the retry candidate failed to resolve), restore
+         * the original SGW so "DNS failure never blocks the attach"
+         * holds on this path too.
+         */
+        if (res->sgw.active && res->sgw.fallback)
+            restore_fallback_sgw(res, sess);
         return;
+    }
 
     mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
     if (!mme_ue)
@@ -672,9 +816,13 @@ static void apply_sgw(mme_dns_resolution_t *res, mme_sess_t *sess)
 
         sgw = mme_sgw_add(addr);
         if (!sgw) {
+            /* Unreachable today (mme_sgw_add() asserts on pool
+             * exhaustion), kept defensively should it ever return
+             * NULL gracefully */
             ogs_error("mme-dns: mme_sgw_add() failed, "
-                    "using statically selected SGW");
+                    "using the previously selected SGW");
             ogs_free(addr);
+            restore_fallback_sgw(res, sess);
             return;
         }
         sgw->dns_origin = true;
@@ -684,9 +832,10 @@ static void apply_sgw(mme_dns_resolution_t *res, mme_sess_t *sess)
                 &sgw->gnode);
         if (rv != OGS_OK) {
             ogs_error("mme-dns: ogs_gtp_connect() to [%s] failed, "
-                    "using statically selected SGW",
+                    "using the previously selected SGW",
                     OGS_ADDR(&cand->addr, buf));
             mme_sgw_remove(sgw);
+            restore_fallback_sgw(res, sess);
             return;
         }
     }
@@ -762,6 +911,16 @@ int mme_dns_prepare(enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
     res->sess_id = sess->id;
     res->enb_ue_id = enb_ue ? enb_ue->id : OGS_INVALID_POOL_ID;
     res->create_action = create_action;
+
+    /* Remember the SGW currently serving the UE so a later fallback
+     * can restore it even after apply_sgw() switched the UE away */
+    {
+        mme_ue_t *mme_ue = mme_ue_find_by_id(sess->mme_ue_id);
+        sgw_ue_t *sgw_ue = mme_ue ?
+            sgw_ue_find_by_id(mme_ue->sgw_ue_id) : NULL;
+        if (sgw_ue)
+            res->fallback_sgw = sgw_ue->sgw;
+    }
     res->state = MME_DNS_ST_PENDING;
     res->csr_attempts = 0;
 
@@ -780,7 +939,14 @@ int mme_dns_prepare(enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
     }
 
     /* PGW leg: skipped when the HSS provided a PGW address
-     * (MIP6-Agent-Info), which always takes precedence. */
+     * (MIP6-Agent-Info), which always takes precedence.
+     *
+     * LIMITATION: the APN-FQDN is built with the SERVING PLMN
+     * (mme_ue->tai.plmn_id). For roaming subscribers the home-PLMN
+     * APN-OI (TS 23.003 9.1.1, needs an IMSI MNC-length table) is not
+     * derived, so locating the home PGW over S8 per GSMA IR.88 only
+     * works if the serving operator provisions x-s8-gtp records for
+     * the APN in its own zone. See configs/open5gs/mme.yaml.in. */
     if (!sess->session->smf_ip.ipv4 && !sess->session->smf_ip.ipv6) {
         res->pgw.svc = MME_DNS_SVC_PGW;
         if (mme_dns_build_apn_fqdn(res->pgw.fqdn, sizeof(res->pgw.fqdn),
@@ -832,12 +998,34 @@ void mme_dns_handle_resolved(mme_event_t *e)
 
     apply_sgw(res, sess);
 
-    res->state = MME_DNS_ST_CONSUMED;
-    res->csr_attempts++;
-
     rv = mme_gtp_send_create_session_request_now(
             enb_ue, sess, res->create_action);
-    ogs_expect(rv == OGS_OK);
+    if (rv != OGS_OK) {
+        /*
+         * The deferred CSR could not be built or committed - nothing
+         * was sent. Undo any SGW switch apply_sgw() performed (no-op
+         * if the UE never moved), or the UE would stay anchored to
+         * the DNS SGW while the resolution - and with it the
+         * fallback_sgw anchor - is discarded, and the next NAS retry
+         * would capture the DNS SGW as its fallback. Then clear the
+         * resolution so that retry starts a fresh selection instead
+         * of finding a stale CONSUMED resolution and
+         * short-circuiting to SEND_NOW.
+         */
+        ogs_error("mme-dns: failed to send deferred "
+                "Create Session Request");
+        restore_fallback_sgw(res, sess);
+        mme_dns_sess_clear(sess);
+        return;
+    }
+
+    /* Only after the CSR transaction was successfully committed
+     * (ogs_gtp_xact_commit() swallows sendto failures, so this is a
+     * build+commit guarantee, not a wire guarantee): the GTP-timeout
+     * retry hook keys on CONSUMED, which is meaningless if no
+     * transaction exists */
+    res->state = MME_DNS_ST_CONSUMED;
+    res->csr_attempts++;
 }
 
 static bool retry_leg(mme_sess_t *sess, mme_dns_leg_t *leg)
@@ -916,7 +1104,7 @@ int mme_dns_open(void)
 {
     int i, rc, optmask = 0;
     struct ares_options opt;
-    char csv[MME_DNS_MAX_SERVER * (OGS_ADDRSTRLEN + 8)];
+    char csv[MME_DNS_MAX_SERVER * (OGS_ADDRSTRLEN + 8)] = "";
     size_t used = 0;
 
     if (!mme_self()->dns.enabled)
@@ -926,6 +1114,58 @@ int mme_dns_open(void)
         ogs_error("mme-dns: no IPv4 GTP-C socket; DNS-based selection "
                 "supports A records only and cannot be enabled");
         return OGS_ERROR;
+    }
+
+    /*
+     * Validate the resolver addresses and build the c-ares server CSV
+     * BEFORE any c-ares initialization, so a configuration error can
+     * simply return without having to unwind the channel/library.
+     *
+     * Each address must be a bare IPv4/IPv6 literal:
+     * - inet_pton() rejects hostnames, %scope suffixes, brackets and
+     *   any other malformed input, which also enforces the <= 45 char
+     *   premise of the fixed CSV buffer below (ogs_snprintf() returns
+     *   the WOULD-BE length on truncation, so an unbounded string
+     *   could otherwise push `used` past the buffer)
+     * - bare link-local IPv6 (fe80::/10) is rejected too: c-ares
+     *   would need the "[fe80::1]:53%eth0" form - scope after the
+     *   port, outside the brackets - plus a dynamically sized CSV,
+     *   and link-local resolvers are not worth that complexity for
+     *   an MME
+     *
+     * c-ares CSV requires an IPv6 address with a port to be
+     * bracketed: "[2001:db8::53]:53". Unbracketed, the whole string -
+     * "2001:db8::53:53" - happens to parse as a VALID IPv6 address
+     * with the default port, so the MME would silently query the
+     * wrong server (verified on c-ares 1.34.5). The resolver's
+     * address family is independent of the A-records-only gateway
+     * limitation.
+     */
+    for (i = 0; i < mme_self()->dns.num_of_server; i++) {
+        const char *address = mme_self()->dns.server[i].address;
+        struct in_addr addr4;
+        struct in6_addr addr6;
+        bool is_ipv6 = false;
+
+        if (inet_pton(AF_INET, address, &addr4) == 1) {
+            is_ipv6 = false;
+        } else if (inet_pton(AF_INET6, address, &addr6) == 1) {
+            if (IN6_IS_ADDR_LINKLOCAL(&addr6)) {
+                ogs_error("mme-dns: link-local DNS resolver [%s] "
+                        "is not supported", address);
+                return OGS_ERROR;
+            }
+            is_ipv6 = true;
+        } else {
+            ogs_error("mme-dns: dns.server address [%s] must be a "
+                    "bare IPv4 or IPv6 literal", address);
+            return OGS_ERROR;
+        }
+
+        used += ogs_snprintf(csv + used, sizeof(csv) - used,
+                is_ipv6 ? "%s[%s]:%d" : "%s%s:%d",
+                i ? "," : "", address,
+                mme_self()->dns.server[i].port);
     }
 
     rc = ares_library_init(ARES_LIB_INIT_ALL);
@@ -943,6 +1183,19 @@ int mme_dns_open(void)
     optmask |= ARES_OPT_FLAGS;
     opt.sock_state_cb = dns_sock_state_cb;
     optmask |= ARES_OPT_SOCK_STATE_CB;
+#ifdef ARES_OPT_QUERY_CACHE
+    /*
+     * c-ares >= 1.31 enables an internal query cache by default (keyed
+     * by the wire TTL, up to 1 hour). The MME maintains its own cache
+     * honoring the operator-configured dns.cache_ttl and the negative
+     * TTL; with the c-ares cache active, entries the MME expired on
+     * purpose would still be answered internally without touching the
+     * wire, silently overriding cache_ttl (and breaking the e2e tests,
+     * which count queries on a stub server). Disable it - 0 = off.
+     */
+    opt.qcache_max_ttl = 0;
+    optmask |= ARES_OPT_QUERY_CACHE;
+#endif
 
     rc = ares_init_options(&g_channel, &opt, optmask);
     if (rc != ARES_SUCCESS) {
@@ -951,13 +1204,6 @@ int mme_dns_open(void)
         return OGS_ERROR;
     }
 
-    csv[0] = 0;
-    for (i = 0; i < mme_self()->dns.num_of_server; i++) {
-        used += ogs_snprintf(csv + used, sizeof(csv) - used, "%s%s:%d",
-                i ? "," : "",
-                mme_self()->dns.server[i].address,
-                mme_self()->dns.server[i].port);
-    }
     rc = ares_set_servers_ports_csv(g_channel, csv);
     if (rc != ARES_SUCCESS) {
         ogs_error("ares_set_servers_ports_csv(%s) failed: %s",

--- a/src/mme/mme-gtp-path.c
+++ b/src/mme/mme-gtp-path.c
@@ -266,6 +266,13 @@ void mme_gtp_close(void)
     ogs_socknode_remove_all(&ogs_gtp_self()->gtpc_list6);
 }
 
+/*
+ * NOTE: OGS_OK does not guarantee that the CSR has been sent.
+ * With DNS-based selection enabled the request may be deferred until
+ * MME_EVENT_DNS_RESOLVED; callers asserting on OGS_OK (e.g. inside
+ * ogs_assert(OGS_OK == ...)) rely on this and MUST NOT expect a GTP
+ * transaction to exist on return.
+ */
 int mme_gtp_send_create_session_request(
         enb_ue_t *enb_ue, mme_sess_t *sess, int create_action)
 {

--- a/src/mme/mme-gtp-path.h
+++ b/src/mme/mme-gtp-path.h
@@ -29,6 +29,8 @@ extern "C" {
 int mme_gtp_open(void);
 void mme_gtp_close(void);
 
+/* OGS_OK may mean the CSR was deferred until MME_EVENT_DNS_RESOLVED
+ * (DNS-based selection); no GTP transaction is guaranteed on return. */
 int mme_gtp_send_create_session_request(
         enb_ue_t *enb_ue, mme_sess_t *sess, int create_action);
 /* Bypasses DNS-based gateway selection (used once selection is done) */

--- a/tests/dns/dns-server.c
+++ b/tests/dns/dns-server.c
@@ -75,6 +75,14 @@ static int put_name(uint8_t *buf, int off, const char *name)
 {
     const char *p = name;
 
+    /* Root name "." encodes as a single null label (RFC 1035 3.1);
+     * needed to serve SRV records with target "." = service not
+     * available (RFC 2782) */
+    if (name[0] == '.' && name[1] == 0) {
+        buf[off++] = 0;
+        return off;
+    }
+
     while (*p) {
         const char *dot = strchr(p, '.');
         size_t l = dot ? (size_t)(dot - p) : strlen(p);

--- a/tests/dns/dns-test.c
+++ b/tests/dns/dns-test.c
@@ -49,6 +49,22 @@ static const test_dns_record_t good_records[] = {
     { .qname = PGW_NAME, .qtype = TEST_DNS_T_A, .ipv4 = "127.0.0.4" },
 };
 
+/*
+ * Regression records for the SRV "no usable target" case: the SGW
+ * NAPTR (flag "s") points at an SRV whose only record has target "."
+ * (service not available, RFC 2782). The MME must skip the candidate
+ * and fall back - a broken MME re-reads the same cache entry forever
+ * and the whole event loop hangs, so this test failing by TIMEOUT is
+ * the regression signature. No PGW records: that leg falls back too.
+ */
+static const test_dns_record_t srv_dot_records[] = {
+    { .qname = TAI_FQDN, .qtype = TEST_DNS_T_NAPTR,
+      .order = 10, .preference = 10, .flags = "s",
+      .service = "x-3gpp-sgw:x-s5-gtp", .replacement = SRV_NAME },
+    { .qname = SRV_NAME, .qtype = TEST_DNS_T_SRV,
+      .priority = 10, .weight = 0, .port = 0, .target = "." },
+};
+
 static void attach_and_detach(abts_case *tc, const char *scheme_output)
 {
     int rv;
@@ -320,6 +336,27 @@ static void test3_timeout_fallback(abts_case *tc, void *data)
     ABTS_TRUE(tc, test_dns_server_num_queries(NULL) >= 1);
 }
 
+/* SRV answer whose only record has target ".": the MME must skip the
+ * candidate and fall back to the static configuration. A regressed MME
+ * hangs its event loop re-reading the same SRV cache entry, so this
+ * test failing by TIMEOUT (no S1AP progress) is the regression
+ * signature. */
+static void test4_srv_dot_fallback(abts_case *tc, void *data)
+{
+    /* Let the (negative) cache entries of the previous case expire */
+    ogs_msleep(1200);
+
+    test_dns_server_set_records(
+            srv_dot_records, OGS_ARRAY_SIZE(srv_dot_records));
+    test_dns_server_reset_counters();
+
+    attach_and_detach(tc, "3746000063");
+
+    /* The chain must have been followed up to the unusable SRV */
+    ABTS_TRUE(tc, test_dns_server_num_queries("tac-lb01.tac-hb00") >= 1);
+    ABTS_TRUE(tc, test_dns_server_num_queries("_gtp._udp") >= 1);
+}
+
 abts_suite *test_dns_select(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -327,6 +364,7 @@ abts_suite *test_dns_select(abts_suite *suite)
     abts_run_test(suite, test1_dns_selection, NULL);
     abts_run_test(suite, test2_empty_fallback, NULL);
     abts_run_test(suite, test3_timeout_fallback, NULL);
+    abts_run_test(suite, test4_srv_dot_fallback, NULL);
 
     return suite;
 }

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -27,7 +27,6 @@ testunit_unit_sources = files('''
     nrf-discovery-test.c
     crash-test.c
     mme-dns-select-test.c
-    ../../src/mme/mme-dns-select.c
 '''.split())
 
 testunit_unit_exe = executable('unit',
@@ -38,6 +37,7 @@ testunit_unit_exe = executable('unit',
                     libgtp_dep,
                     libngap_dep,
                     libnas_eps_dep,
-                    libsbi_dep])
+                    libsbi_dep,
+                    libmme_dep])
 
 test('unit', testunit_unit_exe, is_parallel : false, suite: 'unit')

--- a/tests/unit/mme-dns-select-test.c
+++ b/tests/unit/mme-dns-select-test.c
@@ -237,16 +237,33 @@ static void dns_select_test_srv(abts_case *tc, void *data)
     srv[2].priority = 10; srv[2].weight = 200; /* weight ignored */
     strcpy(srv[2].target, "host-c.example.org");
 
-    mme_dns_candidate_apply_srv(&cand, srv, 3);
+    ABTS_TRUE(tc, mme_dns_candidate_apply_srv(&cand, srv, 3));
     ABTS_STR_EQUAL(tc, "host-a.example.org", cand.fqdn);
     ABTS_INT_EQUAL(tc, 2123, cand.port);
     ABTS_TRUE(tc, !cand.needs_srv);
 
-    /* Empty SRV set leaves the candidate untouched */
+    /* Empty SRV set: returns false, candidate untouched */
     memset(&cand, 0, sizeof(cand));
     strcpy(cand.fqdn, "unchanged");
     cand.needs_srv = true;
-    mme_dns_candidate_apply_srv(&cand, NULL, 0);
+    ABTS_TRUE(tc, !mme_dns_candidate_apply_srv(&cand, NULL, 0));
+    ABTS_STR_EQUAL(tc, "unchanged", cand.fqdn);
+    ABTS_TRUE(tc, cand.needs_srv);
+
+    /* SRV records with no usable target ("." = service not available,
+     * RFC 2782): returns false so the caller knows it must SKIP this
+     * candidate - retrying it would loop forever (see leg_advance in
+     * mme-dns.c) */
+    memset(&cand, 0, sizeof(cand));
+    strcpy(cand.fqdn, "unchanged");
+    cand.needs_srv = true;
+    {
+        mme_dns_srv_record_t dot[2];
+        memset(dot, 0, sizeof(dot));
+        dot[0].priority = 10; strcpy(dot[0].target, ".");
+        dot[1].priority = 20; /* empty target */
+        ABTS_TRUE(tc, !mme_dns_candidate_apply_srv(&cand, dot, 2));
+    }
     ABTS_STR_EQUAL(tc, "unchanged", cand.fqdn);
     ABTS_TRUE(tc, cand.needs_srv);
 }


### PR DESCRIPTION
Follow up the DNS-based SGW/PGW selection introduced by #4693 and harden several fallback, asynchronous completion, cache, resolver, and compatibility paths found during review and testing.

A DNS failure must never prevent an attach when a statically configured gateway remains available. Preserve the SGW serving the UE when a DNS resolution is created and restore it whenever a later DNS-based SGW selection cannot complete.

This is required because a previous Create Session Request attempt may already have switched the UE to a DNS-discovered SGW. If that request times out and the next DNS candidate cannot be resolved, simply returning from apply_sgw() leaves the UE attached to the failed DNS SGW and causes subsequent CSR attempts to continue using it instead of the original fallback SGW.

Restore the pre-DNS SGW when:

* the SGW DNS leg ends in fallback after an earlier SGW switch
* mme_sgw_add() cannot create the selected SGW node
* ogs_gtp_connect() cannot connect the selected SGW
* the deferred Create Session Request cannot be built or committed

The fallback pointer records the SGW currently serving the UE when the resolution is created rather than assuming it is always statically configured. Successfully connected SGW nodes are retained for the process lifetime, so the stored pointer remains valid.

The PGW path does not require the same state restoration. When PGW DNS selection falls back, mme_dns_sess_pgw_addr() returns NULL and the S11 Create Session Request builder selects the statically configured PGW again on each attempt.

Harden deferred CSR completion handling.

post_resolved() runs on the MME main thread, which is also responsible for draining the application event queue. ogs_queue_push() can block indefinitely when that queue is full, causing a self-deadlock because the blocked producer is also the only consumer.

Use ogs_queue_trypush() instead. When it returns OGS_RETRY, return the resolution to PENDING and restart its guard timer. The DNS legs are already complete, so the guard callback simply attempts to post the completed result again. Do not retry when the queue has been terminated during shutdown.

Do not move a resolution to CONSUMED or increment csr_attempts until the deferred CSR transaction has been successfully built and committed. The GTP timeout retry path uses CONSUMED as its eligibility condition, so marking an unsent request as consumed leaves meaningless retry state.

If local CSR creation fails, restore the pre-DNS SGW first and then remove the resolution. This prevents a subsequent NAS retry from capturing the failed DNS SGW as its new fallback and prevents a stale CONSUMED resolution from incorrectly short-circuiting the new request to SEND_NOW.

Document that OGS_OK from mme_gtp_send_create_session_request() may mean that the request was deferred for DNS selection and does not guarantee that a GTP transaction exists when the function returns.

Fix an MME event-loop hang caused by unusable SRV answers.

An SRV record whose target is "." indicates that the service is not available. mme_dns_candidate_apply_srv() previously left the candidate unchanged in this case. leg_advance() then repeatedly read the same cached SRV answer without advancing the candidate cursor, hanging the MME event loop.

Make mme_dns_candidate_apply_srv() return whether it found a usable target. Skip the candidate when all SRV targets are empty or ".", while leaving the candidate unchanged for callers that need to inspect the failure.

Add unit and DNS integration coverage for this case. Extend the test DNS server to encode "." as the DNS root label and verify that the MME skips the unusable SRV candidate and falls back instead of hanging.

Bound the MME DNS cache to prevent expired entries from accumulating indefinitely across many TAC and APN names.

When inserting a new key at capacity:

* remove expired entries
* if the cache remains full, evict entries closest to expiry
* do not make room when replacing an existing key, which would otherwise evict an unrelated entry on every refresh at capacity

Disable the c-ares internal query cache when the installed c-ares version provides ARES_OPT_QUERY_CACHE. c-ares 1.31 and later enable an internal cache by default, which can continue answering a query after the MME's own cache entry has expired and silently override the operator-configured dns.cache_ttl. Set qcache_max_ttl to zero so the MME cache remains authoritative.

Retain compatibility with both older distribution versions of c-ares and newer releases that deprecate the legacy query and reply parsing APIs. Define CARES_NO_DEPRECATED before including ares.h to suppress the newer deprecation attributes without raising the minimum supported c-ares version.

Validate configured resolver addresses before initializing c-ares.

Require each dns.server address to be a bare IPv4 or IPv6 literal. Reject hostnames, malformed addresses, bracketed addresses, scope suffixes, and IPv6 link-local addresses, which require interface scope handling that is not supported by the MME configuration.

Format resolver entries as:

* IPv4: address:port
* IPv6: [address]:port

The brackets are required by the c-ares server CSV format. Without them, a value such as 2001:db8::53:53 is accepted as a different valid IPv6 address using the default DNS port, causing queries to be sent silently to the wrong resolver.

Build and validate the server CSV before c-ares initialization so configuration failures do not require partially initialized channel or library cleanup. The fixed CSV buffer remains safe because inet_pton() guarantees that accepted addresses fit the maximum IPv4 or IPv6 literal length.

Explicitly initialize mme_sess_t::dns_id to OGS_INVALID_POOL_ID instead of relying on the current value of the pool allocator's zero-filled memory.

Update the sample configuration and documentation to describe the current DNS-selection limitations:

* roaming PGW lookup currently builds the APN-FQDN from the serving PLMN rather than deriving the home-PLMN APN-OI
* only A records are used for discovered gateways
* SRV weights are ignored
* non-terminal NAPTR records are not followed
* DNS-discovered SGW nodes are retained for the process lifetime
* resolver addresses must be bare IPv4 or IPv6 literals
* link-local IPv6 resolvers are not supported

Add the c-ares development dependency to Debian, Ubuntu, Fedora, Alpine, CentOS, macOS, and FreeBSD build instructions and container images, and add the c-ares MIT license notice.

Also link the DNS selection unit tests against libmme directly so they exercise the same mme-dns-select implementation built for the MME.