### PR TITLE
amf: fix UAF in old AMF discovery fallback

### DIFF
--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -25,7 +25,7 @@
 
 static bool amf_nnrf_try_old_amf_discovery_fallback(
         amf_ue_t *amf_ue, OpenAPI_nf_type_e requester_nf_type,
-        ogs_sbi_discovery_option_t *discovery_option)
+        bool guami_presence)
 {
     int r;
 
@@ -42,7 +42,7 @@ static bool amf_nnrf_try_old_amf_discovery_fallback(
             amf_ue->nas.registration.value !=
                 OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL ||
             requester_nf_type != OpenAPI_nf_type_AMF ||
-            !discovery_option || !discovery_option->guami_presence)
+            !guami_presence)
         return false;
 
     /*
@@ -128,6 +128,7 @@ void amf_nnrf_handle_nf_discover(
     OpenAPI_nf_type_e target_nf_type = OpenAPI_nf_type_NULL;
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
     ogs_sbi_discovery_option_t *discovery_option = NULL;
+    bool guami_presence = false;
 
     amf_ue_t *amf_ue = NULL;
     amf_sess_t *sess = NULL;
@@ -151,7 +152,15 @@ void amf_nnrf_handle_nf_discover(
     ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
             sbi_object_id <= OGS_MAX_POOL_ID);
 
+    /*
+     * The transaction owns discovery_option, and ogs_sbi_xact_remove()
+     * frees it. Snapshot the only field that is still needed after the
+     * transaction is released, exactly as ran_ue_id is copied out of
+     * xact->user_data below.
+     */
     discovery_option = xact->discovery_option;
+    if (discovery_option)
+        guami_presence = discovery_option->guami_presence;
 
     SearchResult = recvmsg->SearchResult;
     if (!SearchResult) {
@@ -210,7 +219,7 @@ void amf_nnrf_handle_nf_discover(
                     OpenAPI_service_name_ToString(service_name));
 
             if (amf_nnrf_try_old_amf_discovery_fallback(
-                    amf_ue, requester_nf_type, discovery_option))
+                    amf_ue, requester_nf_type, guami_presence))
                 break;
 
             if (amf_ue->nas.message_type ==
@@ -253,7 +262,7 @@ void amf_nnrf_handle_failed_amf_discovery(
     int r;
 
     OpenAPI_nf_type_e requester_nf_type = OpenAPI_nf_type_NULL;
-    ogs_sbi_discovery_option_t *discovery_option = NULL;
+    bool guami_presence = false;
     OpenAPI_service_name_e service_name = OpenAPI_service_name_NULL;
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
@@ -274,7 +283,13 @@ void amf_nnrf_handle_failed_amf_discovery(
     ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
             sbi_object_id <= OGS_MAX_POOL_ID);
 
-    discovery_option = sbi_xact->discovery_option;
+    /*
+     * The transaction owns discovery_option, and ogs_sbi_xact_remove()
+     * frees it. Snapshot the only field that is still needed after the
+     * transaction is released.
+     */
+    if (sbi_xact->discovery_option)
+        guami_presence = sbi_xact->discovery_option->guami_presence;
 
     if (sbi_xact->user_data) {
         amf_sbi_xact_ctx_t *ctx = sbi_xact->user_data;
@@ -302,7 +317,7 @@ void amf_nnrf_handle_failed_amf_discovery(
                 amf_ue->nas.registration.value);
 
         if (amf_nnrf_try_old_amf_discovery_fallback(
-                amf_ue, requester_nf_type, discovery_option))
+                amf_ue, requester_nf_type, guami_presence))
             break;
 
         if (amf_ue->nas.message_type ==


### PR DESCRIPTION
Snapshot the GUAMI presence flag before removing the SBI transaction and pass the copied value to the old AMF discovery fallback helper.

This fixes use-after-free issues in both the NF discovery no-match path and the failed AMF discovery path while preserving the transaction-before-context cleanup ordering.

Related PR: #4698