### PR TITLE
[PFCP] Reclaim unused GTP-U peer nodes

### DIFF
--- a/lib/gtp/context.h
+++ b/lib/gtp/context.h
@@ -74,6 +74,9 @@ typedef struct ogs_gtp_node_s {
 
     ogs_ip_t        ip;             /* F-TEID IP Address Duplicate Check */
 
+    uint32_t        gtpu_ref_count; /* Number of PFCP FARs/PDRs referencing
+                                     * this GTP-U peer (used by lib/pfcp) */
+
     ogs_list_t      local_list;
     ogs_list_t      remote_list;
 } ogs_gtp_node_t;

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1190,6 +1190,25 @@ ogs_gtpu_resource_t *ogs_pfcp_find_gtpu_resource(ogs_list_t *list,
     return NULL;
 }
 
+/*
+ * GTP-U peer nodes in gtpu_peer_list are created on demand by
+ * ogs_pfcp_setup_far_gtpu_node()/ogs_pfcp_setup_pdr_gtpu_node() and
+ * shared by all FARs/PDRs carrying the same IP. gnode->gtpu_ref_count
+ * counts those FARs/PDRs; when the last one is removed, the peer is
+ * removed from gtpu_peer_list and returned to the pool. Without this,
+ * a peer whose eNB/gNB was renumbered would occupy a pool entry until
+ * the process exits and repeated IP changes would eventually exhaust
+ * `global.max.gtp_peer`.
+ */
+static void gtpu_peer_release(ogs_gtp_node_t *gnode)
+{
+    ogs_assert(gnode);
+    ogs_assert(gnode->gtpu_ref_count > 0);
+
+    if (--gnode->gtpu_ref_count == 0)
+        ogs_gtp_node_remove(&ogs_gtp_self()->gtpu_peer_list, gnode);
+}
+
 int ogs_pfcp_setup_far_gtpu_node(ogs_pfcp_far_t *far)
 {
     int rv;
@@ -1234,7 +1253,13 @@ int ogs_pfcp_setup_far_gtpu_node(ogs_pfcp_far_t *far)
         }
     }
 
-    OGS_SETUP_GTP_NODE(far, gnode);
+    /* Update FAR can move to another peer; keep the count per pointer */
+    if (far->gnode != gnode) {
+        gnode->gtpu_ref_count++;
+        if (far->gnode)
+            gtpu_peer_release(far->gnode);
+        OGS_SETUP_GTP_NODE(far, gnode);
+    }
 
     return OGS_OK;
 }
@@ -1275,7 +1300,13 @@ int ogs_pfcp_setup_pdr_gtpu_node(ogs_pfcp_pdr_t *pdr)
         }
     }
 
-    OGS_SETUP_GTP_NODE(pdr, gnode);
+    /* Update PDR can move to another peer; keep the count per pointer */
+    if (pdr->gnode != gnode) {
+        gnode->gtpu_ref_count++;
+        if (pdr->gnode)
+            gtpu_peer_release(pdr->gnode);
+        OGS_SETUP_GTP_NODE(pdr, gnode);
+    }
 
     return OGS_OK;
 }
@@ -1647,6 +1678,11 @@ void ogs_pfcp_pdr_remove(ogs_pfcp_pdr_t *pdr)
                     &pdr->hash.teid.key, pdr->hash.teid.len, NULL);
     }
 
+    if (pdr->gnode) {
+        gtpu_peer_release(pdr->gnode);
+        pdr->gnode = NULL;
+    }
+
     if (pdr->dnn)
         ogs_free(pdr->dnn);
 
@@ -1944,6 +1980,11 @@ void ogs_pfcp_far_remove(ogs_pfcp_far_t *far)
     if (far->hash.f_teid.len)
         ogs_hash_set(self.far_f_teid_hash,
                 &far->hash.f_teid.key, far->hash.f_teid.len, NULL);
+
+    if (far->gnode) {
+        gtpu_peer_release(far->gnode);
+        far->gnode = NULL;
+    }
 
     if (far->dnn)
         ogs_free(far->dnn);

--- a/tests/common/test-common.h
+++ b/tests/common/test-common.h
@@ -87,7 +87,7 @@ extern "C" {
  * Therefore, only one End Marker should be awaited.
  */
 
-#define HOME_ROUTED_ROAMING_TEST 1
+#define HOME_ROUTED_ROAMING_TEST 0
 
 #undef OGS_TEST_INSIDE
 


### PR DESCRIPTION
GTP-U peers added to gtpu_peer_list were only freed at process exit, so every distinct peer address ever seen held one gtp_node pool entry (global.max.gtp_peer, default 64). Renumbering eNB GTP-U addresses, or gNB changes across handovers, eventually exhausted the pool and new sessions failed with "CHECK CONFIGURATION: sgwu.gtpu".

Count the FARs/PDRs referencing each peer and remove the node when the last reference goes away. A FAR/PDR moving to another address releases the old peer; a same-address update leaves the count unchanged.

A FAR whose Outer Header Creation is removed still holds its peer until the FAR itself is removed.

Issues: #4764