### PR TITLE
[SGWC] Re-use indirect data forwarding tunnels

### DIFF
--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -129,6 +129,9 @@ typedef struct sgwc_tunnel_s {
     uint32_t        remote_teid;
     ogs_ip_t        remote_ip;
 
+    /* The indirect PDR/FAR pair has been installed in SGW-U */
+    bool            indirect_data_forwarding_created;
+
     /* Related Context */
     ogs_pool_id_t   bearer_id;
     ogs_gtp_node_t  *gnode;

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -1683,12 +1683,29 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
             req_teid = req->bearer_contexts[i].s1_u_enodeb_f_teid.data;
             ogs_assert(req_teid);
 
-            tunnel = sgwc_tunnel_add(bearer,
+            /*
+             * If the indirect data forwarding tunnel of the previous
+             * handover has not been deleted -- the MME does not always
+             * send Delete Indirect Data Forwarding Tunnel Request --
+             * re-use it.
+             *
+             * OGS_MAX_NUM_OF_PDR is dimensioned for a single forwarding
+             * pair per bearer, so allocating a new PDR/FAR on every
+             * handover exhausts the PDR pool of the session.
+             */
+            tunnel = sgwc_tunnel_find_by_interface_type(bearer,
                     OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING);
-            if (!tunnel) {
-                ogs_error("sgwc_tunnel_add() failed");
-                cause_value = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
-                goto cleanup;
+            if (tunnel) {
+                ogs_error("[%s] Re-use indirect DL tunnel [EBI:%d]",
+                        sgwc_ue->imsi_bcd, bearer->ebi);
+            } else {
+                tunnel = sgwc_tunnel_add(bearer,
+                        OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING);
+                if (!tunnel) {
+                    ogs_error("sgwc_tunnel_add() failed");
+                    cause_value = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
+                    goto cleanup;
+                }
             }
 
             tunnel->remote_teid = be32toh(req_teid->teid);
@@ -1731,12 +1748,20 @@ void sgwc_s11_handle_create_indirect_data_forwarding_tunnel_request(
             req_teid = req->bearer_contexts[i].s12_rnc_f_teid.data;
             ogs_assert(req_teid);
 
-            tunnel = sgwc_tunnel_add(bearer,
+            /* See the comment on the DL data forwarding tunnel above */
+            tunnel = sgwc_tunnel_find_by_interface_type(bearer,
                     OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING);
-            if (!tunnel) {
-                ogs_error("sgwc_tunnel_add() failed");
-                cause_value = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
-                goto cleanup;
+            if (tunnel) {
+                ogs_error("[%s] Re-use indirect UL tunnel [EBI:%d]",
+                        sgwc_ue->imsi_bcd, bearer->ebi);
+            } else {
+                tunnel = sgwc_tunnel_add(bearer,
+                        OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING);
+                if (!tunnel) {
+                    ogs_error("sgwc_tunnel_add() failed");
+                    cause_value = OGS_GTP2_CAUSE_SYSTEM_FAILURE;
+                    goto cleanup;
+                }
             }
 
             tunnel->remote_teid = be32toh(req_teid->teid);

--- a/src/sgwc/sxa-build.c
+++ b/src/sgwc/sxa-build.c
@@ -134,6 +134,15 @@ ogs_pkbuf_t *sgwc_sxa_build_bearer_to_modify_list(
     int num_of_update_pdr = 0;
     int num_of_update_far = 0;
 
+    /*
+     * ogs_pfcp_build_create_far() and ogs_pfcp_build_update_far_activate()
+     * share the same static buffer, so Create FAR and Update FAR in the
+     * same message must not use the same index.
+     *
+     * Note that ogs_pfcp_build_update_far_deactivate() does not use it.
+     */
+    int farbuf_index = 0;
+
     uint64_t modify_flags = 0;
     int total = 0;
 
@@ -210,6 +219,29 @@ ogs_pkbuf_t *sgwc_sxa_build_bearer_to_modify_list(
 
                 } else if (modify_flags & OGS_PFCP_MODIFY_CREATE) {
 
+                    if ((modify_flags & OGS_PFCP_MODIFY_INDIRECT) &&
+                        tunnel->indirect_data_forwarding_created) {
+                        /*
+                         * An indirect data forwarding tunnel left over by
+                         * the previous handover is being re-used.
+                         *
+                         * Its PDR is unchanged, so only the FAR has to
+                         * point to the new target eNodeB.
+                         */
+                        far = tunnel->far;
+                        if (far) {
+                            ogs_pfcp_build_update_far_activate(
+                                    &req->update_far[num_of_update_far],
+                                    farbuf_index, far);
+
+                            num_of_update_far++;
+                            farbuf_index++;
+                        } else
+                            ogs_assert_if_reached();
+
+                        continue;
+                    }
+
                     pdr = tunnel->pdr;
                     if (pdr) {
                         ogs_pfcp_build_create_pdr(
@@ -226,9 +258,10 @@ ogs_pkbuf_t *sgwc_sxa_build_bearer_to_modify_list(
                     if (far) {
                         ogs_pfcp_build_create_far(
                                 &req->create_far[num_of_create_far],
-                                num_of_create_far, far);
+                                farbuf_index, far);
 
                         num_of_create_far++;
+                        farbuf_index++;
                     } else
                         ogs_assert_if_reached();
                 }
@@ -255,9 +288,10 @@ ogs_pkbuf_t *sgwc_sxa_build_bearer_to_modify_list(
 
                         ogs_pfcp_build_update_far_activate(
                                 &req->update_far[num_of_update_far],
-                                num_of_update_far, far);
+                                farbuf_index, far);
 
                         num_of_update_far++;
+                        farbuf_index++;
 
                         /* Clear all FAR flags */
                         tunnel->far->smreq_flags.value = 0;

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -613,6 +613,18 @@ void sgwc_sxa_handle_session_modification_response(
                             &tunnel->local_addr, &tunnel->local_addr6));
                     tunnel->local_teid = pdr->f_teid.teid;
                 }
+
+                /*
+                 * pfcp_cause_value is final at this point, so the tunnel
+                 * is marked as installed only if the UP function has
+                 * accepted every Created PDR.
+                 */
+                if (pfcp_cause_value == OGS_PFCP_CAUSE_REQUEST_ACCEPTED &&
+                    (tunnel->interface_type ==
+                        OGS_GTP2_F_TEID_SGW_GTP_U_FOR_DL_DATA_FORWARDING ||
+                     tunnel->interface_type ==
+                        OGS_GTP2_F_TEID_SGW_GTP_U_FOR_UL_DATA_FORWARDING))
+                    tunnel->indirect_data_forwarding_created = true;
             }
         }
 


### PR DESCRIPTION
The MME may not send a Delete Indirect Data Forwarding Tunnel Request after handover. In this case, every subsequent Create Indirect Data Forwarding Tunnel Request allocated another DL/UL PDR and FAR pair for the same bearer.

Repeated handovers could therefore exhaust the per-session PDR pool and cause SGW-C to abort when creating another bearer.

Re-use an existing indirect forwarding tunnel and preserve its PDR. Once the tunnel has been installed in SGW-U, send an Update FAR with the new remote TEID and address instead of creating another PDR/FAR pair.

Use a common buffer index for Create FAR and Update FAR because both builders share the same static FAR buffer.

Issues: #4719