### PR TITLE
sgwu: Avoid double initialization of variable

### DIFF
--- a/src/sgwu/sxa-build.c
+++ b/src/sgwu/sxa-build.c
@@ -95,7 +95,7 @@ ogs_pkbuf_t *sgwu_sxa_build_session_modification_response(uint8_t type,
     ogs_pfcp_session_modification_response_t *rsp = NULL;
     ogs_pkbuf_t *pkbuf = NULL;
 
-    int i = 0, j = 0;
+    int i, j;
 
     ogs_debug("Session Modification Response");
 


### PR DESCRIPTION
Newer gcc 16.1.1 doesn't like it and warns about it:
```
../src/sgwu/sxa-build.c: In function ‘sgwu_sxa_build_session_modification_response’:
../src/sgwu/sxa-build.c:98:16: warning: variable ‘j’ set but not used [-Wunused-but-set-variable=]
   98 |     int i = 0, j = 0;
      |
```