### PR TITLE
[SMF] Handle late Gx CCA after GTP transaction timeout

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -479,6 +479,12 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
             sess->sm_data.s6b_aar_in_flight = false;
             sess->sm_data.s6b_aaa_err = s6b_message->result_code;
             if (s6b_message->result_code == ER_DIAMETER_SUCCESS) {
+                if (!gtp_xact) {
+                    ogs_warn("[%s] S6B AAA: GTP transaction [%d] "
+                            "already removed",
+                            sess->gx_sid, e->gtp_xact_id);
+                    return;
+                }
                 send_ccr_init_req_gx_gy(sess, gtp_xact);
                 return;
             }
@@ -495,7 +501,13 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
         case OGS_DIAM_GX_CMD_CODE_CREDIT_CONTROL:
             switch(gx_message->cc_request_type) {
             case OGS_DIAM_GX_CC_REQUEST_TYPE_INITIAL_REQUEST:
-                ogs_assert(gtp_xact);
+                if (!gtp_xact) {
+                    ogs_warn("[%s] Gx CCA-Initial: GTP transaction [%d] "
+                            "already removed",
+                            sess->gx_sid, e->gtp_xact_id);
+                    sess->sm_data.gx_ccr_init_in_flight = false;
+                    return;
+                }
                 diam_err = smf_gx_handle_cca_initial_request(sess,
                                 gx_message, gtp_xact);
                 sess->sm_data.gx_ccr_init_in_flight = false;
@@ -515,7 +527,13 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
         case OGS_DIAM_GY_CMD_CODE_CREDIT_CONTROL:
             switch(gy_message->cc_request_type) {
             case OGS_DIAM_GY_CC_REQUEST_TYPE_INITIAL_REQUEST:
-                ogs_assert(gtp_xact);
+                if (!gtp_xact) {
+                    ogs_warn("[%s] Gy CCA-Initial: GTP transaction [%d] "
+                            "already removed",
+                            sess->gy_sid, e->gtp_xact_id);
+                    sess->sm_data.gy_ccr_init_in_flight = false;
+                    return;
+                }
                 diam_err = smf_gy_handle_cca_initial_request(sess,
                                 gy_message, gtp_xact, &need_gy_terminate);
                 sess->sm_data.gy_ccr_init_in_flight = false;
@@ -543,12 +561,21 @@ test_can_proceed:
 
         if (diam_err == ER_DIAMETER_SUCCESS) {
             OGS_FSM_TRAN(s, smf_gsm_state_wait_pfcp_establishment);
-            ogs_assert(gtp_xact);
+            if (!gtp_xact) {
+                ogs_error("GTP transaction already removed but "
+                        "EPC auth succeeded");
+                return;
+            }
             ogs_assert(OGS_OK ==
                 smf_epc_pfcp_send_session_establishment_request(
                     sess,
                     gtp_xact ? gtp_xact->id : OGS_INVALID_POOL_ID, 0));
         } else {
+            if (!gtp_xact) {
+                ogs_warn("GTP transaction already removed, "
+                        "cannot send error response");
+                return;
+            }
             /* Tear down Gx/Gy session if its sm_data.*init_err == ER_DIAMETER_SUCCESS */
             if (sess->sm_data.gx_cca_init_err == ER_DIAMETER_SUCCESS) {
                 sess->sm_data.gx_ccr_term_in_flight = true;


### PR DESCRIPTION
### Problem

  SMF can crash with `SIGABRT` when a Diameter Gx/Gy/S6B response arrives after the corresponding GTP Create Session transaction has already timed out and been removed.

  ### Cause

  The asynchronous Diameter response and GTP transaction have independent lifetimes. When a Gx CCR-Initial is sent but the response is delayed beyond the GTP transaction timeout
  (~3s), the following sequence occurs:

  1. GTP Create Session Request arrives from SGW-C
  2. SMF sends Diameter Gx/Gy CCR-Initial
  3. GTP transaction times out after retries
  4. `ogs_gtp_xact_delete()` removes the transaction
  5. Late Diameter CCA-Initial arrives
  6. `ogs_gtp_xact_find_by_id()` returns NULL
  7. `ogs_assert(gtp_xact)` aborts SMF with SIGABRT

  ### Fix

  Replace unsafe `ogs_assert(gtp_xact)` with defensive null checks in `smf_gsm_state_wait_epc_auth_initial()` at five locations:

  - S6B AAA success path
  - Gx CCA-Initial handler
  - Gy CCA-Initial handler
  - test_can_proceed success path
  - test_can_proceed error path

  When `gtp_xact` is NULL, the handler now:
  - Logs a warning with session ID and transaction ID
  - Clears the corresponding in-flight flag
  - Returns early without dereferencing NULL

  This prevents process termination while preserving normal behavior when the transaction is valid.

  ### Testing

  - Clean build with no warnings
  - Verified against existing Open5GS error handling patterns (sgwc/pfcp-sm.c)
  - No memory leaks (transaction already deleted, session cleanup handled separately)