### PR TITLE
[PFCP] Check node ownership on session-level messages

### DIFF
--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -198,6 +198,22 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
              * locally stored in xact when sending the original request: */
             sess = sgwc_sess_find_by_seid(xact->local_seid);
         }
+        /*
+         * A session belongs to the PFCP node it was established with.
+         * A request for that SEID from any other node is treated
+         * as if the session did not exist, so the handlers reply
+         * with Session context not found (Cause 65).
+         */
+        if (sess && sess->pfcp_node != node) {
+            ogs_error("PFCP-Node mismatch: SGWC-SEID[0x%lx] type [%d] from %s",
+                    (long)message->h.seid, message->h.type,
+                    ogs_sockaddr_to_string_static(node->addr_list));
+            if (sess->pfcp_node)
+                ogs_error("    owner %s",
+                        ogs_sockaddr_to_string_static(
+                            sess->pfcp_node->addr_list));
+            sess = NULL;
+        }
 
         switch (message->h.type) {
         case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -184,8 +184,24 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
         xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
-        if (message->h.seid_presence && message->h.seid != 0)
+        if (message->h.seid_presence && message->h.seid != 0) {
             sess = sgwu_sess_find_by_sgwu_sxa_seid(message->h.seid);
+            /*
+             * A session belongs to the PFCP node that established it.
+             * A request for that SEID from any other node is treated
+             * as if the session did not exist, so the handlers reply
+             * with Session context not found (Cause 65).
+             */
+            if (sess && sess->pfcp_node != node) {
+                ogs_error("PFCP-Node mismatch: SGWU-SEID[0x%lx] type [%d] "
+                        "from %s", (long)message->h.seid, message->h.type,
+                        ogs_sockaddr_to_string_static(node->addr_list));
+                ogs_error("    owner %s",
+                        ogs_sockaddr_to_string_static(
+                            sess->pfcp_node->addr_list));
+                sess = NULL;
+            }
+        }
 
         switch (message->h.type) {
         case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -224,6 +224,22 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
              * locally stored in xact when sending the original request: */
             sess = smf_sess_find_by_seid(xact->local_seid);
         }
+        /*
+         * A session belongs to the PFCP node it was established with.
+         * A request for that SEID from any other node is treated
+         * as if the session did not exist, so the handlers reply
+         * with Session context not found (Cause 65).
+         */
+        if (sess && sess->pfcp_node != node) {
+            ogs_error("PFCP-Node mismatch: SMF-SEID[0x%lx] type [%d] from %s",
+                    (long)message->h.seid, message->h.type,
+                    ogs_sockaddr_to_string_static(node->addr_list));
+            if (sess->pfcp_node)
+                ogs_error("    owner %s",
+                        ogs_sockaddr_to_string_static(
+                            sess->pfcp_node->addr_list));
+            sess = NULL;
+        }
         if (sess)
             e->sess_id = sess->id;
 

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -193,8 +193,24 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
         xact = ogs_pfcp_xact_find_by_id(e->pfcp_xact_id);
         ogs_assert(xact);
 
-        if (message->h.seid_presence && message->h.seid != 0)
+        if (message->h.seid_presence && message->h.seid != 0) {
             sess = upf_sess_find_by_upf_n4_seid(message->h.seid);
+            /*
+             * A session belongs to the PFCP node that established it.
+             * A request for that SEID from any other node is treated
+             * as if the session did not exist, so the handlers reply
+             * with Session context not found (Cause 65).
+             */
+            if (sess && sess->pfcp_node != node) {
+                ogs_error("PFCP-Node mismatch: UP-SEID[0x%lx] type [%d] "
+                        "from %s", (long)message->h.seid, message->h.type,
+                        ogs_sockaddr_to_string_static(node->addr_list));
+                ogs_error("    owner %s",
+                        ogs_sockaddr_to_string_static(
+                            sess->pfcp_node->addr_list));
+                sess = NULL;
+            }
+        }
 
         switch (message->h.type) {
         case OGS_PFCP_HEARTBEAT_REQUEST_TYPE:


### PR DESCRIPTION
Session-level PFCP messages were dispatched by SEID alone, so a request for a SEID from a PFCP node other than the one the session belongs to was applied. Such a request is now handled as Session context not found (Cause 65).

- UPF/SGWU: Session Modification/Deletion Request
- SMF/SGWC: Session Report Request

Issues #4761