### PR TITLE
[UPF] Use monotonic time for URR duration measurement

### DIFF
--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -706,6 +706,14 @@ void upf_sess_urr_acc_add(upf_sess_t *sess, ogs_pfcp_urr_t *urr, size_t size, bo
     if (urr_acc->time_of_first_packet == 0)
         urr_acc->time_of_first_packet = urr_acc->time_of_last_packet;
 
+    /* If ISTM was not set, the reporting interval was never started
+     * (upf_sess_urr_acc_timers_setup() only runs for ISTM URRs); start it
+     * now so Duration Measurement has a valid baseline. */
+    if (urr_acc->time_start == 0) {
+        urr_acc->time_start = ogs_time_ntp32_now();
+        urr_acc->mono_time_start = ogs_get_monotonic_time();
+    }
+
     /* generate report if volume threshold/quota is reached */
     vol = urr_acc->total_octets - urr_acc->last_report.total_octets;
     if ((urr->rep_triggers.volume_quota && urr->vol_quota.tovol && vol >= urr->vol_quota.total_volume) ||
@@ -729,18 +737,19 @@ void upf_sess_urr_acc_fill_usage_report(upf_sess_t *sess, const ogs_pfcp_urr_t *
                                   ogs_pfcp_user_plane_report_t *report, unsigned int idx)
 {
     upf_sess_urr_acc_t *urr_acc = NULL;
-    ogs_time_t last_report_timestamp;
-    ogs_time_t now;
+    ogs_time_t last_report_mono_timestamp;
+    ogs_time_t now, mono_now;
 
     ogs_assert(urr->id > 0 && urr->id <= OGS_MAX_NUM_OF_URR);
     urr_acc = &sess->urr_acc[urr->id-1];
 
     now = ogs_time_now(); /* we need UTC for start_time and end_time */
+    mono_now = ogs_get_monotonic_time(); /* elapsed time for Duration Measurement */
 
-    if (urr_acc->last_report.timestamp)
-        last_report_timestamp = urr_acc->last_report.timestamp;
+    if (urr_acc->last_report.mono_timestamp)
+        last_report_mono_timestamp = urr_acc->last_report.mono_timestamp;
     else
-        last_report_timestamp = ogs_time_from_ntp32(urr_acc->time_start);
+        last_report_mono_timestamp = urr_acc->mono_time_start;
 
     report->type.usage_report = 1;
     report->usage_report[idx].id = urr->id;
@@ -761,8 +770,8 @@ void upf_sess_urr_acc_fill_usage_report(upf_sess_t *sess, const ogs_pfcp_urr_t *
         .uplink_n_packets = urr_acc->ul_pkts - urr_acc->last_report.ul_pkts,
         .downlink_n_packets = urr_acc->dl_pkts - urr_acc->last_report.dl_pkts,
     };
-    if (now >= last_report_timestamp)
-        report->usage_report[idx].dur_measurement = ((now - last_report_timestamp) + (OGS_USEC_PER_SEC/2)) / OGS_USEC_PER_SEC; /* FIXME: should use MONOTONIC here */
+    if (mono_now >= last_report_mono_timestamp)
+        report->usage_report[idx].dur_measurement = ((mono_now - last_report_mono_timestamp) + (OGS_USEC_PER_SEC/2)) / OGS_USEC_PER_SEC;
     /* else memset sets it to 0 */
     report->usage_report[idx].time_of_first_packet = ogs_time_to_ntp32(urr_acc->time_of_first_packet); /* TODO: First since last report? */
     report->usage_report[idx].time_of_last_packet = ogs_time_to_ntp32(urr_acc->time_of_last_packet);
@@ -801,6 +810,7 @@ void upf_sess_urr_acc_snapshot(upf_sess_t *sess, ogs_pfcp_urr_t *urr)
     urr_acc->last_report.dl_pkts = urr_acc->dl_pkts;
     urr_acc->last_report.ul_pkts = urr_acc->ul_pkts;
     urr_acc->last_report.timestamp = ogs_time_now();
+    urr_acc->last_report.mono_timestamp = ogs_get_monotonic_time();
 }
 
 static void upf_sess_urr_acc_timers_cb(void *data)
@@ -882,6 +892,7 @@ void upf_sess_urr_acc_timers_setup(upf_sess_t *sess, ogs_pfcp_urr_t *urr)
     urr_acc = &sess->urr_acc[urr->id-1];
 
     urr_acc->time_start = ogs_time_ntp32_now();
+    urr_acc->mono_time_start = ogs_get_monotonic_time();
     if (urr->rep_triggers.quota_validity_time && urr->quota_validity_time > 0)
         upf_sess_urr_acc_validity_time_setup(sess, urr);
     if (urr->rep_triggers.time_quota && urr->time_quota > 0)

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -75,7 +75,8 @@ typedef struct upf_sess_urr_acc_s {
     ogs_timer_t *t_validity_time; /* Quota Validity Time expiration handler */
     ogs_timer_t *t_time_quota; /* Time Quota expiration handler */
     ogs_timer_t *t_time_threshold; /* Time Threshold expiration handler */
-    uint32_t time_start; /* When t_time_* started */
+    uint32_t time_start; /* When t_time_* started (realtime, for NTP) */
+    ogs_time_t mono_time_start; /* When t_time_* started (monotonic, for Duration Measurement) */
     ogs_pfcp_urr_ur_seqn_t report_seqn; /* Next seqn to use when reporting */
     uint64_t total_octets;
     uint64_t ul_octets;
@@ -93,7 +94,8 @@ typedef struct upf_sess_urr_acc_s {
         uint64_t total_pkts;
         uint64_t ul_pkts;
         uint64_t dl_pkts;
-        ogs_time_t timestamp;
+        ogs_time_t timestamp; /* realtime */
+        ogs_time_t mono_timestamp; /* monotonic, for Duration Measurement */
     } last_report;
 } upf_sess_urr_acc_t;
 

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -36,7 +36,8 @@ static void upf_n4_handle_create_urr(upf_sess_t *sess, ogs_pfcp_tlv_create_urr_t
         if (!urr)
             return;
 
-        /* TODO: enable counters somewhere else if ISTM not set, upon first pkt received */
+        /* If ISTM is not set, the reporting interval is started on the
+         * first received packet instead (see upf_sess_urr_acc_add()). */
         if (urr->meas_info.istm) {
             upf_sess_urr_acc_timers_setup(sess, urr);
         }


### PR DESCRIPTION
## Summary

Use monotonic timestamps for UPF URR Duration Measurement.

PFCP Start Time and End Time continue to use realtime timestamps because they represent UTC time. Duration Measurement now uses monotonic timestamps, so it is not affected by NTP corrections or system clock changes.

When ISTM is not present, the URR reporting interval is initialized when the first packet is accounted. This prevents the first Usage Report from using an uninitialized `time_start`.

The last-report snapshot now stores a monotonic timestamp, which is used as the baseline for the next reporting interval.

## Code changes

* Add monotonic start and last-report timestamps to the URR accumulator
* Use monotonic time to calculate Duration Measurement
* Keep realtime timestamps for PFCP Start Time and End Time
* Start an ISTM-less reporting interval on the first accounted packet
* Save a new monotonic baseline after each Usage Report

## Testing

* [x] Built and tested with Open5GS 5GC and UERANSIM
* [x] Verified an ISTM-less URR with a 104857600-byte downlink volume threshold
* [x] Verified that the first reporting interval starts on the first accounted packet
* [x] Verified consecutive `VOLTH` Usage Reports
* [x] Verified UPF-only realtime clock jump:

  * First report: 14-second wall-clock difference, 14-second Duration Measurement
  * Advanced the realtime clock visible only to the UPF process by 120 seconds
  * Second report: 132-second wall-clock difference, 12-second Duration Measurement
  * The host clock and monotonic clock were not changed

* [x] Verified that both PFCP Session Report Requests received responses from the SMF
* [x] Verified `UR-SEQN` advancement from 0 to 1
* [x] `git diff --check`

```text
=== first usage report ===
UR-SEQN:               0
Trigger:               VOLTH
Start Time:            2026-07-31 07:38:29 UTC
End Time:              2026-07-31 07:38:43 UTC
Downlink Volume:       104857764 bytes
Duration Measurement:  14 seconds

=== second usage report after UPF-only +120 second realtime jump ===
UR-SEQN:               1
Trigger:               VOLTH
Start Time:            2026-07-31 07:38:43 UTC
End Time:              2026-07-31 07:40:55 UTC
Wall-clock difference: 132 seconds
Downlink Volume:       104858402 bytes
Duration Measurement:  12 seconds
```

Package number 32 and 33 on pcap has the information of:

```
Packet Forwarding Control Protocol
      Flags: 0x21, SEID (S)
      Message Type: PFCP Session Report Request (56)
      Length: 137
      SEID: 0x00000000000000ac
      Sequence Number: 5
      Spare: 0
      Report Type :
      Usage Report (Session Report Request) : [Grouped IE]: URR ID: Dynamic by CP 1
          IE Type: Usage Report (Session Report Request) (80)
          IE Length: 116
          URR ID : Dynamic by CP 1
          UR-SEQN : 1
          Usage Report Trigger :
          Start Time : Jul 31, 2026 07:38:43.000000000 UTC
          End Time : Jul 31, 2026 07:40:55.000000000 UTC
          Volume Measurement :
          Duration Measurement : 12 s
          Time of First Packet : Jul 31, 2026 07:38:29.000000000 UTC
          Time of Last Packet : Jul 31, 2026 07:40:55.000000000 UTC
      [Response In: 33]
```

  Start Time:            07:38:43
  End Time:              07:40:55
  Realtime difference:   132 seconds

  Duration Measurement:  12 seconds

  The UPF realtime clock was advanced by 120 seconds:

  Actual elapsed time   ≈ 12 seconds
  Clock jump             = 120 seconds
  PFCP Start/End delta   = 12 + 120 = 132 seconds


PFCP capture attached.
[pfcp_log.tar.gz](https://github.com/user-attachments/files/30586646/pfcp_log.tar.gz)
