### PR TITLE
sbi: Free pending transactions when freeing an SBI object

### DIFF
--- a/lib/sbi/context.c
+++ b/lib/sbi/context.c
@@ -2593,6 +2593,11 @@ void ogs_sbi_object_free(ogs_sbi_object_t *sbi_object)
         ogs_error("SBI running [%d]", ogs_list_count(&sbi_object->xact_list));
         ogs_list_for_each(&sbi_object->xact_list, xact)
             OGS_SBI_XACT_LOG(xact);
+
+        /* The object is being freed, so a late response can no longer be
+         * matched to these transactions. Drop them here, otherwise the
+         * transaction, its request and its timer are leaked. */
+        ogs_sbi_xact_remove_all(sbi_object);
     }
 
     for (i = 0; i < OGS_SBI_MAX_NUM_OF_SERVICE_NAME; i++) {


### PR DESCRIPTION
ogs_sbi_object_free() logged the transactions still attached to the object but never removed them, leaking each transaction along with its request and its response timer. ogs_sbi_xact_remove_all() already does this and had no callers.

To reproduce, build with -O0 and pin to a single CPU so that the SM context modify is still outstanding when the UEContextReleaseRequest arrives:

  meson setup build -Dbuildtype=debug && ninja -C build
  taskset -c 0 ./build/tests/registration/registration dereg-test

Without the fix the AMF logs "SBI running [1]" and three "were not released" lines at exit. reset-test shows the same.