### PR TITLE
amf/mme: reject replayed uplink NAS COUNT

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -2921,6 +2921,7 @@ void amf_ue_save_memento(amf_ue_t *amf_ue, amf_ue_memento_t *memento)
     memcpy(memento->knas_enc, amf_ue->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
     memento->dl_count = amf_ue->dl_count;
     memento->ul_count = amf_ue->ul_count.i32;
+    memento->ul_count_accepted = amf_ue->ul_count_accepted;
     memcpy(memento->kgnb, amf_ue->kgnb, OGS_SHA256_DIGEST_SIZE);
     memcpy(memento->nh, amf_ue->nh, OGS_SHA256_DIGEST_SIZE);
     memento->selected_enc_algorithm = amf_ue->selected_enc_algorithm;
@@ -2948,6 +2949,7 @@ void amf_ue_restore_memento(amf_ue_t *amf_ue, const amf_ue_memento_t *memento)
     memcpy(amf_ue->knas_enc, memento->knas_enc, OGS_SHA256_DIGEST_SIZE/2);
     amf_ue->dl_count = memento->dl_count;
     amf_ue->ul_count.i32 = memento->ul_count;
+    amf_ue->ul_count_accepted = memento->ul_count_accepted;
     memcpy(amf_ue->kgnb, memento->kgnb, OGS_SHA256_DIGEST_SIZE);
     memcpy(amf_ue->nh, memento->nh, OGS_SHA256_DIGEST_SIZE);
     amf_ue->selected_enc_algorithm = memento->selected_enc_algorithm;

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -275,6 +275,7 @@ typedef struct amf_ue_memento_s {
     uint32_t dl_count;
     /* Uplink counter (24-bit stored in uint32_t) */
     uint32_t ul_count;
+    bool ul_count_accepted;
     /* gNB key derived from kasme */
     uint8_t kgnb[OGS_SHA256_DIGEST_SIZE];
 
@@ -505,6 +506,15 @@ struct amf_ue_s {
         } __attribute__ ((packed));
         uint32_t i32;
     } ul_count;
+    /*
+     * Set once an uplink NAS message has been accepted in the current
+     * 5G NAS security context. While it is false, 'ul_count' does not yet
+     * hold a "last accepted" value and the replay check is not applied.
+     *
+     * Both are cleared by the AMF when it takes a new security context
+     * into use, never by the security header type of a received message.
+     */
+    bool            ul_count_accepted;
     /* gNB key derived from kasme */
     uint8_t         kgnb[OGS_SHA256_DIGEST_SIZE];
 

--- a/src/amf/nas-security.c
+++ b/src/amf/nas-security.c
@@ -61,6 +61,7 @@ ogs_pkbuf_t *nas_5gs_security_encode(
     if (new_security_context) {
         amf_ue->dl_count = 0;
         amf_ue->ul_count.i32 = 0;
+        amf_ue->ul_count_accepted = false;
     }
 
     if (amf_ue->selected_enc_algorithm == 0)
@@ -128,10 +129,6 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
         security_header_type.ciphered = 0;
     }
 
-    if (security_header_type.new_security_context) {
-        amf_ue->ul_count.i32 = 0;
-    }
-
     if (amf_ue->selected_enc_algorithm == 0)
         security_header_type.ciphered = 0;
     if (amf_ue->selected_int_algorithm == 0)
@@ -140,6 +137,7 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
     if (security_header_type.ciphered ||
         security_header_type.integrity_protected) {
         ogs_nas_5gs_security_header_t *h = NULL;
+        uint32_t estimated_ul_count = 0;
 
         /* NAS Security Header */
         ogs_assert(ogs_pkbuf_push(pkbuf, 7));
@@ -148,10 +146,20 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
         /* NAS Security Header.Sequence_Number */
         ogs_assert(ogs_pkbuf_pull(pkbuf, 6));
 
-        /* calculate ul_count */
+        /*
+         * TS24.501 4.4.3.1
+         *
+         * Estimate the uplink NAS COUNT of the received message from the
+         * locally stored overflow counter and the received sequence number.
+         *
+         * The estimate is kept local. amf_ue->ul_count is the NAS COUNT of
+         * the last *accepted* uplink NAS message and must never be advanced
+         * by a sequence number that has not been authenticated yet.
+         */
+        estimated_ul_count = amf_ue->ul_count.i32 & 0x00ffff00;
         if (amf_ue->ul_count.sqn > h->sequence_number)
-            amf_ue->ul_count.overflow++;
-        amf_ue->ul_count.sqn = h->sequence_number;
+            estimated_ul_count = (estimated_ul_count + 0x100) & 0x00ffff00;
+        estimated_ul_count |= h->sequence_number;
 
         if (security_header_type.integrity_protected) {
             uint8_t mac[NAS_SECURITY_MAC_SIZE];
@@ -160,7 +168,7 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
 
             /* calculate NAS MAC(message authentication code) */
             ogs_nas_mac_calculate(amf_ue->selected_int_algorithm,
-                amf_ue->knas_int, amf_ue->ul_count.i32,
+                amf_ue->knas_int, estimated_ul_count,
                 amf_ue->nas.access_type,
                 OGS_NAS_SECURITY_UPLINK_DIRECTION, pkbuf, mac);
             h->message_authentication_code = original_mac;
@@ -170,7 +178,34 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
                 ogs_warn("NAS MAC verification failed(0x%x != 0x%x)",
                     be32toh(h->message_authentication_code), be32toh(mac32));
                 amf_ue->mac_failed = 1;
+            } else {
+                /*
+                 * TS33.501 6.4.3.1 (NAS integrity and replay protection)
+                 *
+                 * A valid MAC only proves that the message was produced by a
+                 * holder of KNASint at that NAS COUNT. A replayed message
+                 * carries a valid MAC as well, so the NAS COUNT must also be
+                 * greater than the NAS COUNT of the last accepted uplink NAS
+                 * message in this security context.
+                 */
+                if (amf_ue->ul_count_accepted == true &&
+                    estimated_ul_count <= amf_ue->ul_count.i32) {
+                    ogs_error("NAS COUNT REPLAY DETECTED - uplink NAS "
+                        "message rejected "
+                        "[UL NAS COUNT:0x%06x, LAST ACCEPTED:0x%06x]",
+                        estimated_ul_count, amf_ue->ul_count.i32);
+                    return OGS_ERROR;
+                }
+
+                amf_ue->ul_count.i32 = estimated_ul_count;
+                amf_ue->ul_count_accepted = true;
             }
+        } else {
+            /*
+             * No integrity protection (NIA0). The sequence number cannot be
+             * authenticated, so replay protection is not possible here.
+             */
+            amf_ue->ul_count.i32 = estimated_ul_count;
         }
 
         /* NAS EMM Header or ESM Header */
@@ -183,7 +218,7 @@ int nas_5gs_security_decode(amf_ue_t *amf_ue,
                 return OGS_ERROR;
             }
             ogs_nas_encrypt(amf_ue->selected_enc_algorithm,
-                amf_ue->knas_enc, amf_ue->ul_count.i32,
+                amf_ue->knas_enc, estimated_ul_count,
                 amf_ue->nas.access_type,
                 OGS_NAS_SECURITY_UPLINK_DIRECTION, pkbuf);
         }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -5767,6 +5767,7 @@ void mme_ue_save_memento(mme_ue_t *mme_ue, mme_ue_memento_t *memento)
            OGS_SHA256_DIGEST_SIZE / 2);
     memento->dl_count = mme_ue->dl_count;
     memento->ul_count = mme_ue->ul_count.i32;
+    memento->ul_count_accepted = mme_ue->ul_count_accepted;
     memcpy(memento->kenb, mme_ue->kenb, OGS_SHA256_DIGEST_SIZE);
     memcpy(memento->hash_mme, mme_ue->hash_mme, OGS_HASH_MME_LEN);
     memento->nonceue = mme_ue->nonceue;
@@ -5804,6 +5805,7 @@ void mme_ue_restore_memento(mme_ue_t *mme_ue, const mme_ue_memento_t *memento)
            OGS_SHA256_DIGEST_SIZE / 2);
     mme_ue->dl_count = memento->dl_count;
     mme_ue->ul_count.i32 = memento->ul_count;
+    mme_ue->ul_count_accepted = memento->ul_count_accepted;
     memcpy(mme_ue->kenb, memento->kenb, OGS_SHA256_DIGEST_SIZE);
     memcpy(mme_ue->hash_mme, memento->hash_mme, OGS_HASH_MME_LEN);
     mme_ue->nonceue = memento->nonceue;

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -407,6 +407,7 @@ typedef struct mme_ue_memento_s {
     uint32_t dl_count;
     /* Uplink counter (24-bit stored in uint32_t) */
     uint32_t ul_count;
+    bool ul_count_accepted;
     /* eNB key derived from kasme */
     uint8_t kenb[OGS_SHA256_DIGEST_SIZE];
     /* Hash used for NAS message integrity */
@@ -628,6 +629,15 @@ struct mme_ue_s {
         } __attribute__ ((packed));
         uint32_t i32;
     } ul_count;
+    /*
+     * Set once an uplink NAS message has been accepted in the current
+     * EPS NAS security context. While it is false, 'ul_count' does not yet
+     * hold a "last accepted" value and the replay check is not applied.
+     *
+     * Both are cleared by the MME when it takes a new security context
+     * into use, never by the security header type of a received message.
+     */
+    bool            ul_count_accepted;
     /* eNB key derived from kasme */
     uint8_t         kenb[OGS_SHA256_DIGEST_SIZE];
     /* Hash used for NAS message integrity */

--- a/src/mme/nas-security.c
+++ b/src/mme/nas-security.c
@@ -62,6 +62,7 @@ ogs_pkbuf_t *nas_eps_security_encode(
     if (new_security_context) {
         mme_ue->dl_count = 0;
         mme_ue->ul_count.i32 = 0;
+        mme_ue->ul_count_accepted = false;
     }
 
     if (mme_ue->selected_enc_algorithm == 0)
@@ -128,6 +129,7 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
         uint8_t estimated_sequence_number;
         uint8_t sequence_number_high_3bit;
         uint8_t mac[NAS_SECURITY_MAC_SIZE];
+        uint32_t estimated_ul_count = 0;
 
         if (mme_ue->selected_int_algorithm == 0) {
             ogs_warn("integrity algorithm is not defined");
@@ -144,15 +146,23 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
         }
         estimated_sequence_number += sequence_number_high_3bit;
 
+        /*
+         * TS24.301 4.4.3.1
+         *
+         * The estimate is kept local. mme_ue->ul_count is the NAS COUNT of
+         * the last *accepted* uplink NAS message and must never be advanced
+         * by a sequence number that has not been authenticated yet.
+         */
+        estimated_ul_count = mme_ue->ul_count.i32 & 0x00ffff00;
         if (mme_ue->ul_count.sqn > estimated_sequence_number)
-            mme_ue->ul_count.overflow++;
-        mme_ue->ul_count.sqn = estimated_sequence_number;
+            estimated_ul_count = (estimated_ul_count + 0x100) & 0x00ffff00;
+        estimated_ul_count |= estimated_sequence_number;
 
         memcpy(original_mac, pkbuf->data + 2, SHORT_MAC_SIZE);
 
         ogs_pkbuf_trim(pkbuf, 2);
         ogs_nas_mac_calculate(mme_ue->selected_int_algorithm,
-            mme_ue->knas_int, mme_ue->ul_count.i32, NAS_SECURITY_BEARER,
+            mme_ue->knas_int, estimated_ul_count, NAS_SECURITY_BEARER,
             OGS_NAS_SECURITY_UPLINK_DIRECTION, pkbuf, mac);
 
         ogs_pkbuf_put_data(pkbuf, original_mac, SHORT_MAC_SIZE);
@@ -163,6 +173,19 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
                     ((unsigned char *)pkbuf->data)[3]);
 
             mme_ue->mac_failed = 1;
+        } else {
+            /* TS33.401 8.1.1 : replay protection for uplink NAS */
+            if (mme_ue->ul_count_accepted == true &&
+                estimated_ul_count <= mme_ue->ul_count.i32) {
+                ogs_error("NAS COUNT REPLAY DETECTED - service request "
+                    "rejected "
+                    "[UL NAS COUNT:0x%06x, LAST ACCEPTED:0x%06x]",
+                    estimated_ul_count, mme_ue->ul_count.i32);
+                return OGS_ERROR;
+            }
+
+            mme_ue->ul_count.i32 = estimated_ul_count;
+            mme_ue->ul_count_accepted = true;
         }
 
         return OGS_OK;
@@ -174,10 +197,6 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
         security_header_type.ciphered = 0;
     }
 
-    if (security_header_type.new_security_context) {
-        mme_ue->ul_count.i32 = 0;
-    }
-
     if (mme_ue->selected_enc_algorithm == 0)
         security_header_type.ciphered = 0;
     if (mme_ue->selected_int_algorithm == 0)
@@ -186,6 +205,7 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
     if (security_header_type.ciphered || 
         security_header_type.integrity_protected) {
         ogs_nas_eps_security_header_t *h = NULL;
+        uint32_t estimated_ul_count = 0;
 
         /* NAS Security Header */
         ogs_assert(ogs_pkbuf_push(pkbuf, 6));
@@ -194,10 +214,20 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
         /* NAS Security Header.Sequence_Number */
         ogs_assert(ogs_pkbuf_pull(pkbuf, 5));
 
-        /* calculate ul_count */
+        /*
+         * TS24.301 4.4.3.1
+         *
+         * Estimate the uplink NAS COUNT of the received message from the
+         * locally stored overflow counter and the received sequence number.
+         *
+         * The estimate is kept local. mme_ue->ul_count is the NAS COUNT of
+         * the last *accepted* uplink NAS message and must never be advanced
+         * by a sequence number that has not been authenticated yet.
+         */
+        estimated_ul_count = mme_ue->ul_count.i32 & 0x00ffff00;
         if (mme_ue->ul_count.sqn > h->sequence_number)
-            mme_ue->ul_count.overflow++;
-        mme_ue->ul_count.sqn = h->sequence_number;
+            estimated_ul_count = (estimated_ul_count + 0x100) & 0x00ffff00;
+        estimated_ul_count |= h->sequence_number;
 
         if (security_header_type.integrity_protected) {
             uint8_t mac[NAS_SECURITY_MAC_SIZE];
@@ -206,7 +236,7 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
 
             /* calculate NAS MAC(message authentication code) */
             ogs_nas_mac_calculate(mme_ue->selected_int_algorithm,
-                mme_ue->knas_int, mme_ue->ul_count.i32, NAS_SECURITY_BEARER, 
+                mme_ue->knas_int, estimated_ul_count, NAS_SECURITY_BEARER,
                 OGS_NAS_SECURITY_UPLINK_DIRECTION, pkbuf, mac);
             h->message_authentication_code = original_mac;
 
@@ -215,7 +245,34 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
                 ogs_warn("NAS MAC verification failed(0x%x != 0x%x)",
                     be32toh(h->message_authentication_code), be32toh(mac32));
                 mme_ue->mac_failed = 1;
+            } else {
+                /*
+                 * TS33.401 8.1.1 (NAS integrity and replay protection)
+                 *
+                 * A valid MAC only proves that the message was produced by a
+                 * holder of KNASint at that NAS COUNT. A replayed message
+                 * carries a valid MAC as well, so the NAS COUNT must also be
+                 * greater than the NAS COUNT of the last accepted uplink NAS
+                 * message in this security context.
+                 */
+                if (mme_ue->ul_count_accepted == true &&
+                    estimated_ul_count <= mme_ue->ul_count.i32) {
+                    ogs_error("NAS COUNT REPLAY DETECTED - uplink NAS "
+                        "message rejected "
+                        "[UL NAS COUNT:0x%06x, LAST ACCEPTED:0x%06x]",
+                        estimated_ul_count, mme_ue->ul_count.i32);
+                    return OGS_ERROR;
+                }
+
+                mme_ue->ul_count.i32 = estimated_ul_count;
+                mme_ue->ul_count_accepted = true;
             }
+        } else {
+            /*
+             * No integrity protection (EIA0). The sequence number cannot be
+             * authenticated, so replay protection is not possible here.
+             */
+            mme_ue->ul_count.i32 = estimated_ul_count;
         }
 
         /* NAS EMM Header or ESM Header */
@@ -228,7 +285,7 @@ int nas_eps_security_decode(mme_ue_t *mme_ue,
                 return OGS_ERROR;
             }
             ogs_nas_encrypt(mme_ue->selected_enc_algorithm,
-                mme_ue->knas_enc, mme_ue->ul_count.i32, NAS_SECURITY_BEARER,
+                mme_ue->knas_enc, estimated_ul_count, NAS_SECURITY_BEARER,
                 OGS_NAS_SECURITY_UPLINK_DIRECTION, pkbuf);
         }
     }


### PR DESCRIPTION
Reject integrity-protected uplink NAS messages that reuse an already accepted NAS COUNT.

Calculate the estimated uplink COUNT without updating the UE context, and commit it only after successful MAC verification. Track whether an uplink COUNT has already been accepted so that the first COUNT value of zero remains valid.

Reset the tracking state only when a new security context is created, and preserve it in the UE context memento.

Apply the same handling to AMF, MME, and the EPS Service Request path.

Issues: #4690