### PR TITLE
[AMF/MME/SMF] Deactivate the stale user plane of a held NG context

### DIFF
--- a/src/amf/context.c
+++ b/src/amf/context.c
@@ -1752,8 +1752,19 @@ amf_ue_t *amf_ue_add(ran_ue_t *ran_ue)
 void amf_ue_remove(amf_ue_t *amf_ue)
 {
     int i;
+    ran_ue_t *ran_ue_holding = NULL;
 
     ogs_assert(amf_ue);
+
+    /*
+     * A held NG context keeps a reference back to this context. Sever it
+     * before the pool id can be reused, or the holding timer would
+     * resolve it to an unrelated UE.
+     */
+    ran_ue_holding = ran_ue_find_by_id(amf_ue->ran_ue_holding_id);
+    if (ran_ue_holding &&
+        ran_ue_holding->holding_amf_ue_id == amf_ue->id)
+        ran_ue_holding->holding_amf_ue_id = OGS_INVALID_POOL_ID;
 
     ogs_list_remove(&self.amf_ue_list, amf_ue);
 
@@ -2247,65 +2258,23 @@ static void amf_ue_release_old_context(
 
     ogs_warn("[%s] OLD UE Context Release", display);
     if (CM_CONNECTED(old_amf_ue)) {
-        ran_ue_t *ran_ue = ran_ue_find_by_id(old_amf_ue->ran_ue_id);
-        ran_ue_t *ran_ue_holding = NULL;
-
         /*
          * Keep the old NG context until the new registration is
          * authenticated. CLEAR_NG_CONTEXT(amf_ue) will then send
          * UEContextReleaseCommand to the old NG-RAN context.
          *
-         * Do not use HOLDING_NG_CONTEXT(old_amf_ue) here: that macro
-         * stores the holding id in old_amf_ue, but this function
-         * removes old_amf_ue below after moving the session context
-         * to the new amf_ue.
+         * The hold is recorded in amf_ue rather than old_amf_ue, which is
+         * removed below once its sessions have been moved across.
          */
         ogs_warn("[%s] Holding old NG context", display);
-        if (ran_ue) {
-            int r;
+        HOLDING_NG_CONTEXT_FOR(amf_ue, old_amf_ue);
 
-            ran_ue_holding =
-                ran_ue_find_by_id(amf_ue->ran_ue_holding_id);
-            if (ran_ue_holding) {
-                ogs_error("[%s] Holding NG context already exists",
-                        display);
-                ogs_error("[%s]    RAN_UE_NGAP_ID[%lld] "
-                        "AMF_UE_NGAP_ID[%lld]",
-                        display,
-                        (long long)ran_ue_holding->ran_ue_ngap_id,
-                        (long long)ran_ue_holding->amf_ue_ngap_id);
-                r = ngap_send_ran_ue_context_release_command(
-                        ran_ue_holding,
-                        NGAP_Cause_PR_nas,
-                        NGAP_CauseNas_normal_release,
-                        NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0);
-                ogs_expect(r == OGS_OK);
-            } else if (amf_ue->ran_ue_holding_id !=
-                    OGS_INVALID_POOL_ID) {
-                ogs_error("[%s] Holding NG context has already "
-                        "been removed", display);
-            }
-            amf_ue->ran_ue_holding_id = OGS_INVALID_POOL_ID;
-
-            ran_ue->amf_ue_id = OGS_INVALID_POOL_ID;
-
-            ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] "
-                    "AMF_UE_NGAP_ID[%lld]",
-                    old_amf_ue->suci,
-                    (long long)ran_ue->ran_ue_ngap_id,
-                    (long long)ran_ue->amf_ue_ngap_id);
-
-            ran_ue->ue_ctx_rel_action =
-                NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE;
-            ogs_timer_start(ran_ue->t_ng_holding,
-                    amf_timer_cfg(AMF_TIMER_NG_HOLDING)->duration);
-
-            amf_ue->ran_ue_holding_id = old_amf_ue->ran_ue_id;
-            old_amf_ue->ran_ue_id = OGS_INVALID_POOL_ID;
-        } else {
-            ogs_error("[%s] RAN-NG Context has already been removed",
-                        old_amf_ue->suci);
-        }
+        /*
+         * Unlike the ordinary callers, nothing associates a new NG context
+         * with old_amf_ue after this, so clear it here rather than in the
+         * macro. CM_IDLE(old_amf_ue) has to see the context as released.
+         */
+        old_amf_ue->ran_ue_id = OGS_INVALID_POOL_ID;
     }
 
     /*
@@ -2437,6 +2406,33 @@ void amf_ue_associate_ran_ue(amf_ue_t *amf_ue, ran_ue_t *ran_ue)
 
     amf_ue->ran_ue_id = ran_ue->id;
     ran_ue->amf_ue_id = amf_ue->id;
+}
+
+void amf_ue_note_stale_user_plane(amf_ue_t *amf_ue, ran_ue_t *ran_ue)
+{
+    amf_sess_t *sess = NULL;
+
+    ogs_assert(amf_ue);
+    ogs_assert(ran_ue);
+
+    /*
+     * Only the sessions whose AN resources were established on this NG
+     * context can be left pointing at a GTP-U endpoint that is about to
+     * disappear. psimask.activated is exactly that set.
+     */
+    ogs_list_for_each(&amf_ue->sess_list, sess) {
+        if ((ran_ue->psimask.activated & (1 << sess->psi)) == 0)
+            continue;
+        if (!SESSION_CONTEXT_IN_SMF(sess))
+            continue;
+
+        sess->stale_ran_ue_id = ran_ue->id;
+
+        ogs_debug("[%s:%d] Stale user plane noted "
+                "[RAN_UE_NGAP_ID:%lld]",
+                amf_ue->supi ? amf_ue->supi : "Unknown", sess->psi,
+                (long long)ran_ue->ran_ue_ngap_id);
+    }
 }
 
 void amf_ue_deassociate_ran_ue(amf_ue_t *amf_ue, ran_ue_t *ran_ue)

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -260,6 +260,16 @@ struct ran_ue_s {
     /* Related Context */
     ogs_pool_id_t   gnb_id;
     ogs_pool_id_t   amf_ue_id;
+
+    /*
+     * The AMF-UE context holding this NG context.
+     *
+     * HOLDING_NG_CONTEXT() invalidates amf_ue_id, so this is the only way
+     * back to the UE when the context is finally removed. A valid value
+     * is also what tells NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE that this
+     * context was held.
+     */
+    ogs_pool_id_t   holding_amf_ue_id;
 }; 
 
 typedef struct amf_ue_memento_s {
@@ -579,17 +589,33 @@ struct amf_ue_s {
     /* NG UE context */
     ogs_pool_id_t   ran_ue_id;
 
-#define HOLDING_NG_CONTEXT(__aMF) \
+/*
+ * Put the NG context __sERVING is using on hold, and record the hold in
+ * __hOLDER.
+ *
+ * __hOLDER and __sERVING are the same AMF-UE context in the ordinary
+ * case, which HOLDING_NG_CONTEXT() below spells out. They differ only in
+ * amf_ue_release_old_context(), where the NG context and the sessions
+ * still belong to the old AMF-UE while the hold has to be recorded in the
+ * new one, because the old context is removed as soon as its sessions
+ * have been moved across.
+ *
+ * Each half of this names the UE after the context it is about: the NG
+ * context released on the way in is __hOLDER's, the one put on hold is
+ * __sERVING's. They are the same suci unless the two differ.
+ */
+#define HOLDING_NG_CONTEXT_FOR(__hOLDER, __sERVING) \
     do { \
         ran_ue_t *ran_ue_holding = NULL; \
         \
-        ran_ue_holding = ran_ue_find_by_id((__aMF)->ran_ue_holding_id); \
+        /* Whatever __hOLDER is already holding, named after __hOLDER */ \
+        ran_ue_holding = ran_ue_find_by_id((__hOLDER)->ran_ue_holding_id); \
         if (ran_ue_holding) { \
             int r; \
             ogs_warn("[%s] Holding NG context already exists", \
-                    (__aMF)->suci); \
+                    (__hOLDER)->suci); \
             ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]", \
-                    (__aMF)->suci, \
+                    (__hOLDER)->suci, \
                     (long long)ran_ue_holding->ran_ue_ngap_id, \
                     (long long)ran_ue_holding->amf_ue_ngap_id); \
             r = ngap_send_ran_ue_context_release_command( \
@@ -597,19 +623,24 @@ struct amf_ue_s {
                     NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release, \
                     NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE, 0); \
             ogs_expect(r == OGS_OK); \
-        } else if ((__aMF)->ran_ue_holding_id != OGS_INVALID_POOL_ID) { \
+        } else if ((__hOLDER)->ran_ue_holding_id != OGS_INVALID_POOL_ID) { \
             ogs_warn("[%s] Holding NG context has already been removed", \
-                    (__aMF)->suci); \
+                    (__hOLDER)->suci); \
         } \
-        (__aMF)->ran_ue_holding_id = OGS_INVALID_POOL_ID; \
+        (__hOLDER)->ran_ue_holding_id = OGS_INVALID_POOL_ID; \
         \
-        ran_ue_holding = ran_ue_find_by_id((__aMF)->ran_ue_id); \
+        /* The context being held is __sERVING's, and is named after it */ \
+        ran_ue_holding = ran_ue_find_by_id((__sERVING)->ran_ue_id); \
         if (ran_ue_holding) { \
+            /* The sessions are __sERVING's, the hold is __hOLDER's */ \
+            amf_ue_note_stale_user_plane((__sERVING), ran_ue_holding); \
+            ran_ue_holding->holding_amf_ue_id = (__hOLDER)->id; \
+            \
             ran_ue_holding->amf_ue_id = OGS_INVALID_POOL_ID; \
             \
-            ogs_warn("[%s] Holding NG Context", (__aMF)->suci); \
+            ogs_warn("[%s] Holding NG Context", (__sERVING)->suci); \
             ogs_warn("[%s]    RAN_UE_NGAP_ID[%lld] AMF_UE_NGAP_ID[%lld]", \
-                    (__aMF)->suci, \
+                    (__sERVING)->suci, \
                     (long long)ran_ue_holding->ran_ue_ngap_id, \
                     (long long)ran_ue_holding->amf_ue_ngap_id); \
             \
@@ -618,11 +649,13 @@ struct amf_ue_s {
             ogs_timer_start(ran_ue_holding->t_ng_holding, \
                     amf_timer_cfg(AMF_TIMER_NG_HOLDING)->duration); \
             \
-            (__aMF)->ran_ue_holding_id = (__aMF)->ran_ue_id; \
+            (__hOLDER)->ran_ue_holding_id = (__sERVING)->ran_ue_id; \
         } else \
             ogs_error("[%s] NG Context has already been removed", \
-                    (__aMF)->suci); \
+                    (__sERVING)->suci); \
     } while(0)
+#define HOLDING_NG_CONTEXT(__aMF) \
+    HOLDING_NG_CONTEXT_FOR((__aMF), (__aMF))
 #define CLEAR_NG_CONTEXT(__aMF) \
     do { \
         ran_ue_t *ran_ue_holding = NULL; \
@@ -1003,6 +1036,23 @@ typedef struct amf_sess_s {
      */
     ogs_pool_id_t   ran_ue_id;
 
+    /*
+     * A held NG context that the SMF may still believe this session's user
+     * plane is established on.
+     *
+     * Set when that NG context is put on hold, and cleared only where the
+     * SMF has said otherwise: on a successful Update SM Context response,
+     * when the SM Context is released, or when the context it names is
+     * removed and the note can no longer mean anything. It is deliberately
+     * NOT cleared when a request is dispatched - OGS_OK from
+     * amf_sess_sbi_discover_and_send() means the transaction started, not
+     * that the SMF took it - so a request that never arrives leaves this
+     * standing.
+     *
+     * Unlike ran_ue_id above it is therefore not a "latest known" value.
+     */
+    ogs_pool_id_t   stale_ran_ue_id;
+
     ogs_s_nssai_t s_nssai;
     ogs_s_nssai_t mapped_hplmn;
     bool mapped_hplmn_presence;
@@ -1108,6 +1158,9 @@ OpenAPI_rat_type_e amf_ue_rat_type(amf_ue_t *amf_ue);
  */
 void amf_ue_associate_ran_ue(amf_ue_t *amf_ue, ran_ue_t *ran_ue);
 void amf_ue_deassociate_ran_ue(amf_ue_t *amf_ue, ran_ue_t *ran_ue);
+
+/* Note the sessions of amf_ue whose user plane stays behind on ran_ue */
+void amf_ue_note_stale_user_plane(amf_ue_t *amf_ue, ran_ue_t *ran_ue);
 void source_ue_associate_target_ue(ran_ue_t *source_ue, ran_ue_t *target_ue);
 void source_ue_deassociate_target_ue(ran_ue_t *ran_ue);
 

--- a/src/amf/ngap-handler.c
+++ b/src/amf/ngap-handler.c
@@ -2080,6 +2080,7 @@ void ngap_handle_ue_context_release_action(ran_ue_t *ran_ue)
     switch (ran_ue->ue_ctx_rel_action) {
     case NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE:
         ogs_debug("    Action: NG context remove");
+        amf_sbi_send_deactivate_stale_user_plane(ran_ue);
         ran_ue_remove(ran_ue);
         break;
     case NGAP_UE_CTX_REL_NG_REMOVE_AND_UNLINK:
@@ -5401,7 +5402,10 @@ void ngap_handle_ng_reset(
                             (long long)ran_ue->ran_ue_ngap_id);
             }
 
-            if (old_xact_count == new_xact_count) ran_ue_remove(ran_ue);
+            if (old_xact_count == new_xact_count) {
+                amf_sbi_send_deactivate_stale_user_plane(ran_ue);
+                ran_ue_remove(ran_ue);
+            }
         }
 
         ogs_list_for_each(&gnb->ran_ue_list, iter) {
@@ -5573,6 +5577,8 @@ void ngap_handle_error_indication(amf_gnb_t *gnb, ogs_ngap_message_t *message)
                             amf_self()->time.t3512.value + 240));
             }
         } else {
+            /* A held NG context: no AMF-UE is associated with it */
+            amf_sbi_send_deactivate_stale_user_plane(ran_ue);
             ran_ue_remove(ran_ue);
         }
     }

--- a/src/amf/nnrf-handler.c
+++ b/src/amf/nnrf-handler.c
@@ -267,6 +267,7 @@ void amf_nnrf_handle_failed_amf_discovery(
     ogs_sbi_object_t *sbi_object = NULL;
     ogs_pool_id_t sbi_object_id = OGS_INVALID_POOL_ID;
     ogs_pool_id_t ran_ue_id = OGS_INVALID_POOL_ID;
+    int state = 0;
 
     amf_ue_t *amf_ue = NULL;
     amf_sess_t *sess = NULL;
@@ -278,6 +279,7 @@ void amf_nnrf_handle_failed_amf_discovery(
     ogs_assert(service_name);
     requester_nf_type = sbi_xact->requester_nf_type;
     ogs_assert(requester_nf_type);
+    state = sbi_xact->state;
 
     sbi_object_id = sbi_xact->sbi_object_id;
     ogs_assert(sbi_object_id >= OGS_MIN_POOL_ID &&
@@ -348,6 +350,21 @@ void amf_nnrf_handle_failed_amf_discovery(
 
         ogs_error("[%s:%s:%d:%d] Cannot receive SBI message",
                 amf_ue->supi, amf_ue->suci, sess->psi, sess->pti);
+
+        if (state == AMF_UPDATE_SM_CONTEXT_STALE_USER_PLANE) {
+            /*
+             * [Issue #4741]
+             *
+             * The UE is not waiting on this one. ran_ue_id names the NG
+             * context it is using now, and telling that connection about a
+             * failed cleanup of an NG context that is already gone would
+             * disturb a session that is working. The cleanup is
+             * best-effort and is not retried.
+             */
+            ogs_error("[%s:%d] Stale user plane deactivation timed out",
+                    amf_ue->supi, sess->psi);
+            break;
+        }
 
         amf_nnrf_send_session_failure_to_ran(amf_ue, sess, ran_ue_id);
         break;

--- a/src/amf/nsmf-handler.c
+++ b/src/amf/nsmf-handler.c
@@ -241,6 +241,32 @@ int amf_nsmf_pdusession_handle_create_sm_context(
     return OGS_OK;
 }
 
+/*
+ * [Issue #4741]
+ *
+ * Does a successful Update SM Context of this kind decide where the user
+ * plane is? Only the procedures that carry it do: an activation
+ * (amf_sbi_send_activating_session() and the states that report its N2
+ * outcome), a deactivation, and a handover actually completing. MODIFIED
+ * and the N1-only exchanges say nothing about the DL endpoint.
+ */
+static bool update_sm_context_supersedes_stale_user_plane(int state)
+{
+    switch (state) {
+    case AMF_UPDATE_SM_CONTEXT_ACTIVATED:
+    case AMF_UPDATE_SM_CONTEXT_SETUP_FAIL:
+    case AMF_UPDATE_SM_CONTEXT_DEACTIVATED:
+    case AMF_UPDATE_SM_CONTEXT_REGISTRATION_REQUEST:
+    case AMF_UPDATE_SM_CONTEXT_SERVICE_REQUEST:
+    case AMF_UPDATE_SM_CONTEXT_PATH_SWITCH_REQUEST:
+    case AMF_UPDATE_SM_CONTEXT_HANDOVER_NOTIFY:
+    case AMF_UPDATE_SM_CONTEXT_STALE_USER_PLANE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 int amf_nsmf_pdusession_handle_update_sm_context(
         amf_ue_t *amf_ue, ran_ue_t *ran_ue, amf_sess_t *sess,
         int state, ogs_pool_id_t target_ue_id, ogs_sbi_message_t *recvmsg)
@@ -256,6 +282,26 @@ int amf_nsmf_pdusession_handle_update_sm_context(
 
     if (!amf_ue) {
         ogs_error("UE(amf_ue) Context has already been removed");
+        return OGS_ERROR;
+    }
+
+    if (state == AMF_UPDATE_SM_CONTEXT_STALE_USER_PLANE) {
+        /*
+         * Cleanup for an NG context that is already gone. No NAS procedure
+         * is waiting on it, and the generic handling below would answer an
+         * unexpected or malformed response with an Error Indication
+         * towards ran_ue, which here is the NG context the UE is using
+         * now, so it must not run.
+         */
+        if (recvmsg->res_status == OGS_SBI_HTTP_STATUS_NO_CONTENT ||
+            recvmsg->res_status == OGS_SBI_HTTP_STATUS_OK) {
+            ogs_info("[%s:%d] Stale user plane deactivated",
+                    amf_ue->supi, sess->psi);
+            return OGS_OK;
+        }
+
+        ogs_error("[%s:%d] Stale user plane deactivation failed [%d]",
+                amf_ue->supi, sess->psi, recvmsg->res_status);
         return OGS_ERROR;
     }
 
@@ -999,6 +1045,35 @@ int amf_nsmf_pdusession_handle_update_sm_context(
                 amf_nsmf_pdusession_handle_release_sm_context(
                         amf_ue, ran_ue, sess, AMF_RELEASE_SM_CONTEXT_NO_STATE);
             }
+        }
+
+        /*
+         * [Issue #4741]
+         *
+         * The SMF has accepted a procedure that itself moves the user
+         * plane, issued on a DIFFERENT NG context, so its view has moved
+         * past the one a held context left behind and the note is spent.
+         *
+         * Every condition carries weight, including where this sits. It
+         * comes after all of the processing above so that the returns on
+         * missing or malformed N1/N2 content keep the note: an HTTP
+         * success alone is not the procedure succeeding. An answer for
+         * the noted context itself proves nothing - it is the user plane
+         * that is going stale, and a late ACTIVATED for it must not
+         * silently cancel the cleanup. An answer to a procedure that
+         * does not carry the user plane - MODIFIED, an N1-only exchange -
+         * proves nothing either way. And dispatching is deliberately not
+         * enough: OGS_OK from amf_sess_sbi_discover_and_send() means the
+         * transaction started, not that the SMF took it, so a request
+         * that never arrives leaves the note for the removal of the held
+         * context to act on.
+         */
+        if (sess->stale_ran_ue_id != OGS_INVALID_POOL_ID &&
+            (!ran_ue || sess->stale_ran_ue_id != ran_ue->id) &&
+            update_sm_context_supersedes_stale_user_plane(state)) {
+            ogs_debug("[%s:%d] Stale user plane superseded by the SMF "
+                    "[state:%d]", amf_ue->supi, sess->psi, state);
+            sess->stale_ran_ue_id = OGS_INVALID_POOL_ID;
         }
     } else {
         OpenAPI_sm_context_update_error_t *SmContextUpdateError = NULL;

--- a/src/amf/sbi-path.c
+++ b/src/amf/sbi-path.c
@@ -648,6 +648,152 @@ void amf_sbi_send_deactivate_all_sessions(
     }
 }
 
+/*
+ * Is another user-plane procedure for this session already running on some
+ * other NG context?
+ *
+ * amf_sess_sbi_discover_and_send() records the RAN-UE each transaction was
+ * issued on, which is what tells a procedure belonging to the context being
+ * removed from one belonging to the connection the UE uses now.
+ *
+ * This deliberately counts every kind of Update SM Context, unlike
+ * update_sm_context_supersedes_stale_user_plane(), because the two answer
+ * different questions. A completed procedure must have moved the user
+ * plane for its answer to spend the note, but a procedure still in flight
+ * only has to be ABLE to - racing a handover preparation or an activation
+ * with DEACTIVATED could tear down the user plane it is setting up, and
+ * when in doubt the sweep steps aside. A release never reaches this test:
+ * amf_sbi_send_release_session() consumes the note as it dispatches.
+ */
+static bool newer_procedure_in_progress(amf_sess_t *sess, ran_ue_t *ran_ue)
+{
+    ogs_sbi_xact_t *xact = NULL;
+
+    ogs_assert(sess);
+    ogs_assert(ran_ue);
+
+    ogs_list_for_each(&sess->sbi.xact_list, xact) {
+        amf_sbi_xact_ctx_t *ctx = xact->user_data;
+
+        if (xact->service_name != OpenAPI_service_name_nsmf_pdusession)
+            continue;
+        if (!ctx)
+            continue;
+        if (ctx->ran_ue_id == ran_ue->id)
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+/*
+ * Deactivate the user plane a held NG context left behind.
+ *
+ * Call this immediately before removing a held NG context. It is a no-op
+ * for a context that was never held.
+ *
+ * The deactivation is sent on behalf of the NG context the UE is using
+ * now, because amf_sess_sbi_discover_and_send() records the RAN-UE in
+ * sess->ran_ue_id and the Namf callbacks reach the UE through it.
+ */
+void amf_sbi_send_deactivate_stale_user_plane(ran_ue_t *ran_ue)
+{
+    amf_ue_t *amf_ue = NULL;
+    ran_ue_t *current_ue = NULL;
+    amf_sess_t *sess = NULL;
+
+    ogs_assert(ran_ue);
+
+    if (ran_ue->holding_amf_ue_id == OGS_INVALID_POOL_ID)
+        return;
+
+    amf_ue = amf_ue_find_by_id(ran_ue->holding_amf_ue_id);
+    ran_ue->holding_amf_ue_id = OGS_INVALID_POOL_ID;
+    if (!amf_ue) {
+        ogs_warn("UE(amf_ue) Context has already been removed "
+                "[RAN_UE_NGAP_ID:%lld]",
+                (long long)ran_ue->ran_ue_ngap_id);
+        return;
+    }
+
+    /*
+     * Normally the UE has the newer NG context that caused this one to be
+     * held. If even that is gone, current_ue is NULL, sess->ran_ue_id ends
+     * up invalid, and the cleanup stays best-effort: the SBI path is not
+     * guaranteed to carry a transaction without a RAN-UE to completion.
+     */
+    current_ue = ran_ue_find_by_id(amf_ue->ran_ue_id);
+    if (!current_ue)
+        ogs_warn("[%s] No serving NG context for the stale user plane",
+                amf_ue->supi ? amf_ue->supi : "Unknown");
+
+    /*
+     * Drop the holder's reference before the context is freed. Pool ids are
+     * reused, so a reference left behind can later resolve to an unrelated
+     * NG context and have a UEContextReleaseCommand sent to it.
+     */
+    if (amf_ue->ran_ue_holding_id == ran_ue->id)
+        amf_ue->ran_ue_holding_id = OGS_INVALID_POOL_ID;
+
+    ogs_list_for_each(&amf_ue->sess_list, sess) {
+        if (sess->stale_ran_ue_id != ran_ue->id)
+            continue;
+
+        /*
+         * The context the note is about is going away, and with it the
+         * last chance to act on the note, so it is consumed no matter
+         * which way the decision below goes. What must not stay behind
+         * is the pool id of a freed context, which a later holding
+         * could be assigned.
+         */
+        sess->stale_ran_ue_id = OGS_INVALID_POOL_ID;
+
+        if (!SESSION_CONTEXT_IN_SMF(sess)) {
+            ogs_warn("[%s:%d] SM context has already been released "
+                    "[RAN_UE_NGAP_ID:%lld]",
+                    amf_ue->supi ? amf_ue->supi : "Unknown", sess->psi,
+                    (long long)ran_ue->ran_ue_ngap_id);
+            continue;
+        }
+
+        /*
+         * An Update SM Context issued on a DIFFERENT NG context is a newer
+         * procedure, and it owns where this user plane ends up. Sending
+         * DEACTIVATED now would race it, and if that procedure is the UE
+         * re-activating the session, the loser would be the user plane
+         * that was just set up.
+         *
+         * A transaction issued on the context being removed is the
+         * opposite: it belongs to the user plane that is going stale, and
+         * must not stop the cleanup. An ACTIVATED still in flight for it
+         * would otherwise leave the SMF pointing at a GTP-U endpoint that
+         * is gone, which is the very thing being fixed here.
+         *
+         * Stepping aside moves the responsibility to that procedure.
+         * Should it then fail, the cleanup is not retried: that is the
+         * limit the commit message states.
+         */
+        if (newer_procedure_in_progress(sess, ran_ue)) {
+            ogs_debug("[%s:%d] Stale user plane left to the procedure "
+                    "in progress [RAN_UE_NGAP_ID:%lld]",
+                    amf_ue->supi ? amf_ue->supi : "Unknown", sess->psi,
+                    (long long)ran_ue->ran_ue_ngap_id);
+            continue;
+        }
+
+        ogs_warn("[%s:%d] Deactivating the stale user plane "
+                "[RAN_UE_NGAP_ID:%lld]",
+                amf_ue->supi ? amf_ue->supi : "Unknown", sess->psi,
+                (long long)ran_ue->ran_ue_ngap_id);
+
+        amf_sbi_send_deactivate_session(
+                current_ue, sess, AMF_UPDATE_SM_CONTEXT_STALE_USER_PLANE,
+                NGAP_Cause_PR_nas, NGAP_CauseNas_normal_release);
+    }
+}
+
 static void amf_sbi_release_ran_ue_on_gnb_remove(
         amf_ue_t *amf_ue, ran_ue_t *ran_ue)
 {
@@ -703,6 +849,7 @@ void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state)
 
             if (state == AMF_REMOVE_S1_CONTEXT_BY_LO_CONNREFUSED ||
                 state == AMF_REMOVE_S1_CONTEXT_BY_RESET_ALL) {
+                amf_sbi_send_deactivate_stale_user_plane(ran_ue);
                 ran_ue_remove(ran_ue);
             } else {
                 /* At this point, it does not support other action */
@@ -729,6 +876,13 @@ void amf_sbi_send_release_session(
 
     /* Prevent to invoke SMF for this session */
     CLEAR_SESSION_CONTEXT(sess);
+
+    /* With no SM Context left there is nothing to reconcile either */
+    if (sess->stale_ran_ue_id != OGS_INVALID_POOL_ID) {
+        ogs_debug("[%d] Stale user plane dropped with the SM context",
+                sess->psi);
+        sess->stale_ran_ue_id = OGS_INVALID_POOL_ID;
+    }
 }
 
 void amf_sbi_send_release_all_sessions(

--- a/src/amf/sbi-path.h
+++ b/src/amf/sbi-path.h
@@ -77,6 +77,7 @@ bool amf_sbi_send_request(
 #define AMF_UPDATE_SM_CONTEXT_HANDOVER_REQ_ACK          22
 #define AMF_UPDATE_SM_CONTEXT_HANDOVER_NOTIFY           23
 #define AMF_UPDATE_SM_CONTEXT_HANDOVER_CANCEL           24
+#define AMF_UPDATE_SM_CONTEXT_STALE_USER_PLANE          25
 #define AMF_RELEASE_SM_CONTEXT_NO_STATE                 31
 #define AMF_RELEASE_SM_CONTEXT_REGISTRATION_ACCEPT      33
 #define AMF_RELEASE_SM_CONTEXT_SERVICE_ACCEPT           34
@@ -117,6 +118,9 @@ void amf_sbi_send_deactivate_session(
 void amf_sbi_send_deactivate_all_sessions(
         ran_ue_t *ran_ue, amf_ue_t *amf_ue, int state, int group, int cause);
 void amf_sbi_send_deactivate_all_ue_in_gnb(amf_gnb_t *gnb, int state);
+
+/* Clean up after an NG context that was removed while held */
+void amf_sbi_send_deactivate_stale_user_plane(ran_ue_t *ran_ue);
 
 void amf_sbi_send_release_session(
         ran_ue_t *ran_ue, amf_sess_t *sess, int state, void *data);

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -4439,64 +4439,25 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd,
                     old_mme_ue->ebi_bitmap,
                     ECM_CONNECTED(old_mme_ue) ? 1 : 0);
             if (ECM_CONNECTED(old_mme_ue)) {
-                enb_ue_t *enb_ue = enb_ue_find_by_id(old_mme_ue->enb_ue_id);
-                enb_ue_t *enb_ue_holding = NULL;
-
                 /*
                  * Keep the old S1 context until the new attach/TAU procedure
                  * is authenticated. CLEAR_S1_CONTEXT(mme_ue) will then send
                  * UEContextReleaseCommand to the old E-UTRAN context.
                  *
-                 * Do not use HOLDING_S1_CONTEXT(old_mme_ue) here: that macro
-                 * stores the holding id in old_mme_ue, but this function
-                 * removes old_mme_ue below after moving the session context
-                 * to the new mme_ue.
+                 * The hold is recorded in mme_ue rather than old_mme_ue,
+                 * which is removed below once its sessions have been moved
+                 * across.
                  */
                 ogs_warn("[%s] Holding old S1 context", mme_ue->imsi_bcd);
-                if (enb_ue) {
-                    int r;
+                HOLDING_S1_CONTEXT_FOR(mme_ue, old_mme_ue);
 
-                    enb_ue_holding =
-                        enb_ue_find_by_id(mme_ue->enb_ue_holding_id);
-                    if (enb_ue_holding) {
-                        ogs_error("[%s] Holding S1 context already exists",
-                                mme_ue->imsi_bcd);
-                        ogs_error("[%s]    ENB_UE_S1AP_ID[%d] "
-                                "MME_UE_S1AP_ID[%d]",
-                                mme_ue->imsi_bcd,
-                                enb_ue_holding->enb_ue_s1ap_id,
-                                enb_ue_holding->mme_ue_s1ap_id);
-                        r = s1ap_send_ue_context_release_command(
-                                enb_ue_holding,
-                                S1AP_Cause_PR_nas,
-                                S1AP_CauseNas_normal_release,
-                                S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE, 0);
-                        ogs_expect(r == OGS_OK);
-                    } else if (mme_ue->enb_ue_holding_id !=
-                            OGS_INVALID_POOL_ID) {
-                        ogs_error("[%s] Holding S1 context has already "
-                                "been removed", mme_ue->imsi_bcd);
-                    }
-                    mme_ue->enb_ue_holding_id = OGS_INVALID_POOL_ID;
-
-                    enb_ue->mme_ue_id = OGS_INVALID_POOL_ID;
-
-                    ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]",
-                            old_mme_ue->imsi_bcd,
-                            enb_ue->enb_ue_s1ap_id,
-                            enb_ue->mme_ue_s1ap_id);
-
-                    enb_ue->ue_ctx_rel_action =
-                        S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE;
-                    ogs_timer_start(enb_ue->t_s1_holding,
-                            mme_timer_cfg(MME_TIMER_S1_HOLDING)->duration);
-
-                    mme_ue->enb_ue_holding_id = old_mme_ue->enb_ue_id;
-                    old_mme_ue->enb_ue_id = OGS_INVALID_POOL_ID;
-                } else {
-                    ogs_error("[%s] S1 Context has already been removed",
-                                old_mme_ue->imsi_bcd);
-                }
+                /*
+                 * Unlike the ordinary callers, nothing associates a new S1
+                 * context with old_mme_ue after this, so clear it here
+                 * rather than in the macro. ECM_IDLE(old_mme_ue) has to
+                 * see the context as released.
+                 */
+                old_mme_ue->enb_ue_id = OGS_INVALID_POOL_ID;
             }
 
     /*

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -726,17 +726,33 @@ struct mme_ue_s {
       (enb_ue_find_by_id((__mME)->enb_ue_id) == NULL)))
     ogs_pool_id_t   enb_ue_id;
 
-#define HOLDING_S1_CONTEXT(__mME) \
+/*
+ * Put the S1 context __sERVING is using on hold, and record the hold in
+ * __hOLDER.
+ *
+ * __hOLDER and __sERVING are the same MME-UE context in the ordinary
+ * case, which HOLDING_S1_CONTEXT() below spells out. They differ only in
+ * mme_ue_set_imsi(), where the S1 context and the sessions still belong
+ * to the old MME-UE while the hold has to be recorded in the new one,
+ * because the old context is removed as soon as its sessions have been
+ * moved across.
+ *
+ * Each half of this names the UE after the context it is about: the S1
+ * context released on the way in is __hOLDER's, the one put on hold is
+ * __sERVING's. They are the same imsi_bcd unless the two differ.
+ */
+#define HOLDING_S1_CONTEXT_FOR(__hOLDER, __sERVING) \
     do { \
         enb_ue_t *enb_ue_holding = NULL; \
         \
-        enb_ue_holding = enb_ue_find_by_id((__mME)->enb_ue_holding_id); \
+        /* Whatever __hOLDER is already holding, named after __hOLDER */ \
+        enb_ue_holding = enb_ue_find_by_id((__hOLDER)->enb_ue_holding_id); \
         if (enb_ue_holding) { \
             int r; \
             ogs_warn("[%s] Holding S1 context already exists", \
-                    (__mME)->imsi_bcd); \
+                    (__hOLDER)->imsi_bcd); \
             ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]", \
-                    (__mME)->imsi_bcd, \
+                    (__hOLDER)->imsi_bcd, \
                     enb_ue_holding->enb_ue_s1ap_id, \
                     enb_ue_holding->mme_ue_s1ap_id); \
             r = s1ap_send_ue_context_release_command( \
@@ -744,19 +760,20 @@ struct mme_ue_s {
                     S1AP_Cause_PR_nas, S1AP_CauseNas_normal_release, \
                     S1AP_UE_CTX_REL_S1_CONTEXT_REMOVE, 0); \
             ogs_expect(r == OGS_OK); \
-        } else if ((__mME)->enb_ue_holding_id != OGS_INVALID_POOL_ID) { \
+        } else if ((__hOLDER)->enb_ue_holding_id != OGS_INVALID_POOL_ID) { \
             ogs_warn("[%s] Holding S1 context has already been removed", \
-                    (__mME)->imsi_bcd); \
+                    (__hOLDER)->imsi_bcd); \
         } \
-        (__mME)->enb_ue_holding_id = OGS_INVALID_POOL_ID; \
+        (__hOLDER)->enb_ue_holding_id = OGS_INVALID_POOL_ID; \
         \
-        enb_ue_holding = enb_ue_find_by_id((__mME)->enb_ue_id); \
+        /* The context being held is __sERVING's, and is named after it */ \
+        enb_ue_holding = enb_ue_find_by_id((__sERVING)->enb_ue_id); \
         if (enb_ue_holding) { \
             enb_ue_holding->mme_ue_id = OGS_INVALID_POOL_ID; \
             \
-            ogs_warn("[%s] Holding S1 Context", (__mME)->imsi_bcd); \
+            ogs_warn("[%s] Holding S1 Context", (__sERVING)->imsi_bcd); \
             ogs_warn("[%s]    ENB_UE_S1AP_ID[%d] MME_UE_S1AP_ID[%d]", \
-                    (__mME)->imsi_bcd, \
+                    (__sERVING)->imsi_bcd, \
                     enb_ue_holding->enb_ue_s1ap_id, \
                     enb_ue_holding->mme_ue_s1ap_id); \
             \
@@ -765,11 +782,13 @@ struct mme_ue_s {
             ogs_timer_start(enb_ue_holding->t_s1_holding, \
                     mme_timer_cfg(MME_TIMER_S1_HOLDING)->duration); \
             \
-            (__mME)->enb_ue_holding_id = (__mME)->enb_ue_id; \
+            (__hOLDER)->enb_ue_holding_id = (__sERVING)->enb_ue_id; \
         } else \
             ogs_error("[%s] S1 Context has already been removed", \
-                    (__mME)->imsi_bcd); \
+                    (__sERVING)->imsi_bcd); \
     } while(0)
+#define HOLDING_S1_CONTEXT(__mME) \
+    HOLDING_S1_CONTEXT_FOR((__mME), (__mME))
 #define CLEAR_S1_CONTEXT(__mME) \
     do { \
         enb_ue_t *enb_ue_holding = NULL; \

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -172,6 +172,35 @@ static bool hsmf_update_has_up_cnx_state(smf_sess_t *sess)
     return sess->nsmf_param.up_cnx_state != OpenAPI_up_cnx_state_NULL;
 }
 
+/*
+ * [Issue #4741]
+ *
+ * Record the user-plane state the V-SMF has delegated, as
+ * smf_nsmf_handle_update_sm_context() records it in the V-SMF.
+ *
+ * The buffering and the downlink data report happen on the home side,
+ * and smf_5gc_n4_handle_session_report_request() decides on this field
+ * whether to start a network triggered Service Request. Without it the
+ * H-SMF still believes the user plane is up and drops the report.
+ *
+ * This is called from the accepted upCnxState branches below rather
+ * than where HsmfUpdateData is parsed, so that a combination rejected
+ * as Bad Request leaves the session untouched.
+ */
+static void hsmf_update_record_up_cnx_state(smf_sess_t *sess)
+{
+    smf_ue_t *smf_ue = NULL;
+
+    ogs_assert(sess);
+    smf_ue = smf_ue_find_by_id(sess->smf_ue_id);
+    ogs_assert(smf_ue);
+
+    ogs_info("[%s:%d] upCnxState[%d->%d] recorded in the H-SMF",
+            smf_ue->supi, sess->psi,
+            sess->up_cnx_state, sess->nsmf_param.up_cnx_state);
+    sess->up_cnx_state = sess->nsmf_param.up_cnx_state;
+}
+
 static bool hsmf_update_has_qos_modification(smf_sess_t *sess)
 {
     ogs_assert(sess);
@@ -1195,6 +1224,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
                                 switch (sess->nsmf_param.up_cnx_state) {
                                 case OpenAPI_up_cnx_state_DEACTIVATED:
+                                    hsmf_update_record_up_cnx_state(sess);
     /*
      * UE-requested PDU Session Modification(DEACTIVATED)
      *
@@ -1222,6 +1252,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                                     break;
 
                                 case OpenAPI_up_cnx_state_ACTIVATING:
+                                    hsmf_update_record_up_cnx_state(sess);
     /*
      * UE-requested PDU Session Modification(ACTIVATING)
      *
@@ -1242,6 +1273,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                                     break;
 
                                 case OpenAPI_up_cnx_state_ACTIVATED:
+                                    hsmf_update_record_up_cnx_state(sess);
 
     /*
      * UE-requested PDU Session Modification(ACTIVATED)

--- a/src/smf/sbi-path.c
+++ b/src/smf/sbi-path.c
@@ -258,6 +258,30 @@ ogs_sbi_xact_t *smf_namf_comm_create_n1_n2_message_xact(
     ogs_sbi_discovery_option_set_target_nf_instance_id(
             discovery_option, sess->amf_nf_id);
 
+    /*
+     * [Issue #4741]
+     *
+     * In the H-SMF the AMF this is addressed to lives in the serving
+     * PLMN, so the discovery has to say which PLMN to look in, the same
+     * way the AMF names the home PLMN when it discovers the AUSF or the
+     * UDM of a roaming UE. Without it the discovery stays in the home
+     * PLMN, finds no AMF and the transfer fails with 504, which is why a
+     * network triggered Service Request never left the H-SMF.
+     */
+    if (HOME_ROUTED_ROAMING_IN_HSMF(sess)) {
+        int i;
+
+        ogs_sbi_discovery_option_add_target_plmn_list(
+                discovery_option, &sess->serving_plmn_id);
+
+        ogs_assert(ogs_local_conf()->num_of_serving_plmn_id);
+        for (i = 0; i < ogs_local_conf()->num_of_serving_plmn_id; i++) {
+            ogs_sbi_discovery_option_add_requester_plmn_list(
+                    discovery_option,
+                    &ogs_local_conf()->serving_plmn_id[i]);
+        }
+    }
+
     xact = ogs_sbi_xact_add(
             sess->id, &sess->sbi, OpenAPI_service_name_namf_comm,
             discovery_option,

--- a/tests/common/test-common.h
+++ b/tests/common/test-common.h
@@ -87,7 +87,7 @@ extern "C" {
  * Therefore, only one End Marker should be awaited.
  */
 
-#define HOME_ROUTED_ROAMING_TEST 0
+#define HOME_ROUTED_ROAMING_TEST 1
 
 #undef OGS_TEST_INSIDE
 

--- a/tests/slice/abts-main.c
+++ b/tests/slice/abts-main.c
@@ -23,6 +23,7 @@ abts_suite *test_same_dnn(abts_suite *suite);
 abts_suite *test_different_dnn(abts_suite *suite);
 abts_suite *test_paging(abts_suite *suite);
 abts_suite *test_identity(abts_suite *suite);
+abts_suite *test_holding(abts_suite *suite);
 
 const struct testlist {
     abts_suite *(*func)(abts_suite *suite);
@@ -31,6 +32,7 @@ const struct testlist {
     {test_different_dnn},
     {test_paging},
     {test_identity},
+    {test_holding},
     {NULL},
 };
 

--- a/tests/slice/holding-test.c
+++ b/tests/slice/holding-test.c
@@ -1,0 +1,731 @@
+/*
+ * Copyright (C) 2019-2026 by Sukchan Lee <acetcom@gmail.com>
+ *
+ * This file is part of Open5GS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "test-common.h"
+
+/*
+ * Issue #4741
+ *
+ * The UE reappears on a new NG connection while the AMF still holds the old
+ * one, and its Registration Request carries PDU Session Status but no Uplink
+ * Data Status. That is ordinary UE behaviour: the PDU session is kept, the
+ * user plane is not asked for.
+ *
+ * The gNB never sends UEContextReleaseRequest for the held context, so the
+ * deactivation that normally precedes an AN release is never sent, and the
+ * SMF and the UPF are left with the session ACTIVATED towards the GTP-U
+ * endpoint of the released context.
+ *
+ * The test drives downlink traffic afterwards. If the SMF was told, the
+ * downlink raises a notification and the AMF asks the NG-RAN to set the
+ * resources up again. If it was not, the UPF forwards into a black hole and
+ * no NGAP message ever arrives, which shows up as the test timing out on
+ * testgnb_ngap_read() rather than as a failed assertion.
+ */
+static void test1_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *ngap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *gmmbuf;
+    ogs_pkbuf_t *gsmbuf;
+    ogs_pkbuf_t *nasbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "0000203190");
+    ogs_assert(test_ue);
+
+    test_ue->nr_cgi.cell_id = 0x40001;
+
+    test_ue->nas.registration.tsc = 0;
+    test_ue->nas.registration.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.registration.follow_on_request = 1;
+    test_ue->nas.registration.value = OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    /* gNB connects to AMF */
+    ngap = testngap_client(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, ngap);
+
+    /* gNB connects to UPF */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send NG-Setup Reqeust */
+    sendbuf = testngap_build_ng_setup_request(0x4000, 23);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive NG-Setup Response */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Registration request */
+    gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    test_ue->registration_request_param.gmm_capability = 1;
+    test_ue->registration_request_param.s1_ue_network_capability = 1;
+    test_ue->registration_request_param.requested_nssai = 1;
+    test_ue->registration_request_param.last_visited_registered_tai = 1;
+    test_ue->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    gmmbuf = testgmm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    gmmbuf = testgmm_build_security_mode_complete(test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send PDU session establishment request */
+    sess = test_sess_add_by_dnn_and_psi(test_ue, "internet", 5);
+    ogs_assert(sess);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 1;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive PDUSessionResourceSetupRequest +
+     * DL NAS transport +
+     * PDU session establishment accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            test_ue->ngap_procedure_code);
+
+    /*
+     * Send PDUSessionResourceSetupResponse
+     *
+     * This is what sets ran_ue->psimask.activated for this PSI, which is
+     * how the AMF knows the user plane of this session was established on
+     * this NG context and not on some earlier one.
+     */
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Wait to setup N3 data connection */
+    ogs_msleep(100);
+
+    /* Send GTP-U ICMP Packet */
+    qos_flow = test_qos_flow_find_by_qfi(sess, 1);
+    ogs_assert(qos_flow);
+    rv = test_gtpu_send_ping(gtpu, qos_flow, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive GTP-U ICMP Packet */
+    recvbuf = testgnb_gtpu_read(gtpu);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /*
+     * Send InitialUEMessage on a NEW NG connection +
+     * Registration request
+     *  - Type: Mobility updating
+     *  - PDU Session Status, and deliberately NO Uplink Data Status
+     *
+     * The UE is still CM-CONNECTED here, so the AMF holds the NG context
+     * this session's user plane is established on instead of releasing it
+     * right away. testngap_build_initial_ue_message() allocates the next
+     * RAN_UE_NGAP_ID, which is what makes this a second NG connection.
+     */
+    test_ue->nas.registration.value =
+        OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING;
+
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
+    test_ue->registration_request_param.pdu_session_status = 1;
+    test_ue->registration_request_param.psimask.pdu_session_status =
+        1 << sess->psi;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
+    test_ue->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(test_ue, nasbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, true, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand for the OLD NG context */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /*
+     * Send UEContextReleaseComplete for the OLD NG context
+     *
+     * The held context is removed here. Its user plane was never asked for
+     * again, so this is where the AMF has to tell the SMF about it.
+     */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept
+     *
+     * No user plane is set up: the UE did not ask for it.
+     */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+    ABTS_INT_EQUAL(tc, 0x2000, test_ue->pdu_session_status);
+    ABTS_INT_EQUAL(tc, 0x0000, test_ue->pdu_session_reactivation_result);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Wait for the deactivation to reach the UPF */
+    ogs_msleep(300);
+
+    /* Send GTP-U ICMP Packet */
+    rv = test_gtpu_send_ping(gtpu, qos_flow, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /*
+     * Receive PDUSessionResourceSetupRequest
+     *
+     * This is the assertion the issue is about. The downlink reply has to
+     * be buffered at the UPF and reported, so that the AMF asks the NG-RAN
+     * to set the resources up on the connection the UE is using now.
+     *
+     * Without the deactivation the UPF still forwards to the GTP-U endpoint
+     * of the released context, nothing is reported, and this read blocks
+     * until the test times out.
+     */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send PDUSessionResourceSetupResponse */
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive the buffered GTP-U ICMP Packet */
+    recvbuf = testgnb_gtpu_read(gtpu);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send UEContextReleaseRequest */
+    sendbuf = testngap_build_ue_context_release_request(test_ue,
+            NGAP_Cause_PR_radioNetwork, NGAP_CauseRadioNetwork_user_inactivity,
+            true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* Clear Test UE Context */
+    test_ue_remove(test_ue);
+
+    /* gNB disonncect from UPF */
+    testgnb_gtpu_close(gtpu);
+
+    /* gNB disonncect from AMF */
+    testgnb_ngap_close(ngap);
+}
+
+/*
+ * Issue #4741
+ *
+ * The same hold, but the UE does ask for the user plane again with Uplink
+ * Data Status. The session is re-activated on the new NG connection, so
+ * nothing may be deactivated behind it when the held context is removed.
+ *
+ * This is the regression half of the pair: an over-eager cleanup would tear
+ * down the user plane that was just set up, and the downlink exchange at the
+ * end would stop working.
+ */
+static void test2_func(abts_case *tc, void *data)
+{
+    int rv;
+    ogs_socknode_t *ngap;
+    ogs_socknode_t *gtpu;
+    ogs_pkbuf_t *gmmbuf;
+    ogs_pkbuf_t *gsmbuf;
+    ogs_pkbuf_t *nasbuf;
+    ogs_pkbuf_t *sendbuf;
+    ogs_pkbuf_t *recvbuf;
+
+    ogs_nas_5gs_mobile_identity_suci_t mobile_identity_suci;
+    test_ue_t *test_ue = NULL;
+    test_sess_t *sess = NULL;
+    test_bearer_t *qos_flow = NULL;
+
+    bson_t *doc = NULL;
+
+    /* Setup Test UE & Session Context */
+    memset(&mobile_identity_suci, 0, sizeof(mobile_identity_suci));
+
+    mobile_identity_suci.h.supi_format = OGS_NAS_5GS_SUPI_FORMAT_IMSI;
+    mobile_identity_suci.h.type = OGS_NAS_5GS_MOBILE_IDENTITY_SUCI;
+    mobile_identity_suci.routing_indicator1 = 0;
+    mobile_identity_suci.routing_indicator2 = 0xf;
+    mobile_identity_suci.routing_indicator3 = 0xf;
+    mobile_identity_suci.routing_indicator4 = 0xf;
+    mobile_identity_suci.protection_scheme_id = OGS_PROTECTION_SCHEME_NULL;
+    mobile_identity_suci.home_network_pki_value = 0;
+
+    test_ue = test_ue_add_by_suci(&mobile_identity_suci, "0000203190");
+    ogs_assert(test_ue);
+
+    test_ue->nr_cgi.cell_id = 0x40001;
+
+    test_ue->nas.registration.tsc = 0;
+    test_ue->nas.registration.ksi = OGS_NAS_KSI_NO_KEY_IS_AVAILABLE;
+    test_ue->nas.registration.follow_on_request = 1;
+    test_ue->nas.registration.value = OGS_NAS_5GS_REGISTRATION_TYPE_INITIAL;
+
+    test_ue->k_string = "465b5ce8b199b49faa5f0a2ee238a6bc";
+    test_ue->opc_string = "e8ed289deba952e4283b54e88e6183ca";
+
+    /* gNB connects to AMF */
+    ngap = testngap_client(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, ngap);
+
+    /* gNB connects to UPF */
+    gtpu = test_gtpu_server(1, AF_INET);
+    ABTS_PTR_NOTNULL(tc, gtpu);
+
+    /* Send NG-Setup Reqeust */
+    sendbuf = testngap_build_ng_setup_request(0x4000, 23);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive NG-Setup Response */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /********** Insert Subscriber in Database */
+    doc = test_db_new_simple(test_ue);
+    ABTS_PTR_NOTNULL(tc, doc);
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_insert_ue(test_ue, doc));
+
+    /* Send Registration request */
+    gmmbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    test_ue->registration_request_param.gmm_capability = 1;
+    test_ue->registration_request_param.s1_ue_network_capability = 1;
+    test_ue->registration_request_param.requested_nssai = 1;
+    test_ue->registration_request_param.last_visited_registered_tai = 1;
+    test_ue->registration_request_param.ue_usage_setting = 1;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, false, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Authentication request */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Authentication response */
+    gmmbuf = testgmm_build_authentication_response(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Security mode command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send Security mode complete */
+    gmmbuf = testgmm_build_security_mode_complete(test_ue, nasbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, false);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    /* Send PDU session establishment request */
+    sess = test_sess_add_by_dnn_and_psi(test_ue, "internet", 5);
+    ogs_assert(sess);
+
+    sess->ul_nas_transport_param.request_type =
+        OGS_NAS_5GS_REQUEST_TYPE_INITIAL;
+    sess->ul_nas_transport_param.dnn = 1;
+    sess->ul_nas_transport_param.s_nssai = 1;
+
+    sess->pdu_session_establishment_param.ssc_mode = 1;
+    sess->pdu_session_establishment_param.epco = 1;
+
+    gsmbuf = testgsm_build_pdu_session_establishment_request(sess);
+    ABTS_PTR_NOTNULL(tc, gsmbuf);
+    gmmbuf = testgmm_build_ul_nas_transport(sess,
+            OGS_NAS_PAYLOAD_CONTAINER_N1_SM_INFORMATION, gsmbuf);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive PDUSessionResourceSetupRequest +
+     * DL NAS transport +
+     * PDU session establishment accept */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_PDUSessionResourceSetup,
+            test_ue->ngap_procedure_code);
+
+    /* Send PDUSessionResourceSetupResponse */
+    sendbuf = testngap_sess_build_pdu_session_resource_setup_response(sess);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Wait to setup N3 data connection */
+    ogs_msleep(100);
+
+    /*
+     * Send InitialUEMessage on a NEW NG connection +
+     * Registration request
+     *  - Type: Mobility updating
+     *  - PDU Session Status
+     *  - Uplink Data Status
+     */
+    test_ue->nas.registration.value =
+        OGS_NAS_5GS_REGISTRATION_TYPE_MOBILITY_UPDATING;
+
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
+    test_ue->registration_request_param.pdu_session_status = 1;
+    test_ue->registration_request_param.psimask.pdu_session_status =
+        1 << sess->psi;
+    test_ue->registration_request_param.uplink_data_status = 1;
+    test_ue->registration_request_param.psimask.uplink_data_status =
+        1 << sess->psi;
+    nasbuf = testgmm_build_registration_request(test_ue, NULL, false, false);
+    ABTS_PTR_NOTNULL(tc, nasbuf);
+
+    memset(&test_ue->registration_request_param, 0,
+            sizeof(test_ue->registration_request_param));
+    test_ue->registration_request_param.guti = 1;
+    gmmbuf = testgmm_build_registration_request(test_ue, nasbuf, true, false);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+
+    sendbuf = testngap_build_initial_ue_message(test_ue, gmmbuf,
+                NGAP_RRCEstablishmentCause_mo_Signalling, true, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand for the OLD NG context */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete for the OLD NG context */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive InitialContextSetupRequest +
+     * Registration accept
+     *
+     * The user plane is re-established here, so the removal of the held
+     * context above must not have deactivated anything.
+     */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_InitialContextSetup,
+            test_ue->ngap_procedure_code);
+    ABTS_INT_EQUAL(tc, 0x2000, test_ue->pdu_session_status);
+
+    /* Send InitialContextSetupResponse */
+    sendbuf = testngap_build_initial_context_setup_response(test_ue, true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Send Registration complete */
+    gmmbuf = testgmm_build_registration_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, gmmbuf);
+    sendbuf = testngap_build_uplink_nas_transport(test_ue, gmmbuf);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive Configuration update command */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+
+    ogs_msleep(300);
+
+    /* Send GTP-U ICMP Packet */
+    qos_flow = test_qos_flow_find_by_qfi(sess, 1);
+    ogs_assert(qos_flow);
+    rv = test_gtpu_send_ping(gtpu, qos_flow, TEST_PING_IPV4);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /*
+     * Receive GTP-U ICMP Packet
+     *
+     * The user plane has to still be up. If the removal of the held context
+     * had deactivated it, this read would block until the test times out.
+     */
+    recvbuf = testgnb_gtpu_read(gtpu);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    ogs_pkbuf_free(recvbuf);
+
+    /* Send UEContextReleaseRequest */
+    sendbuf = testngap_build_ue_context_release_request(test_ue,
+            NGAP_Cause_PR_radioNetwork, NGAP_CauseRadioNetwork_user_inactivity,
+            true);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    /* Receive UEContextReleaseCommand */
+    recvbuf = testgnb_ngap_read(ngap);
+    ABTS_PTR_NOTNULL(tc, recvbuf);
+    testngap_recv(test_ue, recvbuf);
+    ABTS_INT_EQUAL(tc,
+            NGAP_ProcedureCode_id_UEContextRelease,
+            test_ue->ngap_procedure_code);
+
+    /* Send UEContextReleaseComplete */
+    sendbuf = testngap_build_ue_context_release_complete(test_ue);
+    ABTS_PTR_NOTNULL(tc, sendbuf);
+    rv = testgnb_ngap_send(ngap, sendbuf);
+    ABTS_INT_EQUAL(tc, OGS_OK, rv);
+
+    ogs_msleep(300);
+
+    /********** Remove Subscriber in Database */
+    ABTS_INT_EQUAL(tc, OGS_OK, test_db_remove_ue(test_ue));
+
+    /* Clear Test UE Context */
+    test_ue_remove(test_ue);
+
+    /* gNB disonncect from UPF */
+    testgnb_gtpu_close(gtpu);
+
+    /* gNB disonncect from AMF */
+    testgnb_ngap_close(ngap);
+}
+
+abts_suite *test_holding(abts_suite *suite)
+{
+    suite = ADD_SUITE(suite)
+
+    abts_run_test(suite, test1_func, NULL);
+    abts_run_test(suite, test2_func, NULL);
+
+    return suite;
+}

--- a/tests/slice/meson.build
+++ b/tests/slice/meson.build
@@ -21,6 +21,7 @@ test5gc_slice_sources = files('''
     different-dnn-test.c
     paging-test.c
     identity-test.c
+    holding-test.c
 '''.split())
 
 test5gc_slice_exe = executable('slice',


### PR DESCRIPTION
When a UE shows up on a new NG connection while the AMF still holds the old one, HOLDING_NG_CONTEXT() detaches the old ran_ue and removes it later, either on UEContextReleaseComplete or when t_ng_holding expires.

The gNB never sends UEContextReleaseRequest for that context, so the Update SM Context (upCnxState=DEACTIVATED) that normally precedes an AN release is never sent. A session the UE keeps but does not re-activate on the new connection stays ACTIVATED in the SMF and the UPF, pointing at a GTP-U endpoint that no longer exists: downlink packets are forwarded into a black hole instead of being buffered, and no downlink data notification is raised, so the UE is never paged.

The UE does not have to be misbehaving to get there. A Registration Request that carries PDU Session Status but no Uplink Data Status is ordinary, and gmm_handle_registration_update() acts only on the sessions listed in Uplink Data Status, so the rest are left as they are.

Note the sessions whose AN resources were established on the NG context being put on hold - psimask.activated is exactly that set, and amf_ue_note_stale_user_plane() writes it down - and deactivate whatever is still noted when that context is removed. Deciding at hold time rather than at release time keeps the outcome independent of whether the gNB answers UEContextReleaseCommand before or after the UE asks for the user plane again.

The note says the SMF may still believe the user plane is on that context. While that context lives, the note is dropped only where the SMF has said otherwise: on the success of a procedure that itself moves the user plane - an activation, a deactivation, a completed handover - and update_sm_context_supersedes_stale_user_plane() is that list, after its N1/N2 content has been handled, since an HTTP success alone is not the procedure succeeding. A MODIFIED or an N1-only exchange proves nothing about the DL endpoint and leaves the note alone, and so does dispatching: OGS_OK from
amf_sess_sbi_discover_and_send() means the transaction started, not that the SMF took it. When the held context is removed the note is consumed with it, whichever way the decision goes, so the pool id of a freed context is never kept, and amf_ue_remove() severs the reverse reference a held context keeps for the same reason.

That leaves the window where a procedure is in flight but not yet answered, and which NG context it was issued on decides. A transaction on some other context is a newer procedure that owns where the user plane ends up; racing it with DEACTIVATED could tear down the user plane it is setting up, so the sweep steps aside and the responsibility moves to that procedure. A transaction on the context being removed is the opposite - a late ACTIVATED for a GTP-U endpoint that is gone - and must not stop the cleanup. amf_sbi_xact_ctx_t already records which RAN-UE a transaction was issued on. For the same reason an answer for the noted context does not clear the note, and a timed-out cleanup is not reported to the NG context the UE is using now: the UE is not waiting on it.

The deactivation itself is normally sent on behalf of that current NG context rather than the one being removed, since
amf_sess_sbi_discover_and_send() records the RAN-UE in sess->ran_ue_id and the Namf callbacks reach the UE through it. If no serving NG context remains either, the cleanup stays best-effort. Its response is handled ahead of the generic N1/N2 and error parsing, which would answer an unexpected or malformed response with an Error Indication towards that same live connection.

NGAP_UE_CTX_REL_NG_CONTEXT_REMOVE is not the only way a held context is destroyed. amf_sbi_send_deactivate_all_ue_in_gnb(), the partial NG Reset and ngap_handle_error_indication() all find no AMF-UE context on a held entry, since holding invalidates amf_ue_id, and remove it directly. All four call the deactivation immediately before ran_ue_remove(), so that the cleanup and the removal are visible together at the call site and ran_ue_remove() stays a plain destructor. Only the two places that hold an NG context leave a holder behind, so a context that was never held passes through untouched, as do the handover release actions.

The hold has to be noted in two places, and one of them was an inlined copy of HOLDING_NG_CONTEXT(). The copy exists because the macro takes a single AMF-UE context and uses it for two roles: the context whose NG connection is being held, and the context that records the hold. Those are the same everywhere except in amf_ue_release_old_context(), where the NG context and the sessions still belong to old_amf_ue while the hold has to be recorded in amf_ue, since old_amf_ue is removed as soon as its sessions have been moved across.

Rather than note it twice, split the two roles into parameters as HOLDING_NG_CONTEXT_FOR() and keep HOLDING_NG_CONTEXT() as the ordinary spelling on top of it, so the copy goes away. The existing callers are unchanged, and both spellings stay macros so that the logs and assertions keep reporting the file and line that triggered them.

mme_ue_set_imsi() carried the same copy of HOLDING_S1_CONTEXT(), for the same reason and with the same two roles, so it gets the same treatment as HOLDING_S1_CONTEXT_FOR(). Nothing about the stale user plane is carried over: Release Access Bearers is per-UE rather than per-session in EPC, and the exposure there is smaller, so only the duplication is addressed.

Each half of both macros names the UE after the context it is about: the one released on the way in is the holder's, the one put on hold is the serving context's.

Folding the copies in changes their log lines. Both reported an existing or already-removed holding context through ogs_error() where the macros use ogs_warn(); in the AMF "RAN-NG Context has already been removed" now reads "NG Context has already been removed" and the lines that named the UE by the caller's display name now follow the rule above; in the MME the macro's "Holding S1 Context" line now appears alongside the caller's "Holding old S1 context". The old-context callers then clear the RAN-UE reference themselves - CM_IDLE() and ECM_IDLE() must see the context as released, and nothing associates a new one with the old UE context - while the macros leave the field alone for the ordinary callers, which associate a new context right after.

tests/slice/holding-test.c covers both halves of the AMF fix: a Registration without Uplink Data Status, where downlink traffic has to raise a notification afterwards, and one with it, where the user plane must survive the removal of the held context.

Deactivating it exposed that a Home Routed Roaming session never started a network triggered Service Request afterwards, which also holds for an ordinary idle transition. Everything for that request already exists on the home side - the V-SMF delegates the deactivation over HsmfUpdateData with upCnxState, the H-UPF buffers and reports to the H-SMF, the report handler builds the N1N2 message transfer, and the AMF to send it to was passed in PduSessionCreateData.amfNfId - but two steps were missing in between.

smf_nsmf_handle_update_data_in_hsmf() copied the received upCnxState into sess->nsmf_param for the PFCP modification and never into sess->up_cnx_state, which is what
smf_5gc_n4_handle_session_report_request() switches on, so the H-SMF still believed the user plane was up and dropped the report. Record it in the session as well, as smf_nsmf_handle_update_sm_context() does in the V-SMF, once the requested combination has been accepted, so that an HsmfUpdateData rejected as Bad Request leaves the session untouched, and log every recording. This also keeps the H-SMF in step when the UE comes back, since the activation is delegated with upCnxState the same way, so the log line appears on the home side for every session activation and shows at a glance that this change is in.

And the N1N2 message transfer itself never left the home PLMN: the discovery option named the AMF NF instance but not where to look for it, so the discovery stayed in the home PLMN, found no AMF and the transfer failed with 504. Name the serving PLMN as the target and the home PLMN as the requester, the same way the AMF names the home PLMN when it discovers the AUSF or the UDM of a roaming UE.

tests/slice/holding-test.c passes in the roaming configuration with the buffering, the report and the N1N2 message transfer all on the home side, crossing to the serving AMF through the SEPP.

Issues #4741