### PR TITLE
[SMF] Fix abort on malformed PFCP Session Report Request

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -969,7 +969,6 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
     ogs_pfcp_xact_t *pfcp_xact = NULL;
     ogs_pfcp_message_t *pfcp_message = NULL;
-    uint8_t pfcp_cause;
 
     ogs_diam_gy_message_t *gy_message = NULL;
     uint32_t diam_err;
@@ -1083,9 +1082,10 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
             break;
 
         case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
-            pfcp_cause = smf_n4_handle_session_report_request(sess, pfcp_xact,
+            release = smf_n4_handle_session_report_request(sess, pfcp_xact,
                             &pfcp_message->pfcp_session_report_request);
-            if (pfcp_cause != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
+            if (release) {
+                e->h.sbi.state = OGS_PFCP_DELETE_TRIGGER_LOCAL_INITIATED;
                 OGS_FSM_TRAN(s, smf_gsm_state_wait_pfcp_deletion);
             }
             break;

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -1589,9 +1589,13 @@ uint8_t smf_epc_n4_handle_session_deletion_response(
     return OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 }
 
-/* Returns OGS_PFCP_CAUSE_REQUEST_ACCEPTED on success,
- * other cause value on failure */
-uint8_t smf_n4_handle_session_report_request(
+/*
+ * Returns true when the report requires the session to be released
+ * (Gy Final-Unit-Indication or no Gy peer).  A malformed or otherwise
+ * rejected report is answered with an error response but never releases
+ * the session, so it returns false.
+ */
+bool smf_n4_handle_session_report_request(
         smf_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_pfcp_session_report_request_t *pfcp_req)
 {
@@ -1603,8 +1607,8 @@ uint8_t smf_n4_handle_session_report_request(
     ogs_pfcp_far_t *far = NULL;
 
     ogs_pfcp_report_type_t report_type;
-    uint8_t cause_value = 0;
     uint16_t pdr_id = 0;
+    bool release_session = false;
     unsigned int i;
 
     smf_metrics_inst_global_inc(SMF_METR_GLOB_CTR_SM_N4SESSIONREPORT);
@@ -1614,23 +1618,26 @@ uint8_t smf_n4_handle_session_report_request(
 
     ogs_debug("Session Report Request");
 
-    cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
-
+    /*
+     * pfcp-sm.c rejects a Session Report Request with no session before it
+     * reaches the FSM, so sess is always set here.  Keep the guard as a
+     * defensive check.
+     */
     if (!sess) {
         ogs_error("No Context");
-        cause_value = OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
+        ogs_pfcp_send_error_message(pfcp_xact, 0,
+                OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
+                OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
+        return false;
     }
 
     if (pfcp_req->report_type.presence == 0) {
         ogs_error("No Report Type");
-        cause_value = OGS_PFCP_CAUSE_MANDATORY_IE_MISSING;
-    }
-
-    if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
         ogs_pfcp_send_error_message(pfcp_xact, 0,
                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
-                cause_value, 0);
-        return cause_value;
+                OGS_PFCP_CAUSE_MANDATORY_IE_MISSING,
+                OGS_PFCP_REPORT_TYPE_TYPE);
+        return false;
     }
 
     ogs_assert(sess);
@@ -1670,7 +1677,7 @@ uint8_t smf_n4_handle_session_report_request(
                         ogs_pfcp_send_error_message(pfcp_xact, 0,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED, 0);
-                        return OGS_PFCP_CAUSE_SERVICE_NOT_SUPPORTED;
+                        return false;
                     }
 
                     if (qfi) {
@@ -1680,7 +1687,7 @@ uint8_t smf_n4_handle_session_report_request(
                             ogs_pfcp_send_error_message(pfcp_xact, 0,
                                 OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
-                            return OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
+                            return false;
                         }
                     }
                 } else {
@@ -1689,23 +1696,37 @@ uint8_t smf_n4_handle_session_report_request(
             }
 
             if (pfcp_req->downlink_data_report.pdr_id.presence) {
-                pdr = ogs_pfcp_pdr_find(&sess->pfcp,
-                    pfcp_req->downlink_data_report.pdr_id.u16);
+                pdr_id = pfcp_req->downlink_data_report.pdr_id.u16;
+                pdr = ogs_pfcp_pdr_find(&sess->pfcp, pdr_id);
                 if (!pdr)
                     ogs_error("Cannot find the PDR-ID[%d]", pdr_id);
             } else {
                 ogs_error("No PDR-ID");
+                ogs_pfcp_send_error_message(pfcp_xact, 0,
+                        OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
+                        OGS_PFCP_CAUSE_MANDATORY_IE_MISSING,
+                        OGS_PFCP_PDR_ID_TYPE);
+                return false;
             }
         } else {
+            /*
+             * TS 29.244 7.5.8.1: the Downlink Data Report IE is required
+             * when the Report Type indicates DLDR.
+             */
             ogs_error("No Downlink Data Report");
+            ogs_pfcp_send_error_message(pfcp_xact, 0,
+                    OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
+                    OGS_PFCP_CAUSE_CONDITIONAL_IE_MISSING,
+                    OGS_PFCP_DOWNLINK_DATA_REPORT_TYPE);
+            return false;
         }
 
         if (!pdr) {
-            ogs_error("No Context");
+            ogs_error("Cannot find the PDR");
             ogs_pfcp_send_error_message(pfcp_xact, 0,
                     OGS_PFCP_SESSION_REPORT_RESPONSE_TYPE,
                     OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
-            return OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
+            return false;
         }
 
         switch (sess->up_cnx_state) {
@@ -1791,13 +1812,12 @@ uint8_t smf_n4_handle_session_report_request(
             } else {
                 ogs_debug("[%s:%s] Rx PFCP report after Gy Final Unit Indication",
                           smf_ue->imsi_bcd, sess->session.name);
-                /* This effectively triggers session release: */
-                cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                release_session = true;
             }
             break;
         case -1:
             ogs_error("No Gy Diameter Peer");
-            cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+            release_session = true;
             break;
         /* default: continue below */
         }
@@ -1893,5 +1913,5 @@ uint8_t smf_n4_handle_session_report_request(
                     0, 0));
         }
     }
-    return cause_value;
+    return release_session;
 }

--- a/src/smf/n4-handler.h
+++ b/src/smf/n4-handler.h
@@ -47,7 +47,7 @@ uint8_t smf_epc_n4_handle_session_deletion_response(
         smf_sess_t *sess, ogs_pfcp_xact_t *xact,
         ogs_pfcp_session_deletion_response_t *rsp);
 
-uint8_t smf_n4_handle_session_report_request(
+bool smf_n4_handle_session_report_request(
         smf_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_pfcp_session_report_request_t *pfcp_req);
 


### PR DESCRIPTION
A rejected PFCP Session Report Request was incorrectly treated as a request to release the session. In the 5GC path, the PFCP event had no deletion trigger, causing an assertion failure during session deletion.

Separate PFCP error handling from the session release decision. Malformed reports now receive an appropriate error response without releasing the session. Gy Final-Unit-Indication and the absence of a Gy peer still trigger a locally initiated session release.

Return Mandatory IE missing or Conditional IE missing with the corresponding Offending IE for missing Report Type, PDR ID, or Downlink Data Report IEs. Also log the actual PDR ID when lookup fails.

Issues #4744