### PR TITLE
[AMF] Add configuration for 5GMM retransmission timer durations

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -55,6 +55,18 @@ amf:
 #      value: 720   # 12 minutes * 60 = 720 seconds
     t3512:
       value: 540    # 9 minutes * 60 = 540 seconds
+    # t3513:
+    #   value: 2
+    # t3522:
+    #   value: 3
+    # t3550:
+    #   value: 6
+    # t3555:
+    #   value: 6
+    # t3560:
+    #   value: 6
+    # t3570:
+    #   value: 3
 
 ################################################################################
 # SBI Server

--- a/lib/app/ogs-config.c
+++ b/lib/app/ogs-config.c
@@ -652,6 +652,18 @@ int ogs_app_parse_local_conf(const char *local)
                             /* handle config in amf */
                         } else if (!strcmp(time_key, "t3512")) {
                             /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3513")) {
+                            /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3522")) {
+                            /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3550")) {
+                            /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3555")) {
+                            /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3560")) {
+                            /* handle config in amf */
+                        } else if (!strcmp(time_key, "t3570")) {
+                            /* handle config in amf */
                         } else if (!strcmp(time_key, "t3402")) {
                             /* handle config in mme */
                         } else if (!strcmp(time_key, "t3412")) {

--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <errno.h>
+
 #include "ngap-path.h"
 
 static amf_context_t self;
@@ -198,6 +200,51 @@ static int amf_context_validation(void)
         return OGS_ERROR;
     }
 
+    return OGS_OK;
+}
+
+static struct {
+    const char *name;
+    amf_timer_e id;
+} amf_gmm_timer_cfg_map[] = {
+    { "t3513", AMF_TIMER_T3513 },
+    { "t3522", AMF_TIMER_T3522 },
+    { "t3550", AMF_TIMER_T3550 },
+    { "t3555", AMF_TIMER_T3555 },
+    { "t3560", AMF_TIMER_T3560 },
+    { "t3570", AMF_TIMER_T3570 },
+};
+
+/* Largest number of seconds that ogs_time_from_sec() can convert
+ * without overflowing ogs_time_t. */
+#define AMF_GMM_TIMER_MAX_SEC (INT64_MAX / OGS_USEC_PER_SEC)
+
+static int amf_gmm_timer_value_from_string(const char *v, const char *key,
+        long long *value)
+{
+    long long parsed;
+    char *endptr = NULL;
+
+    if (!v || *v == '\0') {
+        ogs_error("No amf.time.%s.value in '%s'", key, ogs_app()->file);
+        return OGS_ERROR;
+    }
+
+    errno = 0;
+    parsed = strtoll(v, &endptr, 10);
+    if (errno != 0 || endptr == v || *endptr != '\0') {
+        ogs_error("Invalid amf.time.%s.value `%s` in '%s'",
+                key, v, ogs_app()->file);
+        return OGS_ERROR;
+    }
+
+    if (parsed <= 0 || parsed > AMF_GMM_TIMER_MAX_SEC) {
+        ogs_error("Invalid amf.time.%s.value `%s` in '%s'",
+                key, v, ogs_app()->file);
+        return OGS_ERROR;
+    }
+
+    *value = parsed;
     return OGS_OK;
 }
 
@@ -1062,8 +1109,51 @@ int amf_context_parse_config(void)
                             /* handle config in app library */
                         } else if (!strcmp(time_key, "handover")) {
                             /* handle config in app library */
-                        } else
-                            ogs_warn("unknown key `%s`", time_key);
+                        } else {
+                            size_t i;
+                            bool matched = false;
+
+                            for (i = 0; i < OGS_ARRAY_SIZE(
+                                    amf_gmm_timer_cfg_map); i++) {
+                                ogs_yaml_iter_t gmm_timer_iter;
+
+                                if (strcmp(time_key,
+                                    amf_gmm_timer_cfg_map[i].name))
+                                    continue;
+
+                                matched = true;
+                                ogs_yaml_iter_recurse(
+                                        &time_iter, &gmm_timer_iter);
+
+                                while (ogs_yaml_iter_next(&gmm_timer_iter)) {
+                                    const char *gmm_timer_key =
+                                        ogs_yaml_iter_key(&gmm_timer_iter);
+                                    ogs_assert(gmm_timer_key);
+
+                                    if (!strcmp(gmm_timer_key, "value")) {
+                                        const char *v = ogs_yaml_iter_value(
+                                                &gmm_timer_iter);
+                                        long long value;
+
+                                        rv = amf_gmm_timer_value_from_string(
+                                                v, time_key, &value);
+                                        if (rv != OGS_OK)
+                                            return rv;
+
+                                        amf_timer_cfg(
+                                            amf_gmm_timer_cfg_map[i].id)->
+                                                duration =
+                                                    ogs_time_from_sec(value);
+                                    } else
+                                        ogs_warn("unknown key `%s`",
+                                                gmm_timer_key);
+                                }
+                                break;
+                            }
+
+                            if (!matched)
+                                ogs_warn("unknown key `%s`", time_key);
+                        }
                     }
                 } else if (!strcmp(amf_key, "default")) {
                     /* handle config in sbi library */


### PR DESCRIPTION
## Summary

Add optional configuration for the following AMF 5GMM retransmission timer durations under `amf.time`:

* T3513
* T3522
* T3550
* T3555
* T3560
* T3570

Only the timer duration can be overridden. Retransmission counters and procedure behavior remain unchanged.

When a timer is not configured, the existing default value is used.

Configured values must be valid positive integers and must fit within the internal timer representation. Invalid values cause AMF configuration parsing to fail with an error.

## Configuration

```yaml
amf:
  time:
    t3513:
      value: 2
    t3522:
      value: 3
    t3550:
      value: 6
    t3555:
      value: 6
    t3560:
      value: 6
    t3570:
      value: 3
```

## Testing

* [x] `ninja -C build`
* [x] Unit test suites:

  * `unit:core`
  * `unit:crypt`
  * `unit:unit`
  * `app:sctp`
* [x] Verified that the existing AMF configuration works without timer overrides
* [x] Verified valid overrides for all six timers
* [x] Verified rejection of invalid values:

  * `0`
  * `-1`
  * `abc`
  * `10abc`
  * overflowing integer
* [x] `git diff --check`


```bash
cat /tmp/amf-timer-test/results.txt
=== no-override (expected: accept) -> accepted ===
07/27 18:40:01.761: [app] INFO: Configuration: '/tmp/amf-timer-test/base.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:01.761: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:01.767: [amf] INFO: ngap_server() [127.0.0.5]:38412 (../src/amf/ngap-sctp.c:61)

=== valid-all-six (expected: accept) -> accepted ===
07/27 18:40:04.804: [app] INFO: Configuration: '/tmp/amf-timer-test/valid.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:04.804: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:04.809: [amf] INFO: ngap_server() [127.0.0.5]:38412 (../src/amf/ngap-sctp.c:61)

=== t3513=0 (expected: reject) -> rejected ===
07/27 18:40:07.852: [app] INFO: Configuration: '/tmp/amf-timer-test/bad-zero.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:07.852: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:07.857: [amf] ERROR: Invalid amf.time.t3513.value `0` in '/tmp/amf-timer-test/bad-zero.yaml' (../src/amf/context.c:242)
07/27 18:40:07.857: [app] FATAL: Open5GS initialization failed. Aborted (../src/main.c:224)

=== t3513=-1 (expected: reject) -> rejected ===
07/27 18:40:07.890: [app] INFO: Configuration: '/tmp/amf-timer-test/bad-negative.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:07.890: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:07.894: [amf] ERROR: Invalid amf.time.t3513.value `-1` in '/tmp/amf-timer-test/bad-negative.yaml' (../src/amf/context.c:242)
07/27 18:40:07.894: [app] FATAL: Open5GS initialization failed. Aborted (../src/main.c:224)

=== t3513=abc (expected: reject) -> rejected ===
07/27 18:40:07.933: [app] INFO: Configuration: '/tmp/amf-timer-test/bad-non-numeric.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:07.933: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:07.938: [amf] ERROR: Invalid amf.time.t3513.value `abc` in '/tmp/amf-timer-test/bad-non-numeric.yaml' (../src/amf/context.c:236)
07/27 18:40:07.938: [app] FATAL: Open5GS initialization failed. Aborted (../src/main.c:224)

=== t3513=10abc (expected: reject) -> rejected ===
07/27 18:40:07.973: [app] INFO: Configuration: '/tmp/amf-timer-test/bad-partial-numeric.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:07.973: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:07.979: [amf] ERROR: Invalid amf.time.t3513.value `10abc` in '/tmp/amf-timer-test/bad-partial-numeric.yaml' (../src/amf/context.c:236)
07/27 18:40:07.979: [app] FATAL: Open5GS initialization failed. Aborted (../src/main.c:224)

=== t3513=99999999999999999999 (expected: reject) -> rejected ===
07/27 18:40:08.007: [app] INFO: Configuration: '/tmp/amf-timer-test/bad-overflow.yaml' (../lib/app/ogs-init.c:144)
07/27 18:40:08.007: [app] INFO: File Logging: '/tmp/amf-timer-test/out.log' (../lib/app/ogs-init.c:147)
07/27 18:40:08.012: [amf] ERROR: Invalid amf.time.t3513.value `99999999999999999999` in '/tmp/amf-timer-test/bad-overflow.yaml' (../src/amf/context.c:236)
07/27 18:40:08.012: [app] FATAL: Open5GS initialization failed. Aborted (../src/main.c:224)

```
