### PR TITLE
core: Re-add a pollset entry when its descriptor number was reused

### DIFF
--- a/lib/core/ogs-epoll.c
+++ b/lib/core/ogs-epoll.c
@@ -143,6 +143,21 @@ static int epoll_add(ogs_poll_t *poll)
     ee.data.fd = poll->fd;
 
     rv = epoll_ctl(context->epfd, op, poll->fd, &ee);
+    if (rv < 0 && op == EPOLL_CTL_MOD && ogs_socket_errno == ENOENT) {
+        /* The descriptor was closed without being removed from the pollset
+         * and its number reused, so the map entry is stale. Insert it. */
+        map->read = (poll->when & OGS_POLLIN) ? poll : NULL;
+        map->write = (poll->when & OGS_POLLOUT) ? poll : NULL;
+
+        ee.events = 0;
+        if (map->read)
+            ee.events |= (EPOLLIN|EPOLLRDHUP);
+        if (map->write)
+            ee.events |= EPOLLOUT;
+
+        op = EPOLL_CTL_ADD;
+        rv = epoll_ctl(context->epfd, op, poll->fd, &ee);
+    }
     if (rv < 0) {
         ogs_log_message(OGS_LOG_ERROR, ogs_socket_errno,
                 "epoll_ctl[%d] failed(%d)", op, rv);

--- a/tests/core/poll-test.c
+++ b/tests/core/poll-test.c
@@ -657,6 +657,40 @@ static void test8_func(abts_case *tc, void *data)
     ogs_pollset_destroy(pollset);
 }
 
+static void fd_reuse_handler(short when, ogs_socket_t fd, void *data)
+{
+}
+
+static void fd_reuse_func(abts_case *tc, void *data)
+{
+    ogs_pollset_t *pollset;
+    ogs_poll_t *poll;
+    ogs_socket_t first, second;
+
+    pollset = ogs_pollset_create(512);
+    ABTS_PTR_NOTNULL(tc, pollset);
+
+    first = socket(AF_INET, SOCK_STREAM, 0);
+    ABTS_TRUE(tc, first != INVALID_SOCKET);
+    poll = ogs_pollset_add(pollset, OGS_POLLIN, first, fd_reuse_handler, NULL);
+    ABTS_PTR_NOTNULL(tc, poll);
+
+    /* Closed without ogs_pollset_remove(), so `poll` is abandoned and
+     * ogs_pollset_destroy() reports it. That is what is being tested. */
+    ogs_closesocket(first);
+
+    second = socket(AF_INET, SOCK_STREAM, 0);
+    ABTS_INT_EQUAL(tc, first, second);
+
+    poll = ogs_pollset_add(pollset, OGS_POLLIN, second, fd_reuse_handler, NULL);
+    ABTS_PTR_NOTNULL(tc, poll);
+    if (poll)
+        ogs_pollset_remove(poll);
+
+    ogs_closesocket(second);
+    ogs_pollset_destroy(pollset);
+}
+
 abts_suite *test_poll(abts_suite *suite)
 {
     suite = ADD_SUITE(suite)
@@ -672,6 +706,7 @@ abts_suite *test_poll(abts_suite *suite)
     abts_run_test(suite, test6_func, NULL);
     abts_run_test(suite, test7_func, NULL);
     abts_run_test(suite, test8_func, NULL);
+    abts_run_test(suite, fd_reuse_func, NULL);
 
     return suite;
 }


### PR DESCRIPTION
epoll_add() looks up map_hash by descriptor number to choose between EPOLL_CTL_ADD and EPOLL_CTL_MOD, but a descriptor number is only unique while the descriptor is open. Closing a socket without calling ogs_pollset_remove() first drops it from the kernel's epoll set and leaves the map entry behind, so the next socket given that number is treated as an update of the old one. epoll_ctl() returns ENOENT, ogs_pollset_add() returns NULL, and its callers assert.

The pollset cannot stop a caller from closing a descriptor behind its back, but ENOENT from EPOLL_CTL_MOD says the kernel does not have the descriptor, so the entry is stale and the poll has to be inserted.

A stale entry only exists because a poll was abandoned, so the test has to abandon one. poll-test therefore now prints

  ERROR: 1 in '&pollset->pool[512]' were not released.

which is the condition under test, not a leak in the test. Freeing it would need ogs-poll-private.h, and no test under tests/core reaches into a private header.

The test covers the fix. To see it fail, build with the test but without the fix:

  git checkout HEAD~1 -- lib/core/ogs-epoll.c
  meson setup build && ninja -C build
  ./build/tests/core/core

  poll-test:
    ERROR: epoll_ctl[3] failed(-1) (2:No such file or directory)
    Line 686: expected non-NULL, but saw NULL

  git checkout HEAD -- lib/core/ogs-epoll.c

In a running system this shows up as an occasional abort during shutdown, when client sockets are closing while a server is still accepting:

  ERROR: epoll_ctl[3] failed(-1) (2:No such file or directory)
  FATAL: accept_handler: Assertion `sbi_sess->poll.read' failed.

Seen there roughly once in twenty-four runs of
./build/tests/registration/registration.