### PR TITLE
MME: Learn HSS identity from successful S6a answers

### DIFF
--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -323,6 +323,9 @@ mme:
 #    o realm and host are optional
 #    o realm will be generated from plmn_id if not provided
 #    o host will not be used if not provided
+#    o If no hss_map entry matches, the MME learns Origin-Host/Origin-Realm
+#      from successful S6a answers and uses them as Destination-Host/Realm
+#      in subsequent requests
 #  hss_map:
 #    - plmn_id:
 #        mcc: 001

--- a/lib/diameter/s6a/message.h
+++ b/lib/diameter/s6a/message.h
@@ -237,6 +237,14 @@ typedef struct ogs_diam_s6a_message_s {
     uint32_t                        *err;
     uint32_t                        *exp_err;
 
+    /* Origin-Host/Origin-Realm copied by the freeDiameter callback and
+     * consumed by the MME event thread. DiameterIdentity is limited to
+     * 255 octets; OGS_MAX_FQDN_LEN provides enough storage. */
+    uint8_t                         origin_host[OGS_MAX_FQDN_LEN];
+    uint16_t                        origin_host_len;
+    uint8_t                         origin_realm[OGS_MAX_FQDN_LEN];
+    uint16_t                        origin_realm_len;
+
     ogs_diam_s6a_idr_message_t      idr_message;
     ogs_diam_s6a_clr_message_t      clr_message;
     ogs_diam_s6a_aia_message_t      aia_message;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3224,6 +3224,82 @@ mme_hssmap_t *mme_hssmap_find_by_imsi_bcd(const char *imsi_bcd)
     return NULL;
 }
 
+void mme_ue_set_hss_identity(mme_ue_t *mme_ue,
+        const uint8_t *host, size_t host_len,
+        const uint8_t *realm, size_t realm_len)
+{
+    char *new_host = NULL, *new_realm = NULL;
+    bool same_host, same_realm;
+
+    ogs_assert(mme_ue);
+
+    if (!host || !host_len || !realm || !realm_len) {
+        ogs_warn("[%s] Cannot set incomplete HSS identity "
+                "[host:%s/%zu realm:%s/%zu]",
+                mme_ue->imsi_bcd,
+                host ? "present" : "missing", host_len,
+                realm ? "present" : "missing", realm_len);
+        return;
+    }
+
+    same_host = mme_ue->hss_host &&
+        strlen(mme_ue->hss_host) == host_len &&
+        memcmp(mme_ue->hss_host, host, host_len) == 0;
+    same_realm = mme_ue->hss_realm &&
+        strlen(mme_ue->hss_realm) == realm_len &&
+        memcmp(mme_ue->hss_realm, realm, realm_len) == 0;
+
+    if (same_host && same_realm)
+        return;
+
+    /* Diameter AVPs are OctetStrings and not NUL-terminated. Allocate the
+     * new pair before releasing the old pair so host/realm are replaced
+     * together in the MME event thread. */
+    new_host = ogs_strndup((const char *)host, host_len);
+    ogs_assert(new_host);
+    new_realm = ogs_strndup((const char *)realm, realm_len);
+    ogs_assert(new_realm);
+
+    if (mme_ue->hss_host || mme_ue->hss_realm) {
+        ogs_info("[%s] HSS identity changed [%s/%s] -> [%.*s/%.*s]",
+                mme_ue->imsi_bcd,
+                mme_ue->hss_host ? mme_ue->hss_host : "-",
+                mme_ue->hss_realm ? mme_ue->hss_realm : "-",
+                (int)host_len, (const char *)host,
+                (int)realm_len, (const char *)realm);
+    }
+
+    if (mme_ue->hss_host)
+        ogs_free(mme_ue->hss_host);
+    if (mme_ue->hss_realm)
+        ogs_free(mme_ue->hss_realm);
+
+    mme_ue->hss_host = new_host;
+    mme_ue->hss_realm = new_realm;
+}
+
+void mme_ue_clear_hss_identity(mme_ue_t *mme_ue)
+{
+    ogs_assert(mme_ue);
+
+    if (!mme_ue->hss_host && !mme_ue->hss_realm)
+        return;
+
+    ogs_debug("[%s] Forget HSS identity [%s/%s]",
+            mme_ue->imsi_bcd,
+            mme_ue->hss_host ? mme_ue->hss_host : "-",
+            mme_ue->hss_realm ? mme_ue->hss_realm : "-");
+
+    if (mme_ue->hss_host) {
+        ogs_free(mme_ue->hss_host);
+        mme_ue->hss_host = NULL;
+    }
+    if (mme_ue->hss_realm) {
+        ogs_free(mme_ue->hss_realm);
+        mme_ue->hss_realm = NULL;
+    }
+}
+
 mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
 {
     mme_enb_t *enb = NULL;
@@ -3965,6 +4041,9 @@ void mme_ue_remove(mme_ue_t *mme_ue)
 
     /* Clear Transparent Container */
     OGS_ASN_CLEAR_DATA(&mme_ue->container);
+
+    /* Clear learned HSS identity */
+    mme_ue_clear_hss_identity(mme_ue);
 
     /* Delete All Timers */
     CLEAR_MME_UE_ALL_TIMERS(mme_ue);

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -904,6 +904,12 @@ struct mme_ue_s {
 
     mme_csmap_t     *csmap;
     mme_hssmap_t    *hssmap;
+
+    /* HSS identity dynamically learned from the Origin-Host/Origin-Realm
+     * of successful S6a answers (AIA/ULA), used as Destination-Host/Realm
+     * in subsequent requests as per 3GPP TS 29.272 clause 7.1.6. */
+    char            *hss_host;
+    char            *hss_realm;
 };
 
 #define MME_UE_REMOVE_WITH_PAGING_FAIL(__mME) \
@@ -1158,6 +1164,11 @@ void mme_hssmap_remove(mme_hssmap_t *hssmap);
 void mme_hssmap_remove_all(void);
 
 mme_hssmap_t *mme_hssmap_find_by_imsi_bcd(const char *imsi_bcd);
+
+void mme_ue_set_hss_identity(mme_ue_t *mme_ue,
+        const uint8_t *host, size_t host_len,
+        const uint8_t *realm, size_t realm_len);
+void mme_ue_clear_hss_identity(mme_ue_t *mme_ue);
 
 mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr);
 int mme_enb_remove(mme_enb_t *enb);

--- a/src/mme/mme-fd-path.c
+++ b/src/mme/mme-fd-path.c
@@ -65,8 +65,16 @@ static void mme_add_hss_destination(mme_ue_t *mme_ue, struct msg *req)
     ogs_assert(req);
 
     if (mme_ue->hssmap) {
+        /* Preserve the existing hss_map routing policy for backward
+         * compatibility. The configured/derived host and realm remain an
+         * inseparable pair and take precedence over learned identity. */
         realm = mme_ue->hssmap->realm;
         host = mme_ue->hssmap->host;
+    } else if (mme_ue->hss_host && mme_ue->hss_realm) {
+        /* TS 29.272 clause 7.1.6: when the serving HSS identity is known,
+         * include both Destination-Host and Destination-Realm. */
+        host = mme_ue->hss_host;
+        realm = mme_ue->hss_realm;
     }
 
     if (realm == NULL)
@@ -91,6 +99,39 @@ static void mme_add_hss_destination(mme_ue_t *mme_ue, struct msg *req)
         ret = fd_msg_avp_add(req, MSG_BRW_LAST_CHILD, avp);
         ogs_assert(ret == 0);
     }
+}
+
+/* Copy a successful answer's HSS identity into the event message. The
+ * freeDiameter callback does not modify mme_ue; the MME event thread applies
+ * the pair after receiving MME_EVENT_S6A_MESSAGE. */
+static void mme_store_hss_identity(ogs_diam_s6a_message_t *s6a_message,
+        const uint8_t *ohost, size_t ohost_len,
+        const uint8_t *orealm, size_t orealm_len)
+{
+    ogs_assert(s6a_message);
+
+    if (s6a_message->result_code != ER_DIAMETER_SUCCESS)
+        return;
+
+    if (!ohost || !ohost_len || !orealm || !orealm_len) {
+        ogs_warn("Cannot learn incomplete HSS identity "
+                "[host:%s/%zu realm:%s/%zu]",
+                ohost ? "present" : "missing", ohost_len,
+                orealm ? "present" : "missing", orealm_len);
+        return;
+    }
+
+    if (ohost_len >= sizeof(s6a_message->origin_host) ||
+        orealm_len >= sizeof(s6a_message->origin_realm)) {
+        ogs_warn("Cannot learn oversized HSS identity [%zu/%zu]",
+                ohost_len, orealm_len);
+        return;
+    }
+
+    memcpy(s6a_message->origin_host, ohost, ohost_len);
+    s6a_message->origin_host_len = (uint16_t)ohost_len;
+    memcpy(s6a_message->origin_realm, orealm, orealm_len);
+    s6a_message->origin_realm_len = (uint16_t)orealm_len;
 }
 
 /* s6a process Subscription-Data from avp */
@@ -903,6 +944,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     ogs_diam_s6a_message_t *s6a_message;
     ogs_diam_s6a_aia_message_t *aia_message;
     ogs_diam_e_utran_vector_t *e_utran_vector;
+    const uint8_t *ohost = NULL, *orealm = NULL;
+    size_t ohost_len = 0, orealm_len = 0;
 
     /* Initialize variables */
     sess_data = NULL;
@@ -1022,6 +1065,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        ohost = hdr->avp_value->os.data;
+        ohost_len = hdr->avp_value->os.len;
         ogs_debug("    From '%.*s'",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1041,6 +1086,8 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        orealm = hdr->avp_value->os.data;
+        orealm_len = hdr->avp_value->os.len;
         ogs_debug("         ('%.*s')",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1048,6 +1095,9 @@ static void mme_s6a_aia_cb(void *data, struct msg **msg)
         error++;
         goto cleanup;
     }
+
+    mme_store_hss_identity(s6a_message,
+            ohost, ohost_len, orealm, orealm_len);
 
     if (s6a_message->result_code != ER_DIAMETER_SUCCESS) {
         if (s6a_message->err)
@@ -1458,6 +1508,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     ogs_diam_s6a_ula_message_t *ula_message;
     ogs_subscription_data_t *subscription_data;
     uint32_t subdatamask;
+    const uint8_t *ohost = NULL, *orealm = NULL;
+    size_t ohost_len = 0, orealm_len = 0;
 
     /* Initialize variables */
     sess_data = NULL;
@@ -1573,6 +1625,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        ohost = hdr->avp_value->os.data;
+        ohost_len = hdr->avp_value->os.len;
         ogs_debug("    From '%.*s'",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1592,6 +1646,8 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
     if (avp) {
         ret = fd_msg_avp_hdr(avp, &hdr);
         ogs_assert(ret == 0);
+        orealm = hdr->avp_value->os.data;
+        orealm_len = hdr->avp_value->os.len;
         ogs_debug("         ('%.*s')",
                 (int)hdr->avp_value->os.len, hdr->avp_value->os.data);
     } else {
@@ -1599,6 +1655,9 @@ static void mme_s6a_ula_cb(void *data, struct msg **msg)
         error++;
         goto cleanup;
     }
+
+    mme_store_hss_identity(s6a_message,
+            ohost, ohost_len, orealm, orealm_len);
 
     /* AVP: 'ULA-Flags'(1406)
      * The ULA-Flags AVP contains a bit mask, whose meanings are defined in

--- a/src/mme/mme-s6a-handler.c
+++ b/src/mme/mme-s6a-handler.c
@@ -36,6 +36,34 @@ static uint8_t emm_cause_from_diameter(
 static uint8_t mme_ue_session_from_slice_data(mme_ue_t *mme_ue,
     ogs_slice_data_t *slice_data);
 
+static void mme_s6a_update_hss_identity(mme_ue_t *mme_ue,
+        ogs_diam_s6a_message_t *s6a_message)
+{
+    ogs_assert(mme_ue);
+    ogs_assert(s6a_message);
+
+    if (s6a_message->result_code == ER_DIAMETER_SUCCESS) {
+        if (!s6a_message->origin_host_len ||
+            !s6a_message->origin_realm_len)
+            return;
+
+        mme_ue_set_hss_identity(mme_ue,
+                s6a_message->origin_host,
+                s6a_message->origin_host_len,
+                s6a_message->origin_realm,
+                s6a_message->origin_realm_len);
+    } else if ((s6a_message->err &&
+                (s6a_message->result_code ==
+                    ER_DIAMETER_UNABLE_TO_DELIVER ||
+                 s6a_message->result_code ==
+                    ER_DIAMETER_REALM_NOT_SERVED)) ||
+            (s6a_message->exp_err &&
+             s6a_message->result_code ==
+                OGS_DIAM_S6A_ERROR_USER_UNKNOWN)) {
+        mme_ue_clear_hss_identity(mme_ue);
+    }
+}
+
 uint8_t mme_s6a_handle_aia(
         mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
 {
@@ -44,6 +72,9 @@ uint8_t mme_s6a_handle_aia(
 
     ogs_assert(mme_ue);
     ogs_assert(s6a_message);
+
+    mme_s6a_update_hss_identity(mme_ue, s6a_message);
+
     aia_message = &s6a_message->aia_message;
     ogs_assert(aia_message);
     e_utran_vector = &aia_message->e_utran_vector;
@@ -83,6 +114,9 @@ uint8_t mme_s6a_handle_ula(
 
     ogs_assert(mme_ue);
     ogs_assert(s6a_message);
+
+    mme_s6a_update_hss_identity(mme_ue, s6a_message);
+
     ula_message = &s6a_message->ula_message;
     ogs_assert(ula_message);
     subscription_data = &ula_message->subscription_data;
@@ -311,6 +345,9 @@ void mme_s6a_handle_clr(mme_ue_t *mme_ue, ogs_diam_s6a_message_t *s6a_message)
         break;
     case OGS_DIAM_S6A_CT_MME_UPDATE_PROCEDURE:
     case OGS_DIAM_S6A_CT_SGSN_UPDATE_PROCEDURE:
+        /* The subscriber is moving away from this MME. Forget the learned
+         * serving HSS so any later S6a request is realm-routed again. */
+        mme_ue_clear_hss_identity(mme_ue);
         mme_ue->detach_type = MME_DETACH_TYPE_HSS_IMPLICIT;
 
         /* 3GPP TS 23.401 D.3.5.5 8), 3GPP TS 23.060 6.9.1.2.2 8):


### PR DESCRIPTION
Store the Origin-Host and Origin-Realm received in successful AIA and ULA messages, and use the learned identity for subsequent S6a requests.

Update the learned identity only in the MME event thread to avoid accessing UE-owned string pointers from freeDiameter callback threads.

Preserve existing hss_map routing behavior by using the learned host/realm pair only when no hss_map entry is associated with the UE.

Forget the learned identity when:

* DIAMETER_UNABLE_TO_DELIVER or DIAMETER_REALM_NOT_SERVED is received
* DIAMETER_ERROR_USER_UNKNOWN is received
* an MME or SGSN update Cancel-Location-Request is received
* the UE context is removed

Do not invalidate the identity for other 3xxx result codes, such as DIAMETER_TOO_BUSY, since they do not indicate that the learned identity is invalid.

Document the learned HSS routing behavior and reference TS 29.272 clause 7.1.6.

Related PR: #4692