### PR TITLE
[SMF] Fix negative PFCP session gauge on EPC

### DIFF
--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1532,6 +1532,7 @@ smf_sess_t *smf_sess_add_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type)
 
     ogs_list_add(&smf_ue->sess_list, sess);
 
+    smf_metrics_inst_global_inc(SMF_METR_GLOB_GAUGE_PFCP_SESSIONS_ACTIVE);
     stats_add_smf_session();
 
     return sess;


### PR DESCRIPTION
## Problem

On an EPC (S5/S8) deployment, `smf_pfcp_sessions_active` walks monotonically
downward and goes negative. It resets to 0 only when the SMF restarts, then
immediately starts descending again, one step per session teardown. Observed
on a production PGW-C reaching -72 before a restart.

<img width="1516" height="370" alt="image" src="https://github.com/user-attachments/assets/db39cb13-646a-4a06-a9da-84b5d53ffbf2" />

## Cause

The gauge is incremented in exactly one place, `smf_sess_add_by_psi()`, which
serves only the 5GC creation paths (`smf_sess_add_by_sm_context()` and
`smf_sess_add_by_pdu_session()`).

EPC sessions are created through `smf_sess_add_by_apn()`, used by
`smf_sess_add_by_gtp1_message()` and `smf_sess_add_by_gtp2_message()`. That
path never incremented the gauge.

`smf_sess_remove()` decrements it unconditionally for every session, however
it was created. So on EPC every teardown decrements a counter that was never
incremented, and the gauge has no floor.

Both sides were introduced together in 13585a34e "[Metrics] Added PFCP related
measurement"; the increment simply landed in the 5GC constructor only. The
neighbouring `GTP1_PDPCTXS_ACTIVE` / `GTP2_SESSIONS_ACTIVE` gauges are paired
correctly and are unaffected.

## Fix

Increment the gauge in `smf_sess_add_by_apn()` as well, mirroring the
placement in `smf_sess_add_by_psi()` (immediately before
`stats_add_smf_session()`).

This keeps the existing semantics: the gauge counts session contexts, not
sessions that have completed PFCP establishment. Re-targeting it to actual
PFCP state would mean moving the inc/dec to the establishment-response and
deletion handlers, which is a larger change and out of scope here.


