### PR TITLE
[SGWC] Fix empty session after default bearer deletion

### DIFF
--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -1346,7 +1346,12 @@ void sgwc_s11_handle_delete_bearer_response(
         } else
             ogs_error("No Cause");
 
-        if (rsp->linked_eps_bearer_id.presence)
+        /*
+         * The Linked EPS Bearer ID may be absent from the Response even
+         * though the Request carried it - see the comment in the normal
+         * relay path below. Decide from the local bearer context.
+         */
+        if (bearer == sgwc_default_bearer_in_sess(sess))
             ogs_assert(OGS_OK ==
                 sgwc_pfcp_send_session_deletion_request(
                     sess, OGS_INVALID_POOL_ID, NULL));
@@ -1379,9 +1384,9 @@ void sgwc_s11_handle_delete_bearer_response(
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED)
         goto cleanup;
 
-    if (rsp->linked_eps_bearer_id.presence) {
+    if (bearer == sgwc_default_bearer_in_sess(sess)) {
        /*
-        * << Linked EPS Bearer ID >>
+        * << DEFAULT BEARER >>
         *
         * 1. SMF sends Delete Bearer Request(DEFAULT BEARER) to SGW/MME.
         * 2. MME sends Delete Bearer Response to SGW/SMF.
@@ -1390,6 +1395,19 @@ void sgwc_s11_handle_delete_bearer_response(
         *
         * 1. SMF sends Delete Bearer Request(DEFAULT BEARER) to ePDG.
         * 2. ePDG sends Delete Bearer Response(DEFAULT BEARER) to SMF.
+        *
+        * This used to be decided by the Linked EPS Bearer ID of the
+        * Response, but the peer is not required to echo it when it rejects
+        * the procedure: an MME that cannot page an ECM-IDLE UE answers with
+        * a Cause-only Delete Bearer Response. The deletion of the PDN
+        * connection then took the dedicated bearer path below, which
+        * removed the default bearer while leaving an empty sgwc_sess_t in
+        * sgwc_ue->sess_list.
+        *
+        * The bearer comes from the transaction of the Delete Bearer Request
+        * that the SGW-C relayed, so the local context alone identifies the
+        * procedure. This matches how the Error Indication is handled in
+        * sgwc_sxa_handle_session_report_request().
         */
         if (rsp->cause.presence) {
             ogs_gtp2_cause_t *cause = rsp->cause.data;
@@ -1409,7 +1427,7 @@ void sgwc_s11_handle_delete_bearer_response(
                 sess, s5c_xact->id, gtpbuf));
     } else {
        /*
-        * << EPS Bearer IDs >>
+        * << DEDICATED BEARER >>
         *
         * 1. MME sends Bearer Resource Command to SGW/SMF.
         * 2. SMF sends Delete Bearer Request(DEDICATED BEARER) to SGW/MME.


### PR DESCRIPTION
Use the local bearer context to determine whether a Delete Bearer Response should remove a dedicated bearer or delete the entire PDN session.

An MME may return a failure response without Linked EPS Bearer ID or Bearer Contexts. In that case, relying on the response IEs causes SGW-C to remove only the default bearer and leave an empty session in the UE session list.

The stale session later triggers an assertion failure while handling a Release Access Bearers Request.

Apply the same default-bearer check to both the normal response path and the path where the associated S5-C transaction has already expired.

Issues: #4727 and #4667