### PR TITLE
[SMF] Fix repeated GTP-U Error Indication handling (EPC)

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -252,6 +252,16 @@ typedef struct smf_bearer_s {
     uint8_t         qfi;            /* 5G Core QFI */
     uint8_t         ebi;            /* EPC EBI */
 
+    /*
+     * Set while a GTP-U Error Indication is being handled for this bearer,
+     * so that repeated Error Indications do not start a second deactivation.
+     * Cleared when the procedure cannot go on - the PFCP deactivation or the
+     * final removal is rejected or times out.  Otherwise the procedure ends
+     * by removing the bearer or the whole PDN connection, which drops the
+     * mark with the context.
+     */
+    bool            ei_deactivation;
+
     uint32_t        pgw_s5u_teid;   /* PGW-S5U TEID */
     ogs_sockaddr_t  *pgw_s5u_addr;  /* PGW-S5U IPv4 */
     ogs_sockaddr_t  *pgw_s5u_addr6; /* PGW-S5U IPv6 */

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -131,10 +131,15 @@ static bool send_ccr_termination_req_gx_gy_s6b(
         ogs_error("No Gy Diameter Peer");
         /* TODO: drop Gx connection here,
          * possibly move to another "releasing" state! */
-        uint8_t gtp_cause = (gtp_xact->gtp_version == 1) ?
+        if (gtp_xact) {
+            uint8_t gtp_cause = (gtp_xact->gtp_version == 1) ?
                 OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE :
                 OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
-        send_gtp_delete_err_msg(sess, gtp_xact, gtp_cause);
+            send_gtp_delete_err_msg(sess, gtp_xact, gtp_cause);
+        } else {
+            ogs_error("No GTP transaction : "
+                    "Cannot report 'No Gy Diameter Peer' to the peer");
+        }
         return false;
     }
 
@@ -2315,15 +2320,30 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                             &pfcp_message->pfcp_session_deletion_response);
                 if (pfcp_cause != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
                     /* FIXME: tear down Gy and Gx */
-                    ogs_assert(gtp_xact);
-                    gtp_cause = gtp_cause_from_pfcp(
-                            pfcp_cause, gtp_xact->gtp_version);
-                    send_gtp_delete_err_msg(sess, gtp_xact, gtp_cause);
+                    if (gtp_xact) {
+                        gtp_cause = gtp_cause_from_pfcp(
+                                pfcp_cause, gtp_xact->gtp_version);
+                        send_gtp_delete_err_msg(sess, gtp_xact, gtp_cause);
+                    } else {
+        /*
+         * No peer is waiting for a response, so the session has to be
+         * dropped here.
+         */
+                        ogs_error("No GTP transaction : "
+                                "PFCP Cause [%d] cannot be reported, "
+                                "releasing the session locally", pfcp_cause);
+                        OGS_FSM_TRAN(s, smf_gsm_state_session_will_release);
+                    }
                     break;
                 }
                 if (send_ccr_termination_req_gx_gy_s6b(
-                            sess, gtp_xact) == true)
+                            sess, gtp_xact) == true) {
                     OGS_FSM_TRAN(s, smf_gsm_state_wait_epc_auth_release);
+                } else if (!gtp_xact) {
+                    ogs_error("No GTP transaction : "
+                            "Releasing the session locally");
+                    OGS_FSM_TRAN(s, smf_gsm_state_session_will_release);
+                }
                 /* else: free session? */
             } else {
                 int r, trigger;

--- a/src/smf/gtp-path.c
+++ b/src/smf/gtp-path.c
@@ -37,6 +37,7 @@
 
 #include "event.h"
 #include "gtp-path.h"
+#include "local-path.h"
 #include "pfcp-path.h"
 #include "s5c-build.h"
 #include "gn-build.h"
@@ -759,11 +760,23 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
     switch (type) {
     case OGS_GTP2_DELETE_BEARER_REQUEST_TYPE:
         ogs_error("[%s] No Delete Bearer Response", smf_ue->imsi_bcd);
-        ogs_assert(OGS_OK ==
-            smf_epc_pfcp_send_one_bearer_modification_request(
-                bearer, OGS_INVALID_POOL_ID, OGS_PFCP_MODIFY_REMOVE,
-                OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
-                OGS_GTP2_CAUSE_UNDEFINED_VALUE));
+        if (bearer == smf_default_bearer_in_sess(sess)) {
+        /*
+         * The default bearer represents the PDN connection.  Removing only
+         * that bearer would leave a session whose bearer_list is empty,
+         * while smf_default_bearer_in_sess() is expected to return a bearer
+         * everywhere else.  A Delete Bearer Response carrying the Linked EBI
+         * releases the whole session as well, so do the same on timeout.
+         */
+            smf_trigger_session_release(
+                    sess, NULL, OGS_PFCP_DELETE_TRIGGER_LOCAL_INITIATED);
+        } else {
+            ogs_assert(OGS_OK ==
+                smf_epc_pfcp_send_one_bearer_modification_request(
+                    bearer, OGS_INVALID_POOL_ID, OGS_PFCP_MODIFY_REMOVE,
+                    OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
+                    OGS_GTP2_CAUSE_UNDEFINED_VALUE));
+        }
         break;
     default:
         ogs_error("GTP Timeout : IMSI[%s] Message-Type[%d]",

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -1229,6 +1229,26 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     return OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 }
 
+/*
+ * The Error Indication procedure cannot go on : either no Delete Bearer
+ * Request was sent at all, or the bearer could not be removed.  Drop the
+ * mark so that a later Error Indication can start it again.
+ */
+static void clear_ei_deactivation(
+        smf_sess_t *sess, smf_bearer_t *bearer, uint64_t flags)
+{
+    ogs_assert(sess);
+
+    if (flags &
+            (OGS_PFCP_MODIFY_ERROR_INDICATION|OGS_PFCP_MODIFY_REMOVE)) {
+        if (flags & OGS_PFCP_MODIFY_SESSION)
+            bearer = smf_default_bearer_in_sess(sess);
+
+        if (bearer)
+            bearer->ei_deactivation = false;
+    }
+}
+
 void smf_epc_n4_handle_session_modification_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_gtp2_message_t *recv_message,
@@ -1255,14 +1275,15 @@ void smf_epc_n4_handle_session_modification_response(
 
     ogs_debug("Session Modification Response [epc]");
 
+    flags = xact->modify_flags;
+    ogs_assert(flags);
+
     if (flags & OGS_PFCP_MODIFY_SESSION) {
         /* If smf_epc_pfcp_send_pdr_modification_request() is called */
     } else {
         /* If smf_epc_pfcp_send_bearer_modification_request() is called */
         bearer = smf_bearer_find_by_id(OGS_POINTER_TO_UINT(xact->data));
     }
-    flags = xact->modify_flags;
-    ogs_assert(flags);
 
     /* OGS_PFCP_MODIFY_URR: Modification Response was originally triggered by
        PFCP Session Report Request, xact->assoc_xact is not a gtp_xact. No
@@ -1285,10 +1306,12 @@ void smf_epc_n4_handle_session_modification_response(
     if (rsp->cause.presence) {
         if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
             ogs_error("PFCP Cause [%d] : Not Accepted", rsp->cause.u8);
+            clear_ei_deactivation(sess, bearer, flags);
             return;
         }
     } else {
         ogs_error("No Cause");
+        clear_ei_deactivation(sess, bearer, flags);
         return;
     }
 
@@ -1339,6 +1362,7 @@ void smf_epc_n4_handle_session_modification_response(
 
     if (pfcp_cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
         ogs_error("PFCP Cause [%d] : Not Accepted", pfcp_cause_value);
+        clear_ei_deactivation(sess, bearer, flags);
         return;
     }
 
@@ -1574,6 +1598,7 @@ uint8_t smf_n4_handle_session_report_request(
     smf_ue_t *smf_ue = NULL;
     smf_bearer_t *qos_flow = NULL;
     smf_bearer_t *bearer = NULL;
+    smf_bearer_t *linked_bearer = NULL;
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
 
@@ -1814,6 +1839,7 @@ uint8_t smf_n4_handle_session_report_request(
              * still worked, but the UE could not originate a new VoLTE call
              * until it re-attached (airplane-mode toggle).
              */
+            linked_bearer = smf_default_bearer_in_sess(sess);
             ogs_list_for_each(&sess->bearer_list, bearer) {
                 if (bearer->dl_far == far)
                     break;
@@ -1822,13 +1848,27 @@ uint8_t smf_n4_handle_session_report_request(
                 ogs_error("[%s:%s] Error Indication from SGW-U: "
                         "no bearer found for FAR",
                     smf_ue->imsi_bcd, sess->session.name);
-            } else if (bearer == smf_default_bearer_in_sess(sess)) {
+            } else if (linked_bearer && linked_bearer->ei_deactivation) {
+        /*
+         * The default bearer represents the PDN connection, so releasing it
+         * deactivates every bearer of this session.  Whichever bearer this
+         * Error Indication refers to, the procedure is already running.
+         */
+                ogs_warn("[%s:%s] Ignore Error Indication from SGW-U "
+                        "[EBI:%d] : PDN deactivation already in progress",
+                    smf_ue->imsi_bcd, sess->session.name, bearer->ebi);
+            } else if (bearer->ei_deactivation) {
+                ogs_warn("[%s:%s] Ignore Error Indication from SGW-U "
+                        "[EBI:%d] : bearer deactivation already in progress",
+                    smf_ue->imsi_bcd, sess->session.name, bearer->ebi);
+            } else if (bearer == linked_bearer) {
                 ogs_error("[%s:%s] Error Indication from SGW-U "
                         "[EBI:%d] (default bearer)",
                     smf_ue->imsi_bcd, sess->session.name, bearer->ebi);
                 ogs_assert(OGS_OK ==
                     smf_epc_pfcp_send_deactivation(
                         sess, OGS_GTP2_CAUSE_REACTIVATION_REQUESTED));
+                bearer->ei_deactivation = true;
             } else {
                 ogs_error("[%s:%s] Error Indication from SGW-U "
                         "[EBI:%d] (dedicated bearer)",
@@ -1836,9 +1876,11 @@ uint8_t smf_n4_handle_session_report_request(
                 ogs_assert(OGS_OK ==
                     smf_epc_pfcp_send_one_bearer_modification_request(
                         bearer, OGS_INVALID_POOL_ID,
-                        OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
+                        OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE|
+                        OGS_PFCP_MODIFY_ERROR_INDICATION,
                         OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                         OGS_GTP2_CAUSE_UNDEFINED_VALUE));
+                bearer->ei_deactivation = true;
             }
         } else {
             ogs_warn("[%s:%s] Error Indication from gNB",

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -427,6 +427,7 @@ static void qos_flow_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
 static void sess_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
     smf_sess_t *sess = NULL;
+    smf_bearer_t *bearer = NULL;
     ogs_pool_id_t sess_id = OGS_INVALID_POOL_ID;
     uint8_t type;
 
@@ -448,6 +449,11 @@ static void sess_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
         ogs_warn("No PFCP session establishment response");
         break;
     case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
+        if (xact->modify_flags & OGS_PFCP_MODIFY_ERROR_INDICATION) {
+            bearer = smf_default_bearer_in_sess(sess);
+            if (bearer)
+                bearer->ei_deactivation = false;
+        }
         ogs_error("No PFCP session modification response");
         break;
     case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
@@ -480,6 +486,9 @@ static void bearer_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 
     switch (type) {
     case OGS_PFCP_SESSION_MODIFICATION_REQUEST_TYPE:
+        if (xact->modify_flags &
+                (OGS_PFCP_MODIFY_ERROR_INDICATION|OGS_PFCP_MODIFY_REMOVE))
+            bearer->ei_deactivation = false;
         ogs_error("No PFCP session modification response");
         break;
     default:
@@ -1071,7 +1080,8 @@ int smf_epc_pfcp_send_deactivation(smf_sess_t *sess, uint8_t gtp_cause)
         /* Deactivate this PDN connection */
         rv = smf_epc_pfcp_send_all_pdr_modification_request(
                 sess, OGS_INVALID_POOL_ID, NULL,
-                OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE,
+                OGS_PFCP_MODIFY_DL_ONLY|OGS_PFCP_MODIFY_DEACTIVATE|
+                OGS_PFCP_MODIFY_ERROR_INDICATION,
                 OGS_NAS_PROCEDURE_TRANSACTION_IDENTITY_UNASSIGNED,
                 OGS_GTP2_CAUSE_REACTIVATION_REQUESTED);
         if (rv != OGS_OK) {


### PR DESCRIPTION
Each Error Indication for a bearer started a new deactivation procedure. When multiple Delete Bearer transactions timed out, they sent overlapping PFCP removal requests. The first response removed the bearer, and a later response hit ogs_assert(bearer).

Track an Error Indication deactivation on the bearer and ignore duplicate reports while it is in progress. Clear the mark when the PFCP procedure is rejected or times out so that a later report can retry.

Read modify_flags before resolving session-level modifications, tolerate a missing GTP transaction during local EPC session deletion, and release the whole PDN connection when a Delete Bearer request for the default bearer times out. This prevents a live EPC session from being left without a default bearer.

Issues: #4753