### PR TITLE
fix: support framed routes over EPC Gx

### DIFF
--- a/lib/dbi/session.c
+++ b/lib/dbi/session.c
@@ -251,6 +251,48 @@ done:
                 }
 
             }
+        } else if (!strcmp(child4_key, OGS_IPV4_FRAMED_ROUTES_STRING) &&
+            BSON_ITER_HOLDS_ARRAY(&child4_iter)) {
+            int i = 0;
+
+            session->ipv4_framed_routes = ogs_calloc(
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                    sizeof(session->ipv4_framed_routes[0]));
+            ogs_assert(session->ipv4_framed_routes);
+
+            bson_iter_recurse(&child4_iter, &child5_iter);
+            while (bson_iter_next(&child5_iter) &&
+                    i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI) {
+                const char *route;
+
+                if (!BSON_ITER_HOLDS_UTF8(&child5_iter))
+                    continue;
+                route = bson_iter_utf8(&child5_iter, &length);
+                session->ipv4_framed_routes[i] = ogs_strndup(route, length);
+                ogs_assert(session->ipv4_framed_routes[i]);
+                i++;
+            }
+        } else if (!strcmp(child4_key, OGS_IPV6_FRAMED_ROUTES_STRING) &&
+            BSON_ITER_HOLDS_ARRAY(&child4_iter)) {
+            int i = 0;
+
+            session->ipv6_framed_routes = ogs_calloc(
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                    sizeof(session->ipv6_framed_routes[0]));
+            ogs_assert(session->ipv6_framed_routes);
+
+            bson_iter_recurse(&child4_iter, &child5_iter);
+            while (bson_iter_next(&child5_iter) &&
+                    i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI) {
+                const char *route;
+
+                if (!BSON_ITER_HOLDS_UTF8(&child5_iter))
+                    continue;
+                route = bson_iter_utf8(&child5_iter, &length);
+                session->ipv6_framed_routes[i] = ogs_strndup(route, length);
+                ogs_assert(session->ipv6_framed_routes[i]);
+                i++;
+            }
         } else if (!strcmp(child4_key, OGS_PCC_RULE_STRING) &&
             BSON_ITER_HOLDS_ARRAY(&child4_iter)) {
             int i, pcc_rule_index = 0;

--- a/lib/diameter/gx/dict.c
+++ b/lib/diameter/gx/dict.c
@@ -270,6 +270,8 @@ int ogs_dict_gx_entry(char *conffile)
       {  { .avp_vendor = 10415, .avp_name = "Usage-Monitoring-Information" }, RULE_OPTIONAL, -1, -1 },
       {  { .avp_vendor = 10415, .avp_name = "CSG-Information-Reporting" }, RULE_OPTIONAL, -1, -1 },
       {  { .avp_vendor = 10415, .avp_name = "User-CSG-Information" }, RULE_OPTIONAL, -1, 1 },
+      {  {                      .avp_name = "Framed-Route" }, RULE_OPTIONAL, -1, -1 },
+      {  {                      .avp_name = "Framed-IPv6-Route" }, RULE_OPTIONAL, -1, -1 },
       {  {                      .avp_name = "Error-Message" }, RULE_OPTIONAL, -1, 1 },
       {  {                      .avp_name = "Error-Reporting-Host" }, RULE_OPTIONAL, -1, 1 }
     };

--- a/lib/diameter/gx/message.c
+++ b/lib/diameter/gx/message.c
@@ -37,6 +37,8 @@ struct dict_object *ogs_diam_gx_feature_list_id = NULL;
 struct dict_object *ogs_diam_gx_feature_list = NULL;
 struct dict_object *ogs_diam_gx_framed_ip_address = NULL;
 struct dict_object *ogs_diam_gx_framed_ipv6_prefix = NULL;
+struct dict_object *ogs_diam_gx_framed_route = NULL;
+struct dict_object *ogs_diam_gx_framed_ipv6_route = NULL;
 struct dict_object *ogs_diam_gx_ip_can_type = NULL;
 struct dict_object *ogs_diam_gx_qos_information = NULL;
 struct dict_object *ogs_diam_gx_qos_class_identifier = NULL;
@@ -111,6 +113,8 @@ int ogs_diam_gx_init(void)
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Feature-List", &ogs_diam_gx_feature_list);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Framed-IP-Address", &ogs_diam_gx_framed_ip_address);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Framed-IPv6-Prefix", &ogs_diam_gx_framed_ipv6_prefix);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Framed-Route", &ogs_diam_gx_framed_route);
+    CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "Framed-IPv6-Route", &ogs_diam_gx_framed_ipv6_route);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "IP-CAN-Type", &ogs_diam_gx_ip_can_type);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "QoS-Information", &ogs_diam_gx_qos_information);
     CHECK_dict_search(DICT_AVP, AVP_BY_NAME_ALL_VENDORS, "QoS-Class-Identifier" , &ogs_diam_gx_qos_class_identifier);

--- a/lib/diameter/gx/message.h
+++ b/lib/diameter/gx/message.h
@@ -44,6 +44,8 @@ extern "C" {
 #define OGS_DIAM_GX_AVP_CODE_QOS_INFORMATION                (1016)
 #define OGS_DIAM_GX_AVP_CODE_PRECEDENCE                     (1010)
 #define OGS_DIAM_GX_AVP_CODE_RATING_GROUP                   (432)
+#define OGS_DIAM_GX_AVP_CODE_FRAMED_ROUTE                   (22)
+#define OGS_DIAM_GX_AVP_CODE_FRAMED_IPV6_ROUTE              (99)
 
 extern struct dict_object *ogs_diam_gx_application;
 
@@ -60,6 +62,8 @@ extern struct dict_object *ogs_diam_gx_feature_list_id;
 extern struct dict_object *ogs_diam_gx_feature_list;
 extern struct dict_object *ogs_diam_gx_framed_ip_address;
 extern struct dict_object *ogs_diam_gx_framed_ipv6_prefix;
+extern struct dict_object *ogs_diam_gx_framed_route;
+extern struct dict_object *ogs_diam_gx_framed_ipv6_route;
 #define OGS_DIAM_GX_IP_CAN_TYPE_3GPP_GPRS                   0
 #define OGS_DIAM_GX_IP_CAN_TYPE_DOCSIS                      1
 #define OGS_DIAM_GX_IP_CAN_TYPE_xDSL                        2

--- a/lib/pfcp/build.c
+++ b/lib/pfcp/build.c
@@ -362,6 +362,8 @@ void ogs_pfcp_build_create_pdr(
         message->pdi.framed_route[j].presence = 1;
         message->pdi.framed_route[j].data = pdr->ipv4_framed_routes[j];
         message->pdi.framed_route[j].len = strlen(pdr->ipv4_framed_routes[j]);
+        ogs_debug("PFCP encode Framed-Route in PDR[%u]: %s",
+                pdr->id, pdr->ipv4_framed_routes[j]);
     }
 
     for (j = 0; j < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; j++) {
@@ -370,6 +372,8 @@ void ogs_pfcp_build_create_pdr(
         message->pdi.framed_ipv6_route[j].presence = 1;
         message->pdi.framed_ipv6_route[j].data = pdr->ipv6_framed_routes[j];
         message->pdi.framed_ipv6_route[j].len = strlen(pdr->ipv6_framed_routes[j]);
+        ogs_debug("PFCP encode Framed-IPv6-Route in PDR[%u]: %s",
+                pdr->id, pdr->ipv6_framed_routes[j]);
     }
 
     if (pdr->f_teid_len) {

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -916,6 +916,26 @@ typedef struct ogs_session_data_s {
                 sizeof((__dST)->session.ambr)); \
         memcpy(&(__dST)->session.qos, &(__sRC)->session.qos, \
                 sizeof((__dST)->session.qos)); \
+        if ((__sRC)->session.ipv4_framed_routes) { \
+            (__dST)->session.ipv4_framed_routes = ogs_calloc( \
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI, \
+                    sizeof((__dST)->session.ipv4_framed_routes[0])); \
+            ogs_assert((__dST)->session.ipv4_framed_routes); \
+            for (j = 0; j < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI && \
+                    (__sRC)->session.ipv4_framed_routes[j]; j++) \
+                (__dST)->session.ipv4_framed_routes[j] = ogs_strdup( \
+                        (__sRC)->session.ipv4_framed_routes[j]); \
+        } \
+        if ((__sRC)->session.ipv6_framed_routes) { \
+            (__dST)->session.ipv6_framed_routes = ogs_calloc( \
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI, \
+                    sizeof((__dST)->session.ipv6_framed_routes[0])); \
+            ogs_assert((__dST)->session.ipv6_framed_routes); \
+            for (j = 0; j < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI && \
+                    (__sRC)->session.ipv6_framed_routes[j]; j++) \
+                (__dST)->session.ipv6_framed_routes[j] = ogs_strdup( \
+                        (__sRC)->session.ipv6_framed_routes[j]); \
+        } \
         (__dST)->num_of_pcc_rule = (__sRC)->num_of_pcc_rule; \
         for (j = 0; j < (__dST)->num_of_pcc_rule; j++) { \
             rv = ogs_check_qos_conf(&(__sRC)->pcc_rule[j].qos); \
@@ -930,6 +950,18 @@ typedef struct ogs_session_data_s {
         ogs_assert((__sESSdATA) != NULL); \
         if ((__sESSdATA)->session.name) \
             ogs_free((__sESSdATA)->session.name); \
+        if ((__sESSdATA)->session.ipv4_framed_routes) { \
+            for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI && \
+                    (__sESSdATA)->session.ipv4_framed_routes[i]; i++) \
+                ogs_free((__sESSdATA)->session.ipv4_framed_routes[i]); \
+            ogs_free((__sESSdATA)->session.ipv4_framed_routes); \
+        } \
+        if ((__sESSdATA)->session.ipv6_framed_routes) { \
+            for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI && \
+                    (__sESSdATA)->session.ipv6_framed_routes[i]; i++) \
+                ogs_free((__sESSdATA)->session.ipv6_framed_routes[i]); \
+            ogs_free((__sESSdATA)->session.ipv6_framed_routes); \
+        } \
         for (i = 0; i < (__sESSdATA)->num_of_pcc_rule; i++) \
             OGS_PCC_RULE_FREE(&(__sESSdATA)->pcc_rule[i]); \
         memset((__sESSdATA), 0, sizeof(ogs_session_data_t)); \

--- a/src/pcrf/pcrf-context.c
+++ b/src/pcrf/pcrf-context.c
@@ -452,6 +452,25 @@ int pcrf_db_qos_data(
                     imsi_bcd, apn);
     }
 
+    if (rv == OGS_OK) {
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; i++) {
+            if (!session_data->session.ipv4_framed_routes ||
+                !session_data->session.ipv4_framed_routes[i])
+                break;
+            ogs_debug("DB IPv4 framed route IMSI[%s] APN[%s]: %s",
+                    imsi_bcd, apn,
+                    session_data->session.ipv4_framed_routes[i]);
+        }
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; i++) {
+            if (!session_data->session.ipv6_framed_routes ||
+                !session_data->session.ipv6_framed_routes[i])
+                break;
+            ogs_debug("DB IPv6 framed route IMSI[%s] APN[%s]: %s",
+                    imsi_bcd, apn,
+                    session_data->session.ipv6_framed_routes[i]);
+        }
+    }
+
     /* For EPC, we need to inialize Flow-Status in Pcc-Rule */
     for (i = 0; i < session_data->num_of_pcc_rule; i++) {
         ogs_pcc_rule_t *pcc_rule = &session_data->pcc_rule[i];

--- a/src/pcrf/pcrf-gx-path.c
+++ b/src/pcrf/pcrf-gx-path.c
@@ -638,6 +638,58 @@ static int pcrf_gx_ccr_cb(struct msg **msg, struct avp *avp,
     if (cc_request_type == OGS_DIAM_GX_CC_REQUEST_TYPE_INITIAL_REQUEST ||
         cc_request_type == OGS_DIAM_GX_CC_REQUEST_TYPE_UPDATE_REQUEST) {
 
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; i++) {
+            const char *route;
+
+            if (!gx_message.session_data.session.ipv4_framed_routes ||
+                !gx_message.session_data.session.ipv4_framed_routes[i])
+                break;
+            route = gx_message.session_data.session.ipv4_framed_routes[i];
+
+            ret = fd_msg_avp_new(ogs_diam_gx_framed_route, 0, &avp);
+            if (ret != 0) {
+                ogs_error("Failed to create Framed-Route AVP");
+                error_occurred = 1;
+                goto out;
+            }
+            val.os.data = (uint8_t *)route;
+            val.os.len = strlen(route);
+            ret = fd_msg_avp_setvalue(avp, &val);
+            if (ret != 0 ||
+                fd_msg_avp_add(ans, MSG_BRW_LAST_CHILD, avp) != 0) {
+                ogs_error("Failed to add Framed-Route AVP");
+                error_occurred = 1;
+                goto out;
+            }
+            ogs_debug("Gx CCA add Framed-Route: %s", route);
+        }
+
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI; i++) {
+            const char *route;
+
+            if (!gx_message.session_data.session.ipv6_framed_routes ||
+                !gx_message.session_data.session.ipv6_framed_routes[i])
+                break;
+            route = gx_message.session_data.session.ipv6_framed_routes[i];
+
+            ret = fd_msg_avp_new(ogs_diam_gx_framed_ipv6_route, 0, &avp);
+            if (ret != 0) {
+                ogs_error("Failed to create Framed-IPv6-Route AVP");
+                error_occurred = 1;
+                goto out;
+            }
+            val.os.data = (uint8_t *)route;
+            val.os.len = strlen(route);
+            ret = fd_msg_avp_setvalue(avp, &val);
+            if (ret != 0 ||
+                fd_msg_avp_add(ans, MSG_BRW_LAST_CHILD, avp) != 0) {
+                ogs_error("Failed to add Framed-IPv6-Route AVP");
+                error_occurred = 1;
+                goto out;
+            }
+            ogs_debug("Gx CCA add Framed-IPv6-Route: %s", route);
+        }
+
         for (i = 0; i < gx_message.session_data.num_of_pcc_rule; i++) {
             ogs_pcc_rule_t *pcc_rule = &gx_message.session_data.pcc_rule[i];
             if (pcc_rule->num_of_flow) {

--- a/src/smf/gx-handler.c
+++ b/src/smf/gx-handler.c
@@ -61,6 +61,50 @@ uint32_t smf_gx_handle_cca_initial_request(
         OGS_STORE_PCC_RULE(&sess->policy.pcc_rule[i],
                 &gx_message->session_data.pcc_rule[i]);
 
+    if (sess->session.ipv4_framed_routes) {
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                sess->session.ipv4_framed_routes[i]; i++)
+            ogs_free(sess->session.ipv4_framed_routes[i]);
+        ogs_free(sess->session.ipv4_framed_routes);
+        sess->session.ipv4_framed_routes = NULL;
+    }
+    if (gx_message->session_data.session.ipv4_framed_routes) {
+        sess->session.ipv4_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(sess->session.ipv4_framed_routes[0]));
+        ogs_assert(sess->session.ipv4_framed_routes);
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                gx_message->session_data.session.ipv4_framed_routes[i]; i++) {
+            sess->session.ipv4_framed_routes[i] = ogs_strdup(
+                    gx_message->session_data.session.ipv4_framed_routes[i]);
+            ogs_assert(sess->session.ipv4_framed_routes[i]);
+            ogs_debug("SMF session IPv4 framed route: %s",
+                    sess->session.ipv4_framed_routes[i]);
+        }
+    }
+
+    if (sess->session.ipv6_framed_routes) {
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                sess->session.ipv6_framed_routes[i]; i++)
+            ogs_free(sess->session.ipv6_framed_routes[i]);
+        ogs_free(sess->session.ipv6_framed_routes);
+        sess->session.ipv6_framed_routes = NULL;
+    }
+    if (gx_message->session_data.session.ipv6_framed_routes) {
+        sess->session.ipv6_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(sess->session.ipv6_framed_routes[0]));
+        ogs_assert(sess->session.ipv6_framed_routes);
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                gx_message->session_data.session.ipv6_framed_routes[i]; i++) {
+            sess->session.ipv6_framed_routes[i] = ogs_strdup(
+                    gx_message->session_data.session.ipv6_framed_routes[i]);
+            ogs_assert(sess->session.ipv6_framed_routes[i]);
+            ogs_debug("SMF session IPv6 framed route: %s",
+                    sess->session.ipv6_framed_routes[i]);
+        }
+    }
+
     /* APN-AMBR
      * if PCRF changes APN-AMBR, this should be included. */
     sess->gtp.create_session_response_apn_ambr = false;
@@ -160,6 +204,54 @@ uint32_t smf_gx_handle_cca_initial_request(
     ogs_assert(OGS_OK ==
         ogs_pfcp_paa_to_ue_ip_addr(&sess->paa,
             &ul_pdr->ue_ip_addr, &ul_pdr->ue_ip_addr_len));
+
+    if ((sess->session.ipv4_framed_routes ||
+         sess->session.ipv6_framed_routes) &&
+        !sess->pfcp_node->up_function_features.frrt) {
+        ogs_warn("UPF does not advertise PFCP Framed Routing support");
+    }
+
+    if (sess->session.ipv4_framed_routes &&
+        sess->pfcp_node->up_function_features.frrt) {
+        dl_pdr->ipv4_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(dl_pdr->ipv4_framed_routes[0]));
+        ul_pdr->ipv4_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(ul_pdr->ipv4_framed_routes[0]));
+        ogs_assert(dl_pdr->ipv4_framed_routes);
+        ogs_assert(ul_pdr->ipv4_framed_routes);
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                sess->session.ipv4_framed_routes[i]; i++) {
+            dl_pdr->ipv4_framed_routes[i] =
+                ogs_strdup(sess->session.ipv4_framed_routes[i]);
+            ul_pdr->ipv4_framed_routes[i] =
+                ogs_strdup(sess->session.ipv4_framed_routes[i]);
+            ogs_debug("PFCP DL/UL PDR IPv4 framed route: %s",
+                    sess->session.ipv4_framed_routes[i]);
+        }
+    }
+
+    if (sess->session.ipv6_framed_routes &&
+        sess->pfcp_node->up_function_features.frrt) {
+        dl_pdr->ipv6_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(dl_pdr->ipv6_framed_routes[0]));
+        ul_pdr->ipv6_framed_routes = ogs_calloc(
+                OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                sizeof(ul_pdr->ipv6_framed_routes[0]));
+        ogs_assert(dl_pdr->ipv6_framed_routes);
+        ogs_assert(ul_pdr->ipv6_framed_routes);
+        for (i = 0; i < OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI &&
+                sess->session.ipv6_framed_routes[i]; i++) {
+            dl_pdr->ipv6_framed_routes[i] =
+                ogs_strdup(sess->session.ipv6_framed_routes[i]);
+            ul_pdr->ipv6_framed_routes[i] =
+                ogs_strdup(sess->session.ipv6_framed_routes[i]);
+            ogs_debug("PFCP DL/UL PDR IPv6 framed route: %s",
+                    sess->session.ipv6_framed_routes[i]);
+        }
+    }
 
     /* Set UE-to-CP Flow-Description and Outer-Header-Creation */
     up2cp_pdr->flow[up2cp_pdr->num_of_flow].fd = 1;

--- a/src/smf/gx-path.c
+++ b/src/smf/gx-path.c
@@ -789,6 +789,8 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
     ogs_diam_gx_message_t *gx_message = NULL;
     uint32_t req_slot, cc_request_number = 0;
     int cleanup_needed = 0;
+    int num_of_ipv4_framed_routes = 0;
+    int num_of_ipv6_framed_routes = 0;
 
     ogs_debug("[Credit-Control-Answer]");
 
@@ -1096,6 +1098,56 @@ static void smf_gx_cca_cb(void *data, struct msg **msg)
         case OGS_DIAM_GX_AVP_CODE_QOS_INFORMATION:
         case OGS_DIAM_GX_AVP_CODE_DEFAULT_EPS_BEARER_QOS:
             /* Already processed above */
+            break;
+        case OGS_DIAM_GX_AVP_CODE_FRAMED_ROUTE:
+            if (num_of_ipv4_framed_routes >=
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI) {
+                ogs_warn("Ignoring excess Framed-Route AVP");
+                break;
+            }
+            if (!gx_message->session_data.session.ipv4_framed_routes) {
+                gx_message->session_data.session.ipv4_framed_routes =
+                    ogs_calloc(OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                        sizeof(gx_message->session_data.session.
+                            ipv4_framed_routes[0]));
+                ogs_assert(gx_message->session_data.session.
+                        ipv4_framed_routes);
+            }
+            gx_message->session_data.session.ipv4_framed_routes
+                [num_of_ipv4_framed_routes] = ogs_strndup(
+                    (char *)hdr->avp_value->os.data,
+                    hdr->avp_value->os.len);
+            ogs_assert(gx_message->session_data.session.ipv4_framed_routes
+                    [num_of_ipv4_framed_routes]);
+            ogs_debug("Gx CCA received Framed-Route: %s",
+                    gx_message->session_data.session.ipv4_framed_routes
+                        [num_of_ipv4_framed_routes]);
+            num_of_ipv4_framed_routes++;
+            break;
+        case OGS_DIAM_GX_AVP_CODE_FRAMED_IPV6_ROUTE:
+            if (num_of_ipv6_framed_routes >=
+                    OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI) {
+                ogs_warn("Ignoring excess Framed-IPv6-Route AVP");
+                break;
+            }
+            if (!gx_message->session_data.session.ipv6_framed_routes) {
+                gx_message->session_data.session.ipv6_framed_routes =
+                    ogs_calloc(OGS_MAX_NUM_OF_FRAMED_ROUTES_IN_PDI,
+                        sizeof(gx_message->session_data.session.
+                            ipv6_framed_routes[0]));
+                ogs_assert(gx_message->session_data.session.
+                        ipv6_framed_routes);
+            }
+            gx_message->session_data.session.ipv6_framed_routes
+                [num_of_ipv6_framed_routes] = ogs_strndup(
+                    (char *)hdr->avp_value->os.data,
+                    hdr->avp_value->os.len);
+            ogs_assert(gx_message->session_data.session.ipv6_framed_routes
+                    [num_of_ipv6_framed_routes]);
+            ogs_debug("Gx CCA received Framed-IPv6-Route: %s",
+                    gx_message->session_data.session.ipv6_framed_routes
+                        [num_of_ipv6_framed_routes]);
+            num_of_ipv6_framed_routes++;
             break;
         case OGS_DIAM_GX_AVP_CODE_CHARGING_RULE_INSTALL:
             ret = fd_msg_browse(avp, MSG_BRW_FIRST_CHILD, &avpch1, NULL);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -630,6 +630,8 @@ uint8_t upf_sess_set_ue_ipv4_framed_routes(upf_sess_t *sess,
             continue;
         }
         add_framed_route_to_trie(&sess->ipv4_framed_routes[j], sess);
+        ogs_debug("UPF registered IPv4 framed route[%s] for SEID[0x%lx]",
+                framed_routes[i], (long)sess->upf_n4_seid);
         j++;
     }
     if (j == 0 && sess->ipv4_framed_routes) {
@@ -673,6 +675,8 @@ uint8_t upf_sess_set_ue_ipv6_framed_routes(upf_sess_t *sess,
             continue;
         }
         add_framed_route_to_trie(&sess->ipv6_framed_routes[j], sess);
+        ogs_debug("UPF registered IPv6 framed route[%s] for SEID[0x%lx]",
+                framed_routes[i], (long)sess->upf_n4_seid);
         j++;
     }
     if (j == 0 && sess->ipv6_framed_routes) {


### PR DESCRIPTION
Add IPv4 and IPv6 framed-route support to the LTE/EPC Gx path.

  The PCRF now reads framed routes from MongoDB and sends them in Gx CCA messages using the standard Diameter Framed-Route and Framed-IPv6-Route AVPs. The SMF decodes these routes, stores them in the EPC session, and adds them to both uplink and downlink PDRs before PFCP
  provisioning.

  The existing UPF framed-routing implementation is then used for downlink session lookup and uplink source-address validation.

  ## Validation

  - Full build completed successfully.
  - Core and unit tests passed.
  - Confirmed Framed-Route AVP code 22 in Gx CCA.
  - Confirmed PFCP Framed-Route IE 153 in both UL and DL PDRs.
  - Validated bidirectional GTP-U traffic to a routed IPv4 subnet behind an LTE UE.
  - IPv4 ping test passed with 0% packet loss.
