### PR TITLE
.gitignore: Add subprojects/.wraplock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ subprojects/freeDiameter
 subprojects/libtins
 subprojects/prometheus-client-c
 subprojects/usrsctp
+subprojects/.wraplock
 
 webui/.next


### PR DESCRIPTION
This gets created in my git repo all the time and it's not caught by existing gitignore, so add it.