### PR TITLE
[SMF/PCRF] Fix Diameter Session-Id lifetime handling

### DIFF
--- a/src/pcrf/pcrf-context.c
+++ b/src/pcrf/pcrf-context.c
@@ -26,6 +26,30 @@ static ogs_diam_config_t g_diam_conf;
 
 int __pcrf_log_domain;
 
+/*
+ * IP address to Gx Session-Id mapping
+ *
+ * ogs_hash_t stores the key and the value pointers as given, so an entry
+ * that borrowed them from a Diameter session state would outlive its
+ * owner. Each entry therefore keeps its own key and Session-Id, and
+ * lookups return a copy that the caller frees.
+ */
+#define MAX_IP_KEY_LEN      (OGS_IPV6_DEFAULT_PREFIX_LEN >> 3)
+
+typedef struct ip_sid_s {
+    uint8_t     key[MAX_IP_KEY_LEN];
+    int         klen;
+    uint8_t     *sid;
+} ip_sid_t;
+
+static void ip_sid_free(ip_sid_t *entry)
+{
+    ogs_assert(entry);
+    if (entry->sid)
+        ogs_free(entry->sid);
+    ogs_free(entry);
+}
+
 static int context_initialized = 0;
 
 pcrf_context_t *pcrf_self(void)
@@ -59,8 +83,16 @@ void pcrf_context_init(void)
 
 void pcrf_context_final(void)
 {
+    ogs_hash_index_t *hi = NULL;
+
     ogs_assert(context_initialized == 1);
     ogs_assert(self.ip_hash);
+
+    for (hi = ogs_hash_first(self.ip_hash); hi; hi = ogs_hash_next(hi)) {
+        ip_sid_t *entry = ogs_hash_this_val(hi);
+        ogs_hash_set(self.ip_hash, entry->key, entry->klen, NULL);
+        ip_sid_free(entry);
+    }
     ogs_hash_destroy(self.ip_hash);
     ogs_thread_mutex_destroy(&self.hash_lock);
 
@@ -432,52 +464,74 @@ int pcrf_db_qos_data(
     return rv;
 }
 
-void pcrf_sess_set_ipv4(const void *key, uint8_t *sid)
+static void sess_set(const void *key, int klen, const uint8_t *sid)
 {
+    ip_sid_t *entry = NULL;
+
+    ogs_assert(key);
+    ogs_assert(klen > 0 && klen <= MAX_IP_KEY_LEN);
     ogs_assert(self.ip_hash);
 
     ogs_thread_mutex_lock(&self.hash_lock);
 
-    ogs_hash_set(self.ip_hash, key, OGS_IPV4_LEN, sid);
+    entry = ogs_hash_get(self.ip_hash, key, klen);
+    if (entry) {
+        ogs_hash_set(self.ip_hash, entry->key, entry->klen, NULL);
+        ip_sid_free(entry);
+    }
+
+    if (sid) {
+        entry = ogs_calloc(1, sizeof(*entry));
+        ogs_assert(entry);
+
+        memcpy(entry->key, key, klen);
+        entry->klen = klen;
+        entry->sid = (uint8_t *)ogs_strdup((char *)sid);
+        ogs_assert(entry->sid);
+
+        ogs_hash_set(self.ip_hash, entry->key, entry->klen, entry);
+    }
 
     ogs_thread_mutex_unlock(&self.hash_lock);
 }
-void pcrf_sess_set_ipv6(const void *key, uint8_t *sid)
+
+static uint8_t *sess_find(const void *key, int klen)
 {
+    ip_sid_t *entry = NULL;
+    uint8_t *sid = NULL;
+
+    ogs_assert(key);
     ogs_assert(self.ip_hash);
 
     ogs_thread_mutex_lock(&self.hash_lock);
 
-    ogs_hash_set(self.ip_hash, key, OGS_IPV6_DEFAULT_PREFIX_LEN >> 3, sid);
+    entry = ogs_hash_get(self.ip_hash, key, klen);
+    if (entry) {
+        sid = (uint8_t *)ogs_strdup((char *)entry->sid);
+        ogs_assert(sid);
+    }
 
     ogs_thread_mutex_unlock(&self.hash_lock);
+
+    return sid;
+}
+
+void pcrf_sess_set_ipv4(const void *key, uint8_t *sid)
+{
+    sess_set(key, OGS_IPV4_LEN, sid);
+}
+
+void pcrf_sess_set_ipv6(const void *key, uint8_t *sid)
+{
+    sess_set(key, OGS_IPV6_DEFAULT_PREFIX_LEN >> 3, sid);
 }
 
 uint8_t *pcrf_sess_find_by_ipv4(const void *key)
 {
-    uint8_t *sid = NULL;
-    ogs_assert(key);
-
-    ogs_thread_mutex_lock(&self.hash_lock);
-
-    sid = (uint8_t *)ogs_hash_get(self.ip_hash, key, OGS_IPV4_LEN);
-
-    ogs_thread_mutex_unlock(&self.hash_lock);
-
-    return sid;
+    return sess_find(key, OGS_IPV4_LEN);
 }
 
 uint8_t *pcrf_sess_find_by_ipv6(const void *key)
 {
-    uint8_t *sid = NULL;
-    ogs_assert(key);
-
-    ogs_thread_mutex_lock(&self.hash_lock);
-
-    sid = (uint8_t *)ogs_hash_get(
-            self.ip_hash, key, OGS_IPV6_DEFAULT_PREFIX_LEN >> 3);
-
-    ogs_thread_mutex_unlock(&self.hash_lock);
-
-    return sid;
+    return sess_find(key, OGS_IPV6_DEFAULT_PREFIX_LEN >> 3);
 }

--- a/src/pcrf/pcrf-context.h
+++ b/src/pcrf/pcrf-context.h
@@ -59,6 +59,7 @@ int pcrf_db_qos_data(char *imsi_bcd, char *apn,
 
 void pcrf_sess_set_ipv4(const void *key, uint8_t *sid);
 void pcrf_sess_set_ipv6(const void *key, uint8_t *sid);
+/* Both return a copy of the Session-Id; the caller must free it */
 uint8_t *pcrf_sess_find_by_ipv4(const void *key);
 uint8_t *pcrf_sess_find_by_ipv6(const void *key);
 

--- a/src/pcrf/pcrf-gx-path.c
+++ b/src/pcrf/pcrf-gx-path.c
@@ -450,6 +450,15 @@ static int pcrf_gx_ccr_cb(struct msg **msg, struct avp *avp,
         ret = fd_msg_avp_hdr(avp, &hdr);
         if (ret == 0 && hdr &&
             hdr->avp_value->os.len == sizeof(sess_data->addr)) {
+            /*
+             * This runs for every CC-Request, so retire the previous
+             * binding before the address is overwritten. Otherwise the
+             * old address keeps an entry that nothing ever removes.
+             */
+            if (sess_data->ipv4) {
+                pcrf_sess_set_ipv4(&sess_data->addr, NULL);
+                sess_data->ipv4 = 0;
+            }
             memcpy(&sess_data->addr,
                     hdr->avp_value->os.data, hdr->avp_value->os.len);
             pcrf_sess_set_ipv4(&sess_data->addr, sess_data->sid);
@@ -468,6 +477,10 @@ static int pcrf_gx_ccr_cb(struct msg **msg, struct avp *avp,
         if (ret == 0 && hdr) {
             paa = (ogs_paa_t *)hdr->avp_value->os.data;
             if (paa && paa->len == OGS_IPV6_DEFAULT_PREFIX_LEN) {
+                if (sess_data->ipv6) {
+                    pcrf_sess_set_ipv6(sess_data->addr6, NULL);
+                    sess_data->ipv6 = 0;
+                }
                 memcpy(sess_data->addr6, paa->addr6, paa->len >> 3);
                 pcrf_sess_set_ipv6(sess_data->addr6, sess_data->sid);
                 sess_data->ipv6 = 1;

--- a/src/pcrf/pcrf-rx-path.c
+++ b/src/pcrf/pcrf-rx-path.c
@@ -255,6 +255,10 @@ static int pcrf_rx_aar_cb(struct msg **msg, struct avp *avp,
 
             paa = (ogs_paa_t *)hdr->avp_value->os.data;
             if (paa->len == OGS_IPV6_128_PREFIX_LEN) {
+                if (gx_sid) {
+                    ogs_free(gx_sid);
+                    gx_sid = NULL;
+                }
                 gx_sid = (os0_t)pcrf_sess_find_by_ipv6(paa->addr6);
                 if (!gx_sid) {
                     ogs_warn("Cannot find Gx Session for IPv6:%s",
@@ -548,6 +552,8 @@ static int pcrf_rx_aar_cb(struct msg **msg, struct avp *avp,
         )
 
         ogs_ims_data_free(&rx_message.ims_data);
+        if (gx_sid)
+            ogs_free(gx_sid);
         return 0;
     }
 
@@ -590,6 +596,9 @@ out:
 
     /* Always free IMS data */
     ogs_ims_data_free(&rx_message.ims_data);
+
+    if (gx_sid)
+        ogs_free(gx_sid);
 
     return 0;
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2100,6 +2100,13 @@ void smf_sess_remove(smf_sess_t *sess)
     if (sess->data_change_subscription.client)
         ogs_sbi_client_remove(sess->data_change_subscription.client);
 
+    if (sess->gx_sid)
+        ogs_free(sess->gx_sid);
+    if (sess->gy_sid)
+        ogs_free(sess->gy_sid);
+    if (sess->s6b_sid)
+        ogs_free(sess->s6b_sid);
+
     if (sess->session.name)
         ogs_free(sess->session.name);
     if (sess->full_dnn)

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -198,8 +198,19 @@ void smf_gx_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
 
         ogs_debug("    Allocate new session: [%s]", sess_data->gx_sid);
 
-        /* Save Session-Id to SMF Session Context */
-        sess->gx_sid = (char *)sess_data->gx_sid;
+        /*
+         * Save Session-Id to SMF Session Context
+         *
+         * Keep an independent copy. sess_data->gx_sid is owned by the
+         * Diameter session state and can be released by state_cleanup()
+         * before the SMF session context is removed. Sharing the pointer
+         * would leave sess->gx_sid dangling and could cause a later
+         * request to read freed memory while constructing its
+         * Session-Id AVP.
+         */
+        ogs_assert(!sess->gx_sid);
+        sess->gx_sid = ogs_strdup((char *)sess_data->gx_sid);
+        ogs_assert(sess->gx_sid);
     } else
         ogs_debug("    Retrieve session: [%s]", sess_data->gx_sid);
 
@@ -766,7 +777,7 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
 
     struct sess_state *sess_data = NULL;
     struct timespec ts;
-    struct session *session;
+    struct session *session = NULL;
     struct avp *avp, *avpch1, *avpch2;
     struct avp_hdr *hdr;
     unsigned long dur;
@@ -790,7 +801,11 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
 
     /* Search the session, retrieve its data */
     ret = fd_msg_sess_get(fd_g_config->cnf_dict, *msg, &session, &new);
-    ogs_assert(ret == 0);
+    if (ret != 0) {
+        ogs_error("fd_msg_sess_get() failed with error: %d", ret);
+        error++;
+        goto cleanup;
+    }
     if (new != 0) {
         ogs_error("Session should already exist, but new session flag is set");
         error++;

--- a/src/smf/gy-path.c
+++ b/src/smf/gy-path.c
@@ -731,8 +731,19 @@ void smf_gy_send_ccr(smf_sess_t *sess, ogs_pool_id_t xact_id,
         ogs_assert(sess_data);
 
         ogs_debug("    Allocate new Gy session: [%s]", sess_data->gy_sid);
-        /* Save Session-Id to SMF Session Context */
-        sess->gy_sid = (char *)sess_data->gy_sid;
+        /*
+         * Save Session-Id to SMF Session Context
+         *
+         * Keep an independent copy. sess_data->gy_sid is owned by the
+         * Diameter session state and can be released by state_cleanup()
+         * before the SMF session context is removed. Sharing the pointer
+         * would leave sess->gy_sid dangling and could cause a later
+         * request to read freed memory while constructing its
+         * Session-Id AVP.
+         */
+        ogs_assert(!sess->gy_sid);
+        sess->gy_sid = ogs_strdup((char *)sess_data->gy_sid);
+        ogs_assert(sess->gy_sid);
     } else
         ogs_debug("    Retrieve Gy session: [%s]", sess_data->gy_sid);
     /*
@@ -997,7 +1008,7 @@ static void smf_gy_cca_cb(void *data, struct msg **msg)
 
     struct sess_state *sess_data = NULL;
     struct timespec ts;
-    struct session *session;
+    struct session *session = NULL;
     struct avp *avp, *avpch1;
     struct avp_hdr *hdr;
     unsigned long dur;
@@ -1020,7 +1031,11 @@ static void smf_gy_cca_cb(void *data, struct msg **msg)
 
     /* Search the session, retrieve its data */
     ret = fd_msg_sess_get(fd_g_config->cnf_dict, *msg, &session, &new);
-    ogs_assert(ret == 0);
+    if (ret != 0) {
+        ogs_error("fd_msg_sess_get() failed with error: %d", ret);
+        error++;
+        goto cleanup;
+    }
     if (new != 0) {
         ogs_error("Session should already exist, but new session flag is set");
         error++;

--- a/src/smf/s6b-path.c
+++ b/src/smf/s6b-path.c
@@ -188,8 +188,19 @@ void smf_s6b_send_aar(smf_sess_t *sess, ogs_gtp_xact_t *xact)
 
         ogs_debug("    Allocate new session: [%s]", sess_data->s6b_sid);
 
-        /* Save Session-Id to SMF Session Context */
-        sess->s6b_sid = (char *)sess_data->s6b_sid;
+        /*
+         * Save Session-Id to SMF Session Context
+         *
+         * Keep an independent copy. sess_data->s6b_sid is owned by the
+         * Diameter session state and can be released by state_cleanup()
+         * before the SMF session context is removed. Sharing the pointer
+         * would leave sess->s6b_sid dangling and could cause a later
+         * request to read freed memory while constructing its
+         * Session-Id AVP.
+         */
+        ogs_assert(!sess->s6b_sid);
+        sess->s6b_sid = ogs_strdup((char *)sess_data->s6b_sid);
+        ogs_assert(sess->s6b_sid);
     } else
         ogs_debug("    Retrieve session: [%s]", sess_data->s6b_sid);
 
@@ -387,7 +398,7 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
     int ret;
     struct sess_state *sess_data = NULL;
     struct timespec ts;
-    struct session *session;
+    struct session *session = NULL;
     struct avp *avp, *avpch1;
     struct avp_hdr *hdr;
     unsigned long dur;
@@ -404,7 +415,11 @@ static void smf_s6b_aaa_cb(void *data, struct msg **msg)
 
     /* Search the session, retrieve its data */
     ret = fd_msg_sess_get(fd_g_config->cnf_dict, *msg, &session, &new);
-    ogs_assert(ret == 0);
+    if (ret != 0) {
+        ogs_error("fd_msg_sess_get() failed with error: %d", ret);
+        error++;
+        goto cleanup;
+    }
     if (new != 0) {
         ogs_error("Session should already exist, but new session flag is set");
         error++;
@@ -765,7 +780,7 @@ static void smf_s6b_sta_cb(void *data, struct msg **msg)
     int rv;
     struct sess_state *sess_data = NULL;
     struct timespec ts;
-    struct session *session;
+    struct session *session = NULL;
     struct avp *avp, *avpch1;
     struct avp_hdr *hdr;
     unsigned long dur;
@@ -782,7 +797,11 @@ static void smf_s6b_sta_cb(void *data, struct msg **msg)
 
     /* Search the session, retrieve its data */
     ret = fd_msg_sess_get(fd_g_config->cnf_dict, *msg, &session, &new);
-    ogs_assert(ret == 0);
+    if (ret != 0) {
+        ogs_error("fd_msg_sess_get() failed with error: %d", ret);
+        error++;
+        goto cleanup;
+    }
     if (new != 0) {
         ogs_error("Session should already exist, but new session flag is set");
         error++;


### PR DESCRIPTION
SMF session contexts kept Gx, Gy and S6b Session-Id pointers as aliases of strings owned by the corresponding freeDiameter session state.

Those strings are released by state_cleanup(), while the SMF session context can remain alive longer. This leaves sess->gx_sid, gy_sid or s6b_sid dangling and allows later Diameter requests to read freed memory. Recovery paths could also free the aliased pointer from the SMF side even though the allocation was owned by the Diameter session state.

Give each SMF Session-Id its own copy and release it from smf_sess_remove(), so the SMF context and freeDiameter session state have independent lifetimes.

PCRF had a similar ownership problem in its IP-to-Gx-Session-Id hash. The hash stored pointers to both the address and Session-Id owned by the Gx session state. Releasing or updating that state could therefore leave dangling hash entries or modify a hash key in place.

Make each PCRF hash entry own copies of both its key and Session-Id. Return a copy from IP lookups so callers can safely use the Session-Id after releasing the hash lock, remove old entries before overwriting a stored address, and release remaining entries during PCRF shutdown.

A production smf-ims also aborted while processing a Credit-Control-Answer when fd_msg_sess_get() rejected its Session-Id:

[diam] ERROR: [fd_sess_new@sessions.c](mailto:fd_sess_new@sessions.c):405: Invalid parameter '(fd_os_is_valid_os0(opt, optlen))', 22 [diam] ERROR: [fd_msg_sess_get@messages.c](mailto:fd_msg_sess_get@messages.c):1522: Invalid argument
[smf] FATAL: smf_gx_cca_cb:
Assertion `ret == 0' failed.

A received Diameter answer must not be able to terminate the whole SMF because its Session-Id cannot be resolved. Replace the fd_msg_sess_get() assertions in the Gx, Gy and S6b answer callbacks with error handling that logs and discards the affected answer.

The Session-Id lifetime issues were found while investigating the production failure, but without the corresponding CCR/CCA packet capture they are not claimed to be the proven source of the malformed Session-Id seen in that incident.

Issues: #4737