### PR TITLE
amf: ignore late Namf_Communication response

### DIFF
--- a/src/amf/gmm-sm.c
+++ b/src/amf/gmm-sm.c
@@ -2543,6 +2543,47 @@ void gmm_state_authentication(ogs_fsm_t *s, amf_event_t *e)
             END
             break;
 
+        case OpenAPI_service_name_namf_comm:
+            SWITCH(sbi_message->h.resource.component[0])
+            CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)
+                SWITCH(sbi_message->h.resource.component[2])
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER)
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER_UPDATE)
+/*
+ * Issues: #4691
+ *
+ * gmm_state_authentication()
+ *
+ * Ignore late Namf_Communication response.
+ *
+ * A UEContextTransfer or RegistrationStatusUpdate response may arrive
+ * while the AMF is already handling a subsequent Registration Request.
+ * In this code path, the response belongs to the previous registration
+ * procedure and does not require any further processing.
+ *
+ * The response is intentionally ignored to avoid unnecessary handling.
+ */
+                    ogs_warn("[%s] Ignoring Namf_Communication response"
+                            "[%d] in (%s:%s)",
+                            amf_ue->supi, sbi_message->res_status,
+                            sbi_message->h.method,
+                            sbi_message->h.resource.component[2]);
+                    break;
+
+                DEFAULT
+                    ogs_error("Invalid resource name [%s]",
+                            sbi_message->h.resource.component[2]);
+                    ogs_assert_if_reached();
+                END
+                break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[0]);
+                ogs_assert_if_reached();
+            END
+            break;
+
         default:
             ogs_error("Invalid service name [%s]", sbi_message->h.service.name);
             ogs_assert_if_reached();
@@ -3198,6 +3239,47 @@ void gmm_state_initial_context_setup(ogs_fsm_t *s, amf_event_t *e)
 
                 DEFAULT
                     ogs_error("Unknown method [%s]", sbi_message->h.method);
+                    ogs_assert_if_reached();
+                END
+                break;
+
+            DEFAULT
+                ogs_error("Invalid resource name [%s]",
+                        sbi_message->h.resource.component[0]);
+                ogs_assert_if_reached();
+            END
+            break;
+
+        case OpenAPI_service_name_namf_comm:
+            SWITCH(sbi_message->h.resource.component[0])
+            CASE(OGS_SBI_RESOURCE_NAME_UE_CONTEXTS)
+                SWITCH(sbi_message->h.resource.component[2])
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER)
+                CASE(OGS_SBI_RESOURCE_NAME_TRANSFER_UPDATE)
+/*
+ * Issues: #4691
+ *
+ * gmm_state_initial_context_setup()
+ *
+ * Ignore late Namf_Communication response.
+ *
+ * A UEContextTransfer or RegistrationStatusUpdate response may arrive
+ * while the AMF is already handling a subsequent Registration Request.
+ * In this code path, the response belongs to the previous registration
+ * procedure and does not require any further processing.
+ *
+ * The response is intentionally ignored to avoid unnecessary handling.
+ */
+                    ogs_warn("[%s] Ignoring Namf_Communication response"
+                            "[%d] in (%s:%s)",
+                            amf_ue->supi, sbi_message->res_status,
+                            sbi_message->h.method,
+                            sbi_message->h.resource.component[2]);
+                    break;
+
+                DEFAULT
+                    ogs_error("Invalid resource name [%s]",
+                            sbi_message->h.resource.component[2]);
                     ogs_assert_if_reached();
                 END
                 break;


### PR DESCRIPTION
SBI responses are dispatched to the GMM state the UE is in when the response arrives, not to the state that sent the request.

While the AMF is waiting for a UEContextTransfer or a RegistrationStatusUpdate response from the old AMF, the UE can start a new registration procedure. The FSM then moves to gmm_state_authentication() and on to gmm_state_initial_context_setup(), and neither state had a namf-comm case. The late response therefore reached the service level default and terminated the AMF through ogs_assert_if_reached().

Ignore UEContextTransfer and RegistrationStatusUpdate responses in these two states, since they belong to the superseded registration procedure. Assertions for unexpected services and resources are kept as they are.

Issues: #4691