### PR TITLE
configs/open5gs/pcrf: comment: db_uri is optional

### DIFF
--- a/configs/open5gs/pcrf.yaml.in
+++ b/configs/open5gs/pcrf.yaml.in
@@ -1,3 +1,4 @@
+# Remove the db_uri line to run without mongodb
 db_uri: mongodb://localhost/open5gs
 logger:
   file:


### PR DESCRIPTION
Currently it is not obvious that db_uri can be removed, except when reading the code. Add a comment on top of the line that users may remove it to run open5gs-pcrfd without mongodb.