### PR TITLE
[AMF] Validate AUSF authentication vector hex strings

### DIFF
--- a/lib/core/ogs-conv.c
+++ b/lib/core/ogs-conv.c
@@ -52,6 +52,29 @@ int ogs_ascii_to_hex(char *in, int in_len, void *out, int out_len)
     return j;
 }
 
+int ogs_ascii_to_hex_checked(
+        const char *in, int in_len, void *out, int out_len)
+{
+    int i;
+
+    if (!in || !out)
+        return OGS_ERROR;
+
+    if (in_len < 0 || out_len < 0 || out_len > INT_MAX / 2 ||
+        in_len != out_len * 2)
+        return OGS_ERROR;
+
+    for (i = 0; i < in_len; i++) {
+        if (!((in[i] >= '0' && in[i] <= '9') ||
+              (in[i] >= 'a' && in[i] <= 'f') ||
+              (in[i] >= 'A' && in[i] <= 'F')))
+            return OGS_ERROR;
+    }
+
+    ogs_ascii_to_hex((char *)in, in_len, out, out_len);
+    return OGS_OK;
+}
+
 void *ogs_hex_to_ascii(const void *in, int in_len, void *out, int out_len)
 {
     char *p, *last;

--- a/lib/core/ogs-conv.h
+++ b/lib/core/ogs-conv.h
@@ -29,11 +29,24 @@ extern "C" {
 #endif
 
 int ogs_ascii_to_hex(char *in, int in_len, void *out, int out_len);
+/*
+ * Convert exactly out_len * 2 hexadecimal characters.
+ * Return OGS_OK on success. On error, leave out unchanged.
+ */
+int ogs_ascii_to_hex_checked(
+        const char *in, int in_len, void *out, int out_len);
 static ogs_inline void *ogs_hex_from_string(
         const char *str, void *out, int out_len)
 {
     ogs_ascii_to_hex((char*)str, strlen(str), out, out_len);
     return out;
+}
+static ogs_inline int ogs_hex_from_string_checked(
+        const char *str, void *out, int out_len)
+{
+    if (!str)
+        return OGS_ERROR;
+    return ogs_ascii_to_hex_checked(str, strlen(str), out, out_len);
 }
 
 void *ogs_hex_to_ascii(const void *in, int in_len, void *out, int out_len);

--- a/src/amf/nausf-handler.c
+++ b/src/amf/nausf-handler.c
@@ -24,6 +24,9 @@ int amf_nausf_auth_handle_authenticate(
         amf_ue_t *amf_ue, ogs_sbi_message_t *message)
 {
     int r;
+    uint8_t rand[OGS_RAND_LEN];
+    uint8_t hxres_star[OGS_MAX_RES_LEN];
+    uint8_t autn[OGS_AUTN_LEN];
     OpenAPI_ue_authentication_ctx_t *UeAuthenticationCtx = NULL;
     OpenAPI_ue_authentication_ctx_5g_auth_data_t *AV5G_AKA = NULL;
     OpenAPI_links_value_schema_t *LinksValueSchemeValue = NULL;
@@ -75,6 +78,25 @@ int amf_nausf_auth_handle_authenticate(
 
     if (!AV5G_AKA->autn) {
         ogs_error("[%s] No Av5gAka.autn", amf_ue->suci);
+        return OGS_ERROR;
+    }
+
+    if (ogs_hex_from_string_checked(
+                AV5G_AKA->rand, rand, sizeof(rand)) != OGS_OK) {
+        ogs_error("[%s] Invalid Av5gAka.rand", amf_ue->suci);
+        return OGS_ERROR;
+    }
+
+    if (ogs_hex_from_string_checked(
+                AV5G_AKA->hxres_star,
+                hxres_star, sizeof(hxres_star)) != OGS_OK) {
+        ogs_error("[%s] Invalid Av5gAka.hxresStar", amf_ue->suci);
+        return OGS_ERROR;
+    }
+
+    if (ogs_hex_from_string_checked(
+                AV5G_AKA->autn, autn, sizeof(autn)) != OGS_OK) {
+        ogs_error("[%s] Invalid Av5gAka.autn", amf_ue->suci);
         return OGS_ERROR;
     }
 
@@ -135,12 +157,9 @@ int amf_nausf_auth_handle_authenticate(
 
     STORE_5G_AKA_CONFIRMATION(amf_ue, LinksValueSchemeValue->href);
 
-    ogs_ascii_to_hex(AV5G_AKA->rand, strlen(AV5G_AKA->rand),
-        amf_ue->rand, sizeof(amf_ue->rand));
-    ogs_ascii_to_hex(AV5G_AKA->hxres_star, strlen(AV5G_AKA->hxres_star),
-        amf_ue->hxres_star, sizeof(amf_ue->hxres_star));
-    ogs_ascii_to_hex(AV5G_AKA->autn, strlen(AV5G_AKA->autn),
-        amf_ue->autn, sizeof(amf_ue->autn));
+    memcpy(amf_ue->rand, rand, sizeof(amf_ue->rand));
+    memcpy(amf_ue->hxres_star, hxres_star, sizeof(amf_ue->hxres_star));
+    memcpy(amf_ue->autn, autn, sizeof(amf_ue->autn));
 
     /* Clear Security Context */
     CLEAR_SECURITY_CONTEXT(amf_ue);
@@ -185,12 +204,19 @@ int amf_nausf_auth_handle_authenticate_confirmation(
         return OGS_ERROR;
     }
 
+    if (ConfirmationDataResponse->auth_result ==
+            OpenAPI_auth_result_AUTHENTICATION_SUCCESS) {
+        if (ogs_hex_from_string_checked(ConfirmationDataResponse->kseaf,
+                    kseaf, sizeof(kseaf)) != OGS_OK) {
+            ogs_error("[%s] Invalid Kseaf", amf_ue->suci);
+            return OGS_ERROR;
+        }
+    }
+
     amf_ue->auth_result = ConfirmationDataResponse->auth_result;
     if (amf_ue->auth_result == OpenAPI_auth_result_AUTHENTICATION_SUCCESS) {
 
         amf_ue_set_supi(amf_ue, ConfirmationDataResponse->supi);
-        ogs_ascii_to_hex(ConfirmationDataResponse->kseaf,
-                strlen(ConfirmationDataResponse->kseaf), kseaf, sizeof(kseaf));
 
         ogs_kdf_kamf(amf_ue->supi, amf_ue->abba, amf_ue->abba_len,
                 kseaf, amf_ue->kamf);

--- a/tests/core/conv-test.c
+++ b/tests/core/conv-test.c
@@ -20,6 +20,40 @@
 #include "ogs-core.h"
 #include "core/abts.h"
 
+static void conv_test1(abts_case *tc, void *data)
+{
+    uint8_t expected[4] = { 0x01, 0xab, 0xCD, 0xef };
+    uint8_t output[4] = { 0xff, 0xff, 0xff, 0xff };
+    char non_ascii[8] = {
+        '0', '1', 'a', 'b', 'C', 'D', (char)0x80, 'f' };
+
+    ABTS_INT_EQUAL(tc, OGS_OK,
+            ogs_hex_from_string_checked(
+                "01abCDef", output, sizeof(output)));
+    ABTS_TRUE(tc, memcmp(expected, output, sizeof(output)) == 0);
+
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked("01abCD", 6, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked(
+                "01abCDef00", 10, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked("01abCDe", 7, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked("01abCDZf", 8, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked("01abCD f", 8, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked(
+                non_ascii, sizeof(non_ascii), output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked(NULL, 0, output, sizeof(output)));
+    ABTS_INT_EQUAL(tc, OGS_ERROR,
+            ogs_ascii_to_hex_checked("01abCDef", 8, NULL, sizeof(output)));
+
+    ABTS_TRUE(tc, memcmp(expected, output, sizeof(output)) == 0);
+}
+
 static void conv_test2(abts_case *tc, void *data)
 {
 #define K "4   6  5B5    CE8   B199B49FAA5F0A2EE238A6BC   "
@@ -285,6 +319,7 @@ abts_suite *test_conv(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
 
+    abts_run_test(suite, conv_test1, NULL);
     abts_run_test(suite, conv_test2, NULL);
     abts_run_test(suite, conv_test3, NULL);
     abts_run_test(suite, conv_test4, NULL);


### PR DESCRIPTION
Add strict hex decoding helpers that reject invalid lengths, non-hex characters, and NULL inputs without modifying the output buffer.

Validate RAND, HXRES*, AUTN, and KSEAF before using them. Decode the initial authentication vectors into temporary buffers before updating the UE context, and validate KSEAF before storing a successful authentication result.

Add core conversion tests for malformed, non-ASCII, and NULL inputs, and verify that the output remains unchanged on failure.

Issues #4734