### PR TITLE
IPFW: validate Flow-Description before compilation

### DIFF
--- a/lib/ipfw/ipfw2.c
+++ b/lib/ipfw/ipfw2.c
@@ -74,7 +74,26 @@ int resvd_set_number = RESVD_SET;
 int ipfw_socket = -1;
 
 #if 1 /* modifed by acetcom */
-#define errx(eval, ...) ogs_log_message(OGS_LOG_ERROR, 0, __VA_ARGS__)
+/*
+ * errx() is overridden so that a malformed rule cannot exit() the daemon.
+ *
+ * Logging alone, however, lets the parser fall through and build a rule out
+ * of data that was never populated -- an unresolvable address leaves the
+ * address word zeroed and a "0.0.0.0/32" filter is installed, a bad prefix
+ * length leaves the mask zeroed and the filter widens to "any" -- while
+ * ogs_ipfw_compile_rule() still reports success to its caller.
+ *
+ * Record the failure so that ogs_ipfw_compile_rule() can reject the rule.
+ * The flag is cleared immediately before compile_rule() and read immediately
+ * after it returns; rules are compiled on the NF event loop.
+ */
+int ogs_ipfw_parse_error = 0;
+
+#define errx(eval, ...) \
+    do { \
+        ogs_ipfw_parse_error = 1; \
+        ogs_log_message(OGS_LOG_ERROR, 0, __VA_ARGS__); \
+    } while (0)
 #endif
 
 #define	CHECK_LENGTH(v, len) do {				\
@@ -3281,7 +3300,9 @@ add_mactype(ipfw_insn *cmd, char *av, int cblen)
 		return NULL;
 }
 
-static int
+/* Not static: ogs_ipfw_compile_rule() resolves the protocol name here so
+ * that the same table is used on both sides. */
+int
 ipfw_proto_by_name(const char *name)
 {
 	struct protoent *pe;
@@ -3335,6 +3356,7 @@ add_proto0(ipfw_insn *cmd, char *av, u_char *protop)
 	if (*ep != '\0' || proto <= 0) {
 		proto = ipfw_proto_by_name(av);
 		if (proto < 0) {
+			ogs_ipfw_parse_error = 1;
 			ogs_error("Unknown protocol '%s' in flow description "
 					"(getprotobyname() failed; "
 					"check /etc/protocols)", av);

--- a/lib/ipfw/ogs-ipfw.c
+++ b/lib/ipfw/ogs-ipfw.c
@@ -32,6 +32,299 @@
 
 void compile_rule(char *av[], uint32_t *rbuf, int *rbufsize, void *tstate);
 
+/* Set by the errx() override in ipfw2.c when a rule fails to parse */
+extern int ogs_ipfw_parse_error;
+
+/* Protocol name table shared with add_proto0() in ipfw2.c */
+extern int ipfw_proto_by_name(const char *name);
+
+/*
+ * 3GPP TS 29.212 limits the IPFilterRule carried in a Flow-Description to
+ *
+ *     permit out <proto> from <src> [<ports>] to <dst> [<ports>]
+ *
+ * compile_rule() below is the full ipfw(8) command line parser.  It also
+ * accepts hostnames, address sets, lookup tables and the entire option
+ * keyword space, and -- because errx() no longer exits -- it keeps parsing
+ * after it has already rejected a token, dereferencing arguments that are
+ * not there.  A Flow-Description from a PCF, PCRF or AF can therefore crash
+ * an SMF, UPF or SGW-U:
+ *
+ *     permit out ip                              -> SEGV in add_src()
+ *     permit out ip from 1.2.3.4                 -> SEGV in add_dst()
+ *     permit out ip from 1.2.3.4 to 1.2.3.4 uid  -> SEGV in compile_rule()
+ *     permit out ip from table(1) to assigned    -> SEGV in pack_table()
+ *     permit out 58 from ff02::2/129 to assigned -> exit() from ipv6.c
+ *
+ * Check the token stream against the grammar we accept before handing it
+ * over.  The structure, the addresses and the ports are settled here; an
+ * unrecognised protocol name is the one thing still left to the parser,
+ * which rejects it through ogs_ipfw_parse_error below.
+ */
+static bool ipfw_parse_number(const char *s, int min, int max, int *value)
+{
+    int v = 0;
+
+    if (!s || !*s)
+        return false;
+
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9')
+            return false;
+        v = v * 10 + (*s - '0');
+        if (v > max)
+            return false;
+    }
+
+    if (v < min)
+        return false;
+
+    if (value)
+        *value = v;
+
+    return true;
+}
+
+static bool ipfw_is_number(const char *s, int min, int max)
+{
+    return ipfw_parse_number(s, min, max, NULL);
+}
+
+/*
+ * "ip", a protocol number, or a name that resolves to one.
+ *
+ * The token is rewritten in place as a number so that compile_rule() only
+ * ever sees "ip" or a decimal, because every other spelling it understands
+ * ends up meaning "no protocol restriction" once the rule reaches
+ * ogs_ipfw_rule_t:
+ *
+ *   - add_proto0() stores the number in a u_char without a range check, so
+ *     "256" is truncated to 0 and a UDP filter turns into "ip"; "999"
+ *     becomes protocol 231.
+ *   - add_proto() matches "all" with _substrcmp(), which succeeds on a
+ *     prefix, so "a" and "al" are accepted as "all" -> protocol 0.
+ *   - "ip4", "ipv4", "ip6" and "ipv6" are family selectors emitted as O_IP4
+ *     or O_IP6, opcodes the loop below does not read, so the restriction is
+ *     dropped and protocol 0 is what remains.
+ *   - a name whose number is 0 -- "hopopt" -- passes add_proto0() unchanged
+ *     and lands as protocol 0 as well.
+ *
+ * Resolve the name through ipfw_proto_by_name(), the table add_proto0()
+ * itself uses, rather than keeping a second one here.
+ */
+static int ipfw_check_proto(char **token, char *buf, int size, int *protop)
+{
+    const char *s = *token;
+    const char *p;
+    int proto;
+
+    if (!s || !*s)
+        return OGS_ERROR;
+
+    /* the only name carried through: no protocol restriction */
+    if (strcmp(s, "ip") == 0) {
+        *protop = IPPROTO_IP;
+        return OGS_OK;
+    }
+
+    if (*s >= '0' && *s <= '9') {
+        if (!ipfw_parse_number(s, 1, 255, &proto))
+            return OGS_ERROR;
+    } else {
+        for (p = s; *p; p++) {
+            if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+                (*p >= '0' && *p <= '9') || *p == '-')
+                continue;
+            return OGS_ERROR;
+        }
+
+        /*
+         * "all" and the family selectors would resolve to something, or to
+         * nothing, that no longer means what was written.  Refuse them by
+         * name so that the operator is told to use "ip" instead.
+         */
+        if (strcmp(s, "all") == 0 || strcmp(s, "ip4") == 0 ||
+            strcmp(s, "ipv4") == 0 || strcmp(s, "ip6") == 0 ||
+            strcmp(s, "ipv6") == 0)
+            return OGS_ERROR;
+
+        proto = ipfw_proto_by_name(s);
+        if (proto < 1 || proto > 255)
+            return OGS_ERROR;
+    }
+
+    ogs_snprintf(buf, size, "%d", proto);
+    *token = buf;
+    *protop = proto;
+
+    return OGS_OK;
+}
+
+/*
+ * "any", "assigned", or a literal IPv4/IPv6 address with optional prefix.
+ *
+ * Returns the address family, AF_UNSPEC for the two keywords -- which carry
+ * no family of their own -- or -1 when the token is not an address at all.
+ */
+static int ipfw_addr_family(const char *s)
+{
+    char buf[OGS_ADDRSTRLEN];
+    struct in_addr addr4;
+    struct in6_addr addr6;
+    const char *slash;
+    size_t len;
+
+    if (!s || !*s)
+        return -1;
+
+    if (strcmp(s, "any") == 0 || strcmp(s, "assigned") == 0)
+        return AF_UNSPEC;
+
+    slash = strchr(s, '/');
+    len = slash ? (size_t)(slash - s) : strlen(s);
+    if (len == 0 || len >= sizeof(buf))
+        return -1;
+    memcpy(buf, s, len);
+    buf[len] = '\0';
+
+    if (inet_pton(AF_INET, buf, &addr4) == 1)
+        return (!slash || ipfw_is_number(slash + 1, 0, 32)) ? AF_INET : -1;
+    if (inet_pton(AF_INET6, buf, &addr6) == 1)
+        return (!slash || ipfw_is_number(slash + 1, 0, 128)) ? AF_INET6 : -1;
+
+    return -1;
+}
+
+/*
+ * A single port or a "low-high" range, 1..65535.
+ *
+ * Port 0 must not be accepted: ogs_ipfw_rule_t uses 0 to mean "no port
+ * condition", so "from 1.2.3.4 0" would silently become "from 1.2.3.4" and
+ * widen the filter to every port.  fill_newports() stores the two ends of a
+ * range without comparing them, so a reversed range has to be caught here
+ * as well.
+ */
+static bool ipfw_is_ports(const char *s)
+{
+    char buf[8];
+    const char *dash;
+    size_t len;
+    int low, high;
+
+    if (!s || !*s)
+        return false;
+
+    dash = strchr(s, '-');
+    if (!dash)
+        return ipfw_is_number(s, 1, 65535);
+
+    len = dash - s;
+    if (len == 0 || len >= sizeof(buf))
+        return false;
+    memcpy(buf, s, len);
+    buf[len] = '\0';
+
+    if (!ipfw_parse_number(buf, 1, 65535, &low))
+        return false;
+    if (!ipfw_parse_number(dash + 1, 1, 65535, &high))
+        return false;
+
+    return low <= high;
+}
+
+/*
+ * av[0] is unused and av[1] is "permit", so the tokens to check are
+ * av[2] .. av[last-1].  The direction, which the caller has moved to the
+ * end of the array, is not part of this grammar.
+ */
+static int ipfw_check_tokens(
+        char *av[], int last, char *proto_buf, int proto_buf_size,
+        char *flow_description)
+{
+    int x = 2;
+    int proto = IPPROTO_IP;
+    int src_family, dst_family;
+
+#define REJECT(reason) \
+    do { \
+        ogs_error("Invalid Flow-Description [%s] : %s", \
+                flow_description, reason); \
+        return OGS_ERROR; \
+    } while (0)
+#define REQUIRE(cond, reason) \
+    do { if (!(cond)) REJECT(reason); } while (0)
+
+    REQUIRE(x < last, "no protocol");
+    REQUIRE(ipfw_check_proto(
+                &av[x], proto_buf, proto_buf_size, &proto) == OGS_OK,
+            "bad protocol");
+    x++;
+
+    REQUIRE(x < last && strcmp(av[x], "from") == 0, "missing 'from'");
+    x++;
+
+    REQUIRE(x < last, "no source address");
+/*
+ * Refer to lib/ipfw/ogs-ipfw.h
+ * Issue #338
+ *
+ * A Flow-Description is always written in the downlink orientation, so the
+ * UE address -- "assigned" -- can only appear after "to".  An uplink flow
+ * arrives as RX "permit in from <UE> to <REMOTE>", which flow_rx_to_gx()
+ * has already rewritten into that form before it reaches here.
+ */
+    if (strcmp(av[x], "assigned") == 0)
+        REJECT("'assigned' is the UE address and is only valid after 'to'");
+    src_family = ipfw_addr_family(av[x]);
+    REQUIRE(src_family >= 0, "bad source address");
+    x++;
+
+    if (x < last && strcmp(av[x], "to") != 0) {
+        REQUIRE(ipfw_is_ports(av[x]), "bad source port");
+        x++;
+    }
+
+    REQUIRE(x < last && strcmp(av[x], "to") == 0, "missing 'to'");
+    x++;
+
+    REQUIRE(x < last, "no destination address");
+    dst_family = ipfw_addr_family(av[x]);
+    REQUIRE(dst_family >= 0, "bad destination address");
+    x++;
+
+    if (x < last) {
+        REQUIRE(ipfw_is_ports(av[x]), "bad destination port");
+        x++;
+    }
+
+    REQUIRE(x == last, "trailing token");
+
+    /* one packet cannot carry both families */
+    REQUIRE(src_family == AF_UNSPEC || dst_family == AF_UNSPEC ||
+            src_family == dst_family,
+            "source and destination address family differ");
+
+    /*
+     * Protocol 41 is IPv6 encapsulation, and the outer addresses of a
+     * 6in4 tunnel are legitimately IPv4.  add_src() and add_dst(), however,
+     * treat the number as if it selected the address family: once the
+     * protocol is IPPROTO_IPV6 they send every address through
+     * add_srcip6() and add_dstip6(), whatever it looks like.  ipv6.c calls
+     * the real errx() from err.h -- it never sees the override in
+     * ipfw2.c -- so an IPv4 literal exits the daemon rather than failing
+     * the rule.  Refuse the combination until the parser can carry it.
+     */
+    if (proto == IPPROTO_IPV6)
+        REQUIRE(src_family != AF_INET && dst_family != AF_INET,
+                "IPv4 literal with protocol 41 is unsupported");
+
+#undef REQUIRE
+#undef REJECT
+
+    return OGS_OK;
+}
+
+
 int ogs_ipfw_compile_rule(ogs_ipfw_rule_t *ipfw_rule, char *flow_description)
 {
     char *token, *dir;
@@ -39,6 +332,7 @@ int ogs_ipfw_compile_rule(ogs_ipfw_rule_t *ipfw_rule, char *flow_description)
     int i;
 
     char *av[MAX_NUM_OF_TOKEN];
+    char proto_buf[4];
 	uint32_t rulebuf[MAX_NUM_OF_RULE_BUFFER];
 	int rbufsize;
 	struct ip_fw_rule *rule = (struct ip_fw_rule *)rulebuf;
@@ -89,6 +383,12 @@ int ogs_ipfw_compile_rule(ogs_ipfw_rule_t *ipfw_rule, char *flow_description)
 
     av[i] = NULL;
 
+    if (ipfw_check_tokens(av, i-1, proto_buf, sizeof(proto_buf),
+                flow_description) != OGS_OK) {
+        ogs_free(description);
+        return OGS_ERROR;
+    }
+
     /* "to assigned" --> "to any" */
     for (x = 2; av[x] != NULL; x++) {
         if (strcmp(av[x], "assigned") == 0 && strcmp(av[x-1], "to") == 0) {
@@ -97,9 +397,16 @@ int ogs_ipfw_compile_rule(ogs_ipfw_rule_t *ipfw_rule, char *flow_description)
         }
     }
 
+    ogs_ipfw_parse_error = 0;
 	compile_rule(av, (uint32_t *)rule, &rbufsize, NULL);
 
     memset(ipfw_rule, 0, sizeof(ogs_ipfw_rule_t));
+
+    if (ogs_ipfw_parse_error) {
+        ogs_error("Cannot compile Flow-Description [%s]", flow_description);
+        ogs_free(description);
+        return OGS_ERROR;
+    }
 	for (l = rule->act_ofs, cmd = rule->cmd;
 			l > 0 ; l -= F_LEN(cmd) , cmd += F_LEN(cmd)) {
         uint32_t *a = NULL;

--- a/src/smf/binding.c
+++ b/src/smf/binding.c
@@ -290,6 +290,12 @@ void smf_bearer_binding(smf_sess_t *sess)
 
                 rv = ogs_ipfw_compile_rule(
                         &pf->ipfw_rule, pf->flow_description);
+                if (rv != OGS_OK) {
+                    ogs_error("Invalid Flow-Description[%s]",
+                            pf->flow_description);
+                    smf_pf_remove(pf);
+                    break;
+                }
 /*
  * Refer to lib/ipfw/ogs-ipfw.h
  * Issue #338
@@ -306,13 +312,6 @@ void smf_bearer_binding(smf_sess_t *sess)
  */
                 if (flow->direction == OGS_FLOW_UPLINK_ONLY)
                     ogs_ipfw_rule_swap(&pf->ipfw_rule);
-
-                if (rv != OGS_OK) {
-                    ogs_error("Invalid Flow-Description[%s]",
-                            pf->flow_description);
-                    smf_pf_remove(pf);
-                    break;
-                }
 
                 /*
                  * To add a flow to an existing tft.
@@ -668,6 +667,12 @@ void smf_qos_flow_binding(smf_sess_t *sess)
 
                 rv = ogs_ipfw_compile_rule(
                         &pf->ipfw_rule, pf->flow_description);
+                if (rv != OGS_OK) {
+                    ogs_error("Invalid Flow-Description[%s]",
+                            pf->flow_description);
+                    smf_pf_remove(pf);
+                    break;
+                }
 /*
  * Refer to lib/ipfw/ogs-ipfw.h
  * Issue #338
@@ -684,13 +689,6 @@ void smf_qos_flow_binding(smf_sess_t *sess)
  */
                 if (flow->direction == OGS_FLOW_UPLINK_ONLY)
                     ogs_ipfw_rule_swap(&pf->ipfw_rule);
-
-                if (rv != OGS_OK) {
-                    ogs_error("Invalid Flow-Description[%s]",
-                            pf->flow_description);
-                    smf_pf_remove(pf);
-                    break;
-                }
 
                 /*
                  * To add a flow to an existing tft.

--- a/tests/unit/abts-main.c
+++ b/tests/unit/abts-main.c
@@ -39,6 +39,7 @@ abts_suite *test_security(abts_suite *suite);
 abts_suite *test_nrf_discovery(abts_suite *suite);
 abts_suite *test_crash(abts_suite *suite);
 abts_suite *test_mme_dns_select(abts_suite *suite);
+abts_suite *test_ipfw(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -53,6 +54,7 @@ const struct testlist {
     {test_nrf_discovery},
     {test_crash},
     {test_mme_dns_select},
+    {test_ipfw},
     {NULL},
 };
 

--- a/tests/unit/ipfw-test.c
+++ b/tests/unit/ipfw-test.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ipfw/ogs-ipfw.h"
+#include "core/abts.h"
+
+static int compile(ogs_ipfw_rule_t *rule, const char *flow_description)
+{
+    char buf[OGS_HUGE_LEN];
+
+    ogs_cpystrn(buf, flow_description, sizeof(buf));
+
+    memset(rule, 0, sizeof(ogs_ipfw_rule_t));
+    return ogs_ipfw_compile_rule(rule, buf);
+}
+
+#define ACCEPT(tc, s) ABTS_INT_EQUAL(tc, OGS_OK, compile(&rule, s))
+#define REJECT(tc, s) ABTS_INT_EQUAL(tc, OGS_ERROR, compile(&rule, s))
+
+/*
+ * A rule that compiles can still mean something other than what was
+ * written, so check the canonical form the encoder produces rather than
+ * the return value alone.
+ */
+static void encodes_to(abts_case *tc,
+        const char *flow_description, const char *expected, int lineno)
+{
+    ogs_ipfw_rule_t rule;
+    char *encoded = NULL;
+
+    if (compile(&rule, flow_description) != OGS_OK) {
+        abts_fail(tc, "Flow-Description was rejected", lineno);
+        return;
+    }
+
+    encoded = ogs_ipfw_encode_flow_description(&rule);
+    abts_str_equal(tc, expected, encoded, lineno);
+
+    if (encoded)
+        ogs_free(encoded);
+}
+
+#define ENCODES_TO(tc, s, e) encodes_to(tc, s, e, __LINE__)
+
+/* what Open5GS itself emits and what configs/ and tests/ use */
+static void ipfw_test_accepted(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out ip from any to assigned");
+    ACCEPT(tc, "permit out icmp from any to any");
+    ACCEPT(tc, "permit out icmp from any to assigned");
+    ACCEPT(tc, "permit out 58 from ff02::2/128 to assigned");
+    ACCEPT(tc, "permit out 17 from 172.20.166.84 to 10.45.0.2 20001");
+    ACCEPT(tc, "permit out udp from 172.30.0.50 49000-50000 to assigned");
+    ACCEPT(tc, "permit out udp from 10.200.136.98/32 1-65535 to assigned 50021");
+    ACCEPT(tc, "permit out 6 from 2001:db8::1/64 to assigned");
+
+    ENCODES_TO(tc, "permit out ip from any to assigned",
+            "permit out ip from any to assigned");
+    ENCODES_TO(tc, "permit out 17 from 172.20.166.84 to 10.45.0.2 20001",
+            "permit out 17 from 172.20.166.84 to 10.45.0.2 20001");
+    ENCODES_TO(tc, "permit out udp from 172.30.0.50 49000-50000 to assigned",
+            "permit out 17 from 172.30.0.50 49000-50000 to assigned");
+    ENCODES_TO(tc,
+            "permit out udp from 10.200.136.98/32 1-65535 to assigned 50021",
+            "permit out 17 from 10.200.136.98 1-65535 to assigned 50021");
+    ENCODES_TO(tc, "permit out 6 from 2001:db8::1/64 to assigned",
+            "permit out 6 from 2001:db8::/64 to assigned");
+}
+
+static void ipfw_test_structure(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    REJECT(tc, "permit out");
+    REJECT(tc, "permit out ip");
+    REJECT(tc, "permit out ip from");
+    REJECT(tc, "permit out ip from 1.2.3.4");
+    REJECT(tc, "permit out ip from 1.2.3.4 to");
+    REJECT(tc, "permit out ip from to");
+    REJECT(tc, "permit out ip from any to");
+    REJECT(tc, "permit in ip from any to assigned");
+
+    /* ipfw(8) syntax that a Flow-Description must not carry */
+    REJECT(tc, "permit out ip from 1.2.3.4 to 1.2.3.4 uid");
+    REJECT(tc, "permit out ip from 1.2.3.4 to 1.2.3.4 keep-state");
+    REJECT(tc, "permit out ip from 1.2.3.4 to 1.2.3.4 fwd 1.2.3.4");
+    REJECT(tc, "permit out ip from table(1) to assigned");
+    REJECT(tc, "permit out ip from me to assigned");
+    REJECT(tc, "permit out ip from 1.2.3.4,2.3.4.5 to any");
+    REJECT(tc, "permit out ip from 1.2.3.4{1,2,3,4,5,6,7,8} to any");
+    REJECT(tc, "permit out ip from no.such.host.invalid to assigned");
+}
+
+static void ipfw_test_proto(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out 1 from 1.2.3.4 to assigned");
+    ABTS_INT_EQUAL(tc, 1, rule.proto);
+    ACCEPT(tc, "permit out 255 from 1.2.3.4 to assigned");
+    ABTS_INT_EQUAL(tc, 255, rule.proto);
+    ACCEPT(tc, "permit out udp from 1.2.3.4 to assigned");
+    ABTS_INT_EQUAL(tc, IPPROTO_UDP, rule.proto);
+    ACCEPT(tc, "permit out ipv6-icmp from ff02::2/128 to assigned");
+    ABTS_INT_EQUAL(tc, IPPROTO_ICMPV6, rule.proto);
+    /* the one name carried through: no protocol restriction */
+    ACCEPT(tc, "permit out ip from 1.2.3.4 to assigned");
+    ABTS_INT_EQUAL(tc, IPPROTO_IP, rule.proto);
+
+    /*
+     * add_proto0() stores the protocol in a u_char without a range check,
+     * so 256 would be truncated to 0 -- widening the filter to all of IP --
+     * and 999 would become 231.
+     */
+    REJECT(tc, "permit out 0 from 1.2.3.4 to assigned");
+    REJECT(tc, "permit out 256 from 1.2.3.4 to assigned");
+    REJECT(tc, "permit out 999 from 1.2.3.4 to assigned");
+    REJECT(tc, "permit out unknown-protocol from 1.2.3.4 to assigned");
+
+    /* add_proto() matches "all" with _substrcmp(), which takes a prefix */
+    REJECT(tc, "permit out a from 1.2.3.4 to assigned");
+    REJECT(tc, "permit out al from 1.2.3.4 to assigned");
+    REJECT(tc, "permit out all from 1.2.3.4 to assigned");
+
+    /* family selectors: O_IP4/O_IP6 are dropped, leaving protocol 0 */
+    REJECT(tc, "permit out ip4 from any to assigned");
+    REJECT(tc, "permit out ipv4 from any to assigned");
+    REJECT(tc, "permit out ip6 from any to assigned");
+    REJECT(tc, "permit out ipv6 from any to assigned");
+
+    /* a name whose protocol number is 0 */
+    REJECT(tc, "permit out hopopt from 1.2.3.4 to assigned");
+}
+
+static void ipfw_test_port(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out udp from 1.2.3.4 1 to assigned");
+    ABTS_INT_EQUAL(tc, 1, rule.port.src.low);
+    ACCEPT(tc, "permit out udp from 1.2.3.4 65535 to assigned");
+    ABTS_INT_EQUAL(tc, 65535, rule.port.src.high);
+    ACCEPT(tc, "permit out udp from 1.2.3.4 1-65535 to assigned");
+    ABTS_INT_EQUAL(tc, 1, rule.port.src.low);
+    ABTS_INT_EQUAL(tc, 65535, rule.port.src.high);
+
+    /* 0 means "no port condition", so it must not arrive as a port */
+    REJECT(tc, "permit out udp from 1.2.3.4 0 to assigned");
+    REJECT(tc, "permit out udp from 1.2.3.4 to assigned 0");
+
+    REJECT(tc, "permit out udp from 1.2.3.4 65536 to assigned");
+    /* fill_newports() never compares the two ends of a range */
+    REJECT(tc, "permit out udp from 1.2.3.4 50000-40000 to assigned");
+    REJECT(tc, "permit out udp from 1.2.3.4 1-0 to assigned");
+}
+
+static void ipfw_test_prefix(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out ip from 1.2.3.4/0 to assigned");
+    ACCEPT(tc, "permit out ip from 1.2.3.4/32 to assigned");
+    REJECT(tc, "permit out ip from 1.2.3.4/33 to assigned");
+    REJECT(tc, "permit out ip from 10.45.0.0/99 to assigned");
+
+    ACCEPT(tc, "permit out 58 from ff02::2/0 to assigned");
+    ACCEPT(tc, "permit out 58 from ff02::2/128 to assigned");
+    /* ipv6.c calls the real errx(), which would exit() the daemon */
+    REJECT(tc, "permit out 58 from ff02::2/129 to assigned");
+    REJECT(tc, "permit out 58 from :::::: to assigned");
+}
+
+/*
+ * add_src() and add_dst() send every address through the IPv6 helpers once
+ * the protocol is IPPROTO_IPV6, and ipv6.c calls the real errx(), which
+ * exits the daemon.  A packet also cannot carry both families at once.
+ */
+static void ipfw_test_family(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out 41 from 2001:db8::1 to assigned");
+    ACCEPT(tc, "permit out 41 from any to assigned");
+    REJECT(tc, "permit out 41 from 192.0.2.1 to assigned");
+    /* "any" carries no family, so this can only be the protocol 41 rule */
+    REJECT(tc, "permit out 41 from any to 192.0.2.1");
+    REJECT(tc, "permit out 41 from 192.0.2.1 to 192.0.2.2");
+
+    ACCEPT(tc, "permit out 17 from 10.45.0.5 50026 to 10.45.0.3 50022");
+    REJECT(tc, "permit out tcp from 2001:db8::1 to 192.0.2.1");
+    REJECT(tc, "permit out tcp from 192.0.2.1 to 2001:db8::1");
+
+    ACCEPT(tc, "permit out 41 from any to 2001:db8::1");
+}
+
+/*
+ * ogs_ipfw_rule_t holds one contiguous range per direction, so the comma
+ * separated lists an IPFilterRule may carry cannot be represented -- the
+ * parser would keep the first range and drop the rest.
+ */
+static void ipfw_test_port_list(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    REJECT(tc, "permit out tcp from any to assigned 80,443");
+    REJECT(tc, "permit out udp from any to assigned 1000-2000,3000");
+    REJECT(tc, "permit out tcp from any 80,443 to assigned");
+}
+
+/*
+ * Refer to lib/ipfw/ogs-ipfw.h
+ * Issue #338, Issue #4711
+ *
+ * A Flow-Description is always written in the downlink orientation, so the
+ * UE address -- "assigned" -- can only appear after "to".
+ */
+static void ipfw_test_assigned(abts_case *tc, void *data)
+{
+    ogs_ipfw_rule_t rule;
+
+    ACCEPT(tc, "permit out udp from 172.30.0.50 49000-50000 to assigned");
+    REJECT(tc, "permit out udp from assigned to 172.30.0.50 49000-50000");
+    REJECT(tc, "permit out ip from assigned to assigned");
+}
+
+abts_suite *test_ipfw(abts_suite *suite)
+{
+    int id = ogs_log_get_domain_id("core");
+    ogs_log_level_e level = ogs_log_get_domain_level(id);
+
+    suite = ADD_SUITE(suite)
+
+    /*
+     * These cases feed malformed input to the parser to prove that it
+     * neither crashes (SEGV, exit) nor accepts the rule.  Only the return
+     * value matters here, so the diagnostic each rejection prints is not
+     * wanted -- silence the domain while the suite runs.
+     */
+    ogs_log_set_domain_level(id, OGS_LOG_NONE);
+
+    abts_run_test(suite, ipfw_test_accepted, NULL);
+    abts_run_test(suite, ipfw_test_structure, NULL);
+    abts_run_test(suite, ipfw_test_proto, NULL);
+    abts_run_test(suite, ipfw_test_port, NULL);
+    abts_run_test(suite, ipfw_test_prefix, NULL);
+    abts_run_test(suite, ipfw_test_family, NULL);
+    abts_run_test(suite, ipfw_test_port_list, NULL);
+    abts_run_test(suite, ipfw_test_assigned, NULL);
+
+    ogs_log_set_domain_level(id, level);
+
+    return suite;
+}

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -27,6 +27,7 @@ testunit_unit_sources = files('''
     nrf-discovery-test.c
     crash-test.c
     mme-dns-select-test.c
+    ipfw-test.c
 '''.split())
 
 testunit_unit_exe = executable('unit',
@@ -38,6 +39,7 @@ testunit_unit_exe = executable('unit',
                     libngap_dep,
                     libnas_eps_dep,
                     libsbi_dep,
+                    libipfw_dep,
                     libmme_dep])
 
 test('unit', testunit_unit_exe, is_parallel : false, suite: 'unit')


### PR DESCRIPTION
### Summary

This PR validates Flow-Description strings before passing them to the bundled ipfw parser.

The current parser can silently truncate or discard parts of malformed rules. Certain inputs can also reach `errx()` paths in the vendored parser and terminate the process.

The validation is intentionally limited to the subset of IPFilterRule syntax that `ogs_ipfw_rule_t` can represent.

### Changes

* Validate the action, direction, protocol, addresses, prefixes, ports, and trailing tokens.

* Reject protocol numbers outside the supported range instead of allowing integer truncation.

* Reject invalid port numbers and reversed port ranges.

* Reject comma-separated port lists because `ogs_ipfw_rule_t` can only represent one continuous range per direction.

* Reject mixed IPv4 and IPv6 literal addresses.

* Reject IPv4 literals used with protocol 41.

  Protocol 41 can legitimately use IPv4 outer addresses for IPv6 encapsulation. However, the bundled ipfw parser currently treats protocol 41 as an address-family selector and sends IPv4 literals to its IPv6 address parser, which can terminate the process. This combination is therefore rejected until the parser can handle it safely.

* Reject `assigned` in the source position with a clear diagnostic.

* Propagate `compile_rule()` failures to the caller.

* Swap uplink rules only after successful compilation.

* Add unit tests for valid, invalid, and previously crashing Flow-Description inputs.

### Issue #4711

The Flow-Description form reported in #4711 now fails cleanly and is not installed.

This PR does **not** add support for `assigned` in the source position.

### Testing

* IPFW unit tests: SUCCESS
* 27 malformed inputs: all rejected without a crash
* 10 valid test inputs: no regression
* 15 Flow-Description strings found in the repository: no regression
* Protocol 41 source and destination crash paths: rejected without terminating the process
* Valid protocol 41 rules using IPv6 literals, `any`, or `assigned`: still accepted

### Notes

The bundled ipfw parser still contains direct `errx()` paths. This PR prevents the identified malformed Flow-Description inputs from reaching those paths, but replacing the underlying parser termination behavior should be handled separately.

Related: #4711
